### PR TITLE
Initial commit of Stop-DbaProcess to fix issue #486

### DIFF
--- a/functions/Stop-DbaProcess.ps1
+++ b/functions/Stop-DbaProcess.ps1
@@ -160,7 +160,7 @@ Shows what would happen if the command were executed.
 			$login = $session.login
 			$database = $session.database
 			$program = $session.program
-			$host = $session.host
+			$hostname = $session.host
 			
 			$info = @()
 			
@@ -179,9 +179,9 @@ Shows what would happen if the command were executed.
 				$info += "Program: $program"
 			}
 			
-			if ($host.length -gt 1)
+			if ($hostname.length -gt 1)
 			{
-				$info += "Host: $host"
+				$info += "Host: $hostname"
 			}
 			
 			$info = $info -join ", "


### PR DESCRIPTION
$host changed to $hostname to prevent the error in the issue record

All other functionality unchanged. Output is still sent to the caller in the same format, this is only an internal name change

Fixes # 
Issue #486 
Needed to do a clean db process kill for the restore work (better to use a standard cmdlet than reinvent the wheel)

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

