### PR TITLE
Fixed Find-SqlUnusedIndex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
 # dbatools
-<img src="https://camo.githubusercontent.com/8a859030e83bd44826807447bca2767c20f19121/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f506f7765725368656c6c2d332e302d626c75652e737667" alt="Minimum Supported PowerShell Version" data-canonical-src="https://img.shields.io/badge/PowerShell-3.0-blue.svg" style="max-width:100%;">
 [![licence badge]][licence]
 [![Build status](https://ci.appveyor.com/api/projects/status/cy5sm45x6atculse/branch/master?svg=true)](https://ci.appveyor.com/project/sqlcollaborative/dbatools/branch/master)
 


### PR DESCRIPTION
Fixes # 
Adding schema name to DROP script

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

