### PR TITLE
Added schema support to Import-CsvToSql

### DIFF
--- a/functions/CsvSqlimport.ps1
+++ b/functions/CsvSqlimport.ps1
@@ -33,6 +33,14 @@ Connect to SQL Server using specified SQL Login credentials.
 .PARAMETER Database
 Required. The name of the database where the CSV will be imported into. This parameter is autopopulated using the -SqlServer and -SqlCredential (optional) parameters. 
 
+.PARAMETER Schema
+The schema in which the SQL table or view where CSV will be imported into resides.
+Default is dbo
+
+If a schema name is not specificed, and a CSV with multiple . (ie; something.data.csv) then this will be interpreted as a request to import into a table [data] in the schema [something]
+
+If a schema does not currently exist, it will be created, after a prompt to confirm this. Authorization will be set to dbo by default
+
 .PARAMETER Table
 SQL table or view where CSV will be imported into. 
 
@@ -146,6 +154,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 		[string]$SqlServer,
 		[object]$SqlCredential,
 		[string]$Table,
+        [string]$Schema = "dbo",
 		[switch]$Truncate,
 		[string]$Delimiter = ",",
 		[switch]$FirstRowColumns,
@@ -630,7 +639,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 				$sqldatatypes += "$sqlcolumnname $sqldatatype"
 			}
 			
-			$sql = "BEGIN CREATE TABLE [$table] ($($sqldatatypes -join ' NULL,')) END"
+			$sql = "BEGIN CREATE TABLE [$schema].[$table] ($($sqldatatypes -join ' NULL,')) END"
 			$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
 			try { $null = $sqlcmd.ExecuteNonQuery() }
 			catch
@@ -639,7 +648,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 				throw "Failed to execute $sql. `nDid you specify the proper delimiter? `n$errormessage"
 			}
 			
-			Write-Output "[*] Successfully created table $table with the following column definitions:`n $($sqldatatypes -join "`n ")"
+			Write-Output "[*] Successfully created table $schema.$table with the following column definitions:`n $($sqldatatypes -join "`n ")"
 			# Write-Warning "All columns are created using a best guess, and use their maximum datatype."
 			Write-Warning "This is inefficient but allows the script to import without issues."
 			Write-Warning "Consider creating the table first using best practices if the data will be used in production."
@@ -761,7 +770,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 			
 			$sql = "SELECT t.name as datatype FROM sys.columns c
 				JOIN sys.types t ON t.system_type_id = c.system_type_id 
-				WHERE c.object_id = object_id('$table') and t.name != 'sysname'"
+				WHERE c.object_id = object_id('$schema.$table') and t.name != 'sysname'"
 			$sqlcheckcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlcheckconn)
 			$sqlcolumns = New-Object System.Data.DataTable
 			$sqlcolumns.load($sqlcheckcmd.ExecuteReader("CloseConnection"))
@@ -864,18 +873,47 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 		if ($table.length -eq 0)
 		{
 			$table = [IO.Path]::GetFileNameWithoutExtension($csv[0])
-			$title = "Table name not specified."
-			$message = "Would you like to use the automatically generated name: $table"
-			$yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Uses table name $table for import."
-			$no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Allows you to specify an alternative table name."
-			$options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
-			$result = $host.ui.PromptForChoice($title, $message, $options, 0)
-			if ($result -eq 1)
-			{
-				do { $table = Read-Host "Please enter a table name" }
-				while ($table.Length -eq 0)
-			}
-		}
+            
+            #Count the dots in the file name.
+            #1 dot, treat it as schema.table naming
+            #2 or more dots, really should catch it as bad practice, but the rest of the script appears to let it pass
+            if (($table.ToCharArray() | ?{$_ -eq '.'} | Measure-Object).count -gt 0)
+            {
+                if (($schema -ne $table.Split('.')[0]) -and ($schema -ne 'dbo'))
+                {
+                    $title = "Conflicting schema names specified"
+                    $message = "Please confirm which schema you want to use."
+                    $schemaA = New-Object System.Management.Automation.Host.ChoiceDescription "&A - $schema", "Use schema name $schema for import."
+		            $schemaB = New-Object System.Management.Automation.Host.ChoiceDescription "&B - $($table.Split('.')[0])", "Use schema name $($table.Split('.')[0]) for import."
+		            $options = [System.Management.Automation.Host.ChoiceDescription[]]($schemaA, $schemaB)
+			        $result = $host.ui.PromptForChoice($title, $message, $options, 0)
+                    if ($result -eq 1)
+                    {
+                        $schema = $table.Split('.')[0]
+                        $tmparray = $table.split('.')
+                        $table = $tmparray[1..$tmparray.Length] -join '.'
+                    }
+                }
+
+            } 
+            else 
+            {
+                $title = "Table name not specified."
+		        $message = "Would you like to use the automatically generated name: $table"
+		        $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Uses table name $table for import."
+		        $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Allows you to specify an alternative table name."
+		        $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+			    $result = $host.ui.PromptForChoice($title, $message, $options, 0)
+			    if ($result -eq 1)
+		        {
+			        do { $table = Read-Host "Please enter a table name" }
+			            while ($table.Length -eq 0)
+			        }
+                
+            }
+            }
+
+
 		
 		# If the shell has switched, decode the $query string.
 		if ($shellswitch -eq $true)
@@ -943,9 +981,27 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 		Write-Output "[*] Database exists"
 		
 		$sqlconn.ChangeDatabase($database)
