### PR TITLE
Fred's branch

### DIFF
--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -1,158 +1,180 @@
 Function Set-DbaMaxMemory
 {
-<# 
-.SYNOPSIS 
-Sets SQL Server 'Max Server Memory' configuration setting to a new value then displays information this setting. 
+    <# 
+        .SYNOPSIS 
+            Sets SQL Server 'Max Server Memory' configuration setting to a new value then displays information this setting. 
 
-.DESCRIPTION
-Sets SQL Server max memory then displays information relating to SQL Server Max Memory configuration settings. 
+        .DESCRIPTION
+            Sets SQL Server max memory then displays information relating to SQL Server Max Memory configuration settings. 
 
-Inspired by Jonathan Kehayias's post about SQL Server Max memory (http://bit.ly/sqlmemcalc), this uses a formula to 
-determine the default optimum RAM to use, then sets the SQL max value to that number.
+            Inspired by Jonathan Kehayias's post about SQL Server Max memory (http://bit.ly/sqlmemcalc), this uses a formula to 
+            determine the default optimum RAM to use, then sets the SQL max value to that number.
 
-Jonathan notes that the formula used provides a *general recommendation* that doesn't account for everything that may 
-be going on in your specific environment. 
+            Jonathan notes that the formula used provides a *general recommendation* that doesn't account for everything that may 
+            be going on in your specific environment.
 
+        .PARAMETER SqlServer
+            Allows you to specify a comma separated list of servers to query.
 
-.PARAMETER SqlServer
-Allows you to specify a comma separated list of servers to query.
+        .PARAMETER MaxMb
+            Specifies the max megabytes
 
-.PARAMETER MaxMb
-Specifies the max megabytes
+        .PARAMETER SqlCredential 
+            Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+          
+            $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.  
+         
+            Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials 
+        	being passed as credentials. To connect as a different Windows user, run PowerShell as that user. 
 
-.PARAMETER SqlCredential 
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
-  
-$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.  
- 
-Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials 
-	being passed as credentials. To connect as a different Windows user, run PowerShell as that user. 
+        .PARAMETER Collection
+            Results of Get-DbaMaxMemory to be passed into the command
+    
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
 
-.PARAMETER Collection
-Results of Get-DbaMaxMemory to be passed into the command
+        .EXAMPLE 
+            Set-DbaMaxMemory sqlserver1
 
-.NOTES 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+            Set max memory to the recommended MB on just one server named "sqlserver1"
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+        .EXAMPLE 
+            Set-DbaMaxMemory -SqlServer sqlserver1 -MaxMb 2048
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+            Explicitly max memory to 2048 MB on just one server, "sqlserver1"
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+        .EXAMPLE 
+            Get-SqlRegisteredServerName -SqlServer sqlserver| Test-DbaMaxMemory | Where-Object { $_.SqlMaxMB -gt $_.TotalMB } | Set-DbaMaxMemory
 
-.LINK 
-https://dbatools.io/Set-DbaMaxMemory
+            Find all servers in SQL Server Central Management server that have Max SQL memory set to higher than the total memory 
+            of the server (think 2147483647), then pipe those to Set-DbaMaxMemory and use the default recommendation.
 
-.EXAMPLE 
-Set-DbaMaxMemory sqlserver1
+        .NOTES 
+            dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+            Copyright (C) 2016 Chrissy LeMaire
 
-Set max memory to the recommended MB on just one server named "sqlserver1"
+            This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
-.EXAMPLE 
-Set-DbaMaxMemory -SqlServer sqlserver1 -MaxMb 2048
+            This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-Explicitly max memory to 2048 MB on just one server, "sqlserver1"
+            You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-.EXAMPLE 
-Get-SqlRegisteredServerName -SqlServer sqlserver| Test-DbaMaxMemory | Where-Object { $_.SqlMaxMB -gt $_.TotalMB } | Set-DbaMaxMemory
-
-Find all servers in SQL Server Central Management server that have Max SQL memory set to higher than the total memory 
-of the server (think 2147483647), then pipe those to Set-DbaMaxMemory and use the default recommendation.
-
-#>
-	[CmdletBinding()]
-	Param (
-		[parameter(Position = 0)]
-		[Alias("ServerInstance", "SqlInstance", "SqlServers")]
-		[object]$SqlServer,
-		[parameter(Position = 1)]
-		[int]$MaxMb,
-		[Parameter(ValueFromPipeline = $True)]
-		[object]$Collection,
-		[System.Management.Automation.PSCredential]$SqlCredential
-	)
-	PROCESS
-	{
-		if ($SqlServer.length -eq 0 -and $collection -eq $null)
-		{
-			throw "You must specify a server list source using -SqlServer or you can pipe results from Test-DbaMaxMemory"
-		}
-		
-		if ($MaxMB -eq 0)
-		{
-			$UseRecommended = $true
-		}
-		
-		if ($Collection -eq $null)
-		{
-			$Collection = Test-DbaMaxMemory -SqlServer $SqlServer -SqlCredential $SqlCredential
-		}
-		
-		$Collection | Add-Member -NotePropertyName OldMaxValue -NotePropertyValue 0
-		
-		foreach ($row in $Collection)
-		{
-			if ($row.server -eq $null)
-			{
-				$row = Test-DbaMaxMemory -sqlserver $row
-				$row | Add-Member -NotePropertyName OldMaxValue -NotePropertyValue 0
-			}
-			
-			Write-Verbose "Attempting to connect to $($row.server)"
-			
-			try
-			{
-				$server = Connect-SqlServer -SqlServer $row.server -SqlCredential $SqlCredential
-			}
-			catch
-			{
-				Write-Warning "Can't connect to $sqlserver or access denied. Skipping."
-				continue
-			}
-			
-			if (!(Test-SqlSa -SqlServer $server))
-			{
-				Write-Error "Not a sysadmin on $sqlserver. Skipping."
-				continue
-			}
-			
-			$row.OldMaxValue = $row.SqlMaxMB
-			
-			try
-			{
-				if ($UseRecommended)
-				{
-					Write-Verbose "Changing $($row.server) SQL Server max from $($row.SqlMaxMB) to $($row.RecommendedMB) MB"
-					
-					if ($row.RecommendedMB -eq 0 -or $row.RecommendedMB -eq $null)
-					{
-						$maxmem = (Test-DbaMaxMemory -SqlServer $server).RecommendedMB
-						Write-wearning $maxmem
-						$server.Configuration.MaxServerMemory.ConfigValue = $maxmem
-					}
-					else
-					{
-						
-						$server.Configuration.MaxServerMemory.ConfigValue = $row.RecommendedMB
-					}
-					
-					$row.SqlMaxMB = $row.RecommendedMB
-				}
-				else
-				{
-					Write-Verbose "Changing $($row.server) SQL Server max from $($row.SqlMaxMB) to $MaxMB MB"
-					$server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
-					$row.SqlMaxMB = $MaxMB
-				}
-				$server.Configuration.Alter()
-			}
-			catch
-			{
-				Write-Warning "Could not modify Max Server Memory for $($row.server)"
-			}
-			
-			$row | Select-Object Server, TotalMB, OldMaxValue, @{ name = "CurrentMaxValue"; expression = { $_.SqlMaxMB } }
-		}
-	}
+        .LINK 
+            https://dbatools.io/Set-DbaMaxMemory
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    Param (
+        [Parameter(Position = 0)]
+        [Alias("ServerInstance", "SqlInstance", "SqlServers", 'ComputerName')]
+        [object]
+        $SqlServer,
+        
+        [Parameter(Position = 1)]
+        [int]
+        $MaxMb,
+        
+        [Parameter(ValueFromPipeline = $True)]
+        [object]
+        $Collection,
+        
+        [Alias('Credential')]
+        [System.Management.Automation.PSCredential]
+        $SqlCredential,
+        
+        [switch]
+        $Silent
+    )
+    Process
+    {
+        if ($SqlServer.length -eq 0 -and $collection -eq $null)
+        {
+            Stop-Function -Silent $Silent -Category InvalidArgument -Message "You must specify a server list source using -SqlServer or you can pipe results from Test-DbaMaxMemory"
+            return
+        }
+        
+        if ($MaxMB -eq 0)
+        {
+            $UseRecommended = $true
+        }
+        
+        if ($Collection -eq $null)
+        {
+            $Collection = Test-DbaMaxMemory -SqlServer $SqlServer -SqlCredential $SqlCredential
+        }
+        
+        # We ignore errors, because this will error if we pass the same collection items twice.
+        # Given that it is an engine internal command, there is no other plausible error it could encounter.
+        $Collection | Add-Member -NotePropertyName OldMaxValue -NotePropertyValue 0 -ErrorAction Ignore
+        
+        foreach ($row in $Collection)
+        {
+            if ($row.server -eq $null)
+            {
+                $row = Test-DbaMaxMemory -sqlserver $row
+                $row | Add-Member -NotePropertyName OldMaxValue -NotePropertyValue 0
+            }
+            
+            Write-Verbose "Attempting to connect to $($row.server)"
+            
+            try
+            {
+                $server = Connect-SqlServer -SqlServer $row.server -SqlCredential $SqlCredential -ErrorAction Stop
+            }
+            catch
+            {
+                Stop-Function -Message "Can't connect to $($row.server) or access denied. Skipping." -Silent $Silent -Category ConnectionError -InnerErrorRecord $_ -Target $row -Continue
+            }
+            
+            if (!(Test-SqlSa -SqlServer $server))
+            {
+                Stop-Function -Message "Not a sysadmin on $($row.server). Skipping." -Silent $Silent -Category PermissionDenied -InnerErrorRecord $_ -Target $row -Continue
+            }
+            
+            $row.OldMaxValue = $row.SqlMaxMB
+            
+            try
+            {
+                if ($UseRecommended)
+                {
+                    Write-Verbose "Changing $($row.server) SQL Server max from $($row.SqlMaxMB) to $($row.RecommendedMB) MB"
+                    
+                    if ($row.RecommendedMB -eq 0 -or $row.RecommendedMB -eq $null)
+                    {
+                        $maxmem = (Test-DbaMaxMemory -SqlServer $server).RecommendedMB
+                        Write-Warning $maxmem
+                        $server.Configuration.MaxServerMemory.ConfigValue = $maxmem
+                    }
+                    else
+                    {
+                        
+                        $server.Configuration.MaxServerMemory.ConfigValue = $row.RecommendedMB
+                    }
+                }
+                else
+                {
+                    Write-Verbose "Changing $($row.server) SQL Server max from $($row.SqlMaxMB) to $MaxMB MB"
+                    $server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
+                }
+                if ($PSCmdlet.ShouldProcess($row.Server, "Changing maximum memory from $($row.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)"))
+                {
+                    try
+                    {
+                        $server.Configuration.Alter()
+                        $row.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue
+                    }
+                    catch
+                    {
+                        Stop-Function -Message "Failed to apply configuration change for $($row.Server): $($_.Exception.Message)" -Silent $Silent -InnerErrorRecord $_ -Target $row -Continue
+                    }
+                }
+            }
+            catch
+            {
+                Stop-Function -Message "Could not modify Max Server Memory for $($row.server): $($_.Exception.Message)" -Silent $Silent -InnerErrorRecord $_ -Target $row -Continue
+            }
+            
+            $row | Select-Object Server, TotalMB, OldMaxValue, @{ name = "CurrentMaxValue"; expression = { $_.SqlMaxMB } }
+        }
+    }
 }

