### PR TITLE
Export-SqlLogin: Try Catch around dynamic params to prevent Null exception

### DIFF
--- a/functions/Export-SqlLogin.ps1
+++ b/functions/Export-SqlLogin.ps1
@@ -113,10 +113,15 @@ https://dbatools.io/Export-SqlLogin
 	{
 		if ($sqlserver)
 		{
-			$dbparams = Get-ParamSqlDatabases -SqlServer $sqlserver -SqlCredential $SqlCredential
-			$allparams = Get-ParamSqlLogins -SqlServer $sqlserver -SqlCredential $SqlCredential
-			$null = $allparams.Add("Databases", $dbparams.Databases)
-			return $allparams
+			try { 
+				$dbparams = Get-ParamSqlDatabases -SqlServer $sqlserver -SqlCredential $SqlCredential
+				$allparams = Get-ParamSqlLogins -SqlServer $sqlserver -SqlCredential $SqlCredential
+				$null = $allparams.Add("Databases", $dbparams.Databases)
+				return $allparams
+			} catch {
+				# empty 
+			} 
+			
 		}
 	}
 	


### PR DESCRIPTION
Fixes #660 

Tested on Windows 10/2012R2, SQL2014/16, Powershell 5

Changes proposed in this pull request:
 - Wrap Dynamic Param in Try/Catch to prevent null exception

How to test this code: 
- [ ] Export-SqlLogin -SqlServer SQL01 -FilePath C:\logins.sql

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

