### PR TITLE
Get-SqlRegisteredServerName - fix to allow working with nested groups

### DIFF
--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -1020,13 +1020,44 @@ filled with server groups from specified SQL Server Central Management server na
 	
 	if ($cmstore -eq $null) { return }
 	
+	# unfortunately the logic is quite cumbersome because group names accept also the '\'
+	# character, that is also the de-facto standard to give a hierarchy.
+	# e.g.
+	# 
+	# cms
+	# +--foo
+	#    +--bar\baz
+	#    +--foo
+	#       +--registered server
+	# The only short-circuit would be something like:
+	# cms
+	# +--foo
+	# |  +--bar
+	# +--foo\bar
+	Function Parse-CmsGroup($CmsGrp, $base = '')
+	{
+		$results = @()
+		foreach($el in $CmsGrp) {
+			if($base -eq ''){
+				$partial = $el.name
+			} else {
+				$partial = "$base\$($el.name)"
+			}
+			$results += $partial
+			foreach($group in $el.ServerGroups) {
+				$results += Parse-CmsGroup $group $partial
+			}
+		}
+		return $results
+	}
+	
 	$newparams = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 	$paramattributes = New-Object System.Management.Automation.ParameterAttribute
 	$paramattributes.ParameterSetName = "__AllParameterSets"
 	$paramattributes.Mandatory = $false
 	$paramattributes.Position = 3
 	
-	$argumentlist = $cmstore.DatabaseEngineServerGroup.ServerGroups.name
+	$argumentlist = Parse-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups
 	
 	if ($argumentlist -ne $null)
 	{

--- a/functions/Get-SqlRegisteredServerName.ps1
+++ b/functions/Get-SqlRegisteredServerName.ps1
@@ -102,14 +102,33 @@ Gets a list of server IP addresses in the HR and Accouting groups from the Centr
 	
 	PROCESS
 	{
-		
+		# see notes at Get-ParamSqlCmsGroups
+		Function Find-CmsGroup($CmsGrp, $base = '', $stopat)
+		{
+			$results = @()
+			foreach($el in $CmsGrp) {
+				if($base -eq ''){
+					$partial = $el.name
+				} else {
+					$partial = "$base\$($el.name)"
+				}
+				if ($partial -eq $stopat) {
+					return $el
+				} else {
+					foreach($group in $el.ServerGroups) {
+						$results += Find-CmsGroup $group $partial $stopat
+					}
+				}
+			}
+			return $results
+		}
 		
 		$servers = @()
 		if ($groups -ne $null)
 		{
 			foreach ($group in $groups)
 			{
-				$cms = $cmstore.ServerGroups["DatabaseEngineServerGroup"].ServerGroups[$group]
+				$cms = Find-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups '' $group
 				$servers += ($cms.GetDescendantRegisteredServers()).servername
 			}
 		}


### PR DESCRIPTION
Fixes #350

Changes proposed in this pull request:
 - validate cmsgroups also with "nested notation"
 - retrieve registered servers also with "nested notation"

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

See the notes about the lenghty addition to the implementation.