### PR TITLE
Fixed Arithmetic Overflows

### DIFF
--- a/functions/Get-DbaDatabaseFreespace.ps1
+++ b/functions/Get-DbaDatabaseFreespace.ps1
@@ -87,45 +87,45 @@ Returns database files and free space information for the db1 and db2 on localho
 				    ,f.name AS [FileName]
 				    ,fg.name AS [Filegroup] 
 				    ,f.physical_name AS [PhysicalName]
-				    ,CAST(CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS DECIMAL(15,2)) as [UsedSpaceMB]
-				    ,CAST(f.size/128.0 - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS DECIMAL(15,2)) AS [FreeSpaceMB]
-				    ,CAST((f.size/128.0) AS DECIMAL(15,2)) AS [FileSizeMB]
-				    ,CAST((FILEPROPERTY(f.name, 'SpaceUsed')/(f.size/1.0)) * 100 as DECIMAL(15,2)) as [PercentUsed]
-					,CAST((f.growth/128.0) AS DECIMAL(15,2)) AS [GrowthMB]
+				    ,CAST(CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS FLOAT) as [UsedSpaceMB]
+				    ,CAST(f.size/128.0 - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS FLOAT) AS [FreeSpaceMB]
+				    ,CAST((f.size/128.0) AS FLOAT) AS [FileSizeMB]
+				    ,CAST((FILEPROPERTY(f.name, 'SpaceUsed')/(f.size/1.0)) * 100 as FLOAT) as [PercentUsed]
+					,CAST((f.growth/128.0) AS FLOAT) AS [GrowthMB]
 					,CASE is_percent_growth WHEN 1 THEN 'pct' WHEN 0 THEN 'MB' ELSE 'Unknown' END AS [GrowthType]
-					,CASE f.max_size WHEN -1 THEN 2147483648. ELSE CAST((f.max_size/128.0) AS DECIMAL(15,2)) END AS [MaxSizeMB]
-					,CAST((f.size/128.0) AS DECIMAL(15,2)) - CAST(CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS DECIMAL(15,2)) AS [SpaceBeforeAutoGrow]
+					,CASE f.max_size WHEN -1 THEN 2147483648. ELSE CAST((f.max_size/128.0) AS FLOAT) END AS [MaxSizeMB]
+					,CAST((f.size/128.0) AS FLOAT) - CAST(CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int)/128.0 AS FLOAT) AS [SpaceBeforeAutoGrow]
 					,CASE f.max_size	WHEN (-1)
-										THEN CAST(((2147483648.) - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS DECIMAL(15,2))
-										ELSE CAST((f.max_size - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS DECIMAL(15,2))
+										THEN CAST(((2147483648.) - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
+										ELSE CAST((f.max_size - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
 										END AS [SpaceBeforeMax]
 					,CASE f.growth	WHEN 0 THEN 0.00
 									ELSE	CASE f.is_percent_growth	WHEN 0
 													THEN	CASE f.max_size
 															WHEN (-1)
-															THEN CAST(((((2147483648.)-f.Size)/f.Growth)*f.Growth)/128.0 AS DECIMAL(15,2))
-															ELSE CAST((((f.max_size-f.Size)/f.Growth)*f.Growth)/128.0 AS DECIMAL(15,2))
+															THEN CAST(((((2147483648.)-f.Size)/f.Growth)*f.Growth)/128.0 AS FLOAT)
+															ELSE CAST((((f.max_size-f.Size)/f.Growth)*f.Growth)/128.0 AS FLOAT)
 															END
 													WHEN 1
 													THEN	CASE f.max_size
 															WHEN (-1)
-															THEN CAST(CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],(2147483648.))/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))/128.0 AS DECIMAL(15,2))
-															ELSE CAST(CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],f.Max_Size)/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))/128.0 AS DECIMAL(15,2))
+															THEN CAST(CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],(2147483648.))/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))/128.0 AS FLOAT)
+															ELSE CAST(CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],f.Max_Size)/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))/128.0 AS FLOAT)
 															END
 													ELSE (0)
 													END
 									END AS [PossibleAutoGrowthMB]
 					, CASE f.growth	WHEN 0 THEN	CASE f.max_size
 												WHEN (-1)
-												THEN CAST(((2147483648.) - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS DECIMAL(15,2))
-												ELSE CAST((f.max_size - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS DECIMAL(15,2))
+												THEN CAST(((2147483648.) - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
+												ELSE CAST((f.max_size - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
 												END
 									ELSE CAST((f.max_size - f.size - (	CASE f.is_percent_growth
 												WHEN 0
 												THEN	CASE f.max_size
 														WHEN (-1)
-														THEN ((((2147483648.)-f.Size)/f.Growth)*f.Growth)
-														ELSE (((f.max_size-f.Size)/f.Growth)*f.Growth)
+														THEN CONVERT(FLOAT,((((2147483648.)-f.Size)/f.Growth)*f.Growth))
+														ELSE CONVERT(FLOAT,(((f.max_size-f.Size)/f.Growth)*f.Growth))
 														END
 												WHEN 1
 												THEN	CASE f.max_size
@@ -134,7 +134,7 @@ Returns database files and free space information for the db1 and db2 on localho
 														ELSE CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],f.Max_Size)/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))
 														END
 														ELSE (0)
-														END ))/128.0 AS DECIMAL(15,2))
+														END ))/128.0 AS FLOAT)
 									END AS [UnusableSpaceMB]
  
 				FROM sys.database_files AS f WITH (NOLOCK) 
@@ -186,6 +186,7 @@ Returns database files and free space information for the db1 and db2 on localho
 				try
 				{
 					Write-Verbose "Querying $($s) - $($db.name)."
+                    #write-debug $sql
 					#Execute query against individual database and add to output
 					$outputraw += ($db.ExecuteWithResults($sql)).Tables[0]
 				}
@@ -211,15 +212,15 @@ Returns database files and free space information for the db1 and db2 on localho
 				'FileName' = $row.FileName;`
 				'FileGroup' = $row.FileGroup;`
 				'PhysicalName' = $row.PhysicalName;`
-				'UsedSpaceMB' = $row.UsedSpaceMB;`
-				'FreeSpaceMB' = $row.FreeSpaceMB;`
+				'UsedSpaceMB' = [Math]::Round($row.UsedSpaceMB,2);`
+				'FreeSpaceMB' = [Math]::Round($row.FreeSpaceMB,2);`
 				'FileSizeMB' = $row.FileSizeMB;`
-				'PercentUsed' = $row.PercentUSed;`
+				'PercentUsed' = [Math]::Round($row.PercentUsed,2);`
 				'AutoGrowth' = $row.GrowthMB;`
 				'AutoGrowType' = $row.GrowthType;`
-				'SpaceUntilMaxSizeMB' = $row.SpaceBeforeMax;`
+				'SpaceUntilMaxSizeMB' = [Math]::Round($row.SpaceBeforeMax,2);`
 				'AutoGrowthPossibleMB' = $row.PossibleAutoGrowthMB;`
-				'UnusableSpaceMB' = $row.UnusableSpaceMB
+				'UnusableSpaceMB' = [Math]::Round($row.UnusableSpaceMB,2)
 			}
 			$output += New-Object psobject -Property $outrow
 		}


### PR DESCRIPTION
Some of my SQL Servers were causing arithmetic overflows grabbing the
space information.  The issue was in the SQL query itself.  I tried
changing Decimal(15,2) all the way up to (38,2) but it would not correct
the issue.  I chagned the decimals to floats.  Also there was a case
statement missing the converts that I had to add in UnusableSpaceMD.
This seems to work now on my servers.