### PR TITLE
Test-DbaVirtualLogFile, fixes #465

### DIFF
--- a/functions/Test-DbaVirtualLogFile.ps1
+++ b/functions/Test-DbaVirtualLogFile.ps1
@@ -67,7 +67,7 @@ Test-DbaVirtualLogFile -SqlServer sqlcluster -Databases db1, db2
 Returns VLF counts for the db1 and db2 databases on sqlcluster.
 #>
 	[CmdletBinding()]
-    [OutputType([System.Collections.ArrayList])]
+	[OutputType([System.Collections.ArrayList])]
 	param ([parameter(ValueFromPipeline, Mandatory = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
 		[object[]]$SqlServer,
@@ -76,7 +76,7 @@ Returns VLF counts for the db1 and db2 databases on sqlcluster.
 		[switch]$Detailed
 	)
 
-	DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $SourceSqlCredential } }
+	DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $SqlCredential } }
 
 	BEGIN
 	{
@@ -91,35 +91,35 @@ Returns VLF counts for the db1 and db2 databases on sqlcluster.
 		{
 			#For each SQL Server in collection, connect and get SMO object
 			Write-Verbose "Connecting to $servername"
-			$server = Connect-SqlServer $servername -SqlCredential $SqlCredential
-
-			#If IncludeSystemDBs is true, include systemdbs
-			#only look at online databases (Status equal normal)
-			try
-			{
-				if ($databases.length -gt 0)
-				{
-					$dbs = $server.Databases | Where-Object { $databases -contains $_.Name }
-				}
-				elseif ($IncludeSystemDBs)
-				{
-					$dbs = $server.Databases | Where-Object { $_.status -eq 'Normal' }
-				}
-				else
-				{
-					$dbs = $server.Databases | Where-Object { $_.status -eq 'Normal' -and $_.IsSystemObject -eq 0 }
-				}
-
-				if ($exclude.length -gt 0)
-				{
-					$dbs = $dbs | Where-Object { $exclude -notcontains $_.Name }
-				}
+			try {
+				$server = Connect-SqlServer $servername -SqlCredential $SqlCredential
 			}
 			catch
 			{
-				Write-Exception $_
-				Write-Warning "Unable to gather dbs for $servername"
-				continue
+				Write-Warning "Can't connect to $instance, skipping..."
+				Continue
+			}
+
+			$dbs = $server.Databases
+			#If IncludeSystemDBs is true, include systemdbs
+			#only look at online databases (Status equal normal)
+
+			if ($databases.count -gt 0)
+			{
+				$dbs = $dbs | Where-Object { $databases -contains $_.Name }
+			}
+			if ($exclude.count -gt 0)
+			{
+				$dbs = $dbs | Where-Object { $exclude -notcontains $_.Name }
+			}
+
+			if ($IncludeSystemDBs)
+			{
+				$dbs = $dbs | Where-Object { $_.status -eq 'Normal' }
+			}
+			else
+			{
+				$dbs = $dbs | Where-Object { $_.status -eq 'Normal' -and $_.IsSystemObject -eq 0 }
 			}
 
 			foreach ($db in $dbs)


### PR DESCRIPTION
Fixes #465

Changes proposed in this pull request:
 - the credential parameter is correctly passed down to dynamicparams
 - the filtering is done ANDing -Exclude and -Database, and then filtering out OFFLINE databases. Then the logic to keep out system dbs kicks in. Before you could easily trigger an exception passing -Databases an_offline_db

Everything that'll be "stylistic" is left intentionally out of this PR, waiting for the final directions before doing anything

How to test this code: 
- [ ] if Test-DbaVirtualLogFile has been already properly tested, this just fixes a small bit. Just redo all of them just to confirm nothing blows up

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

