### PR TITLE
Adding rtrim and ltrim to remove null bytes for sql2000

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -100,7 +100,8 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 				EXEC xp_dirtree @dir, 1, 1;
 
 				UPDATE #enum
-				SET parent = @dir
+				SET parent = @dir,
+				fs_filename = ltrim(rtrim(fs_filename))
 				WHERE parent IS NULL;"
 			
 			$query_files_sql = "SELECT e.fs_filename AS filename, e.parent
@@ -178,13 +179,6 @@ Finds the orphaned ending with ".fsf" and ".mld" in addition to the default file
 			$dirtreefiles = $valid = $paths = $matching = @()
 			
 			$server = Connect-SqlServer -SqlServer $servername -SqlCredential $SqlCredential
-			
-			if ($server.VersionMajor -lt 9)
-			{
-				# SQL Server 2000 has crazy output and sometimes doesn't work
-				Write-Warning "SQL Server 2000 not supported"
-				continue
-			}
 			
 			# Get the default data and log directories from the instance
 			Write-Debug "Adding paths"


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Adding ltrim and rtrim to filenames to remove null byes in all versions, but specifically to resolve SQL 2000 issues

How to test this code: 
- Create database 
- Detach database
- Run command Find-DbaOrphanedFile -SqlServer ServerName 

Has been tested on minimum requirements:
- [ X ]  Powershell 3
- [ X ]  Windows 7
- [ X ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [ ] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers


