### PR TITLE
Get-ParamSqlDatabases - Adding -NoSystem to dynamic parameter to include SystemDB's

### DIFF
--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -159,7 +159,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		[object]$DbPipeline
 	)
 	
-	DynamicParam { if ($source) { return Get-ParamSqlDatabases -SqlServer $source -SqlCredential $SourceSqlCredential } }
+	DynamicParam { if ($source) { return Get-ParamSqlDatabases -SqlServer $source -SqlCredential $SourceSqlCredential -NoSystem $true} }
 	
 	BEGIN
 	{

--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -65,7 +65,8 @@ filled with database list from specified SQL Server server.
 		[Parameter(Mandatory = $true)]
 		[Alias("ServerInstance","SqlInstance")]
 		[object]$SqlServer,
-		[System.Management.Automation.PSCredential]$SqlCredential
+		[System.Management.Automation.PSCredential]$SqlCredential,		
+		[bool]$NoSystem 
 	)
 
 	try { $server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential -ParameterConnection }
@@ -75,7 +76,7 @@ filled with database list from specified SQL Server server.
 
 	# Populate arrays
 	$databaselist = @()
-
+	
 	if ($server.Databases.Count -gt 255)
 	{
 		# Don't slow them down by building a list that likely won't be used anyway
@@ -92,10 +93,19 @@ filled with database list from specified SQL Server server.
 
 	foreach ($database in $server.databases)
 	{
-		if ((!$database.IsSystemObject) -and $SupportDbs -notcontains $database.name)
-		{
-			$databaselist += $database.name
+		if ( $NoSystem ) {
+			if ((!$database.IsSystemObject) -and $SupportDbs -notcontains $database.name)
+			{
+				$databaselist += $database.name
+			}
+		} else 
+		{ 
+			if ($SupportDbs -notcontains $database.name)
+			{
+				$databaselist += $database.name
+			}
 		}
+			
 	}
 
 	# Reusable parameter setup

--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -75,8 +75,7 @@ filled with database list from specified SQL Server server.
 	$SupportDbs = "ReportServer", "ReportServerTempDb", "distribution"
 
 	# Populate arrays
-	$databaselist = @()
-	
+	$databaselist = @()	
 	if ($server.Databases.Count -gt 255)
 	{
 		# Don't slow them down by building a list that likely won't be used anyway

--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -66,7 +66,7 @@ filled with database list from specified SQL Server server.
 		[Alias("ServerInstance","SqlInstance")]
 		[object]$SqlServer,
 		[System.Management.Automation.PSCredential]$SqlCredential,		
-		[bool]$NoSystem 
+		[bool]$NoSystem=$false
 	)
 
 	try { $server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential -ParameterConnection }

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -65,7 +65,7 @@ Returns a custom object filled with information for server1, server2 and server3
 	{
 		Function Get-AllDiskSpace
 		{
-			
+
 			$measure = "1$unit"
 			$alldisks = @()
 			

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -65,6 +65,7 @@ Returns a custom object filled with information for server1, server2 and server3
 	{
 		Function Get-AllDiskSpace
 		{
+			
 			$measure = "1$unit"
 			$alldisks = @()
 			

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -65,7 +65,6 @@ Returns a custom object filled with information for server1, server2 and server3
 	{
 		Function Get-AllDiskSpace
 		{
-
 			$measure = "1$unit"
 			$alldisks = @()
 			


### PR DESCRIPTION
Simple addition for Issue [#253](https://github.com/sqlcollaborative/dbatools/issues/253)

Added [Bool]NoSystem to Get-ParamSqlDatabases which defaults to $false so that it will not exclude system DB's by default. 

Set of Tests for this PR: 

SQL 2000 - 2016: 
- [x] Run: ** Copy-SqlDatabase -Source localhost -Destination localhost -Databases** to get the dynamic window list. Should not see any System DB's 

- [x] Run: **Remove-SqlOrphanUser -SqlServer localhost -Databases ** to get the dynamic window list, does show the system DB's 


