### PR TITLE
Initial commit of Restore Get files

### DIFF
--- a/Get-DirectoryRestoreFile.ps1
+++ b/Get-DirectoryRestoreFile.ps1
@@ -1,0 +1,39 @@
+function Get-DirectoryRestoreFile
+{
+<#
+.SYNOPSIS
+Internal Function to get SQL Server backfiles from a specified folder
+
+.DESCRIPTION
+Takes path, checks for validity. Scans for usual backup file 
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[string]$Path
+	)
+       
+        Write-Verbose "$FunctionName - Starting"
+        Write-Verbose "$FunctionName - Checking Path"
+        if ((Test-Path $Path) -ne $true){
+            break
+        }
+        #Path needs to end \* to use includes, which is faster than Where-Object
+        $PathCheckArray = $path.ToCharArray()
+        if ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -eq '*'){
+            #We're good    
+        } elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -eq '*') {
+            #We have \\some\path*, insert a \
+            write-verbose "here"
+            $Path = ($PathCheckArray[0..(($PathCheckArray.length)-2)] -join (''))+"\*"
+        } elseif ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -ne '*') {
+            #Append a * to the end
+            $Path = "$Path*"
+        } elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -ne '*') {
+            #Append a \* to the end
+            $Path = "$Path\*"
+        }
+        Write-Verbose "$FunctionName - Scanning $path"
+        $Results = Get-ChildItem -path $Path -include *.bak, *.trn
+        return $Results
+}

--- a/Get-OlaHRestoreFile.ps1
+++ b/Get-OlaHRestoreFile.ps1
@@ -1,0 +1,44 @@
+function Get-OlaHRestoreFile
+{
+<#
+.SYNOPSIS
+Internal Function to get SQL Server backfiles from a specified folder that's formatted according to Ola Hallengreen's scripts.
+
+.DESCRIPTION
+Takes path, checks for validity. Scans for usual backup file 
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[string]$Path
+	)
+        $FunctionName = "Get-OlaHRestoreFile"
+        Write-Verbose "$FunctionName - Starting"
+        Write-Verbose "$FunctionName - Checking Path"
+        if ((Test-Path $Path) -ne $true){
+           [System.IO.FileNotFoundException] "Error: $Path is not valid"
+       
+        }
+        #There should be at least FULL folder, DIFF and LOG are nice as well
+        Write-Verbose "$FunctionName - Checking we have a FULL folder"
+        if (Test-Path $Path\FULL)
+        {
+            Write-Verbose "$FunctionName - We have a FULL folder, scanning"
+            $Results = Get-ChildItem $Path\FULL -Filter *.bak
+        } else {
+            Write-Verbose "$FunctionName - Don't have a FULL folder, throw and exit"
+            break
+        }
+        if (Test-Path $Path\Log)
+        {
+            Write-Verbose "$FunctionName - We have a LOG folder, scanning"
+            $Results += Get-ChildItem $Path\LOG -filter *.trn
+        }
+        if(Test-Path $Path\Diff)
+        {
+            Write-Verbose "$FunctionName - We have a DIFF folder, scanning"
+            $Results += Get-ChildItem $Path\DIFF -filter *.bak
+        }
+
+        return $Results
+}

--- a/Get-XpDirTreeRestoreFile.ps1
+++ b/Get-XpDirTreeRestoreFile.ps1
@@ -1,0 +1,52 @@
+function Get-XpDirTreeRestoreFile
+{
+<#
+.SYNOPSIS
+Internal Function to get SQL Server backfiles from a specified folder using xp_dirtree
+
+.DESCRIPTION
+Takes path, checks for validity. Scans for usual backup file 
+
+.PARAMETER Path
+
+.PARAMETER 
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[string]$Path,
+        [parameter(Mandatory = $true)]
+		[Alias("ServerInstance", "SqlInstance")]
+		[object]$SqlServer,
+		[System.Management.Automation.PSCredential]$SqlCredential
+	)
+       
+        $FunctionName = "Get-XpDirTreeRestoreFile"
+        
+        Write-Verbose "$FunctionName - Starting"
+        Write-Verbose "$FunctionName - Checking Path"
+
+        If (((Test-SQLConnection -SqlServer $SqlServer -SqlCredential $SqlCredential)[11].ConnectSuccess -eq $false))
+        {
+            Write-Error "$FunctionName - SQL Connection details not valid"
+            return $null
+            break
+        }
+
+        if ((Test-SqlSa -SqlServer $SqlServer -SqlCredential $SqlCredential) -eq $false)
+        {
+            Write-Error "$FunctionName - Not sysadmin, this will not work"
+        }
+
+        if ($Path[-1] -ne "\")
+        {
+            $Path = $Path + "\"
+        }
+
+        $query = "EXEC master.sys.xp_dirtree '$path',1,1;"
+
+        $queryResult = Invoke-Sqlcmd2 -ServerInstance $sqlServer -Database tempdb -Query $query
+        $Results = $queryResult | Select @{Name="FullName";Expression={$_."Subdirectory"}}
+        $Results = $Results | %{"$path$($_.FullName)"} | select @{Name="Fullname";Expression={$_}}
+        return $Results
+}


### PR DESCRIPTION
commands that scan for the restore files

Fixes # 

Changes proposed in this pull request:
 Adds the 3 scanning cmdlets for the restore framework

Get-DirectoryRestoreFile - scans a given folder for backups files and returns them
Get-OlaHRestoreFile - scans an OlaH style folder structure for backup files
Get-XpDirTreeRestoreFile - uses sql server's xp_dirtree to scan a folder for backup files (checks for the users ability to do so first)
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

