### PR TITLE
Update-SqlPermissions, Sync-SqlLoginPermissions - Fixes for inaccessible databases

### DIFF
--- a/functions/SharedFunctions.ps1
+++ b/functions/SharedFunctions.ps1
@@ -1500,7 +1500,7 @@ Function Update-SqlPermissions
 		{
 			if (!$destdb.IsAccessible)
 			{
-				Write-Output "Database is not accessible. Skipping"
+				Write-Output "Database [$($destdb.Name)] is not accessible. Skipping"
 				Continue
 			}
 			if ($destdb.users[$dbusername] -eq $null)

--- a/functions/SharedFunctions.ps1
+++ b/functions/SharedFunctions.ps1
@@ -1498,6 +1498,11 @@ Function Update-SqlPermissions
 		
 		if ($destdb -ne $null)
 		{
+			if (!$destdb.IsAccessible)
+			{
+				Write-Output "Database is not accessible. Skipping"
+				Continue
+			}
 			if ($destdb.users[$dbusername] -eq $null)
 			{
 				If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname"))

--- a/functions/Sync-SqlLoginPermissions.ps1
+++ b/functions/Sync-SqlLoginPermissions.ps1
@@ -398,7 +398,7 @@ https://dbatools.io/Sync-SqlLoginPermissions
 				{
 					if (!$destdb.IsAccessible)
 					{
-					    Write-Output "Database is not accessible. Skipping"
+					    Write-Output "Database [$($destdb.Name)] is not accessible. Skipping"
 					    Continue
 					}
 					

--- a/functions/Sync-SqlLoginPermissions.ps1
+++ b/functions/Sync-SqlLoginPermissions.ps1
@@ -396,6 +396,12 @@ https://dbatools.io/Sync-SqlLoginPermissions
 				
 				if ($destdb -ne $null)
 				{
+					if (!$destdb.IsAccessible)
+					{
+					    Write-Output "Database is not accessible. Skipping"
+					    Continue
+					}
+					
 					if ($destdb.users[$dbusername] -eq $null)
 					{
 						If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname"))


### PR DESCRIPTION
Adjust sharedfunctions and update-sqlpermissions to account for databases not being accessible, but not causing issues during migrations.

Fixes #222 