+
+        # Enure Schema exists
+        $sql = "select count(*) from $database.sys.schemas where name='$schema'"
+        $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
+		$schemaexists = $sqlcmd.ExecuteScalar()
+        
+        # If Schema doesn't exist create it
+        # Defaulting to dbo.
+        if ($schemaexists -eq $false)
+        {
+            Write-Output "[*] Creating schema $schema"
+			$sql = "CREATE SCHEMA [$schema] AUTHORIZATION dbo"
+			$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
+			try { $null = $sqlcmd.ExecuteNonQuery() }
+			catch { Write-Warning "Could not create $schema" }
+
+        }
+
 		
 		# Ensure table exists
-		$sql = "select count(*) from $database.sys.tables where name = '$table'"
+		$sql = "select count(*) from $database.sys.tables where name = '$table' and schema_id=schema_id('$schema')"
 		$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
 		$tablexists = $sqlcmd.ExecuteScalar()
 		
@@ -964,18 +1020,18 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 		if ($truncate -eq $true)
 		{
 			Write-Output "[*] Truncating table"
-			$sql = "TRUNCATE TABLE [$table]"
+			$sql = "TRUNCATE TABLE [$schema].[$table]"
 			$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
 			try { $null = $sqlcmd.ExecuteNonQuery() }
-			catch { Write-Warning "Could not truncate $table" }
+			catch { Write-Warning "Could not truncate $schema.$table" }
 		}
 		
 		# Get columns for column mapping
 		if ($columnMappings -eq $null)
 		{
 			$olecolumns = ($columns | ForEach-Object { $_ -Replace "\[|\]" })
-			$sql = "select name from sys.columns where object_id = object_id('$table') order by column_id"
-			$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
+			$sql = "select name from sys.columns where object_id = object_id('$schema.$table') order by column_id"
+            $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
 			$sqlcolumns = New-Object System.Data.DataTable
 			$sqlcolumns.Load($sqlcmd.ExecuteReader())
 		}
@@ -998,6 +1054,8 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 			Write-Output "[*] Starting bulk copy for $(Split-Path $file -Leaf)"
 			
 			# Setup bulk copy options
+
+
 			$bulkCopyOptions = @()
 			$options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default", "Truncate"
 			foreach ($option in $options)
@@ -1011,7 +1069,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 			if ($bulkCopyOptions.count -gt 1) { $bulkcopy = New-Object Data.SqlClient.SqlBulkCopy($oleconnstring, $bulkCopyOptions, $transaction) }
 			else { $bulkcopy = New-Object Data.SqlClient.SqlBulkCopy($sqlconn, "Default", $transaction) }
 			
-			$bulkcopy.DestinationTableName = "[$table]"
+			$bulkcopy.DestinationTableName = "[$schema].[$table]"
 			$bulkcopy.bulkcopyTimeout = 0
 			$bulkCopy.BatchSize = $BatchSize
 			$bulkCopy.NotifyAfter = $NotifyAfter
@@ -1108,7 +1166,7 @@ Triggers are fired for all rows. Note that this does slightly slow down the impo
 					# Get table column info from SQL Server
 					$sql = "SELECT c.name as colname, t.name as datatype, c.max_length, c.is_nullable FROM sys.columns c
 						JOIN sys.types t ON t.system_type_id = c.system_type_id 
-						WHERE c.object_id = object_id('$table') and t.name != 'sysname'	
+						WHERE c.object_id = object_id('$schema.$table') and t.name != 'sysname'	
 						order by c.column_id"
 					$sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
 					$sqlcolumns = New-Object System.Data.DataTable


### PR DESCRIPTION
Fixes #312 
Fixed 
Changes proposed in this pull request:
 Schema support added to Import-CsvToSql
User can now specify schema if required (default is dbo, so will work on SS2000 as it does now)
Adds ability to load csv of form schema.table.csv into [schema].[table]
Alerts user if file spec and schema parameter conflicts and allows resolution
If schema doesn't exist creates it.

 - 

How to test this code: 
- [ ] Import-CSVToSQL -SqlServer localhost\sqlexpress2016 -Csv .\test.csv -Database csvdb -Schema CsvTest
Should import contents of test.csv into table [csvdb].[CsvTest].[test]
- [ ] Import-CSVToSQL -SqlServer localhost\sqlexpress2016 -Csv .\csvtest.test.csv -Database csvdb
Should import contents of test.csv into table [csvdb].[CsvTest].[test]
-[ ] Import-CSVToSQL -SqlServer localhost\sqlexpress2016 -Csv .\csvtest.test.csv -Database csvdb -schema SomethingElse
should prompt user that they have conflicting options set. Depending on testers choice should import contents of test.csv into table [csvdb].[CsvTest].[test] or [csvdb].[SomethingElse].[test]

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 2008R2 (don't have a 7 box to hand)
- [x]  SQL Server 2000  
   Works if used as previously, but will barf if user provides a schema unsuprisingly. A version check could be added to command, though feel that needs to be a more centrally managed option as lots of commands could do with that for filtering options)

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers


In response to issue #321 'Import-CsvToSql - does not work for schemas
other than dbo'

Cmdlet now takes a schema parameter.
default value is dbo, so no change for existing use
Incorporated schema checks into all table/column lookups

Added support for getting schema from csv name
If file has more than 1 . in  it, parse as schema
Checks for conflict with schema parameter and lets caller decided how to
proceed