### PR TITLE
Initial commit for Get-DbaDatabaseState

### DIFF
--- a/functions/Get-DbaDatabaseState.ps1
+++ b/functions/Get-DbaDatabaseState.ps1
@@ -1,0 +1,172 @@
+Function Get-DbaDatabaseState
+{
+<#
+.SYNOPSIS
+Gets various options for databases, hereby called "states"
+
+.DESCRIPTION
+Gets some common "states" on databases:
+ - "RW" options : READ_ONLY or READ_WRITE
+ - "Status" options : ONLINE, OFFLINE, EMERGENCY
+ - "Access" options : SINGLE_USER, RESTRICTED_USER, MULTI_USER
+
+Returns an object with SqlInstance, Database, RW, Status, Access
+
+.PARAMETER SqlInstance
+The SQL Server that you're connecting to
+
+.PARAMETER Credential
+Credential object used to connect to the SQL Server as a different user
+
+.PARAMETER Database
+Gets options only on these databases
+
+.PARAMETER Exclude
+Gets options for all but these specific databases
+
+.PARAMETER WhatIf
+Shows what would happen if the command were to run. No actions are actually performed.
+
+.PARAMETER Confirm
+Prompts you for confirmation before executing any operation within the command.
+
+.NOTES
+Author: niphlod
+
+dbatools PowerShell module (https://dbatools.io)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+
+.LINK
+https://dbatools.io/Get-DbaDatabaseState
+
+.EXAMPLE
+Get-DbaDatabaseState -SqlServer sqlserver2014a
+
+Gets options for all databases of the sqlserver2014a instance
+
+.EXAMPLE
+Get-DbaDatabaseState -SqlServer sqlserver2014a -Database HR, Accounting
+
+Gets options for both HR and Accounting database of the sqlserver2014a instance
+
+.EXAMPLE
+Get-DbaDatabaseState -SqlServer sqlserver2014a -Exclude HR
+
+Gets options for all databases of the sqlserver2014a instance except HR
+
+.EXAMPLE
+Get-DbaDatabaseState -SqlServer sqlserver2014a, sqlserver2014b
+
+Gets options for all databases of sqlserver2014a and sqlserver2014b instances
+
+#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[string[]]$SqlInstance,
+		[PSCredential]
+		[System.Management.Automation.CredentialAttribute()]$Credential
+	)
+
+	DynamicParam
+	{
+		if ($SqlInstance)
+		{
+			Get-ParamSqlDatabases -SqlInstance $SqlInstance[0] -SqlCredential $Credential -NoSystem
+		}
+	}
+
+	BEGIN
+	{
+		$databases = $psboundparameters.Databases
+		$exclude = $psboundparameters.Exclude
+
+
+		$UserAccessHash = @{
+			'Single' = 'SINGLE_USER'
+			'Restricted' = 'RESTRICTED_USER'
+			'Multiple' = 'MULTI_USER'
+		}
+		$ReadOnlyHash = @{
+			$true = 'READ_ONLY'
+			$false = 'READ_WRITE'
+		}
+		$StatusHash = @{
+			'Offline' = 'OFFLINE'
+			'Normal' = 'ONLINE'
+			'EmergencyMode' = 'EMERGENCY'
+		}
+
+		function Get-DbState($db)
+		{
+			$base = [PSCustomObject]@{
+				'Access' = ''
+				'Status' = ''
+				'RW' = ''
+			}
+			$base.RW = $ReadOnlyHash[$db.ReadOnly]
+			$base.Access = $UserAccessHash[$db.UserAccess.toString()]
+			foreach($status in $StatusHash.Keys)
+			{
+				if($db.Status -match $status)
+				{
+					$base.Status = $StatusHash[$status]
+					break
+				}
+			}
+			return $base
+		}
+
+		$RWExclusive = @('ReadOnly', 'ReadWrite')
+		$StatusExclusive = @('Online', 'Offline', 'Emergency', 'Detached')
+		$AccessExclusive = @('SingleUser', 'RestrictedUser', 'MultiUser')
+	}
+	PROCESS
+	{
+		foreach ($instance in $SqlInstance)
+		{
+			Write-Verbose "Connecting to $instance"
+			try
+			{
+				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $Credential
+			}
+			catch
+			{
+				Write-Warning "Can't connect to $instance"
+				Continue
+			}
+			$all_dbs = $server.Databases
+			$dbs = $all_dbs | Where-Object { @('master', 'model', 'msdb', 'tempdb', 'distribution') -notcontains $_.Name }
+
+			if ($databases.count -gt 0)
+			{
+				$dbs = $dbs | Where-Object { $databases -contains $_.Name }
+			}
+			if ($exclude.count -gt 0)
+			{
+				$dbs = $dbs | Where-Object { $exclude -notcontains $_.Name }
+			}
+			foreach($db in $dbs)
+			{
+				If ($Pscmdlet.ShouldProcess($instance, "Getting states for '$($db.Name)'"))
+				{
+					$db_status = Get-DbState $db
+
+					[PSCustomObject]@{
+						SqlInstance   = $server.Name
+						InstanceName  = $server.ServiceName
+						ComputerName  = $server.NetName
+						DatabaseName  = $db.Name
+						RW            = $db_status.RW
+						Status        = $db_status.Status
+						Access        = $db_status.Access
+					} | Select-DefaultField -Property SqlInstance, DatabaseName, RW, Status, Access
+				}
+			}
+		}
+	}
+}

