### PR TITLE
now using Resolve-DbaNetworkName

### DIFF
--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -87,6 +87,7 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
         foreach ($Computer in $ComputerName)
         {
             Write-Verbose "Connecting to $Computer"
+			$reply = Resolve-DbaNetworkName -ComputerName $Computer -ErrorAction SilentlyContinue
             if ( $reply.ComputerName )
             {
                 $Computer = $reply.ComputerName

--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -87,7 +87,8 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
         foreach ($Computer in $ComputerName)
         {
             Write-Verbose "Connecting to $Computer"
-			if ( $reply = Resolve-DbaNetworkName -ComputerName $Computer -erroraction silentlycontinue)
+			$reply = Resolve-DbaNetworkName -ComputerName $Computer -erroraction silentlycontinue
+            if ( $reply.ComputerName )
             {
                 $Computer = $reply.ComputerName
                 Write-Verbose "$Computer is up and running"

--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -87,7 +87,6 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
         foreach ($Computer in $ComputerName)
         {
             Write-Verbose "Connecting to $Computer"
-			$reply = Resolve-DbaNetworkName -ComputerName $Computer -erroraction silentlycontinue
             if ( $reply.ComputerName )
             {
                 $Computer = $reply.ComputerName


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

