### PR TITLE
Initial commit of Get-DbaXEventsSession

### DIFF
--- a/functions/Get-DbaXEventsSession.ps1
+++ b/functions/Get-DbaXEventsSession.ps1
@@ -58,7 +58,7 @@ Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Stat
 	{
 		if ([System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.XEvent") -eq $null)
 		{
-			throw "SMO version is too old. To collect Extended Events, you must have Shared Management Objects 2008 R2 or higher installed."
+			throw "SMO version is too old. To collect Extended Events, you must have SQL Server Management Studio 2012 or higher installed."
 		}
 		$sessions = $psboundparameters.Sessions
 	}

--- a/functions/Get-DbaXEventsSession.ps1
+++ b/functions/Get-DbaXEventsSession.ps1
@@ -4,11 +4,7 @@
 Get a list of Extended Events Sessions
 
 .DESCRIPTION
-Retrieves a list of Extended Events Sessions.
-
-For now, the SQLSERVER: provider is the way to collect XEvents Sessions.
-	
-See  http://www.mikefal.net/2015/06/09/tsql2sday-powershell-and-extended-events/ for more information
+Retrieves a list of Extended Events Sessions
 
 .PARAMETER SqlInstance
 The SQL Instances that you're connecting to.
@@ -30,12 +26,12 @@ You should have received a copy of the GNU General Public License along with thi
 https://dbatools.io/Get-DbaXEventsSession
 
 .EXAMPLE
-Get-DbaXEventsSession -SqlInstance ServerA\sql987
+Get-DbaXEventsSession -SqlServer ServerA\sql987
 
 Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Status and other properties.
 
 .EXAMPLE
-Get-DbaXEventsSession -SqlInstance ServerA\sql987 | Format-Table ComputerName, SQLInstance, Session, Status -AutoSize
+Get-DbaXEventsSession -SqlServer ServerA\sql987 | Format-Table ComputerName, SQLInstance, Session, Status -AutoSize
 
 Returns a formatted table displaying ComputerName, SQLInstance, Session, and Status.
 
@@ -71,7 +67,7 @@ Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Stat
                 Write-Warning " Failed to connect to $instance ."
                 continue
             }
-            if($server.versionmajor -ge '11')
+            if($server.versionmajor -ge 11)
             {
 		        $SqlConn = $server.ConnectionContext.SqlConnectionObject
 		        $SqlStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $SqlConn

--- a/functions/Get-DbaXEventsSession.ps1
+++ b/functions/Get-DbaXEventsSession.ps1
@@ -1,0 +1,104 @@
+﻿ function Get-DbaXEventsSession {
+ <#
+.SYNOPSIS
+Get a list of Extended Events Sessions
+
+.DESCRIPTION
+Retrieves a list of Extended Events Sessions.
+
+For now, the SQLSERVER: provider is the way to collect XEvents Sessions.
+	
+See  http://www.mikefal.net/2015/06/09/tsql2sday-powershell-and-extended-events/ for more information
+
+.PARAMETER SqlInstance
+The SQL Instances that you're connecting to.
+
+.PARAMETER Credential
+Credential object used to connect to the SQL Server as a different user
+
+.NOTES
+Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+	
+dbatools PowerShell module (https://dbatools.io)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+	
+.LINK
+https://dbatools.io/Get-DbaXEventsSession
+
+.EXAMPLE
+Get-DbaXEventsSession -SqlInstance ServerA\sql987
+
+Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Status and other properties.
+
+.EXAMPLE
+Get-DbaXEventsSession -SqlInstance ServerA\sql987 | Format-Table ComputerName, SQLInstance, Session, Status -AutoSize
+
+Returns a formatted table displaying ComputerName, SQLInstance, Session, and Status.
+
+.EXAMPLE
+'ServerA\sql987','ServerB' | Get-DbaXEventsSession
+
+Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Status and other properties, from multiple SQL Instances.
+#>
+    [CmdletBinding()]
+    param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[string[]]$SqlInstance,
+		[PsCredential]$SqlCredential
+    )
+    BEGIN {}
+    PROCESS {
+        foreach ( $instance in $SqlInstance )
+        {
+            Write-Verbose "Connecting to $instance ."
+			try
+			{
+				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $Credential -ErrorAction SilentlyContinue
+                Write-Verbose "SQL Instance $instance is version $($server.versionmajor) ."
+            }
+            catch
+            {
+                Write-Warning " Failed to connect to $instance ."
+                continue
+            }
+            if($server.versionmajor -ge '11')
+            {
+                Write-Verbose "Getting XEvents Sessions on $instance ."
+                if ($instance -notlike '*\*') { $instance = "$instance\DEFAULT" }
+                try
+                {
+                    Get-ChildItem SQLSERVER:\XEvent\$instance\sessions -ErrorAction SilentlyContinue -WarningAction SilentlyContinue | 
+                    ForEach-Object {
+                        [PSCustomObject]@{
+                            ComputerName = $server.NetName
+                            SQLInstance = $server.ServiceName
+                            Session = $_.Name
+                            Status = switch ( $_.IsRunning ) { $true {"Running"} $false {"Stopped"} }
+                            StartTime = $_.StartTime
+                            AutoStart = $_.AutoStart
+                            State = $_.State
+                            Targets = $_.Targets
+                            Events = $_.Events
+                            MaxMemory = $_.MaxMemory
+                            MaxEventSize = $_.MaxEventSize
+                            }
+	                }
+                }
+                catch
+                {
+                    Write-Warning "Failed to get XEvents Sessions on $instance ."
+                }
+            }
+            else
+            {
+                Write-Warning "SQL Instance $instance is SQL Version $($server.versionmajor) . This is not supported."
+            }
+        }
+    }
+    END {}
+}

--- a/functions/Get-DbaXEventsSession.ps1
+++ b/functions/Get-DbaXEventsSession.ps1
@@ -1,4 +1,5 @@
-﻿ function Get-DbaXEventsSession {
+﻿function Get-DbaXEventsSession
+{
  <#
 .SYNOPSIS
 Get a list of Extended Events Sessions
@@ -11,6 +12,9 @@ The SQL Instances that you're connecting to.
 
 .PARAMETER Credential
 Credential object used to connect to the SQL Server as a different user
+
+.PARAMETER Sessions
+Only return specific sessions. This parameter is auto-populated.
 
 .NOTES
 Author: Klaas Vandenberghe ( @PowerDBAKlaas )
@@ -40,69 +44,82 @@ Returns a formatted table displaying ComputerName, SQLInstance, Session, and Sta
 
 Returns a custom object with ComputerName, SQLInstance, Session, StartTime, Status and other properties, from multiple SQL Instances.
 #>
-    [CmdletBinding()]
-    param (
+	[CmdletBinding()]
+	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[string[]]$SqlInstance,
 		[PsCredential]$SqlCredential
-    )
-    BEGIN {
-        if ([System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.XEvent") -eq $null)
+	)
+	
+	DynamicParam { if ($SqlInstance) { return (Get-ParamSqlExtendedEvents -SqlServer $SqlInstance[0] -SqlCredential $SqlCredential) } }
+	
+	BEGIN
+	{
+		if ([System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.XEvent") -eq $null)
 		{
 			throw "SMO version is too old. To collect Extended Events, you must have Shared Management Objects 2008 R2 or higher installed."
 		}
-    }
-    PROCESS {
-        foreach ( $instance in $SqlInstance )
-        {
-            Write-Verbose "Connecting to $instance ."
+		$sessions = $psboundparameters.Sessions
+	}
+	PROCESS
+	{
+		foreach ($instance in $SqlInstance)
+		{
+			Write-Verbose "Connecting to $instance ."
 			try
 			{
 				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $Credential -ErrorAction SilentlyContinue
-                Write-Verbose "SQL Instance $instance is version $($server.versionmajor) ."
-            }
-            catch
-            {
-                Write-Warning " Failed to connect to $instance ."
-                continue
-            }
-            if($server.versionmajor -ge 11)
-            {
-		        $SqlConn = $server.ConnectionContext.SqlConnectionObject
-		        $SqlStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $SqlConn
-		        $XEStore = New-Object  Microsoft.SqlServer.Management.XEvent.XEStore $SqlStoreConnection
-                Write-Verbose "Getting XEvents Sessions on $instance ."
-
-                try
-                {
-                $XEStore.sessions | 
-                    ForEach-Object {
-                        [PSCustomObject]@{
-                            ComputerName = $server.NetName
-                            SQLInstance = $server.ServiceName
-                            Session = $_.Name
-                            Status = switch ( $_.IsRunning ) { $true {"Running"} $false {"Stopped"} }
-                            StartTime = $_.StartTime
-                            AutoStart = $_.AutoStart
-                            State = $_.State
-                            Targets = $_.Targets
-                            Events = $_.Events
-                            MaxMemory = $_.MaxMemory
-                            MaxEventSize = $_.MaxEventSize
-                            }
-                    }
-	            }
-                catch
-                {
-                Write-Warning "Failed to get XEvents Sessions on $instance ."
-                }
-            }
-            else
-            {
-                Write-Warning "SQL Instance $instance is SQL Version $($server.versionmajor) . This is not supported."
-            }
-        }
-    }
-    END {}
+				Write-Verbose "SQL Instance $instance is version $($server.versionmajor) ."
+			}
+			catch
+			{
+				Write-Warning " Failed to connect to $instance ."
+				continue
+			}
+			if ($server.versionmajor -ge 11)
+			{
+				$SqlConn = $server.ConnectionContext.SqlConnectionObject
+				$SqlStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $SqlConn
+				$XEStore = New-Object  Microsoft.SqlServer.Management.XEvent.XEStore $SqlStoreConnection
+				Write-Verbose "Getting XEvents Sessions on $instance ."
+				
+				$xesessions = $XEStore.sessions
+				
+				if ($sessions)
+				{
+					$xesessions = $xesessions | Where-Object { $_.Name -in $sessions }
+				}
+				
+				try
+				{
+					$xesessions |
+					ForEach-Object {
+						[PSCustomObject]@{
+							ComputerName = $server.NetName
+							SQLInstance = $server.ServiceName
+							Session = $_.Name
+							Status = switch ($_.IsRunning) { $true { "Running" } $false { "Stopped" } }
+							StartTime = $_.StartTime
+							AutoStart = $_.AutoStart
+							State = $_.State
+							Targets = $_.Targets
+							Events = $_.Events
+							MaxMemory = $_.MaxMemory
+							MaxEventSize = $_.MaxEventSize
+						}
+					}
+				}
+				catch
+				{
+					Write-Warning "Failed to get XEvents Sessions on $instance ."
+				}
+			}
+			else
+			{
+				Write-Warning "SQL Instance $instance is SQL Version $($server.versionmajor) . This is not supported."
+			}
+		}
+	}
+	END { }
 }


### PR DESCRIPTION
Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

