### PR TITLE
Restore related internal cmdlets (3 of 4)

### DIFF
--- a/internal/Rename-LogicalFile.ps1
+++ b/internal/Rename-LogicalFile.ps1
@@ -1,0 +1,99 @@
+Function Rename-LogicalFile
+{
+<# 
+	.SYNOPSIS
+	Internal function. Renames logical files.
+    Can either use  prefix with -Prefix, ALL files log and data will be prefixed
+
+    Or pass in a mapping hash like:
+    $mapping = @{
+        'File1'='NewNamefile1'
+        'File3'='somethingelse'
+    }
+    Can select which files need remappping.
+#>
+	[CmdletBinding()]
+	param (
+        [parameter(Mandatory = $true)]
+		[Alias("ServerInstance", "SqlInstance")]
+		[object]$SqlServer,
+		[string]$DbName,
+		[System.Management.Automation.PSCredential]$SqlCredential,
+        [string]$Prefix,
+        [hashtable]$Mapping
+	)
+    $FunctionName = "Rename-LogicalFile"
+    if ('' -ne $Prefix -and $Mapping.count -ne 0)
+    {
+        Write-Error "$FunctionName only accepts a new prefix OR a mapping hash"
+        return $false
+    }
+
+    $server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
+    if ($null -eq $server.Databases[$DbName])
+    {
+        Write-Error "$FunctionName - Database $DbName does not exist"
+        return $false
+        break
+    }
+    $database = $server.Databases[$DbName]
+    Write-Verbose "$FunctionName - Getting data files"
+    $LogicalFiles = @()
+    foreach ($FileGroup in $Database.filegroups)
+    {
+        foreach($File in $FileGroup.files)
+        {
+            $LogicalFiles += $File
+        }
+    }
+    Write-Verbose "$FunctionName - getting log files"
+    foreach ($File in $Database.LogFiles)
+    {
+        $LogicalFiles += $File
+    }
+    if ($null -ne $Mapping -and $LogicalFiles.count -lt $Mapping.count)
+    {
+        Write-Error "$FunctionName - More mappings than files"
+        return $false
+    }
+    Write-Verbose "File Count = $($LogicalFiles.count)"
+    if ('' -ne $Prefix)
+    {
+        foreach ($File in $LogicalFiles)
+        {
+            $NewName = $Prefix+$File.Name
+            Write-Verbose "$FunctionName prefixing $($File.Name) to $NewName"
+            try {
+                $File.Rename($NewName)    
+            }
+            catch  {
+                Write-Exception $_
+                return 
+            }
+            
+        }
+    }
+    if ($null -ne $Mapping)
+    {
+        foreach ($File in $LogicalFiles)
+        {
+            if ($null -eq $Mapping[($File.Name)])
+            {
+                Write-Verbose "$FunctionName - No mapping for $($File.Name) "
+            }
+            else
+            {
+                $NewName = $Mapping[($File.Name)]
+                Write-Verbose "$FunctionName - mapping $($File.Name) to $NewName"
+                try {
+                    $File.Rename($NewName)    
+                }
+                catch  {
+                    Write-Exception $_
+                    return 
+                }
+            }
+        }
+    }
+    return $true
+}

