### PR TITLE
Get-DbaRoleMember - Fixed issue with offline databases

### DIFF
--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -7,7 +7,7 @@ Returns all stored procedures that contain a specific case-insensitive string or
 .DESCRIPTION
 This function can either run against specific databases or all databases searching all user or user and system stored procedures.
 	
-.PARAMETER SqlServer
+.PARAMETER SqlInstance
 SQLServer name or SMO object representing the SQL Server to connect to. This can be a collection and recieve pipeline input
 
 .PARAMETER SqlCredential
@@ -39,22 +39,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 https://dbatools.io/Find-DbaStoredProcedure
 
 .EXAMPLE
-Find-DbaStoredProcedure -SqlServer DEV01 -Pattern whatever
+Find-DbaStoredProcedure -SqlInstance DEV01 -Pattern whatever
 
 Searches all user databases stored procedures for "whatever" in the textbody
 	
 .EXAMPLE
-Find-DbaStoredProcedure -SqlServer sql2016 -Pattern '\w+@\w+\.\w+'
+Find-DbaStoredProcedure -SqlInstance sql2016 -Pattern '\w+@\w+\.\w+'
 
 Searches all databases for all stored procedures that contain a valid email pattern in the textbody
 
 .EXAMPLE
-Find-DbaStoredProcedure -SqlServer DEV01 -Databases MyDB -Pattern 'some string' -Verbose
+Find-DbaStoredProcedure -SqlInstance DEV01 -Databases MyDB -Pattern 'some string' -Verbose
 
 Searches in "mydb" database stored procedures for "some string" in the textbody
 
 .EXAMPLE
-Find-DbaStoredProcedure -SqlServer sql2016 -Databases MyDB -Pattern RUNTIME -IncludeSystemObjects
+Find-DbaStoredProcedure -SqlInstance sql2016 -Databases MyDB -Pattern RUNTIME -IncludeSystemObjects
 
 Searches in "mydb" database stored procedures for "runtime" in the textbody
 


### PR DESCRIPTION
Fixes #640 

Changes proposed in this pull request:
 - Adds check for Database.IsAccessible property equal to True before trying to read the Database.Roles collection
 - Adds verbose output for accessibility check and inaccessible database
 - 

How to test this code: 
- Execute Get-DbaRoleMember against target instances with offline databases or non-readable secondary Availability Group replica databases 
- [ ] 

Has been tested on minimum requirements:
- [No]  Powershell 3
- [No]  Windows 7
- [No]  SQL Server 2000

Has been tested on maximum requirements:
- [Yes]  SQL Server vNext
- [Yes]  Windows 10
- [No]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

