### PR TITLE
function does not exit anymore if there is no ICMP reply

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -54,18 +54,18 @@ Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostNa
 	[CmdletBinding()]
 	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("cn", "host", "ServerInstance", "SqlInstance", "Server", "SqlServer")]
+		[Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
 		[object]$ComputerName,
 		[PsCredential]$Credential
 	)
 	
 	PROCESS
 	{
-		foreach ($Computer in $ComputerName)
+		foreach ( $Computer in $ComputerName )
 		{
 			$conn = $ipaddress = $CIMsession = $null
 			
-			if ($Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server])
+			if ( $Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server] )
 			{
 				$Computer = $Computer.NetName
 			}
@@ -75,56 +75,59 @@ Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostNa
 			Write-Verbose "Connecting to server $Computer"
 			$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
 			
-			if ($ipaddress)
+			if ( $ipaddress )
 			{
-				if ($host.Version.Major -gt 2)
+			    Write-Verbose "IP Address from $Computer is $ipaddress"
+			}
+			else
+			{
+				Write-Warning "No IP Address returned from Computer $Computer"
+			}
+			if ( $host.Version.Major -gt 2 )
+			{
+				Write-Verbose "Your PowerShell Version is $($host.Version.Major)"
+				try
 				{
-					Write-Verbose "Your PowerShell Version is $($host.Version.Major)"
-					Write-Verbose "IP Address from $Computer is $ipaddress"
+					Write-Verbose "Getting computer information from server $Computer via CIM (WSMan)"
+					$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
+					$conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
+				}
+				catch
+				{
+					Write-Verbose "No WSMan connection to $Computer"
+				}
+				if ( !$conn )
+				{
 					try
 					{
-						Write-Verbose "Getting computer information from server $Computer via CIM (WinRM)"
-						$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
+						Write-Verbose "Getting computer information from server $Computer via CIM (DCOM)"
+						$sessionoption = New-CimSessionOption -Protocol DCOM
+						$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
 						$conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
 					}
 					catch
 					{
-						Write-Verbose "No WinRM connection to $Computer"
+						Write-Warning "No DCOM connection for CIM to $Computer"
 					}
-					if (!$conn)
+				}
+			    if ( !$conn )
+			    {
+				    Write-Verbose "Getting computer information from server $Computer via WMI (DCOM)"
+				    $conn = Get-WmiObject -ComputerName $Computer -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -ErrorAction SilentlyContinue -Credential $Credential
+					if ( !$conn )
 					{
-						try
-						{
-							Write-Verbose "Getting computer information from server $Computer via CIM (DCOM)"
-							$sessionoption = New-CimSessionOption -Protocol DCOM
-							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
-							$conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
-						}
-						catch
-						{
-							Write-Warning "No DCOM connection to $Computer"
-						}
+						Write-Warning "No DCOM connection for WMI to $Computer"
 					}
-				}
-				if (!$conn)
-				{
-					Write-Verbose "Getting computer information from server $Computer via WMI (DCOM)"
-					$conn = Get-WmiObject -ComputerName $Computer -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -ErrorAction SilentlyContinue -Credential $Credential
-				}
-				
-				[PSCustomObject]@{
-					InputName = $OGComputer
-					ComputerName = $conn.Name
-					IPAddress = $ipaddress
-					DNSHostName = $conn.DNSHostname
-					Domain = $conn.Domain
-					FQDN = "$($conn.DNSHostname).$($conn.Domain)"
-				}
+			    }
 			}
-			
-			else
-			{
-				Write-Warning "Computer $Computer not available"
+				
+			[PSCustomObject]@{
+				InputName = $OGComputer
+				ComputerName = $conn.Name
+				IPAddress = $ipaddress
+				DNSHostName = $conn.DNSHostname
+				Domain = $conn.Domain
+				FQDN = "$($conn.DNSHostname).$($conn.Domain)"
 			}
 		}
 	}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - because ICMP may be blocked by Firewall while WSMan is not, we now continue even if there is no ICMP reply
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

