### PR TITLE
Fixed and oversight with piped input to Restore-DBFromFilteredArray.ps1

### DIFF
--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -24,127 +24,148 @@ Function Restore-DBFromFilteredArray
 		[System.Management.Automation.PSCredential]$SqlCredential
 	)
     
+	    Begin
+    {
+        $FunctionName = "Filter-DBFromFilteredArray"
+        Write-Verbose "$FunctionName - Starting"
 
-	$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
-	$servername = $server.name
-	$server.ConnectionContext.StatementTimeout = 0
-	$restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
-	$restore.ReplaceDatabase = $ReplaceDatabase
 
-    $OrderedRestores = $files | Sort-object -Property BackupStartDate, BackupType
-	Write-Verbose "of = $($OrderedRestores.Backupfilename)"
-	foreach ($restorefile in $OrderedRestores)
-	{
-		if ($restore.RelocateFiles.count -gt 0)
+
+        $results = @()
+        $InternalFiles = @()
+    }
+    # -and $_.BackupStartDate -lt $RestoreTime
+    process
+        {
+
+        foreach ($file in $files){
+            $InternalFiles += $file
+        }
+    }
+    End
+    {
+
+		$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
+		$servername = $server.name
+		$server.ConnectionContext.StatementTimeout = 0
+		$restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
+		$restore.ReplaceDatabase = $ReplaceDatabase
+
+		$OrderedRestores = $InternalFiles | Sort-object -Property BackupStartDate, BackupType
+		Write-Verbose "of = $($OrderedRestores.Backupfilename)"
+		foreach ($restorefile in $OrderedRestores)
 		{
-			$restore.RelocateFiles.Clear()
-		}
-		foreach ($file in $restorefile.Filelist)
-		{
-
-			if ($RestoreLocation -ne '' -and $filestructure -eq $NUll)
+			if ($restore.RelocateFiles.count -gt 0)
 			{
-				
-				$movefile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
-				$movefile.LogicalFileName = $file.logicalname
-				$movefile.PhysicalFileName = $RestoreLocation + (split-path $file.PhysicalName -leaf)
-				$null = $restore.RelocateFiles.Add($movefile)
-				
-			} elseif ($RestoreLocation -eq '' -and $filestructure -ne $NUll)
+				$restore.RelocateFiles.Clear()
+			}
+			foreach ($file in $restorefile.Filelist)
 			{
 
-				$filestructure = $filestructure.values
-
-				foreach ($file in $filestructure)
+				if ($RestoreLocation -ne '' -and $filestructure -eq $NUll)
 				{
+					
 					$movefile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
-					$movefile.LogicalFileName = $file.logical
-					$movefile.PhysicalFileName = $file.physical
-
+					$movefile.LogicalFileName = $file.logicalname
+					$movefile.PhysicalFileName = $RestoreLocation + (split-path $file.PhysicalName -leaf)
 					$null = $restore.RelocateFiles.Add($movefile)
-				}	
-			} elseif ($RestoreLocation -ne '' -and $filestructure -ne $NUll)
-			{
-				Write-Error "Conflicting options only one of FileStructure or RestoreLocation allowed"
-			} 		
-		}
-
-		try
-		{
-			Write-Verbose "in try"
-			$percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
-				Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
-			}
-			$restore.add_PercentComplete($percent)
-			$restore.PercentCompleteNotification = 1
-			$restore.add_Complete($complete)
-			$restore.ReplaceDatabase = $ReplaceDatabase
-			$restore.Database = $dbname
-			$action = switch ($restorefile.BackupType)
-    			{
-					'1' {'Database'}
-					'2' {'Log'}
-					'5' {'Database'}
-					Default {}
-   				}
-			Write-Verbose "action = $action"
-			$restore.Action = $action 
-			if ($restorefile -eq $OrderedRestores[-1])
-			{
-				#Do recovery on last file
-				$restore.NoRecovery = $false
-			}
-			else 
-			{
-				$restore.NoRecovery = $true
-			}
-
-				$device = New-Object -TypeName Microsoft.SqlServer.Management.Smo.BackupDeviceItem
-				$device.name = $restorefile.BackupFileName
-				$device.devicetype = "File"
-				$restore.Devices.Add($device)
-
-			Write-Verbose "PAst setup"
-			if ($ScriptOnly)
-			{
-				$restore.Script($server)
-			}
-			elseif ($VerifyOnly)
-			{
-				Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
-				$verify = $restore.sqlverify($server)
-				Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -status "Complete" -Completed
-				
-				if ($verify -eq $true)
+					
+				} elseif ($RestoreLocation -eq '' -and $filestructure -ne $NUll)
 				{
-					return "Verify successful"
-				}
-				else
+
+					$filestructure = $filestructure.values
+
+					foreach ($file in $filestructure)
+					{
+						$movefile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
+						$movefile.LogicalFileName = $file.logical
+						$movefile.PhysicalFileName = $file.physical
+
+						$null = $restore.RelocateFiles.Add($movefile)
+					}	
+				} elseif ($RestoreLocation -ne '' -and $filestructure -ne $NUll)
 				{
-					return "Verify failed"
-				}
+					Write-Error "Conflicting options only one of FileStructure or RestoreLocation allowed"
+				} 		
 			}
