### PR TITLE
Initial commit of Get-DbaPageFileSetting

### DIFF
--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -48,7 +48,7 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 BEGIN {}
 PROCESS
     {
-        foreach ($Computer in $ComputerName)
+        foreach ( $Computer in $ComputerName )
         {
 			$reply = Resolve-DbaNetworkName -ComputerName $Computer -erroraction silentlycontinue
             if ( $reply.ComputerName ) # we can reach $computer
@@ -59,9 +59,10 @@ PROCESS
                 if ( $CompSys ) # we have computersystem class via WSMan
                 {
                     Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via WSMan"
-                    if ( $CompSys.automaticmanagedpagefile ) # pagefile exists on $computer
+                    if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
+                    $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile"
                     {
-                        if ($CompSys.automaticmanagedpagefile -eq $False) # pagefile is not automatically managed, so get settings via WSMan
+                        if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via WSMan
                         {
                             $PF = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefile" # deprecated !
                             $PFU = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefileUsage"
@@ -84,10 +85,10 @@ PROCESS
                     if ( $CompSys ) # we have computersystem class via DCom
                     {
                         Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via WSMan"
-                        if ( $CompSys.automaticmanagedpagefile ) # pagefile exists on $computer
+                        if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
                         {
                             Write-Verbose "Successfully retrieved PageFile information on $Computer via DCom"
-                            if ($CompSys.automaticmanagedpagefile -eq $False) # pagefile is not automatically managed, so get settings via DCom CimSession
+                            if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via DCom CimSession
                             {
                                 $PF = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefile" # deprecated !
                                 $PFU = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefileUsage"
@@ -106,7 +107,7 @@ PROCESS
                         continue
 			        }
                 }
-                if ($CompSys.automaticmanagedpagefile -eq $False) # pagefile is not automatic managed, so return settings
+                if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatic managed, so return settings
                 {
                     [PSCustomObject]@{
                                 'ComputerName' = $Computer;

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -60,7 +60,6 @@ PROCESS
                 {
                     Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via WSMan"
                     if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
-                    $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile"
                     {
                         if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via WSMan
                         {

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -43,7 +43,7 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 		[Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
 		[Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
 		[object]$ComputerName,
-		[PsCredential]$Credential
+		[PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential
 	)
 	BEGIN {}
 	PROCESS {

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -45,8 +45,8 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 		[object]$ComputerName,
 		[PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential
 	)
-	BEGIN {}
-	PROCESS {
+BEGIN {}
+PROCESS {
         foreach ($Computer in $ComputerName)
         {
             Write-Verbose "Connecting to $Computer"
@@ -56,7 +56,7 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
                 $computer = $reply.ComputerName
             }
             Write-Verbose "Connecting to $Computer via CIM (WSMan)"
-            $CompSys = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr -Credential $Credential
+            $CompSys = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr
             if ( $CompSys )
             {
                 Write-Verbose "Successfully retrieved PageFile information on $Computer via WSMan"
@@ -88,8 +88,8 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
                     }
                     else
                     {
-                    Write-Warning "$computer Operating System too old. No Pagefile information available."
-                    continue
+                        Write-Warning "$computer Operating System too old. No Pagefile information available."
+                        continue
                     }
                 }
 			    else
@@ -132,5 +132,8 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
             }
         }
 	}
-	END {}
+
+END {
+        Get-CimSession | Remove-CimSession
+    }
 }

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -58,9 +58,10 @@ PROCESS
                 $CompSys = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr
                 if ( $CompSys ) # we have computersystem class via WSMan
                 {
-                    Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via WSMan"
+                    Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via CIM (WSMan)"
                     if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
                     {
+                        Write-Verbose "Successfully retrieved PageFile information on $Computer via CIM (WSMan)"
                         if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via WSMan
                         {
                             $PF = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefile" # deprecated !
@@ -83,10 +84,10 @@ PROCESS
                     $CompSys = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr
                     if ( $CompSys ) # we have computersystem class via DCom
                     {
-                        Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via WSMan"
+                        Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via CIM (DCOM)"
                         if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
                         {
-                            Write-Verbose "Successfully retrieved PageFile information on $Computer via DCom"
+                            Write-Verbose "Successfully retrieved PageFile information on $Computer via CIM (DCOM)"
                             if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via DCom CimSession
                             {
                                 $PF = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefile" # deprecated !

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -130,10 +130,9 @@ PROCESS {
                             'CurrentUsage' = "";
                             }
             }
+        Remove-CimSession $CIMsession
         }
 	}
 
-END {
-        Get-CimSession | Remove-CimSession
-    }
+END {}
 }

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -1,0 +1,136 @@
+﻿Function Get-DbaPageFileSetting {
+<#
+.SYNOPSIS
+Returns information about the network connection of the target computer including NetBIOS name, IP Address, domain name and fully qualified domain name (FQDN).
+
+.DESCRIPTION
+   WMI class Win32_ComputerSystem tells us if Page File is managed automatically.
+   If TRUE all other properties do not exist.
+   If FALSE classes Win32_PageFile, Win32_PageFileSetting en Win32_PageFileUsage are examined.
+   CIM is used, first via WinRM, and if not successful, via DCOM.
+
+.PARAMETER ComputerName
+The Server that you're connecting to.
+This can be the name of a computer, a SMO object, an IP address or a SQL Instance.
+
+.PARAMETER Credential
+Credential object used to connect to the Computer as a different user
+
+.NOTES
+Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+
+dbatools PowerShell module (https://dbatools.io)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+
+.LINK
+ https://dbatools.io/Get-DbaPageFileSetting
+
+.EXAMPLE
+Get-DbaPageFileSetting -ComputerName ServerA,ServerB
+
+Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status, LastModified, LastAccessed, AllocatedBaseSize, InitialSize, MaximumSize, PeakUsage, CurrentUsage  for ServerA and ServerB
+
+.EXAMPLE
+ ServerA | Get-DbaPageFileSetting
+
+Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status, LastModified, LastAccessed, AllocatedBaseSize, InitialSize, MaximumSize, PeakUsage, CurrentUsage  for ServerA
+
+#>[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+		[Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
+		[object]$ComputerName,
+		[PsCredential]$Credential
+	)
+	BEGIN {}
+	PROCESS {
+        foreach ($Computer in $ComputerName)
+        {
+            Write-Verbose "Connecting to $Computer"
+			$reply = Resolve-DbaNetworkName -ComputerName $Computer -erroraction silentlycontinue
+            if ( $reply.ComputerName )
+            {
+                $computer = $reply.ComputerName
+            }
+            Write-Verbose "Connecting to $Computer via CIM (WSMan)"
+            $CompSys = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr -Credential $Credential
+            if ( $CompSys )
+            {
+                Write-Verbose "Successfully retrieved PageFile information on $Computer via WSMan"
+                if ($CompSys.automaticmanagedpagefile -eq $False)
+                {
+                    $PF = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefile" # deprecated !
+                    $PFU = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefileUsage"
+                    $PFS = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefileSetting"
+                }
+            }
+			else
+            {
+				Write-Verbose "No WSMan connection to $Computer"
+                Write-Verbose "Getting computer information from server $Computer via CIM (DCOM)"
+			    $sessionoption = New-CimSessionOption -Protocol DCOM
+			    $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -Credential $Credential
+                $CompSys = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_computersystem" -ErrorVariable $MyErr
+                if ( $CompSys )
+                {
+                    if ( $CompSys.automaticmanagedpagefile )
+                    {
+                        Write-Verbose "Successfully retrieved PageFile information on $Computer via DCom"
+                        if ($CompSys.automaticmanagedpagefile -eq $False)
+                        {
+                            $PF = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefile" # deprecated !
+                            $PFU = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefileUsage"
+                            $PFS = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefileSetting"
+                        }
+                    }
+                    else
+                    {
+                    Write-Warning "$computer Operating System too old. No Pagefile information available."
+                    continue
+                    }
+                }
+			    else
+			    {
+				    Write-Warning "No WSMan nor DCom connection to $Computer"
+                    continue
+			    }
+            }
+            if ($CompSys.automaticmanagedpagefile -eq $False)
+            {
+                [PSCustomObject]@{
+                            'ComputerName' = $Computer;
+                            'AutoPageFile' = $CompSys.automaticmanagedpagefile;
+                            'FileName' = $PF.name; # deprecated !
+                            'Status' = $PF.status; # deprecated !
+                            'LastModified' = $PF.LastModified;
+                            'LastAccessed' = $PF.LastAccessed;
+                            'AllocatedBaseSize' = $PFU.AllocatedBaseSize; # in MB, between Initial and Maximum Size
+                            'InitialSize' = $PFS.InitialSize; # in MB
+                            'MaximumSize' = $PFS.MaximumSize; # in MB
+                            'PeakUsage' = $PFU.peakusage; # in MB
+                            'CurrentUsage' = $PFU.currentusage; # in MB
+                            }
+            }
+            else
+            {
+                [PSCustomObject]@{
+                            'ComputerName' = $Computer;
+                            'AutoPageFile' = $CompSys.automaticmanagedpagefile;
+                            'FileName' = "";
+                            'Status' = "";
+                            'LastModified' = "";
+                            'LastAccessed' = "";
+                            'AllocatedBaseSize' = "";
+                            'InitialSize' = "";
+                            'MaximumSize' = "";
+                            'PeakUsage' = "";
+                            'CurrentUsage' = "";
+                            }
+            }
+        }
+	}
+	END {}
+}

--- a/tests/Get-DbaPagefileSetting.Tests.ps1
+++ b/tests/Get-DbaPagefileSetting.Tests.ps1
@@ -1,0 +1,41 @@
+﻿#Thank you Warren http://ramblingcookiemonster.github.io/Testing-DSC-with-Pester-and-AppVeyor/
+
+if(-not $PSScriptRoot)
+{
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+$Verbose = @{}
+if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
+{
+    $Verbose.add("Verbose",$True)
+}
+
+
+
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace('.Tests.', '.')
+Import-Module $PSScriptRoot\..\functions\$sut -Force
+Import-Module PSScriptAnalyzer
+## Added PSAvoidUsingPlainTextForPassword as credential is an object and therefore fails. We can ignore any rules here under special circumstances agreed by admins :-)
+$Rules = (Get-ScriptAnalyzerRule).Where{$_.RuleName -notin ('PSAvoidUsingPlainTextForPassword') }
+$Name = $sut.Split('.')[0]
+
+    Describe 'Script Analyzer Tests' {
+            Context "Testing $Name for Standard Processing" {
+                foreach ($rule in $rules) { 
+                    $i = $rules.IndexOf($rule)
+                    It "passes the PSScriptAnalyzer Rule number $i - $rule  " {
+                        (Invoke-ScriptAnalyzer -Path "$PSScriptRoot\..\functions\$sut" -IncludeRule $rule.RuleName ).Count | Should Be 0 
+                    }
+                }
+            }
+        }
+   ## needs some proper tests for the function here
+    Describe "$Name Tests"{
+        Context "Some Tests" {
+              It "Should have some Pester Tests added" {
+                  $true | Should Be $true
+              }
+		}
+    }
+    
+    


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

