### PR TITLE
New command Get-DbaStartupParameter

### DIFF
--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -5,16 +5,17 @@
 Displays SQL Server Startup Parameters
 
 .DESCRIPTION
-Displays a detailed list of SQL Server Startup Parameters. 
-	
+Displays values for a detailed list of SQL Server Startup Parameters including Master Data Path, Master Log path, ErrorLog, Trace Flags, Parameter String and much more.
+
+See https://msdn.microsoft.com/en-us/library/ms190737.aspx for more information.
 .PARAMETER SqlServer
 The SQL Server that you're connecting to.
 
 .PARAMETER Credential
 Credential object used to connect to the SQL Server as a different user be it Windows or SQL Server. Windows users are determiend by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
 
-.PARAMETER Detailed
-(should we be detailed by default or use -Simple to simplify?)
+.PARAMETER Simple
+Shows a simplified output including only Server, Master Data Path, Master Log path, ErrorLog, TraceFlags and ParameterString
 
 .NOTES
 dbatools PowerShell module (https://dbatools.io)
@@ -29,7 +30,7 @@ You should have received a copy of the GNU General Public License along with thi
 .EXAMPLE
 Get-DbaStartupParameter -SqlServer sql2014
 
-xyz
+Logs into sql2014 using trusted authentication then displays the values for numerous startup parameters.
 
 .EXAMPLE
 $cred = Get-Credential sqladmin
@@ -82,7 +83,7 @@ Logs into sql2014 using SQL credentials and displays a simplified output of para
 					}
 					
 					$object = [PSCustomObject]@{
-						Instance = $Servername
+						Server = $Servername
 						MasterData = $masterdata.TrimStart('-d')
 						MasterLog = $masterlog.TrimStart('-l')
 						ErrorLog = $errorlog.TrimStart('-e')
@@ -144,6 +145,7 @@ Logs into sql2014 using SQL credentials and displays a simplified output of para
 							ParameterString = $wmisvc.StartupParameters
 						}
 					}
+					
 					return $object
 				}
 				

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -2,18 +2,21 @@
 {
 <#
 .SYNOPSIS
-Displays SQL Server Startup Parameters
+Displays values for a detailed list of SQL Server Startup Parameters.
 
 .DESCRIPTION
-Displays values for a detailed list of SQL Server Startup Parameters including Master Data Path, Master Log path, ErrorLog, Trace Flags, Parameter String and much more.
+Displays values for a detailed list of SQL Server Startup Parameters including Master Data Path, Master Log path, Error Log, Trace Flags, Parameter String and much more.
 
+This command relies on remote Windows Server (SQL WMI/WinRm) access. You can pass alternative Windows credentials by using the -Credential parameter. 
+	
 See https://msdn.microsoft.com/en-us/library/ms190737.aspx for more information.
+	
 .PARAMETER SqlServer
 The SQL Server that you're connecting to.
 
 .PARAMETER Credential
-Credential object used to connect to the SQL Server as a different user be it Windows or SQL Server. Windows users are determiend by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
-
+Credential object used to connect to the Windows Server as a different Windows user. 
+	
 .PARAMETER Simple
 Shows a simplified output including only Server, Master Data Path, Master Log path, ErrorLog, TraceFlags and ParameterString
 
@@ -30,14 +33,14 @@ You should have received a copy of the GNU General Public License along with thi
 .EXAMPLE
 Get-DbaStartupParameter -SqlServer sql2014
 
-Logs into sql2014 using trusted authentication then displays the values for numerous startup parameters.
+Logs into SQL WMI as the current user then displays the values for numerous startup parameters.
 
 .EXAMPLE
-$cred = Get-Credential sqladmin
-Get-DbaStartupParameter -SqlServer sql2014 -Credential $cred -Simple
+$wincred = Get-Credential ad\sqladmin
+Get-DbaStartupParameter -SqlServer sql2014 -Credential $wincred -Simple
 
-Logs into sql2014 using SQL credentials and displays a simplified output of parameters.
-
+Logs in to WMI using the ad\sqladmin credential and gathers simplified information about the SQL Server Startup Parameters.
+	
 #>	
 	[CmdletBinding()]
 	param ([parameter(ValueFromPipeline, Mandatory = $true)]

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -78,6 +78,13 @@ Logs in to WMI using the ad\sqladmin credential and gathers simplified informati
 					$errorlog = $params | Where-Object { $_.StartsWith('-e') }
 					$traceflags = $params | Where-Object { $_.StartsWith('-T') }
 					
+					$debugflag = $params | Where-Object { $_.StartsWith('-t') }
+					
+					if ($debugflag.length -ne 0)
+					{
+						Write-Warning "$servername is using the lowercase -t trace flag. This is for internal debugging only. Please ensure this was intentional."
+					}
+					
 					if ($traceflags.length -eq 0)
 					{
 						$traceflags = "None"

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -73,7 +73,6 @@ Logs in to WMI using the ad\sqladmin credential and gathers simplified informati
 					
 					$params = $wmisvc.StartupParameters -split ';'
 					
-					$traceflags = $params | Where-Object { @('-d', '-l', '-e') -notcontains $_.SubString(0, 2) }
 					$masterdata = $params | Where-Object { $_.StartsWith('-d') }
 					$masterlog = $params | Where-Object { $_.StartsWith('-l') }
 					$errorlog = $params | Where-Object { $_.StartsWith('-e') }

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -44,7 +44,7 @@ xyz
 		[Alias("SqlCredential")]
 		[PSCredential]$Credential,
 		[switch]$Detailed
-	}
+		)
 	
 	PROCESS
 	{

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -43,7 +43,7 @@ xyz
 		[object[]]$SqlServer,
 		[Alias("SqlCredential")]
 		[PSCredential]$Credential,
-		[switch]$Detailed
+		[switch]$Simple
 		)
 	
 	PROCESS
@@ -89,7 +89,7 @@ xyz
 						ParameterString = $wmisvc.StartupParameters
 					}
 					
