### PR TITLE
Test-DbaDatabaseFreespace - Sql200 is not supported, Skip over without breaking loop

### DIFF
--- a/functions/Get-DbaDatabaseFreespace.ps1
+++ b/functions/Get-DbaDatabaseFreespace.ps1
@@ -104,10 +104,19 @@ Returns database files and free space information for the db1 and db2 on localho
 		foreach ($s in $SqlServer)
 		{
 			#For each SQL Server in collection, connect and get SMO object
+
+			
+
 			Write-Verbose "Connecting to $s"
 			$server = Connect-SqlServer $s -SqlCredential $SqlCredential
 			#If IncludeSystemDBs is true, include systemdbs
 			#only look at online databases (Status equal normal)
+
+			if ($server.VersionMajor -eq '8'){
+				Write-Warning "SQL Server 2000 is not supported. Skipping: $($server.Name)"
+				continue
+			}
+
 			try
 			{
 				if ($databases.length -gt 0)

--- a/functions/Get-DbaDatabaseFreespace.ps1
+++ b/functions/Get-DbaDatabaseFreespace.ps1
@@ -104,9 +104,6 @@ Returns database files and free space information for the db1 and db2 on localho
 		foreach ($s in $SqlServer)
 		{
 			#For each SQL Server in collection, connect and get SMO object
-
-			
-
 			Write-Verbose "Connecting to $s"
 			$server = Connect-SqlServer $s -SqlCredential $SqlCredential
 			#If IncludeSystemDBs is true, include systemdbs


### PR DESCRIPTION
Fixes #529 
Tested on Windows 10, powershell 5, against sql2000, 2005, 2012, 2016 

Changes proposed in this pull request:
 - adds an if for version 8 and skips over sql2000 without breaking the loop 

How to test this code: 
- [ ] Test with Windows Auth, against sql2000. Best if there are multiple servers 
- [ ] Test with SQL Login Auth, against sql2000. Best if there are multiple servers 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

