### PR TITLE
Fix get-dbarolemember

### DIFF
--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -1,0 +1,87 @@
+﻿FUNCTION Get-DbaAgentOperator
+{
+<#
+.SYNOPSIS
+Returns all SQL Agent operators on a SQL Server Agent.
+
+.DESCRIPTION
+This function returns SQL Agent operators.
+
+.PARAMETER SqlServer
+SQLServer name or SMO object representing the SQL Server to connect to.
+This can be a collection and receive pipeline input.
+
+.PARAMETER SqlCredential
+PSCredential object to connect as. If not specified, currend Windows login will be used.
+
+.NOTES 
+Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+Date: 2017-01-16
+
+dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+Copyright (C) 2016 Chrissy LeMaire
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.	
+
+.LINK
+https://dbatools.io/Get-DbaAgentOperator
+
+.EXAMPLE
+Get-DbaAgentOperator -SqlServer ServerA,ServerB\instanceB
+Returns any SQL Agent operators on serverA and serverB\instanceB
+
+.EXAMPLE
+'serverA','serverB\instanceB' | Get-DbaAgentOperator
+Returns all SQL Agent operators  on serverA and serverB\instanceB
+
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "Instance", "SqlServer")]
+		[string[]]$SqlInstance,
+		[PSCredential] [System.Management.Automation.CredentialAttribute()]$SqlCredential
+	)
+	BEGIN {}
+	PROCESS
+	{
+		foreach ($Instance in $SqlInstance)
+		{
+			try
+			{
+				$Instance = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to $Instance"
+				continue
+			}
+			
+			$operators = $Instance.jobserver.operators
+			
+			if (!$operators)
+			{
+				Write-Verbose "No operators on $Instance"
+			}
+			else
+			{
+				foreach ($operator in $operators)
+				{
+					[pscustomobject]@{
+                        ComputerName = $Instance.NetName
+						InstanceName = $Instance.ServiceName
+                        SqlInstance = $Instance.Name
+                        OperatorID = $operator.ID
+                        IsEnabled = $operator.Enabled
+                        EmailAddress = $operator.EmailAddress
+                        LastEmailDate = $operator.LastEmailDate
+					}
+				}
+			}
+		}
+	}
+	END	{}
+}

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -45,11 +45,12 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 		[string[]]$SqlInstance,
 		[PSCredential] [System.Management.Automation.CredentialAttribute()]$SqlCredential
 	)
-	BEGIN {}
-	PROCESS
+BEGIN {}
+PROCESS
 	{
-		foreach ($Instance in $SqlInstance)
+		foreach ( $Instance in $SqlInstance )
 		{
+            Write-Verbose "Connecting to $Instance"
 			try
 			{
 				$Instance = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
@@ -59,16 +60,26 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 				Write-Warning "Failed to connect to $Instance"
 				continue
 			}
+            Write-Verbose "Connecting to SQL Agent on $Instance"
+			try
+			{
+				$Jobserver = $Instance.jobserver
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to SQL Agent on $Instance"
+				continue
+			}
+		    Write-Verbose "Getting SQL Agent operators on $Instance"
+			$operators = $Jobserver.operators
 			
-			$operators = $Instance.jobserver.operators
-			
-			if (!$operators)
+			if ( $operators.count -lt 1 )
 			{
 				Write-Verbose "No operators on $Instance"
 			}
 			else
 			{
-				foreach ($operator in $operators)
+				foreach ( $operator in $operators )
 				{
 					[pscustomobject]@{
                         ComputerName = $Instance.NetName
@@ -83,5 +94,5 @@ Returns all SQL Agent operators  on serverA and serverB\instanceB
 			}
 		}
 	}
-	END	{}
+END	{}
 }

--- a/functions/Get-DbaRoleMember.ps1
+++ b/functions/Get-DbaRoleMember.ps1
@@ -74,84 +74,86 @@ Returns a gridview displaying SQLServer, Database, Role, Member for both ServerR
 		}
 	}
 	