--- a/functions/Get-DbaDatabaseState.ps1
+++ b/functions/Get-DbaDatabaseState.ps1
@@ -24,11 +24,6 @@ Gets options only on these databases
 .PARAMETER Exclude
 Gets options for all but these specific databases
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run. No actions are actually performed.
-
-.PARAMETER Confirm
-Prompts you for confirmation before executing any operation within the command.
 
 .NOTES
 Author: niphlod
@@ -58,12 +53,12 @@ Get-DbaDatabaseState -SqlServer sqlserver2014a -Exclude HR
 Gets options for all databases of the sqlserver2014a instance except HR
 
 .EXAMPLE
-Get-DbaDatabaseState -SqlServer sqlserver2014a, sqlserver2014b
+sqlserver2014a, sqlserver2014b | Get-DbaDatabaseState
 
 Gets options for all databases of sqlserver2014a and sqlserver2014b instances
 
 #>
-	[CmdletBinding(SupportsShouldProcess = $true)]
+	[CmdletBinding()]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
@@ -121,9 +116,6 @@ Gets options for all databases of sqlserver2014a and sqlserver2014b instances
 			return $base
 		}
 
-		$RWExclusive = @('ReadOnly', 'ReadWrite')
-		$StatusExclusive = @('Online', 'Offline', 'Emergency', 'Detached')
-		$AccessExclusive = @('SingleUser', 'RestrictedUser', 'MultiUser')
 	}
 	PROCESS
 	{
@@ -152,20 +144,17 @@ Gets options for all databases of sqlserver2014a and sqlserver2014b instances
 			}
 			foreach($db in $dbs)
 			{
-				If ($Pscmdlet.ShouldProcess($instance, "Getting states for '$($db.Name)'"))
-				{
-					$db_status = Get-DbState $db
+				$db_status = Get-DbState $db
 
-					[PSCustomObject]@{
-						SqlInstance   = $server.Name
-						InstanceName  = $server.ServiceName
-						ComputerName  = $server.NetName
-						DatabaseName  = $db.Name
-						RW            = $db_status.RW
-						Status        = $db_status.Status
-						Access        = $db_status.Access
-					} | Select-DefaultField -Property SqlInstance, DatabaseName, RW, Status, Access
-				}
+				[PSCustomObject]@{
+					SqlInstance   = $server.Name
+					InstanceName  = $server.ServiceName
+					ComputerName  = $server.NetName
+					DatabaseName  = $db.Name
+					RW            = $db_status.RW
+					Status        = $db_status.Status
+					Access        = $db_status.Access
+				} | Select-DefaultField -Property SqlInstance, DatabaseName, RW, Status, Access
 			}
 		}
 	}


### PR DESCRIPTION
How to test this code: 
- [ ] database state consistent with the one in the backend (combinations included, i.e. "offline\read-only")
- [ ] no "zero-width" properties are returned (i.e. no '' on RW, Status, Access)

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

