### PR TITLE
Update TabExpansionPlusPlus Showcase

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -51,12 +51,28 @@ foreach ($assembly in $assemblies)
 
 #>
 
-# All internal functions privately avaialble within the toolset
+# All internal functions privately available within the toolset
 foreach ($function in (Get-ChildItem "$PSScriptRoot\internal\*.ps1")) { . $function }
-foreach ($function in (Get-ChildItem "$PSScriptRoot\internal\dynamicparams\*.ps1")) { . $function }
 
 # All exported functions
 foreach ($function in (Get-ChildItem "$PSScriptRoot\functions\*.ps1")) { . $function }
+
+# Finally register autocompletion
+# Use the conditional clause to make the TabExpansionPlusPlus module optional.
+if (Get-Command -Name Register-ArgumentCompleter -ErrorAction Ignore)
+{
+    # Test whether we have Tab Expansion Plus available (used in dynamicparams scripts ran below)
+    if (Get-Command TabExpansionPlusPlus\Register-ArgumentCompleter -ErrorAction Ignore)
+    {
+        $TEPP = $true
+    }
+    else
+    {
+        $TEPP = $false
+    }
+    
+    foreach ($function in (Get-ChildItem "$PSScriptRoot\internal\dynamicparams\*.ps1")) { . $function }
+}
 
 # Not supporting the provider path at this time
 # if (((Resolve-Path .\).Path).StartsWith("SQLSERVER:\")) { throw "Please change to another drive and reload the module." }

--- a/internal/dynamicparams/tag.ps1
+++ b/internal/dynamicparams/tag.ps1
@@ -1,19 +1,37 @@
-Register-ArgumentCompleter -ParameterName Tag -ScriptBlock {
-	param (
-		$commandName,
-		$parameterName,
-		$wordToComplete,
-		$commandAst,
-		$fakeBoundParameter
-	)
-	
-	$collection =  "Migration","AgentServer" # This should actually be a list of all available tags dynamically populated somehow
-	
-	if ($collection)
-	{
-		foreach ($item in $collection)
-		{
-			New-CompletionResult -CompletionText $item -ToolTip $item
-		}
-	}
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $collection = "Migration", "AgentServer" # This should actually be a list of all available tags dynamically populated somehow
+    
+    if ($collection)
+    {
+        foreach ($item in $collection)
+        {
+            New-CompletionResult -CompletionText $item -ToolTip $item
+        }
+    }
+}
+
+$ParameterName = "Tag"
+
+# Get all internal functions
+# Null the variable before you call, as on Windows 6.1 machines it might otherwise reregister previous commands if the current one returns no result
+# (So yeah, it's an insurance)
+$commands = $null
+$commands = Get-Command -Name "*-Dba*" -CommandType Function -ListImported -ParameterName $ParameterName -ErrorAction Ignore
+
+foreach ($command in $commands)
+{
+    if ($TEPP) { TabExpansionPlusPlus\Register-ArgumentCompleter -CommandName $command.Name -ParameterName $ParameterName -ScriptBlock $ScriptBlock }
+    else { Register-ArgumentCompleter -CommandName $command.Name -ParameterName $ParameterName -ScriptBlock $ScriptBlock }
 }


### PR DESCRIPTION
Updated the TEPP demo implementation by ...
- Preventing it being applied to all commands with parameters of the
specified name, irrespective of source
- Only runs when the necessary commands are available, so neither TEPP
nor PowerShell v5 become mandatory
- Prefers using the TEPP implementation, because those can be discovered
using Get-ArgumentCompleter