### PR TITLE
Copy-SqlLogin: Remove parameter set from Destination param 

### DIFF
--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -119,9 +119,9 @@ Limitations: Does not support Application Roles yet
 	
 	[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 	Param (
-		[parameter(Mandatory=$true, ValueFromPipeline = $true)]
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[object]$Source,
-		[parameter(Mandatory=$true)]
+		[parameter(Mandatory = $true)]
 		[object]$Destination,
 		[object]$SourceSqlCredential,
 		[object]$DestinationSqlCredential,

--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -119,9 +119,9 @@ Limitations: Does not support Application Roles yet
 	
 	[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 	Param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[parameter(Mandatory=$true, ValueFromPipeline = $true)]
 		[object]$Source,
-		[parameter(ParameterSetName = "Live", Mandatory = $true)]
+		[parameter(Mandatory=$true)]
 		[object]$Destination,
 		[object]$SourceSqlCredential,
 		[object]$DestinationSqlCredential,


### PR DESCRIPTION
Fixes #651 

Tested with SQL Server 2014/16 on windows 10,2012R2 Powershell 5 

Changes proposed in this pull request:
 - Remove Parameterset from -Destination param so it is required when fired. 
 - If you need to use outfile with no destination, we should use Export-SqlLogin
 - 

How to test this code: 
- [ ] Copy-SqlLogin -Source SQL01 -SourceSqlCredential $cred -Destination Dest01 (works)
- [ ] Copy-SqlLogin -Source SQL01 -SourceSqlCredential $cred (asks for dest) 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

