### PR TITLE
TestDbaLastBackup - issue #591

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -354,7 +354,7 @@ Restores data and log files to alternative locations and only restores databases
 						FileExists = $fileexists
 						RestoreResult = $restoreresult
 						DbccResult = $dbccresult
-						SizeMB = $lastbackup.TotalSizeMB
+						SizeMB = ($lastbackup.TotalSizeMB | Measure-Object -Sum).Sum
 						BackupTaken = $lastbackup.Start
 						BackupFiles = $lastbackup.Path
 					}


### PR DESCRIPTION
Now sums the Sizes returned. So for multiple backup files its the total of all files restore, for single backup files it's the same value as before

Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

