### PR TITLE
Add error handling for failed connections

### DIFF
--- a/functions/Get-DbaRoleMember.ps1
+++ b/functions/Get-DbaRoleMember.ps1
@@ -74,84 +74,86 @@ Returns a gridview displaying SQLServer, Database, Role, Member for both ServerR
 		}
 	}
 	
-	BEGIN
-	{
+BEGIN
+    {
 		$databases = $psboundparameters.Databases
 	}
 	
-	PROCESS
+PROCESS
 	{
-		foreach ($instance in $sqlinstance)
-		{
-			$server = $null
-			$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlCredential
-			if ($Server.count -eq 1)
+        foreach ($instance in $sqlinstance)
+        {
+            Write-Verbose "Connecting to $Instance"
+			try
 			{
-				if ($IncludeServerLevel)
+				$server = Connect-SqlServer -SqlServer $Instance -SqlCredential $sqlcredential
+			}
+			catch
+			{
+				Write-Warning "Failed to connect to $Instance"
+				continue
+			}
+
+			if ($IncludeServerLevel)
+			{
+				Write-Verbose "Server Role Members included"
+				$instroles = $null
+				Write-Verbose "Getting Server Roles on $instance"
+				$instroles = $server.roles
+				if ($NoFixedRole)
 				{
-					Write-Verbose "Server Role Members included"
-					$instroles = $null
-					Write-Verbose "Getting Server Roles on $instance"
-					$instroles = $server.roles
-					if ($NoFixedRole)
-					{
-						$instroles = $instroles | Where-Object { $_.isfixedrole -eq $false }
-					}
-					ForEach ($instrole in $instroles)
-					{
-						Write-Verbose "Getting Server Role Members for $instrole on $instance"
-						$irmembers = $null
-						$irmembers = $instrole.enumserverrolemembers()
-						ForEach ($irmem in $irmembers)
-						{
-							[PSCustomObject]@{
-								SQLInstance = $instance
-								Database = $null
-								Role = $instrole.name
-								Member = $irmem.tostring()
-							}
-						}
-					}
+					$instroles = $instroles | Where-Object { $_.isfixedrole -eq $false }
 				}
-				
-				$dbs = $server.Databases
-				
-				if ($databases.count -gt 0)
+				ForEach ($instrole in $instroles)
 				{
-					$dbs = $dbs | Where-Object { $databases -contains $_.Name  }
-				}
-				
-				foreach ($db in $dbs)
-				{
-					$dbroles = $db.roles
-					Write-Verbose "Getting Database Roles for $($db.name) on $instance"
-					
-					if ($NoFixedRole)
+					Write-Verbose "Getting Server Role Members for $instrole on $instance"
+					$irmembers = $null
+					$irmembers = $instrole.enumserverrolemembers()
+					ForEach ($irmem in $irmembers)
 					{
-						$dbroles = $dbroles | Where-Object { $_.isfixedrole -eq $false }
-					}
-					
-					foreach ($dbrole in $dbroles)
-					{
-						Write-Verbose "Getting Database Role Members for $dbrole in $($db.name) on $instance"
-						$dbmembers = $dbrole.enummembers()
-						ForEach ($dbmem in $dbmembers)
-						{
-							[PSCustomObject]@{
-								SqlInstance = $instance
-								Database = $db.name
-								Role = $dbrole.name
-								Member = $dbmem.tostring()
-							}
+						[PSCustomObject]@{
+							SQLInstance = $instance
+							Database = $null
+							Role = $instrole.name
+							Member = $irmem.tostring()
 						}
 					}
 				}
 			}
-			else
+				
+			$dbs = $server.Databases
+				
+			if ($databases.count -gt 0)
 			{
-				Write-Warning "Can't connect to $instance. Moving on."
-				Continue
+				$dbs = $dbs | Where-Object { $databases -contains $_.Name  }
+			}
+				
+			foreach ($db in $dbs)
+			{
+				$dbroles = $db.roles
+				Write-Verbose "Getting Database Roles for $($db.name) on $instance"
+					
+				if ($NoFixedRole)
+				{
+					$dbroles = $dbroles | Where-Object { $_.isfixedrole -eq $false }
+				}
+					
+				foreach ($dbrole in $dbroles)
+				{
+					Write-Verbose "Getting Database Role Members for $dbrole in $($db.name) on $instance"
+					$dbmembers = $dbrole.enummembers()
+					ForEach ($dbmem in $dbmembers)
+					{
+						[PSCustomObject]@{
+							SqlInstance = $instance
+							Database = $db.name
+							Role = $dbrole.name
+							Member = $dbmem.tostring()
+						}
+					}
+				}
 			}
 		}
 	}
+END {}
 }


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - error when connect-sqlserver fails now in try catch
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