-					if ($Detailed -eq $true)
+					if ($Simple -ne $true)
 					{
 						# From https://msdn.microsoft.com/en-us/library/ms190737.aspx
 						
@@ -127,7 +127,7 @@ xyz
 						}
 						
 						$object = [PSCustomObject]@{
-							Instance = $Servername
+							Server = $Servername
 							MasterData = $masterdata.TrimStart('-d')
 							MasterLog = $masterlog.TrimStart('-l')
 							ErrorLog = $errorlog.TrimStart('-e')

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -2,10 +2,11 @@
 {
 <#
 .SYNOPSIS
-
+Displays SQL Server Startup Parameters
 
 .DESCRIPTION
-
+Displays a detailed list of SQL Server Startup Parameters. 
+	
 .PARAMETER SqlServer
 The SQL Server that you're connecting to.
 
@@ -31,10 +32,10 @@ Get-DbaStartupParameter -SqlServer sql2014
 xyz
 
 .EXAMPLE
-$wincred = Get-Credential ad\sqladmin
-Get-DbaStartupParameter -SqlServer sql2014 -Credential $wincred
+$cred = Get-Credential sqladmin
+Get-DbaStartupParameter -SqlServer sql2014 -Credential $cred -Simple
 
-xyz
+Logs into sql2014 using SQL credentials and displays a simplified output of parameters.
 
 #>	
 	[CmdletBinding()]
@@ -44,7 +45,7 @@ xyz
 		[Alias("SqlCredential")]
 		[PSCredential]$Credential,
 		[switch]$Simple
-		)
+	)
 	
 	PROCESS
 	{
@@ -55,7 +56,7 @@ xyz
 			{
 				$instancename = ($servername.Split('\'))[1]
 				Write-Verbose "Attempting to connect to $servername"
-			
+				
 				if ($instancename.Length -eq 0) { $instancename = "MSSQLSERVER" }
 				
 				$displayname = "SQL Server ($instancename)"
@@ -100,7 +101,7 @@ xyz
 						$instancestartparm = $params | Where-Object { $_ -eq '-s' }
 						$disablemonitoringparm = $params | Where-Object { $_ -eq '-x' }
 						$increasedextentsparm = $params | Where-Object { $_ -ceq '-E' }
-												
+						
 						$minimalstart = $noeventlogs = $instancestart = $disablemonitoring = $false
 						$increasedextents = $commandprompt = $singleuser = $false
 						

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -1,0 +1,170 @@
+﻿Function Get-DbaStartupParameter
+{
+<#
+.SYNOPSIS
+
+
+.DESCRIPTION
+
+.PARAMETER SqlServer
+The SQL Server that you're connecting to.
+
+.PARAMETER Credential
+Credential object used to connect to the SQL Server as a different user be it Windows or SQL Server. Windows users are determiend by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
+
+.PARAMETER Detailed
+(should we be detailed by default or use -Simple to simplify?)
+
+.NOTES
+dbatools PowerShell module (https://dbatools.io)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+
+.LINK
+ https://dbatools.io/Get-DbaStartupParameter
+
+.EXAMPLE
+Get-DbaStartupParameter -SqlServer sql2014
+
+xyz
+
+.EXAMPLE
+$wincred = Get-Credential ad\sqladmin
+Get-DbaStartupParameter -SqlServer sql2014 -Credential $wincred
+
+xyz
+
+#>	
+	[CmdletBinding()]
+	param ([parameter(ValueFromPipeline, Mandatory = $true)]
+		[Alias("ServerInstance", "SqlInstance")]
+		[object[]]$SqlServer,
+		[Alias("SqlCredential")]
+		[PSCredential]$Credential,
+		[switch]$Detailed
+	}
+	
+	PROCESS
+	{
+		foreach ($servername in $SqlServer)
+		{
+			$servercount++
+			try
+			{
+				$instancename = ($servername.Split('\'))[1]
+				Write-Verbose "Attempting to connect to $servername"
+			
+				if ($instancename.Length -eq 0) { $instancename = "MSSQLSERVER" }
+				
+				$displayname = "SQL Server ($instancename)"
+				
+				$Scriptblock = {
+					$servername = $args[0]
+					$displayname = $args[1]
+					$detailed = $args[2]
+					
+					$wmisvc = $wmi.Services | Where-Object { $_.DisplayName -eq $displayname }
+					
+					$params = $wmisvc.StartupParameters -split ';'
+					
+					$traceflags = $params | Where-Object { @('-d', '-l', '-e') -notcontains $_.SubString(0, 2) }
+					$masterdata = $params | Where-Object { $_.StartsWith('-d') }
+					$masterlog = $params | Where-Object { $_.StartsWith('-l') }
+					$errorlog = $params | Where-Object { $_.StartsWith('-e') }
+					$traceflags = $params | Where-Object { $_.StartsWith('-T') }
+					
+					if ($traceflags.length -eq 0)
+					{
+						$traceflags = "None"
+					}
+					
+					$object = [PSCustomObject]@{
+						Instance = $Servername
+						MasterData = $masterdata.TrimStart('-d')
+						MasterLog = $masterlog.TrimStart('-l')
+						ErrorLog = $errorlog.TrimStart('-e')
+						TraceFlags = $traceflags -join ','
+						ParameterString = $wmisvc.StartupParameters
+					}
+					
+					if ($Detailed -eq $true)
+					{
+						# From https://msdn.microsoft.com/en-us/library/ms190737.aspx
+						
+						$commandpromptparm = $params | Where-Object { $_ -eq '-c' }
+						$minimalstartparm = $params | Where-Object { $_ -eq '-f' }
+						$memorytoreserve = $params | Where-Object { $_.StartsWith('-g') }
+						$noeventlogsparm = $params | Where-Object { $_ -eq '-n' }
+						$instancestartparm = $params | Where-Object { $_ -eq '-s' }
+						$disablemonitoringparm = $params | Where-Object { $_ -eq '-x' }
+						$increasedextentsparm = $params | Where-Object { $_ -ceq '-E' }
+												
+						$minimalstart = $noeventlogs = $instancestart = $disablemonitoring = $false
+						$increasedextents = $commandprompt = $singleuser = $false
+						
+						if ($commandpromptparm -ne $null) { $commandprompt = $true }
+						if ($minimalstartparm -ne $null) { $minimalstart = $true }
+						if ($memorytoreserve -eq $null) { $memorytoreserve = 0 }
+						if ($noeventlogsparm -ne $null) { $noeventlogs = $true }
+						if ($instancestartparm -ne $null) { $instancestart = $true }
+						if ($disablemonitoringparm -ne $null) { $disablemonitoring = $true }
+						if ($increasedextentsparm -ne $null) { $increasedextents = $true }
+						
+						$singleuserparm = $params | Where-Object { $_.StartsWith('-m') }
+						
+						if ($singleuserparm.length -ne 0)
+						{
+							$singleuser = $true
+							$singleuserdetails = $singleuserparm.TrimStart('-m')
+							# It's possible the person specified an application name
+							# if not, just say that single user is $true
+							if ($singleuserdetails.length -eq 0)
+							{
+								$singleuser = $singleuserdetails
+							}
+						}
+						
+						$object = [PSCustomObject]@{
+							Instance = $Servername
+							MasterData = $masterdata.TrimStart('-d')
+							MasterLog = $masterlog.TrimStart('-l')
+							ErrorLog = $errorlog.TrimStart('-e')
+							TraceFlags = $traceflags -join ','
+							CommandPromptStart = $commandprompt
+							MinimalStart = $minimalstart
+							MemoryToReserve = $memorytoreserve
+							SingleUser = $singleuser
+							NoLoggingToWinEvents = $noeventlogs
+							StartAsNamedInstance = $instancestart
+							DisableMonitoring = $disablemonitoring
+							IncreasedExtents = $increasedextents
+							ParameterString = $wmisvc.StartupParameters
+						}
+					}
+					return $object
+				}
+				
+				# This command is in the internal function
+				# It's sorta like Invoke-Command. 
+				$return = Invoke-ManagedComputerCommand -ComputerName $servername -Credential $credential -ScriptBlock $Scriptblock -ArgumentList $servername, $displayname, $detailed
+			}
+			catch
+			{
+				Write-Exception $_
+				if ($servercount -eq 1)
+				{
+					throw $_
+				}
+				else
+				{
+					Write-Exception $_
+					Write-Warning "$servername encountered an error. Continuing."
+					Continue
+				}
+			}
+		}
+		$return
+	}
+}


### PR DESCRIPTION
Why isn't my template showing up like it did for @ConstantineK? 👎  

- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [x] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers
