### PR TITLE
initial commit of Test-PSRemoting

### DIFF
--- a/internal/Test-PSRemoting.ps1
+++ b/internal/Test-PSRemoting.ps1
@@ -1,0 +1,39 @@
+﻿#requires -version 3.0
+ 
+Function Test-PSRemoting {
+<#
+Jeff Hicks
+https://www.petri.com/test-network-connectivity-powershell-test-connection-cmdlet
+#>
+  [cmdletbinding()]
+ 
+  Param(
+    [Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
+    [ValidateNotNullorEmpty()]
+    [string]$Computername,
+    [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty
+  )
+ 
+  Begin {
+    Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"  
+  } #begin
+ 
+  Process {
+    Write-Verbose -Message "Testing $computername"
+    Try {
+      $r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
+      $True 
+    }
+    Catch {
+      Write-Verbose $_.Exception.Message
+      $False
+ 
+    }
+ 
+  } #Process
+ 
+  End {
+    Write-Verbose -Message "Ending $($MyInvocation.Mycommand)"
+  } #end
+ 
+} #close function


### PR DESCRIPTION
wrapper for Test-WSMan by Jeff Hicks

will test if we can use WinRM before we actually execute Invoke-Command or Get-Ciminstance or ...

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

