### PR TITLE
Read-DbaBackupHeader - added runspaces and support for piping Get-ChildItem

### DIFF
--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -164,6 +164,10 @@ Similar to running Read-DbaBackupHeader -SqlServer sql2016 -Path "C:\temp\myfile
 			$version = $datatable.Columns.Add("SQLVersion")
 			$dbversion = $datatable.rows[0].DatabaseVersion
 			
+			# NEED TO GET THIS TO WORK
+			$parent = (Split-Path -Parent $MyInvocation.MyCommand.Definition).Parent
+			. "$parent\internal\Convert-DbVersionToSqlVersion.ps1"
+			
 			$datatable.rows[0].SQLVersion = (Convert-DbVersionToSqlVersion $dbversion)
 			
 			if ($Simple)

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -97,11 +97,8 @@ Similar to running Read-DbaBackupHeader -SqlServer sql2016 -Path "C:\temp\myfile
 			continue
 		}
 		
-		[int]$numprocessors = $env:NUMBER_OF_PROCESSORS
-		$maxrunspaces = $numprocessors + 1
-		
 		# STEP 1: Create and open runspace pool, setup runspaces array
-		$pool = [RunspaceFactory]::CreateRunspacePool(1, $maxrunspaces)
+		$pool = [RunspaceFactory]::CreateRunspacePool(1, [int]$env:NUMBER_OF_PROCESSORS+1)
 		$pool.ApartmentState = "MTA"
 		$pool.Open()
 		$runspaces = @()


### PR DESCRIPTION
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [x] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers
