### PR TITLE
raise fs warning properly, thanks rjohnson for spotting

### DIFF
--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -766,6 +766,12 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		{
 			throw "Source Sql Server version build must be <= destination Sql Server for database migration."
 		}
+
+		# SMO's filestreamlevel is sometimes null
+		$sql = "select coalesce(SERVERPROPERTY('FilestreamConfiguredLevel'),0) as fs"
+		$sourcefilestream = $sourceserver.ConnectionContext.ExecuteScalar($sql)
+		$destfilestream = $destserver.ConnectionContext.ExecuteScalar($sql)
+		if ($sourcefilestream -gt 0 -and $destfilestream -eq 0) { $fswarning = $true }
 		
 		Write-Output "Writing warning about filestream being enabled"
 		if ($fswarning)
@@ -806,11 +812,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			throw "You did not select any databases to migrate. Please use -AllDatabases or -Databases or -IncludeSupportDbs"
 		}
 		
-		# SMO's filestreamlevel is sometimes null
-		$sql = "select coalesce(SERVERPROPERTY('FilestreamConfiguredLevel'),0) as fs"
-		$sourcefilestream = $sourceserver.ConnectionContext.ExecuteScalar($sql)
-		$destfilestream = $destserver.ConnectionContext.ExecuteScalar($sql)
-		if ($sourcefilestream -gt 0 -and $destfilestream -eq 0) { $fswarning = $true }
+
 
 		Write-Output "Building database list"
 		$databaselist = New-Object System.Collections.ArrayList


### PR DESCRIPTION
Changes proposed in this pull request:
 - $fs_warning being calculated BEFORE warning

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [x]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

