### PR TITLE
Script analyzer fixes

### DIFF
--- a/functions/Test-DbaConnectionAuthScheme.ps1
+++ b/functions/Test-DbaConnectionAuthScheme.ps1
@@ -60,12 +60,13 @@ Returns the results of "SELECT * from sys.dm_exec_connections WHERE session_id =
 	
 #>
 	[CmdletBinding()]
+	[OutputType("System.Collections.ArrayList")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[string[]]$SqlServer,
         [Alias("Credential", "Cred")]
-		[PsCredential]$SqlCredential,
+		[System.Management.Automation.PSCredential]$SqlCredential,
 		[switch]$Kerberos,
 		[switch]$Ntlm,
 		[switch]$Detailed

--- a/functions/Test-DbaDatabaseCollation.ps1
+++ b/functions/Test-DbaDatabaseCollation.ps1
@@ -57,11 +57,12 @@ Returns db/server collation information for every database on every server liste
 	
 #>
 	[CmdletBinding()]
+	[OutputType("System.Collections.ArrayList")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[string[]]$SqlServer,
-		[PsCredential]$Credential,
+		[System.Management.Automation.PSCredential]$Credential,
 		[switch]$Detailed
 	)
 	

--- a/functions/Test-DbaDatabaseCompatibility.ps1
+++ b/functions/Test-DbaDatabaseCompatibility.ps1
@@ -57,11 +57,12 @@ Returns db/server compatibility information for every database on every server l
 	
 #>
 	[CmdletBinding()]
+	[OutputType("System.Collections.ArrayList")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[string[]]$SqlServer,
-		[PsCredential]$Credential,
+		[System.Management.Automation.PSCredential]$Credential,
 		[switch]$Detailed
 	)
 	

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -62,13 +62,13 @@ Test-DbaDatabaseOwner -SqlServer localhost -TargetLogin 'DOMAIN\account'
 Returns all databases where the owner does not match 'DOMAIN\account'. Note
 that TargetLogin must be a valid security principal that exists on the target server.
 #>
-[OutputType([Object[]])]	
+[OutputType("System.Object[]")]	
 [CmdletBinding()]
 	Param (
 		[parameter(Mandatory = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[object[]]$SqlServer,
-		[object]$SqlCredential,
+		[System.Management.Automation.PSCredential]$SqlCredential,
 		[string]$TargetLogin,
 		[Switch]$Detailed
 	)

--- a/functions/Test-DbaFullRecoveryModel.ps1
+++ b/functions/Test-DbaFullRecoveryModel.ps1
@@ -61,11 +61,12 @@ Shows all databases which actual configured recovery model is FULL and says if t
 	
 #>
 	[CmdletBinding()]
+    [OutputType("System.Collections.ArrayList")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[object[]]$SqlServer,
-        [object]$SqlCredential,
+        [System.Management.Automation.PSCredential]$SqlCredential,
         [switch]$Detailed
 	)
     DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer -SqlCredential $SqlCredential } }

--- a/functions/Test-DbaJobOwner.ps1
+++ b/functions/Test-DbaJobOwner.ps1
@@ -63,11 +63,12 @@ Returns all databases where the owner does not match DOMAIN\account. Note
 that TargetLogin must be a valid security principal that exists on the target server.
 #>
 	[CmdletBinding()]
+	[OutputType('System.Object[]')]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[object[]]$SqlServer,
-		[object]$SqlCredential,
+		[System.Management.Automation.PSCredential]$SqlCredential,
 		[string]$TargetLogin,
 		[Switch]$Detailed
 	)

