### PR TITLE
Fix/get sql registered server name

### DIFF
--- a/functions/Get-SqlRegisteredServerName.ps1
+++ b/functions/Get-SqlRegisteredServerName.ps1
@@ -103,13 +103,33 @@ Gets a list of server IP addresses in the HR and Accouting groups from the Centr
 	PROCESS
 	{
 		
+		# see notes at Get-ParamSqlCmsGroups
+		Function Find-CmsGroup($CmsGrp, $base = '', $stopat)
+		{
+			$results = @()
+			foreach($el in $CmsGrp) {
+				if($base -eq ''){
+					$partial = $el.name
+				} else {
+					$partial = "$base\$($el.name)"
+				}
+				if ($partial -eq $stopat) {
+					return $el
+				} else {
+					foreach($group in $el.ServerGroups) {
+						$results += Find-CmsGroup $group $partial $stopat
+					}
+				}
+			}
+			return $results
+		}
 		
 		$servers = @()
 		if ($groups -ne $null)
 		{
 			foreach ($group in $groups)
 			{
-				$cms = $cmstore.ServerGroups["DatabaseEngineServerGroup"].ServerGroups[$group]
+				$cms = Find-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups '' $group
 				$servers += ($cms.GetDescendantRegisteredServers()).servername
 			}
 		}


### PR DESCRIPTION
Fixes #350

Changes proposed in this pull request:
 - validate cmsgroups also with "nested notation"
 - retrieve registered servers also with "nested notation"

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

See the notes about the lenghty addition to the implementation.