### PR TITLE
Added IgnoreCopyOnly switch to Get-DbaBackupHistory

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -277,7 +277,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								 INNER JOIN msdb..backupmediaset mediaset ON mediafamily.media_set_id = mediaset.media_set_id
 								 INNER JOIN msdb..backupset backupset ON backupset.media_set_id = mediaset.media_set_id"
 					
-					if ($databases -or $Since -or $Last -or $LastFull -or $LastLog -or $LastDiff)
+					if ($databases -or $Since -or $Last -or $LastFull -or $LastLog -or $LastDiff -or $IgnoreCopyOnly)
 					{
 						$where = " WHERE "
 					}

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -38,6 +38,9 @@ Returns last differential backup set
 .PARAMETER LastLog
 Returns last log backup set
 
+.PARAMETER IgnoreCopyOnly
+If set, Get-DbaBackupHistory will ignore CopyOnly backups
+
 .NOTES 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire
@@ -100,6 +103,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 		[object[]]$SqlServer,
 		[Alias("SqlCredential")]
 		[PsCredential]$Credential,
+		[switch]$IgnoreCopyOnly,
 		[Parameter(ParameterSetName = "NoLast")]
 		[switch]$Force,
 		[Parameter(ParameterSetName = "NoLast")]
@@ -295,6 +299,11 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 					if ($Since -ne $null)
 					{
 						$wherearray += "backupset.backup_finish_date >= '$since'"
+					}
+
+					if ($IgnoreCopyOnly)
+					{
+						$wherearray += "is_copy_only='0'"	
 					}
 					
 					if ($where.length -gt 0)


### PR DESCRIPTION
If IgnoreCopyOnly used then sql query is filtered  using
is_copy_only=0
This stops us getting copy only backups mucking up restore chains when they
get piped into the restore work.

Fixes #691

Changes proposed in this pull request:
- Added IgnoreCopyOnly switch to Get-DbaBackupHistory
 - No changes to any other functionality or output 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

