### PR TITLE
Set-DbaMaxMemory, adding sql credential to test cmdlet call

### DIFF
--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -86,7 +86,7 @@ of the server (think 2147483647), then pipe those to Set-DbaMaxMemory and use th
 		
 		if ($Collection -eq $null)
 		{
-			$Collection = Test-DbaMaxMemory -SqlServer $SqlServer
+			$Collection = Test-DbaMaxMemory -SqlServer $SqlServer -SqlCredential $SqlCredential
 		}
 		
 		$Collection | Add-Member -NotePropertyName OldMaxValue -NotePropertyValue 0


### PR DESCRIPTION
Fixes #525 

Tested on Windows 10, Powershell 5, SQL Server 2008R2, SQL Server 2016 

Changes proposed in this pull request:
 - Adding $sqlcredential param to the test-dbamaxmemory call so it works with SQL Logins 

How to test this code: 
- [ ] Test with Windows Auth 
- [ ] Test with SQL Login Auth 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

