### PR TITLE
Check for SMO and DMO XPs Enabled on an instance

### DIFF
--- a/internal/Connect-SqlServer.ps1
+++ b/internal/Connect-SqlServer.ps1
@@ -1,4 +1,4 @@
-Function Connect-SqlServer
+﻿Function Connect-SqlServer
 {
 <# 
 .SYNOPSIS 
@@ -70,6 +70,14 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 	
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlServer
 	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
+
+    if ($server.Configuration.SmoAndDmoXPsEnabled.RunValue -eq 0)
+    {
+        Write-Error "Accessing this server via SQL Management Objects (SMO) or Distributed Management Objects (DMO) is currently not permitted.
+                     Enable the option 'SMO and DMO XPs' on your instance using sp_configure to continue.
+                     Note that this will require 'Show Advanced Options' to be enabled using sp_configure as well."
+        break
+    }
 	
 	try
 	{


### PR DESCRIPTION
Many thanks to @ConstantineK for the help with this one. Git and I had a few...words...to say about each other.

Fixes #448 

Changes proposed in this pull request:
 - Added configuration check for 'SMO and DMO XPs enabled' and errors out if found.
 - 
 - 

How to test this code: 
- [ ] Attempt to connect to an instance with 'SMO and DMO XPs enabled' set to 1.
- [ ] Attempt to connect to an instance with 'SMO and DMO XPs enabled' set to 0.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

