### PR TITLE
Remove Move-SqlDatabaseFile cmdlet

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -137,7 +137,6 @@
 		'Test-DbaJobOwner',
 		'Set-DbaJobOwner',
 		'Test-DbaVirtualLogFile',
-        'Move-SqlDatabaseFile'
 	)
 	
 	# Cmdlets to export from this module


### PR DESCRIPTION
Removing the Move-SqlDatabaseFile from the list of exported cmdlets, it
hasn't been tested yet.