### PR TITLE
Restore filter files (2 of 4)

### DIFF
--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -13,7 +13,8 @@ Takes an array of FileSystem Objects and then filters them down by date to get a
         [object[]]$Files,
         [parameter(Mandatory = $true)]
         [object]$SqlServer,
-        [DateTime]$RestoreTime = (Get-Date).addyears(1)  
+        [DateTime]$RestoreTime = (Get-Date).addyears(1),
+        [System.Management.Automation.PSCredential]$SqlCredential 
 
 	)
     Begin
@@ -37,7 +38,7 @@ Takes an array of FileSystem Objects and then filters them down by date to get a
     End
     {
         Write-Verbose "$FunctionName - Read File headers (Read-DBABackupHeader)"
-        $SQLBackupdetails  = $InternalFiles | Select-Object -ExpandProperty FullName | Read-DBAbackupheader -sqlserver $SQLSERVER 
+        $SQLBackupdetails  = $InternalFiles | Select-Object -ExpandProperty FullName | Read-DBAbackupheader -sqlserver $SQLSERVER -SqlCredential:$SqlCredential
         Write-Verbose "$FunctionName - Find Newest Full backup"
         $Fullbackup = $SQLBackupdetails | where-object {$_.BackupType -eq "1" -and $_.BackupStartDate -lt $RestoreTime} | Sort-Object -Property BackupStartDate -descending | Select-Object -First 1
         if ($Fullbackup -eq $null)

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -1,0 +1,70 @@
+function Get-FilteredRestoreFile
+{
+<#
+.SYNOPSIS
+Internal Function to Filter a set of SQL Server backup files
+
+.DESCRIPTION
+Takes an array of FileSystem Objects and then filters them down by date to get a potential Restore set
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [object[]]$Files,
+        [parameter(Mandatory = $true)]
+        [object]$SqlServer,
+        [DateTime]$RestoreTime = (Get-Date).addyears(1)  
+
+	)
+    Begin
+    {
+        $FunctionName = "Filter-RestoreFile"
+        Write-Verbose "$FunctionName - Starting"
+
+
+
+        $Results = @()
+        $InternalFiles = @()
+    }
+    # -and $_.BackupStartDate -lt $RestoreTime
+    process
+        {
+
+        foreach ($file in $files){
+            $InternalFiles += $file
+        }
+    }
+    End
+    {
+        Write-Verbose "$FunctionName - Read File headers (Read-DBABackupHeader)"
+        $SQLBackupdetails  = $InternalFiles | Select-Object -ExpandProperty FullName | Read-DBAbackupheader -sqlserver $SQLSERVER 
+        Write-Verbose "$FunctionName - Find Newest Full backup"
+        $Fullbackup = $SQLBackupdetails | where-object {$_.BackupType -eq "1" -and $_.BackupStartDate -lt $RestoreTime} | Sort-Object -Property BackupStartDate -descending | Select-Object -First 1
+        if ($Fullbackup -eq $null)
+        {
+            Write-Error "$FunctionName - No Full backup found to anchor the restore"
+        }
+
+       $Results += $Fullbackup
+        
+        Write-Verbose "$FunctionName - Got a Full backup, now find all diffs"
+        $Diffbackups = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Database Differential' -and $_.BackupStartDate -gt $Fullbackup.backupStartDate -and $_.BackupStartDate -lt $RestoreTime}
+        $Results += $Diffbackups
+        if ($Diffbackups.count -gt 0){
+            Write-Verbose "$FunctionName - we have at least one diff so look for tlogs after the last one"
+            $TlogStartDate = ($DiffBackups | sort-object -property BackupStartDate -Descending | select-object -first 1).BackupStartDate
+        }else{
+            Write-Verbose "$FunctionName - we have no diffs, so T-logs post full backup start "
+            $TlogStartDate = $Fullbackup.BackupStartDate 
+        }
+        
+        Write-Verbose "$FunctionName - Got a Full/Diff backups, now find all Tlogs needed"
+        $Tlogs = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log' -and $_.backupStartDate -gt $TlogStartDate-and $_.BackupStartDate -lt $RestoreTime}
+        $Results += $Tlogs
+        #Catch the last Tlog that covers the restore time!
+        $Tlogfinal = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log' -and $_.BackupStartDate -gt $RestoreTime} | Sort-Object -Property LastLSN  | select -First 1
+        $Results +=$Tlogfinal
+        Write-Verbose "$FunctionName - Returning Results to caller"
+        $Results
+    }
+}

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -1,0 +1,197 @@
+Function Restore-DBFromFilteredArray
+{
+<# 
+	.SYNOPSIS
+	Internal function. Restores .bak file to SQL database. Creates db if it doesn't exist. $filestructure is
+	a custom object that contains logical and physical file locations.
+#>
+	[CmdletBinding()]
+	param (
+        [parameter(Mandatory = $true)]
+		[Alias("ServerInstance", "SqlInstance")]
+		[object]$SqlServer,
+		[string]$DbName,
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [object[]]$Files,
+        [String]$RestoreLocation,
+        [DateTime]$RestoreTime = (Get-Date).addyears(1),  
+		[switch]$NoRecovery,
+		[switch]$ReplaceDatabase,
+		[switch]$Scripts,
+        [switch]$ScriptOnly,
+		[switch]$VerifyOnly,
+		[object]$filestructure,
+		[System.Management.Automation.PSCredential]$SqlCredential
+	)
+    
+	    Begin
+    {
+        $FunctionName = "Restore-DBFromFilteredArray"
+        Write-Verbose "$FunctionName - Starting"
+
+
+
+        $Results = @()
+        $InternalFiles = @()
+    }
+    # -and $_.BackupStartDate -lt $RestoreTime
+    process
+        {
+
+        foreach ($File in $Files){
+            $InternalFiles += $File
+        }
+    }
+    End
+    {
+
+		$Server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
+		$ServerName = $Server.name
+		$Server.ConnectionContext.StatementTimeout = 0
+		$Restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
+		$Restore.ReplaceDatabase = $ReplaceDatabase
+
+		If ($null -ne $Server.Databases[$DbName])
+		{
+			try
+			{
+				Write-Verbose "$FunctionName - Set $DbName offline to kill processes"
+				Invoke-SQLcmd2 -ServerInstance:$SqlServer -Credential:$SqlCredential -query "Alter database $DbName set offline with rollback immediate; use $DbName"
+
+			}
+			catch
+			{
+				Write-Verbose "$FunctionName - No processes to kill"
+			}
+		}
+
+		$OrderedRestores = $InternalFiles | Sort-object -Property BackupStartDate, BackupType
+		Write-Verbose "of = $($OrderedRestores.Backupfilename)"
+		foreach ($RestoreFile in $OrderedRestores)
+		{
+			if ($Restore.RelocateFiles.count -gt 0)
+			{
+				$Restore.RelocateFiles.Clear()
+			}
+			foreach ($File in $RestoreFile.Filelist)
+			{
+
+				if ($RestoreLocation -ne '' -and $FileStructure -eq $NUll)
+				{
+					
+					$MoveFile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
+					$MoveFile.LogicalFileName = $File.LogicalName
+					$MoveFile.PhysicalFileName = $RestoreLocation + (split-path $file.PhysicalName -leaf)
+					$null = $Restore.RelocateFiles.Add($MoveFile)
+					
+				} elseif ($RestoreLocation -eq '' -and $FileStructure -ne $NUll)
+				{
+
+					$FileStructure = $FileStructure.values
+
+					foreach ($File in $FileStructure)
+					{
+						$MoveFile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
+						$MoveFile.LogicalFileName = $File.logical
+						$MoveFile.PhysicalFileName = $File.physical
+
+						$null = $Restore.RelocateFiles.Add($MoveFile)
+					}	
+				} elseif ($RestoreLocation -ne '' -and $FileStructure -ne $NUll)
+				{
+					Write-Error "Conflicting options only one of FileStructure or RestoreLocation allowed"
+				} 		
+			}
+
+			try
+			{
+				Write-Verbose "$FunctionName - Beginning Restore"
+				$percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
+					Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
+				}
+				$Restore.add_PercentComplete($percent)
+				$Restore.PercentCompleteNotification = 1
+				$Restore.add_Complete($complete)
+				$Restore.ReplaceDatabase = $ReplaceDatabase
+				$Restore.ToPointInTime = $RestoreTime
+				if ($DbName -ne '')
+				{
+					$Restore.Database = $DbName
+				}
+				else
+				{
+					$Restore.Database = $RestoreRile.DatabaseName
+				}
+				$Action = switch ($RestoreFile.BackupType)
+					{
+						'1' {'Database'}
+						'2' {'Log'}
+						'5' {'Database'}
+						Default {}
+					}
+				Write-Verbose "$FunctionName restore action = $Action"
+				$restore.Action = $Action 
+				if ($RestoreFile -eq $OrderedRestores[-1] -and $NoRecovery -ne $true)
+				{
+					#Do recovery on last file
+					Write-Verbose "$FunctionName - Doing Recovery on last file"
+					$Restore.NoRecovery = $false
+				}
+				else 
+				{
+					$Restore.NoRecovery = $true
+				}
+
+					$Device = New-Object -TypeName Microsoft.SqlServer.Management.Smo.BackupDeviceItem
+					$Device.Name = $RestoreFile.BackupPath
+					$Device.devicetype = "File"
+					$Restore.Devices.Add($device)
+
+				Write-Verbose "$FunctionName - Performaing restore action"
+				if ($ScriptOnly)
+				{
+					$restore.Script($server)
+				}
+				elseif ($VerifyOnly)
+				{
+					Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+					$Verify = $restore.sqlverify($server)
+					Write-Progress -id 1 -activity "Verifying $dbname backup file on $servername" -status "Complete" -Completed
+					
+					if ($verify -eq $true)
+					{
+						return "Verify successful"
+					}
+					else
+					{
+						return "Verify failed"
+					}
+				}
+				else
+				{
+					Write-Progress -id 1 -activity "Restoring $DbName to ServerName" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+					$Restore.sqlrestore($Server)
+					if ($scripts)
+					{
+						$restore.Script($Server)
+					}
+					Write-Progress -id 1 -activity "Restoring $DbName to $ServerName" -status "Complete" -Completed
+					
+					#return "Success"
+				}
+				$null = $Restore.Devices.Remove($Device)
+				Remove-Variable device
+			}
+			catch
+			{
+				Write-Warning $_.Exception.InnerException
+			}
+			
+		}
+		if ($NoRecovery -eq $false -and $ScriptOnly -eq $false)
+		{
+			Invoke-SQLcmd2 -ServerInstance:$SqlServer -Credential:$SqlCredential -query "Restore database $DbName with recovery"
+		}
+		#$server.ConnectionContext.Disconnect()
+	}
+}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 Adds the 2 cmdlets that do the filtering of restore files for the new Restore framework.
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

