### PR TITLE
Get-DbaDatabaseFreespace, added Try block to server connect & fixed bug with NULL Sizes

### DIFF
--- a/functions/Get-DbaDatabaseFreespace.ps1
+++ b/functions/Get-DbaDatabaseFreespace.ps1
@@ -228,8 +228,8 @@ Returns database files and free space information for the db1 and db2 on localho
             If ($row.UnusableSpaceMB -is [System.DBNull]) { $UnusableSpace = 0 } Else { $UnusableSpace = [Math]::Round($row.UnusableSpaceMB) }
 
 			$outrow = [ordered]@{
-				'SqlServer' = $row.SqlServer;`
-				'DatabaseName' = $row.DBName;`
+				'Server' = $row.SqlServer;`
+				'Database' = $row.DBName;`
 				'FileName' = $row.FileName;`
 				'FileGroup' = $row.FileGroup;`
 				'PhysicalName' = $row.PhysicalName;`


### PR DESCRIPTION
The server connect code was not in a try block.  Script would crash out
if it couldn't find the server.  Also, sometimes Full Text indexes would
return NULL values for size information.  The previous code was reusing values that were not
correct.  I had to check for NULL then set to zero.  The introduction of
a Round function on a previous update also threw errors with NULL
values.