### PR TITLE
Enhancements copy sqldb - fixes #500 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # dbatools
+<img src="https://camo.githubusercontent.com/8a859030e83bd44826807447bca2767c20f19121/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f506f7765725368656c6c2d332e302d626c75652e737667" alt="Minimum Supported PowerShell Version" data-canonical-src="https://img.shields.io/badge/PowerShell-3.0-blue.svg" style="max-width:100%;">
 [![licence badge]][licence]
 [![stars badge]][stars]
 [![forks badge]][forks]
@@ -13,8 +14,7 @@
 [licence]:https://github.com/sqlcollaborative/dbatools/blob/master/LICENSE.txt
 [stars]:https://github.com/sqlcollaborative/dbatools/stargazers
 [forks]:https://github.com/sqlcollaborative/dbatools/network
-[issues]:https://github.com/sqlcollaborative/dbatools/issues
-[![Stories in Ready](https://badge.waffle.io/sqlcollaborative/dbatools.png?label=ready&title=Ready)](https://waffle.io/sqlcollaborative/dbatools)
+[issues]:https://github.com/sqlcollaborative/dbatools/issues 
 
 This module is a SQL Server DBA's best friend.
 

--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -435,10 +435,17 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				{
 					foreach ($backupfile in $filestodelete)
 					{
-						If (Test-Path $backupfile)
-						{
-							Remove-Item $backupfile
-						}
+                        try
+                        {
+						    If (Test-Path $backupfile -ErrorAction Stop)
+						    {
+							    Remove-Item $backupfile
+						    }
+                        }
+                        catch
+                        {
+                            Write-Warning "You can't access backup file $backupfile"
+                        }
 					}
 				}
 				
@@ -782,10 +789,18 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				throw "Network share must be a valid UNC path (\\server\share)."
 			}
 			
-			if (!(Test-Path $NetworkShare))
-			{
-				Write-Warning "$networkshare share cannot be accessed. Still trying anyway, in case the SQL Server service accounts have access."
-			}
+            try
+            {
+				if (Test-Path $NetworkShare -ErrorAction Stop)
+			    {
+				    Write-Verbose "$networkshare share can be accessed."
+			    }
+            }
+            catch
+            {
+                Write-Warning "$networkshare share cannot be accessed. Still trying anyway, in case the SQL Server service accounts have access."
+            }
+			
 		}
 		
 		Write-Output "Checking to ensure server is not SQL Server 7 or below"

--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -607,7 +607,17 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 					}
 					catch
 					{
-						throw "$_ `n This sometimes happens with cloned VMs. You can try again or use Backup and Restore"
+						Write-Warning "Start-BitsTransfer did not succeed. Now attempting with Copy-Item - no progress bar will be shown."
+						try
+						{
+							Copy-Item -Path $from -Destination $remotefilename -ErrorAction Stop
+						}
+						catch
+						{
+							Write-Warning "Access denied. This can happen for a number of reasons including issues with cloned disks."
+							Write-Warning "Alternatively, you may need to run PowerShell as Administrator, especially when running on localhost."
+							break
+						}
 					}
 				}
 			}
@@ -712,6 +722,17 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		$sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 		
+		if ($DetachAttach)
+		{
+			if ($sourceserver.netname -eq $env:COMPUTERNAME -or $destserver.netname -eq $env:COMPUTERNAME)
+			{
+				If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+				{
+					Write-Warning "When running DetachAttach locally on the console, it's likely you'll need to Run As Administrator. Trying anyway."
+				}
+			}
+		}
+		
 		$source = $sourceserver.DomainInstanceName
 		$destination = $destserver.DomainInstanceName
 		
@@ -719,12 +740,23 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		{
 			if ($(Test-SqlPath -SqlServer $sourceserver -Path $NetworkShare) -eq $false)
 			{
-				throw "$Source cannot access $NetworkShare"
+				Write-Warning "$Source may not be able to access $NetworkShare. Trying anyway."
 			}
 			
 			if ($(Test-SqlPath -SqlServer $destserver -Path $NetworkShare) -eq $false)
 			{
-				throw "$Destination cannot access $NetworkShare"
+				Write-Warning "$Destination may not be able to access $NetworkShare. Trying anyway."
+			}
+			
+			if ($networkshare.StartsWith('\\'))
+			{
+				$shareserver = ($networkshare -split "\\")[2]
+				$hostentry = ([Net.Dns]::GetHostEntry($shareserver)).HostName -split "\."
+				
+				if ($shareserver -ne $hostentry[0])
+				{
+					Write-Warning "Using CNAME records for the network share may present an issue if an SPN has not been created. Trying anyway. If it doesn't work, use a different (A record) hostname."
+				}
 			}
 		}
 		
@@ -1077,19 +1109,9 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 					
 					If ($Pscmdlet.ShouldProcess($destination, "Detach $dbname from $source and attach, then update dbowner"))
 					{
-						$result = Start-SqlDetachAttach $sourceserver $destserver $filestructure $dbname
+						$migrationresult = Start-SqlDetachAttach $sourceserver $destserver $filestructure $dbname
 						
 						$dbfinish = Get-Date
-						
-						if ($result -eq $true)
-						{
-							Write-Output "Successfully attached $dbname to $destination"
-						}
-						else
-						{
-							Write-Warning "Failed to attach $dbname to $destination. Aborting routine for this database."
-							continue
-						}
 						
 						if ($reattach -eq $true)
 						{
@@ -1118,6 +1140,17 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 							{
 								Write-Warning "Could not reattach $dbname to $source."
 							}
+						}
+						
+						
+						if ($migrationresult -eq $true)
+						{
+							Write-Output "Successfully attached $dbname to $destination"
+						}
+						else
+						{
+							Write-Warning "Failed to attach $dbname to $destination. Aborting routine for this database."
+							continue
 						}
 					}
 				}


### PR DESCRIPTION
I just spent like 20 minutes trying to remove the README.md and couldn't. It looks like it won't cause a conflict tho.

Nevertheless, here are the things I changed

- [x] Added an extra try to copying files in DetachAttach
- [x] Moved up the Reattach routine (if specified) so that databases get reattached if the file doesn't work
- [x] Offered more suggestions as to why a transfer can fail
- [x] Checked for localhost and if so, displays a warning if detachattach is used but Run As Admin was not used
- [x] Removed a throw and changed to a warn for network path accessibility 
- [x] Put in a check for cname usage and displayed a warning (should we do verbose?)