### PR TITLE
Handle NULL values passed into Out-DbaDataTable

### DIFF
--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -109,7 +109,10 @@ Similar to above but $dbalist gets piped in
 				}
 				else
 				{
-					$datarow.Item($property.Name) = $property.value
+                    if($property.value.length -gt 0)
+					    {
+                            $datarow.Item($property.Name) = $property.value
+                        }
 				}
 			}
 			$datatable.Rows.Add($datarow)


### PR DESCRIPTION
When NULL values were being passed to Out-DbaDataTable through the pipe
and an error was generated.  Testing for NULL did not match.  I test for
.length instead and it works.  When the length of the property value is
0, it does not add the value to the data table row item.  The row will
then contain a NULL value for that field.