### PR TITLE
Copy-SqlLogin - Add warning for SQL logins when mixed mode not enabled on destination

### DIFF
--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -154,7 +154,7 @@ Limitations: Does not support Application Roles yet
 				
 				if($destserver.LoginMode -ne "Mixed")
 				{ 
-					Write-Output "$Destination does not have Mixed Mode enabled. Enable this after the migration."
+					Write-Warning "$Destination does not have Mixed Mode enabled. Enable this after the migration."
 					continue 
 				}
 

--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -152,6 +152,12 @@ Limitations: Does not support Application Roles yet
 					continue
 				}
 				
+				if($destserver.LoginMode -ne "Mixed")
+				{ 
+					Write-Output "$Destination does not have Mixed Mode enabled. Enable this after the migration."
+					continue 
+				}
+
 				$userbase = ($username.Split("\")[0]).ToLower()
 				if ($servername -eq $userbase -or $username.StartsWith("NT "))
 				{


### PR DESCRIPTION
Fixes #177 

Changes proposed in this pull request:
 - Add warning to Copy-SqlLogin when the server is not set to mixed mode. 

How to test this code: 
- [x]  Attempt to migrate SQL Logins from Source server to a Dest Server without Mixed Mode enabled. Should write warning to console. "$Destination does not have Mixed Mode enabled. Enable this after the migration."

Tests for tester:

- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [x] No un-handled errors which stop the command working with multiple servers