--- a/functions/Test-SqlConnection.ps1
+++ b/functions/Test-SqlConnection.ps1
@@ -98,7 +98,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	$baseaddress = $sqlserver.Split("\")[0]
 	try { $instance = $sqlserver.Split("\")[1] }
 	catch { $instance = "(Default)" }
-	if ($instance -eq $null) { $instance = "(Default)" }
+	if ([string]::IsNullOrEmpty($instance)) { $instance = "(Default)" }
 	
 	if ($baseaddress -eq "." -or $baseaddress -eq $env:COMPUTERNAME)
 	{
@@ -125,8 +125,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	Write-Output "Resolving NetBIOS name"
 	try
 	{
-		$hostname = (Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=TRUE -ComputerName $ipaddr -ErrorAction SilentlyContinue).PSComputerName
-		if ($hostname -eq $null) { $hostname = (nbtstat -A $ipaddr | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim() }
+		$sessionoptions = New-CimSessionOption -Protocol DCOM
+		$CIMsession = New-CimSession -ComputerName $ipaddr -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $SqlCredential
+		$hostname = (Get-CimInstance -CimSession $CIMsession -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled=TRUE").PSComputerName
+
+		if ([string]::IsNullOrEmpty($hostname)) { $hostname = (nbtstat -A $ipaddr | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim() }
 	}
 	catch { $hostname = "Unknown" }
 	

--- a/functions/Test-SqlMigrationConstraint.ps1
+++ b/functions/Test-SqlMigrationConstraint.ps1
@@ -85,7 +85,7 @@ Test-SqlMigrationConstraint -Source sqlserver2014a -Destination sqlcluster -Data
 Only db1 database will be verified for features in use that can't be supported on the destination server
 	
 #>
-    [CmdletBinding(DefaultParameterSetName = "DbMigration", SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = "DbMigration")]
 	Param (
             [parameter(Position = 1, Mandatory = $true, ValueFromPipeline = $True)]
 		    [object]$Source,
@@ -180,7 +180,7 @@ Only db1 database will be verified for features in use that can't be supported o
                         $dbstatus = $db.Status.ToString()
                         $dbName = $db.Name
                     }
-                    Write-Host "`r`nChecking database: '$dbName'"
+                    Write-Output "`r`nChecking database: '$dbName'"
 
                     if ($dbstatus.Contains("Offline") -eq $false)
                     {
@@ -234,7 +234,6 @@ Only db1 database will be verified for features in use that can't be supported o
                 }
                 if ($dbFail)
                 {
-                    Write-Host "`r`n"
                     Write-Warning "One or more databases will fail. For more information please see: https://msdn.microsoft.com/en-us/library/cc280724(v=sql.130).aspx"
                 }
             }

--- a/functions/Watch-SqlDbLogin.ps1
+++ b/functions/Watch-SqlDbLogin.ps1
@@ -113,7 +113,7 @@ In the above example, a list of servers is generated using database instance nam
 
 #>
 		
-		if ($sqlcredential.Username -ne $null)
+		if ($sqlcredential.UserName)
 		{
 			$username = $sqlcredential.Username
 			$password = $SqlCredential.GetNetworkCredential().Password
@@ -149,7 +149,7 @@ In the above example, a list of servers is generated using database instance nam
 			try { $cmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection) }
 			catch { throw "Cannot access Central Management Server" }
 			
-			if ($SqlCmsGroups -ne $null)
+			if ($SqlCmsGroups)
 			{
 				foreach ($groupname in $SqlCmsGroups)
 				{
@@ -186,7 +186,7 @@ In the above example, a list of servers is generated using database instance nam
 			
 			
 			$procs = $server.EnumProcesses() | Where-Object { $_.Host -ne $sourceserver.ComputerNamePhysicalNetBIOS -and ![string]::IsNullOrEmpty($_.Host) }
-			$procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program } | Select Login, Host, Database, Program
+			$procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program } | Select-Object Login, Host, Database, Program
 			
 			foreach ($p in $procs)
 			{


### PR DESCRIPTION
Working through issues for the PSScriptAnalzyer rules to clean up the issue count.

Changes proposed in this pull request:
	fixes #400
 	fixes #405 
 	fixes #399 
 	fixes #398 
 	fixes #394 
 	fixes #393 
 	fixes #392 
 	fixes #391 
 	fixes #389 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers
