### PR TITLE
Copy-SqlSpConfigure, fix

### DIFF
--- a/functions/Copy-SqlSpConfigure.ps1
+++ b/functions/Copy-SqlSpConfigure.ps1
@@ -90,15 +90,6 @@ Shows what would happen if the command were executed.
     }
     PROCESS
     {
-	    If ($Pscmdlet.ShouldProcess("$Destination", "Updating sp_configure to show advanced options"))
-	    {
-			#Interesting note, using SMO there's no need to adjust the Advanced Options setting. Seems to be TSQL only.
-			
-			#$sourceserver.Configuration.ShowAdvancedOptions.ConfigValue = $true
-		    #$sourceserver.Configuration.Alter()
-		    #$destserver.Configuration.ShowAdvancedOptions.ConfigValue = $true
-		    #$destserver.Configuration.Alter()
-	    }
 		
 	    $destprops = $destserver.Configuration.Properties
 		
@@ -125,7 +116,7 @@ Shows what would happen if the command were executed.
 		    $destprop = $destprops | Where-Object{ $_.Displayname -eq $displayname }
 		    if ($destprop -eq $null)
 		    {
-			    Write-Warning "Configuration option '$displayname' does not exists on the destination instance."
+			    Write-Warning "Configuration option '$displayname' does not exist on the destination instance."
 			    continue
 		    }
 			
@@ -147,27 +138,9 @@ Shows what would happen if the command were executed.
 					Write-Error "Could not $($destprop.displayname) to $($sourceprop.configvalue). Feature may not be supported."
 				}
 			}
-			
-			If ($Pscmdlet.ShouldProcess($destination, "Altering configuration"))
-		    {
-			    try
-			    {
-				    $destserver.Configuration.Alter()
-			    }
-			    catch
-			    {
-				    Write-Warning "Configuration option '$displayname' requires restart."
-			    }
-		    }
+		  
 	    }
-		
-	    If ($Pscmdlet.ShouldProcess("both servers", "Updating sp_configure so that it does not show advanced options"))
-	    {
-		    #$sourceserver.Configuration.ShowAdvancedOptions.ConfigValue = $false
-		   # $sourceserver.ConnectionContext.ExecuteNonQuery("RECONFIGURE WITH OVERRIDE") | Out-Null
-		    #$destserver.Configuration.ShowAdvancedOptions.ConfigValue = $false
-		    #$destserver.Configuration.Alter()
-	    }
+
     }
     END
     {


### PR DESCRIPTION
Fixes #513 

Changes proposed in this pull request:
 - Remove reconfigure with override command - prevent putting SQL in a bad state
 - Include notification for configs that require an instance restart to take effect
 - Removed adjusting "show advanced options" as it's not required when making config changes via SMO (this appears to impact TSQL only0

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

