### PR TITLE
Test-DbaPowerPlan: Properly terminates try/catch on empty ip

### DIFF
--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -81,7 +81,8 @@ To return detailed information Power Plans
 			try
 			{
 				Write-Verbose "Testing connection to $server and resolving IP address"
-				$ipaddr = (Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1
+				$ipaddr = (Test-Connection $server -Count 1 -ErrorAction Stop).Ipv4Address | Select-Object -First 1
+
 			}
 			catch
 			{

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -82,7 +82,6 @@ To return detailed information Power Plans
 			{
 				Write-Verbose "Testing connection to $server and resolving IP address"
 				$ipaddr = (Test-Connection $server -Count 1 -ErrorAction Stop).Ipv4Address | Select-Object -First 1
-
 			}
 			catch
 			{


### PR DESCRIPTION
Fixes #425 

Tested on Windows 10, Powershell 5, SQL 2016 & 2008R2

Changes proposed in this pull request:
 - Change -ErrorAction from SilentlyContinue to Stop so if Test-Connection fails it terminates the try/catch

How to test this code: 
- [ ] Run against a server that you know will cause it to fail 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

