### PR TITLE
Set-DbaMaxDop, Adding sqlcredential to the test-dbamaxdop

### DIFF
--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -118,11 +118,11 @@ Set recommended Max DOP setting for all databases on server sql2016.
 		
 		if ($collection -eq $null)
 		{
-			$collection = Test-DbaMaxDop -SqlServer $SqlServer -Verbose:$false
+			$collection = Test-DbaMaxDop -SqlServer $SqlServer -SqlCredential $SqlCredential -Verbose:$false
 		}
 		elseif ($collection.Instance -eq $null)
 		{
-			$collection = Test-DbaMaxDop -SqlServer $SqlServer -Verbose:$false
+			$collection = Test-DbaMaxDop -SqlServer $SqlServer -SqlCredential $SqlCredential -Verbose:$false
 		}
 		
 		$collection | Add-Member -NotePropertyName OldInstanceMaxDopValue -NotePropertyValue 0
@@ -141,7 +141,7 @@ Set recommended Max DOP setting for all databases on server sql2016.
 				$servername = $server
 			}
 			
-			Write-Verbose "Attempting to connect to $servername"
+			Write-Output "Attempting to connect to $servername"
 			try
 			{
 				$server = Connect-SqlServer -SqlServer $servername -SqlCredential $SqlCredential

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -141,7 +141,7 @@ Set recommended Max DOP setting for all databases on server sql2016.
 				$servername = $server
 			}
 			
-			Write-Output "Attempting to connect to $servername"
+			Write-Verbose "Attempting to connect to $servername"
 			try
 			{
 				$server = Connect-SqlServer -SqlServer $servername -SqlCredential $SqlCredential


### PR DESCRIPTION
Fixes #517 

Tested on Windows 10, Powershell 5, SQL Server 2008R2 and Windows Server 2012R2 SQL 2016 SP1 

Changes proposed in this pull request:
 - Adding SqlCredential to Test-Dbamaxdop calls in set-DbaMaxDop
 

How to test this code: 
- [ ] Test changing maxdop with SQL Login
- [ ] Test changing maxdop with NT/Windows Auth

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

