### PR TITLE
Updated Find-DbaOrphanedFile

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -93,7 +93,7 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 			)	
 			# use sysaltfiles in lower versions
 			
-			$q1 = "CREATE TABLE #enum ( id int IDENTITY, fs_filename nvarchar(512), depth int, is_file int, parent nvarchar(512) ); DECLARE @dir nvarchar(512);"
+			$q1 = "CREATE TABLE #enum ( id int IDENTITY, fs_filename varchar(512), depth int, is_file int, parent nvarchar(512) ); DECLARE @dir nvarchar(512);"
 			$q2 = @"
 				SET @dir = 'dirname';
 
@@ -162,7 +162,8 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 		function Format-Path {
 			param ($path)
 			$path = $path.Trim()
-			$path = $path.Replace(' ','` ')
+			$Path = $path -replace '\x00', ''
+			$path = $path.Replace(' ','/ ')
 			return $path.Replace('\','\\')
 		}
 		$Paths = @()
@@ -200,6 +201,7 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 			
             
 			$valid_sqlfiles = Get-SqlFileStructure $server | % { 
+
                 Write-Debug $( Format-Path $_ ) 
                 [IO.Path]::GetFullPath( $(Format-Path $_) )
             } | Sort-Object -Unique

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -162,9 +162,9 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 		function Format-Path {
 			param ($path)
 			$path = $path.Trim()
-			$Path = $path -replace '\x00', ''
-			$path = $path.Replace(' ','/ ')
-			return $path.Replace('\','\\')
+			#Thank you windows 2000
+			$Path = $path -replace '\W', ''			
+			return $path
 		}
 		$Paths = @()
 		$allfiles = @()

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -93,7 +93,7 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 			)	
 			# use sysaltfiles in lower versions
 			
-			$q1 = "CREATE TABLE #enum ( id int IDENTITY, fs_filename varchar(512), depth int, is_file int, parent nvarchar(512) ); DECLARE @dir nvarchar(512);"
+			$q1 = "CREATE TABLE #enum ( id int IDENTITY, fs_filename nvarchar(512), depth int, is_file int, parent nvarchar(512) ); DECLARE @dir nvarchar(512);"
 			$q2 = @"
 				SET @dir = 'dirname';
 


### PR DESCRIPTION
Fixes #300  

Changes proposed in this pull request:
 - comparison for the complete filepath
 - lowercase comparison
 - path normalization via [IO.Path]::GetFullPath($_)

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

fixing some subtleties on top of the mods made on https://github.com/sqlcollaborative/dbatools/pull/307

BTW: dunno why it's there but I left a FIXME just to point out something that should be fixed in the following releases