### PR TITLE
Initial commit of Get-DbaAgentOperator

### DIFF
--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -1,0 +1,87 @@
+﻿FUNCTION Get-DbaAgentOperator
+{
+<#
+.SYNOPSIS
+Returns all SQL Agent operators on a SQL Server Agent.
+
+.DESCRIPTION
+This function returns SQL Agent operators.
+
+.PARAMETER SqlServer
+SQLServer name or SMO object representing the SQL Server to connect to.
+This can be a collection and receive pipeline input.
+
+.PARAMETER SqlCredential
+PSCredential object to connect as. If not specified, currend Windows login will be used.
+
+.NOTES 
+Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+Date: 2017-01-16
+
+dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.	
+
+.LINK
+https://dbatools.io/Get-DbaAgentOperator
+
+.EXAMPLE
+Get-DbaAgentOperator -SqlServer ServerA,ServerB\instanceB
+Returns any SQL Agent operators on serverA and serverB\instanceB
+
+.EXAMPLE
+'serverA','serverB\instanceB' | Get-DbaAgentOperator
+Returns all SQL Agent operators  on serverA and serverB\instanceB
+
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "Instance", "SqlServer")]
+		[string[]]$SqlInstance,
+		[PSCredential] [System.Management.Automation.CredentialAttribute()]$SqlCredential
+	)
+	BEGIN {}
+	PROCESS
+	{
+		foreach ($Instance in $SqlInstance)
+		{
+			try
+			{
+				$Instance = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to $Instance"
+				continue
+			}
+			
+			$operators = $Instance.jobserver.operators
+			
+			if (!$operators)
+			{
+				Write-Verbose "No operators on $Instance"
+			}
+			else
+			{
+				foreach ($operator in $operators)
+				{
+					[pscustomobject]@{
+                        ComputerName = $Instance.NetName
+						InstanceName = $Instance.ServiceName
+                        SqlInstance = $Instance.Name
+                        OperatorID = $operator.ID
+                        IsEnabled = $operator.Enabled
+                        EmailAddress = $operator.EmailAddress
+                        LastEmailDate = $operator.LastEmailDate
+					}
+				}
+			}
+		}
+	}
+	END	{}
+}

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -48,11 +48,11 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 BEGIN {}
 PROCESS
 	{
-		foreach ( $Instance in $SqlInstance )
+		foreach ($Instance in $SqlInstance)
 		{
-            Write-Verbose "Connecting to $Instance"
 			try
 			{
+                Write-Verbose "Connecting to $Instance"
 				$Instance = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
 			}
 			catch
@@ -60,18 +60,14 @@ PROCESS
 				Write-Warning "Failed to connect to $Instance"
 				continue
 			}
-            Write-Verbose "Connecting to SQL Agent on $Instance"
-			try
-			{
-				$Jobserver = $Instance.jobserver
-			}
-			catch
-			{
-				Write-Warning "Failed to connect to SQL Agent on $Instance"
-				continue
-			}
-		    Write-Verbose "Getting SQL Agent operators on $Instance"
-			$operators = $Jobserver.operators
+            Write-Verbose "Getting Edition from $($Instance.Name)"
+            Write-Verbose "$($Instance.Name) is a $($Instance.Edition)"
+			if ( $Instance.Edition -like 'Express*' )
+            {
+            Write-Warning "There is no SQL Agent on $($Instance.Name) , it's a $($Instance.Edition)"
+            continue
+            }
+			$operators = $instance.Jobserver.operators
 			
 			if ( $operators.count -lt 1 )
 			{

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -45,11 +45,12 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 		[string[]]$SqlInstance,
 		[PSCredential] [System.Management.Automation.CredentialAttribute()]$SqlCredential
 	)
-	BEGIN {}
-	PROCESS
+BEGIN {}
+PROCESS
 	{
-		foreach ($Instance in $SqlInstance)
+		foreach ( $Instance in $SqlInstance )
 		{
+            Write-Verbose "Connecting to $Instance"
 			try
 			{
 				$Instance = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
@@ -59,16 +60,26 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 				Write-Warning "Failed to connect to $Instance"
 				continue
 			}
+            Write-Verbose "Connecting to SQL Agent on $Instance"
+			try
+			{
+				$Jobserver = $Instance.jobserver
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to SQL Agent on $Instance"
+				continue
+			}
+		    Write-Verbose "Getting SQL Agent operators on $Instance"
+			$operators = $Jobserver.operators
 			
-			$operators = $Instance.jobserver.operators
-			
-			if (!$operators)
+			if ( $operators.count -lt 1 )
 			{
 				Write-Verbose "No operators on $Instance"
 			}
 			else
 			{
-				foreach ($operator in $operators)
+				foreach ( $operator in $operators )
 				{
 					[pscustomobject]@{
                         ComputerName = $Instance.NetName
@@ -83,5 +94,5 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 			}
 		}
 	}
-	END	{}
+END	{}
 }

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -1,0 +1,41 @@
+﻿#Thank you Warren http://ramblingcookiemonster.github.io/Testing-DSC-with-Pester-and-AppVeyor/
+
+if(-not $PSScriptRoot)
+{
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+$Verbose = @{}
+if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
+{
+    $Verbose.add("Verbose",$True)
+}
+
+
+
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace('.Tests.', '.')
+Import-Module $PSScriptRoot\..\functions\$sut -Force
+Import-Module PSScriptAnalyzer
+## Added PSAvoidUsingPlainTextForPassword as credential is an object and therefore fails. We can ignore any rules here under special circumstances agreed by admins :-)
+$Rules = (Get-ScriptAnalyzerRule).Where{$_.RuleName -notin ('PSAvoidUsingPlainTextForPassword') }
+$Name = $sut.Split('.')[0]
+
+    Describe 'Script Analyzer Tests' {
+            Context "Testing $Name for Standard Processing" {
+                foreach ($rule in $rules) { 
+                    $i = $rules.IndexOf($rule)
+                    It "passes the PSScriptAnalyzer Rule number $i - $rule  " {
+                        (Invoke-ScriptAnalyzer -Path "$PSScriptRoot\..\functions\$sut" -IncludeRule $rule.RuleName ).Count | Should Be 0 
+                    }
+                }
+            }
+        }
+   ## needs some proper tests for the function here
+    Describe "$Name Tests"{
+        Context "Some Tests" {
+              It "Should have some Pester Tests added" {
+                  $true | Should Be $true
+              }
+		}
+    }
+    
+    


### PR DESCRIPTION
Changes proposed in this pull request:
 - New function to list the SQL Agent Operators
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers

