### PR TITLE
Remove sql database safely   sql agent check #192 

### DIFF
--- a/functions/Remove-SqlDatabaseSafely.ps1
+++ b/functions/Remove-SqlDatabaseSafely.ps1
@@ -209,7 +209,7 @@ If there is a DBCC Error it will continue to perform rest of the actions and wil
 		
 		if ($alldatabases -or $databases.count -eq 0)
 		{
-			$databases = ($sourceserver.databases | Where-Object{ $_.IsSystemObject -eq $false }).Name
+			$databases = ($sourceserver.databases | Where-Object{ $_.IsSystemObject -eq $false -and ($_.Status -match 'Offline') -eq  $false}).Name
 		}
 		
 		if (!(Test-SqlPath -SqlServer $destserver -Path $backupFolder))

--- a/tests/Remove-SQLDatabaseSafely.Tests.ps1
+++ b/tests/Remove-SQLDatabaseSafely.Tests.ps1
@@ -20,7 +20,7 @@ $Rules = (Get-ScriptAnalyzerRule).Where{$_.RuleName -notin ('PSAvoidUsingPlainTe
 $Name = $sut.Split('.')[0]
 
     Describe 'Script Analyzer Tests' {
-            Context 'Testing $sut for Standard Processing' {
+            Context "Testing $Name for Standard Processing" {
                 foreach ($rule in $rules) { 
                     $i = $rules.IndexOf($rule)
                     It "passes the PSScriptAnalyzer Rule number $i - $rule  " {


### PR DESCRIPTION
Fixes #359 

Changes proposed in this pull request:
Handles Off-Line Databases

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

