### PR TITLE
Install-SqlWhoIsActive, Show-SqlWhoIsActive - Bug fixes

### DIFF
--- a/functions/Install-SqlWhoIsActive.ps1
+++ b/functions/Install-SqlWhoIsActive.ps1
@@ -140,7 +140,10 @@ This command doesn't support passing both servers and default database, but you 
 			{
 				try
 				{
-					Write-Output "Downloading sp_WhoIsActive zip file, unzipping and installing."
+					if ($OutputDatabaseName -eq $false)
+					{
+						Write-Output "Downloading sp_WhoIsActive zip file, unzipping and installing."
+					}
 					Get-SpWhoIsActive
 				}
 				catch

--- a/functions/Show-SqlWhoIsActive.ps1
+++ b/functions/Show-SqlWhoIsActive.ps1
@@ -280,6 +280,9 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
 			
 			if ($database.Length -gt 0)
 			{
+				# database is being returned as something weird. change it to string without using a method then trim.
+				$database = "$database"
+				$database = $database.Trim()
 				$sqlconnection.ChangeDatabase($database)
 			}
 			
@@ -287,7 +290,7 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
 			$sqlcommand.CommandType = "StoredProcedure"
 			$sqlcommand.CommandText = "dbo.sp_WhoIsActive"
 			$sqlcommand.Connection = $sqlconnection
-				
+			
 			foreach ($param in $passedparams)
 			{
 				$sqlparam = $paramdictionary[$param]
@@ -346,7 +349,7 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
 	}
 	
 	PROCESS
-	{		
+	{
 		$database = $psboundparameters.Database
 		$passedparams = $psboundparameters.Keys | Where-Object { 'SqlServer', 'SqlCredential', 'OutputAs', 'ServerInstance', 'SqlInstance', 'Database' -notcontains $_ }
 		$localparams = $psboundparameters
@@ -371,6 +374,7 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
 					$database = Install-SqlWhoisActive -SqlServer $sourceserver -OutputDatabaseName
 				}
 				
+				
 				try
 				{
 					$datatable = Invoke-SpWhoisActive
@@ -383,7 +387,7 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
 			}
 			else
 			{
-				Write-warning "Invalid query."	
+				Write-warning "Invalid query."
 			}
 		}
 	}


### PR DESCRIPTION
To test, ensure that who_is_active_v11_11.sql does not exist in $env:temp. Also remove the sproc from the destination SQL Server if it exists.
Run

Show-SqlWhoIsActive -SqlServer sql2005 -ShowSystemSpids

Select the destination database. It should auto install and an OGV should pop up with the info.