### PR TITLE
Account for when port number is added to SQL Instance with a colon. Fixes #354

### DIFF
--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -94,7 +94,7 @@ filled with database list from specified SQL Server server.
 	{
 		if ($NoSystem)
 		{
-			if (!($database.IsSystemObject -and $SupportDbs) -notcontains $database.name)
+			if (!($database.IsSystemObject) -and $SupportDbs -notcontains $database.name)
 			{
 				$databaselist += $database.name
 			}


### PR DESCRIPTION
@ConstantineK slowly but surely getting the handle of this I think. What do you think of this mess that is my code :tada: 

Fixes #354

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