--- a/internal/Test-DbaLsnChain.ps1
+++ b/internal/Test-DbaLsnChain.ps1
@@ -1,0 +1,115 @@
+function Test-DbaLsnChain
+{
+<#
+.SYNOPSIS 
+Checks that a filtered array from Get-FilteredRestore contains a restorabel chain of LSNs
+
+.DESCRIPTION
+	
+.PARAMETER FilterdRestoreFiles
+	
+.PARAMETER RestoreTime
+Returns fewer columns for an easy overview
+	
+
+.NOTES 
+dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+Copyright (C) 2016 Chrissy LeMaire
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+.EXAMPLE
+Test-DbaLsnChain -FilteredRestoreFiles $FilteredFiles
+
+Checks that the Restore chain in $FilteredFiles is complete and can be fully restored
+
+.EXAMPLE
+Test-DbaLsnChain -FilteredRestoreFiles $FilteredFiles -RestoreTime '23/12/2016 06:55'
+
+Checks that the Restore chain in $FilteredFiles is complete and can be fully restored to the Point In Time '23/12/2016 06:55'
+	
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory = $true)]
+        [object[]]$FilteredRestoreFiles,
+        [DateTime]$RestoreTime = (Get-Date).addyears(1)
+	)
+
+    #Need to anchor  with full backup:
+    $FunctionName = "Test-DbaLsnChain"
+    $FullDBAnchor = $FilteredRestoreFiles | Where-Object {$_.BackupTypeDescription -eq 'Database'}
+    if (($FullDBAnchor | Measure-Object).count -ne 1)
+    {
+        Write-Error "$FunctionName - More than 1 full backup, or less than 1, neither supported"
+        return $false
+        break;
+    }
+    #Check all the backups relate to the full backup
+    #Via RecoveryForkID:
+    if (($FilteredRestoreFiles | Where-Object {$_.RecoveryForkID -ne $FullDBAnchor.RecoveryForkID}).count -gt 0)
+    {
+        Write-Error "$FunctionName - Multiple RecoveryForkIDs found, not supported"
+        return $false
+        break
+    }
+    #Via LSN chain:
+    $BackupWrongLSN = $FilteredRestoreFiles | Where-Object {$_.DatabaseBackupLSN -ne $FullDBAnchor.CheckPointLSN}
+    #Should be 0 in there, if not, lets check that they're from during the full backup
+    if ($BackupWrongLSN.count -gt 0 ) 
+    {
+        if (($BackupWrongLSN | Where-Object {$_.LastLSN -lt $FullDBAnchor.LastSN}).count -gt 0)
+        {
+            Write-Error "$FunctionName - We have non matching LSNs - not supported"
+            return $false
+            break;
+        }
+    }
+    $DiffAnchor = $FilteredRestoreFiles | Where-Object {$_.BackupTypeDescription -eq 'Database Differential'}
+    #Check for no more than a single Differential backup
+    if (($DiffAnchor | Measure-Object).count -gt 1)
+    {
+        Write-Error "$FunctionName - More than 1 differential backup, not  supported"
+        return $false
+        break;        
+    } 
+    elseif (($DiffAnchor | Measure-Object).count -gt 1)
+    {
+        $TlogAnchor = $DiffAnchor
+    } 
+    else 
+    {
+        $TlogAnchor = $FullDBAnchor
+    }
+
+
+    #Check T-log LSNs form a chain.
+    $TranLogBackups = $FilteredRestoreFiles | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log' -and $_.DatabaseBackupLSN -eq $FullDBAnchor.CheckPointLSN} | Sort-Object -Propert LastLSN
+    for ($i=0; $i -lt ($TranLogBackups.count)-1)
+    {
+        if ($i -eq 0)
+        {
+            if ($TranLogBackups[$i].FirstLSN -gt $TlogAnchor.LastLSN)
+            {
+                Write-Error "$FunctionName - Break in LSN Chain between $($TlogAnchor.BackupPath) and $($TranLogBackups[($i)].BackupPath) "
+                return $false
+                break
+            }
+        }else {
+            if ($TranLogBackups[($i-1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN)
+            {
+                Write-Error "$FunctionName - Break in transaction log between $($TranLogBackups[($i-1)].BackupPath) and $($TranLogBackups[($i)].BackupPath) "
+                return $false
+                break
+            }
+        }
+        $i++
+
+    }    
+    return $true
+}
+


### PR DESCRIPTION
Rename-LogicalFile -Renames logical files
Test-DbaLsnChain - Check the backups constitute a restorable chain

Fixes # 

Changes proposed in this pull request:
Adds 2 internal helper functions for the restore work:
Test-DbaLsnChain - Checks we have a valid set of restore files based on LSN
Rename-LogicalFile - Renames logical files using either a prefix or a mapping hashtable (works with filegroups)
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