-	BEGIN
-	{
+BEGIN
+    {
 		$databases = $psboundparameters.Databases
 	}
 	
-	PROCESS
+PROCESS
 	{
-		foreach ($instance in $sqlinstance)
-		{
-			$server = $null
-			$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlCredential
-			if ($Server.count -eq 1)
+        foreach ($instance in $sqlinstance)
+        {
+            Write-Verbose "Connecting to $Instance"
+			try
 			{
-				if ($IncludeServerLevel)
+				$server = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to $Instance"
+				continue
+			}
+
+			if ($IncludeServerLevel)
+			{
+				Write-Verbose "Server Role Members included"
+				$instroles = $null
+				Write-Verbose "Getting Server Roles on $instance"
+				$instroles = $server.roles
+				if ($NoFixedRole)
 				{
-					Write-Verbose "Server Role Members included"
-					$instroles = $null
-					Write-Verbose "Getting Server Roles on $instance"
-					$instroles = $server.roles
-					if ($NoFixedRole)
-					{
-						$instroles = $instroles | Where-Object { $_.isfixedrole -eq $false }
-					}
-					ForEach ($instrole in $instroles)
-					{
-						Write-Verbose "Getting Server Role Members for $instrole on $instance"
-						$irmembers = $null
-						$irmembers = $instrole.enumserverrolemembers()
-						ForEach ($irmem in $irmembers)
-						{
-							[PSCustomObject]@{
-								SQLInstance = $instance
-								Database = $null
-								Role = $instrole.name
-								Member = $irmem.tostring()
-							}
-						}
-					}
+					$instroles = $instroles | Where-Object { $_.isfixedrole -eq $false }
 				}
-				
-				$dbs = $server.Databases
-				
-				if ($databases.count -gt 0)
+				ForEach ($instrole in $instroles)
 				{
-					$dbs = $dbs | Where-Object { $databases -contains $_.Name  }
-				}
-				
-				foreach ($db in $dbs)
-				{
-					$dbroles = $db.roles
-					Write-Verbose "Getting Database Roles for $($db.name) on $instance"
-					
-					if ($NoFixedRole)
+					Write-Verbose "Getting Server Role Members for $instrole on $instance"
+					$irmembers = $null
+					$irmembers = $instrole.enumserverrolemembers()
+					ForEach ($irmem in $irmembers)
 					{
-						$dbroles = $dbroles | Where-Object { $_.isfixedrole -eq $false }
-					}
-					
-					foreach ($dbrole in $dbroles)
-					{
-						Write-Verbose "Getting Database Role Members for $dbrole in $($db.name) on $instance"
-						$dbmembers = $dbrole.enummembers()
-						ForEach ($dbmem in $dbmembers)
-						{
-							[PSCustomObject]@{
-								SqlInstance = $instance
-								Database = $db.name
-								Role = $dbrole.name
-								Member = $dbmem.tostring()
-							}
+						[PSCustomObject]@{
+							SQLInstance = $instance
+							Database = $null
+							Role = $instrole.name
+							Member = $irmem.tostring()
 						}
 					}
 				}
 			}
-			else
+				
+			$dbs = $server.Databases
+				
+			if ($databases.count -gt 0)
 			{
-				Write-Warning "Can't connect to $instance. Moving on."
-				Continue
+				$dbs = $dbs | Where-Object { $databases -contains $_.Name  }
+			}
+				
+			foreach ($db in $dbs)
+			{
+				$dbroles = $db.roles
+				Write-Verbose "Getting Database Roles for $($db.name) on $instance"
+					
+				if ($NoFixedRole)
+				{
+					$dbroles = $dbroles | Where-Object { $_.isfixedrole -eq $false }
+				}
+					
+				foreach ($dbrole in $dbroles)
+				{
+					Write-Verbose "Getting Database Role Members for $dbrole in $($db.name) on $instance"
+					$dbmembers = $dbrole.enummembers()
+					ForEach ($dbmem in $dbmembers)
+					{
+						[PSCustomObject]@{
+							SqlInstance = $instance
+							Database = $db.name
+							Role = $dbrole.name
+							Member = $dbmem.tostring()
+						}
+					}
+				}
 			}
 		}
 	}
+END {}
 }

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -1,0 +1,41 @@
+﻿#Thank you Warren http://ramblingcookiemonster.github.io/Testing-DSC-with-Pester-and-AppVeyor/
+
+if(-not $PSScriptRoot)
+{
+    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+$Verbose = @{}
+if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
+{
+    $Verbose.add("Verbose",$True)
+}
+
+
+
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace('.Tests.', '.')
+Import-Module $PSScriptRoot\..\functions\$sut -Force
+Import-Module PSScriptAnalyzer
+## Added PSAvoidUsingPlainTextForPassword as credential is an object and therefore fails. We can ignore any rules here under special circumstances agreed by admins :-)
+$Rules = (Get-ScriptAnalyzerRule).Where{$_.RuleName -notin ('PSAvoidUsingPlainTextForPassword') }
+$Name = $sut.Split('.')[0]
+
+    Describe 'Script Analyzer Tests' {
+            Context "Testing $Name for Standard Processing" {
+                foreach ($rule in $rules) { 
+                    $i = $rules.IndexOf($rule)
+                    It "passes the PSScriptAnalyzer Rule number $i - $rule  " {
+                        (Invoke-ScriptAnalyzer -Path "$PSScriptRoot\..\functions\$sut" -IncludeRule $rule.RuleName ).Count | Should Be 0 
+                    }
+                }
+            }
+        }
+   ## needs some proper tests for the function here
+    Describe "$Name Tests"{
+        Context "Some Tests" {
+              It "Should have some Pester Tests added" {
+                  $true | Should Be $true
+              }
+		}
+    }
+    
+    


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - a failed Connect-SqlServer no longer ends the function
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