--- a/internal/Stop-Function.ps1
+++ b/internal/Stop-Function.ps1
@@ -1,0 +1,165 @@
+﻿function Stop-Function
+{
+    <#
+        .SYNOPSIS
+            Function that interrupts a function.
+        
+        .DESCRIPTION
+            Function that interrupts a function.
+            
+            This function is a utility function used by other functions to reduce error catching overhead.
+            It is designed to allow gracefully terminating a function with a warning by default and also allow opt-in into terminating errors.
+            It also allows simple integration into loops.
+    
+            Note:
+            When calling this function with the intent to terminate the calling function in non-silent mode too, you need to add a return below the call.
+        
+        .PARAMETER Message
+            A message to pass along, explaining just what the error was.
+        
+        .PARAMETER Silent
+            Whether the silent switch was set in the calling function.
+            If true, it will throw an error.
+            If false, it will print a warning.
+        
+        .PARAMETER Category
+            What category does this termination belong to?
+            Mandatory so long as no inner exception is passed.
+        
+        .PARAMETER InnerErrorRecord
+            An option to include an inner exception in the error record (and in the exception thrown, if one is thrown).
+            Use this, whenever you call Stop-Function in a catch block.
+    
+            Note:
+            Pass the full error record, not just the exception.
+        
+        .PARAMETER FunctionName
+            The name of the function to crash.
+            This parameter is very optional, since it automatically selects the name of the calling function.
+            The function name is used as part of the errorid.
+            That in turn allows easily figuring out, which exception belonged to which function when checking out the $error variable.
+        
+        .PARAMETER Target
+            The object that was processed when the error was thrown.
+            For example, if you were trying to process a Database Server object when the processing failed, add the object here.
+            This object will be in the error record (which will be written, even in non-silent mode, just won't show it).
+            If you specify such an object, it becomes simple to actually figure out, just where things failed at.
+        
+        .PARAMETER Continue
+            This will cause the function to call continue while not running silently.
+            Useful when mass-processing items where an error shouldn't break the loop.
+        
+        .PARAMETER SilentlyContinue
+            This will cause the function to call continue while running silently.
+            Useful when mass-processing items where an error shouldn't break the loop.
+        
+        .PARAMETER ContinueLabel
+            When specifying a label in combination with "-Continue" or "-SilentlyContinue", this function will call continue with this specified label.
+            Helpful when trying to continue on an upper level named loop.
+        
+        .EXAMPLE
+            Stop-Function -Message "Foo failed bar! $($_.Exception.Message)" -Silent $Silent -InnerErrorRecord $_
+            return
+            
+            Depending on whether $silent is true or false it will:
+            - Throw a bloody terminating error. Game over.
+            - Write a nice warning about how Foo failed bar, then terminate the function. The return on the next line will then end the calling function.
+    
+        .EXAMPLE
+            Stop-Function -Message "Foo failed bar!" -Silent $Silent -Category InvalidOperation -Target $foo -Continue
+    
+            Depending on whether $silent is true or false it will:
+            - Throw a bloody terminating error. Game over.
+            - Write a nice warning about how Foo failed bar, then call continue to process the next item in the loop.
+            In both cases, the error record added to $error will have the content of $foo added, the better to figure out what went wrong.
+        
+        .NOTES
+            Author:      Friedrich Weinmann
+            Editors:     -
+            Created on:  08.02.2017
+            Last Change: 08.02.2017
+            Version:     1.0
+            
+            Release 1.0 (08.02.2017, Friedrich Weinmann)
+            - Initial Release
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Plain')]
+    Param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Message,
+        
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $Silent,
+        
+        [Parameter(Mandatory = $true, ParameterSetName = 'Plain')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Exception')]
+        [System.Management.Automation.ErrorCategory]
+        $Category,
+        
+        [Parameter(ParameterSetName = 'Exception')]
+        [System.Management.Automation.ErrorRecord]
+        $InnerErrorRecord,
+        
+        [string]
+        $FunctionName = ((Get-PSCallStack)[0].Command),
+        
+        [object]
+        $Target,
+        
+        [switch]
+        $Continue,
+        
+        [switch]
+        $SilentlyContinue,
+        
+        [string]
+        $ContinueLabel
+    )
+    
+    $Exception = New-Object System.Exception($Message, $InnerErrorRecord.Exception)
+    if (-not $Category) { $Category = $InnerErrorRecord.CategoryInfo.Category }
+    $record = New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools-$FunctionName", $Category, $Target)
+    
+    # Manage Debugging
+    Write-Debug "[$FunctionName] $Message"
+    
+    #region Silent Mode
+    if ($Silent)
+    {
+        if ($SilentlyContinue)
+        {
+            Write-Error $record -Category $Category -TargetObject $Target -Exception $Exception -ErrorId $record.FullyQualifiedErrorId
+            if ($ContinueLabel) { continue $ContinueLabel }
+            else { Continue }
+        }
+        
+        Write-Debug "[$FunctionName] Terminating function"
+        
+        
+        throw $record
+    }
+    #endregion Silent Mode
+    
+    #region Non-Silent Mode
+    else
+    {
+        Write-Warning -Message $Message
+        
+        # This ensures that the error is stored in the $error variable AND has its Stacktrace (simply adding the record would lack the stacktrace)
+        $null = Write-Error $record -Category $Category -TargetObject $Target -Exception $Exception -ErrorId $record.FullyQualifiedErrorId 2>&1
+        
+        if ($Continue)
+        {
+            if ($ContinueLabel) { continue $ContinueLabel }
+            else { Continue }
+        }
+        else
+        {
+            Write-Debug "[$FunctionName] Terminating function!"
+            return
+        }
+    }
+    #endregion Non-Silent Mode
+}

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -76,8 +76,8 @@ foreach ($command in $commands)
 		
 		Context "Test parameter help for $commandName" {
 			
-			$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
-			'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
+			$Common = 'Confirm', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
+			'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'WhatIf'
 			
 			$parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object { $_.Name -notin $common }
 			$parameterNames = $parameters.Name

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -79,7 +79,7 @@ foreach ($command in $commands)
 			$Common = 'Confirm', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
 			'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'WhatIf'
 			
-			$parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object { $_.Name -notin $common }
+			$parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
 			$parameterNames = $parameters.Name
 			$HelpParameterNames = $Help.Parameters.Parameter.Name | Sort-Object -Unique
 			


### PR DESCRIPTION
New internal function "Stop-Function" used to gracefully stop other functions while still allowing for terminating errors where needed.
Implemented it in Set-DbaMaxMemory as a proof of concept.

Fixes #

 - Some bugs in Set-DbaMaxMemory were quietly retired.
 - Fixed the help test: June didn't quite catch all common parameters

Changes proposed in this pull request:

 - How to handle errors, combining user friendliness with error handling when used by other functions