### PR TITLE
Fix exportlogin not enumerating database permissions

### DIFF
--- a/functions/Export-SqlLogin.ps1
+++ b/functions/Export-SqlLogin.ps1
@@ -337,7 +337,7 @@ CREATE LOGIN [$username] FROM WINDOWS WITH DEFAULT_DATABASE = [$defaultdb], DEFA
 			
 			if ($NoDatabases -eq $false)
 			{
-				if ($databases.length -eq 0) { $databases = $sourcelogin.EnumDatabaseMappings() }
+				{ $databases = $sourcelogin.EnumDatabaseMappings() }
 				# Adding database mappings and securables
 				foreach ($db in $databases)
 				{

--- a/functions/Export-SqlLogin.ps1
+++ b/functions/Export-SqlLogin.ps1
@@ -337,7 +337,7 @@ CREATE LOGIN [$username] FROM WINDOWS WITH DEFAULT_DATABASE = [$defaultdb], DEFA
 			
 			if ($NoDatabases -eq $false)
 			{
-				{ $databases = $sourcelogin.EnumDatabaseMappings() }
+				$databases = $sourcelogin.EnumDatabaseMappings() 
 				# Adding database mappings and securables
 				foreach ($db in $databases)
 				{


### PR DESCRIPTION
Fixes #328 

Changes proposed in this pull request:
 - Removed a check for a variable that was not needed, should now enumerate database permissions more correctly. 
 - 
 - 

How to test this code: 
- Export-SqlLogin -SqlServer servername -FilePath savepath

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [x]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