-			else
+
+			try
 			{
-				Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
-				$restore.sqlrestore($server)
-				if ($scripts)
+				Write-Verbose "in try"
+				$percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
+					Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
+				}
+				$restore.add_PercentComplete($percent)
+				$restore.PercentCompleteNotification = 1
+				$restore.add_Complete($complete)
+				$restore.ReplaceDatabase = $ReplaceDatabase
+				$restore.Database = $dbname
+				$action = switch ($restorefile.BackupType)
+					{
+						'1' {'Database'}
+						'2' {'Log'}
+						'5' {'Database'}
+						Default {}
+					}
+				Write-Verbose "action = $action"
+				$restore.Action = $action 
+				if ($restorefile -eq $OrderedRestores[-1])
+				{
+					#Do recovery on last file
+					$restore.NoRecovery = $false
+				}
+				else 
+				{
+					$restore.NoRecovery = $true
+				}
+
+					$device = New-Object -TypeName Microsoft.SqlServer.Management.Smo.BackupDeviceItem
+					$device.name = $restorefile.BackupFileName
+					$device.devicetype = "File"
+					$restore.Devices.Add($device)
+
+				Write-Verbose "PAst setup"
+				if ($ScriptOnly)
 				{
 					$restore.Script($server)
 				}
-				Write-Progress -id 1 -activity "Restoring $dbname to $servername" -status "Complete" -Completed
-				
-				#return "Success"
-			}
-			$null = $restore.Devices.Remove($device)
-			Remove-Variable device
+				elseif ($VerifyOnly)
+				{
+					Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+					$verify = $restore.sqlverify($server)
+					Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -status "Complete" -Completed
+					
+					if ($verify -eq $true)
+					{
+						return "Verify successful"
+					}
+					else
+					{
+						return "Verify failed"
+					}
+				}
+				else
+				{
+					Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+					$restore.sqlrestore($server)
+					if ($scripts)
+					{
+						$restore.Script($server)
+					}
+					Write-Progress -id 1 -activity "Restoring $dbname to $servername" -status "Complete" -Completed
+					
+					#return "Success"
+				}
+				$null = $restore.Devices.Remove($device)
+				Remove-Variable device
 
+			}
+			catch
+			{
+				$_.Exception.Message
+				$_.Exception.ItemName
+			}
+			
 		}
-		catch
-		{
-			$_.Exception.Message
-    		$_.Exception.ItemName
-		}
-		
 	}
 }


### PR DESCRIPTION
Fixes # 
Didn't cope with non ordered pipeline input, put in Begin/Process/Finish blocks
to make sure it's ordered before it hits the lineage checks.

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers


Didn't cope with non ordered pipeline input, put in Begin/Process/Finish blocks
to make sure it's ordered before it hits the lineage checks.