### PR TITLE
Add support for SQL Server 2016

### DIFF
--- a/functions/Get-SqlServerKey.ps1
+++ b/functions/Get-SqlServerKey.ps1
@@ -214,6 +214,7 @@ Gets SQL Server versions, editions and product keys for all instances listed wit
 					}
 					11 { $key = "$basepath\110\Tools\Setup\DigitalProductID"; $sqlversion = "SQL Server 2012 $servicePack" }
 					12 { $key = "$basepath\120\Tools\Setup\DigitalProductID"; $sqlversion = "SQL Server 2014 $servicePack" }
+					13 { $key = "$basepath\130\Tools\Setup\DigitalProductID"; $sqlversion = "SQL Server 2016 $servicePack" }
 					default { Write-Warning "SQL version not currently supported."; continue }
 				}
 				if ($server.Edition -notlike "*Express*")


### PR DESCRIPTION
Still need to test on 2016 box, fixes #215

Fixes #215 

Changes proposed in this pull request:
 - Add one liner to support 2016 paths and messages.
 - Added simple debug statement to verify my assumptions

How to test this code: 
- This is a minimal bug fix, but you should now be able to `Get-SqlServerKey Sql2016 | select "Product Key"` on SQL 2016 instances.

