### PR TITLE
Initial commit for Find-DbaCommand, connects to #692

### DIFF
--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -10,10 +10,15 @@ Finds dbatools commands searching through the inline help text, building a conso
 .PARAMETER Tag
 Finds all commands tagged with this tag
 
+.PARAMETER Author
+Finds all commands tagged with this author
+
+.PARAMETER Rebuild
+Rebuilds the index
+
 .NOTES
 Tags: find
 Author: niphlod
-
 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -16,6 +16,15 @@ Finds all commands tagged with this author
 .PARAMETER Rebuild
 Rebuilds the index
 
+.PARAMETER Pattern
+Searches help for all commands in dbatools for the specified pattern and displays all results
+
+.PARAMETER Confirm
+Confirms overwrite of index
+
+.PARAMETER WhatIf
+Displays what would happen if the command is run
+
 .NOTES
 Tags: find
 Author: niphlod

--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -107,7 +107,7 @@ Finds all commands searching the entire help for "snapshot", rebuilding the inde
                 $x = Get-DbaHelp $c.Key
                 $helpcoll.Add($x)
             }
-            $dest = Get-DbaIdxPath
+            $dest = Get-ConfigValue -Name 'Path.TagCache' -Fallback "$(Resolve-Path $PSScriptRoot\..)\dbatools-index.json"
             if ($Pscmdlet.ShouldProcess($dest, "Recreating index"))
             {
                 $helpcoll | ConvertTo-Json | Out-File $dest

--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -1,0 +1,146 @@
+Function Find-DbaCommand
+{
+<#
+.SYNOPSIS
+Finds dbatools commands searching through the inline help text
+
+.DESCRIPTION
+Finds dbatools commands searching through the inline help text, building a consolidated json index and querying it because Get-Help is too slow
+
+.PARAMETER Tag
+Finds all commands tagged with this tag
+
+.NOTES
+Tags: find
+Author: niphlod
+
+
+dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+Copyright (C) 2016 Chrissy LeMaire
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+.LINK
+https://dbatools.io/Find-DbaCommand
+
+.EXAMPLE
+Find-DbaCommand "snapshot"
+
+For lazy typers: finds all commands searching the entire help for "snapshot"
+
+.EXAMPLE
+Find-DbaCommand -Pattern "snapshot"
+
+For rigorous typers: finds all commands searching the entire help for "snapshot"
+
+.EXAMPLE
+Find-DbaCommand -Tag copy
+
+Finds all commands tagged with "copy"
+
+.EXAMPLE
+Find-DbaCommand -Author "chrissy"
+
+Finds every command whose author contains our beloved "chrissy"
+
+.EXAMPLE
+Find-DbaCommand -Pattern "snapshot" -Rebuild
+
+Finds all commands searching the entire help for "snapshot", rebuilding the index (good for developers)
+#>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    Param (
+        [String]$Pattern,
+        [String]$Tag,
+        [String]$Author,
+        [switch]$Rebuild
+    )
+    BEGIN
+    {
+        $tagsRex = ([regex]'(?m)^[\s]{0,15}Tags:(.*)$')
+        $authorRex = ([regex]'(?m)^[\s]{0,15}Author:(.*)$')
+
+        function Get-DbaHelp([String]$commandname) {
+            $thishelp = Get-Help $commandname -Full
+            $thebase = @{}
+            $thebase.CommandName = $commandname
+            $thebase.Name = $thishelp.name
+
+            ## fetch the description
+            $thebase.Description = $thishelp.Description.text
+
+            ## fetch examples
+            $thebase.Examples = $thishelp.Examples | Out-String -Width 120
+
+            ## fetch help link
+            $thebase.Links = ($thishelp.relatedLinks).navigationLink.uri
+
+            ## fetch the synopsis
+            $thebase.Synopsis = $thishelp.Synopsis
+
+            ## store notes
+            $as = $thishelp.alertSet | Out-String -Width 120
+
+            ## fetch the tags
+            $tags = $tagsrex.Match($as).Groups[1].Value
+            if($tags) {
+                $thebase.Tags = $tags.Trim().Split(',')
+            }
+            ## fetch the author
+            $author = $authorRex.Match($as).Groups[1].Value
+            if($author) {
+                $thebase.Author = $author.Trim()
+            }
+
+            [pscustomobject]$thebase
+        }
+
+        function Get-DbaIdxPath() {
+            $docs = [Environment]::GetFolderPath("mydocuments")
+            $idxpath = Join-Path $docs "dbatools-index.json"
+            $idxpath
+        }
+
+        function Get-DbaIndex() {
+            $dbamodule = Get-Module dbatools
+            $allcommands = $dbamodule.ExportedCommands
+            $helpcoll = New-Object System.Collections.Generic.List[System.Object]
+            foreach($c in $allcommands.GetEnumerator()) {
+                $x = Get-DbaHelp $c.Key
+                $helpcoll.Add($x)
+            }
+            $dest = Get-DbaIdxPath
+            if ($Pscmdlet.ShouldProcess($dest, "Recreating index"))
+            {
+                $helpcoll | ConvertTo-Json | Out-File $dest
+            }
+        }
+    }
+    PROCESS
+    {
+        $idxfile = Get-DbaIdxPath
+        if(!(Test-Path $idxfile) -or $Rebuild) {
+            Write-Verbose "Rebuilding index into $idxfile"
+            $swrebuild = [system.diagnostics.stopwatch]::startNew()
+            Get-DbaIndex
+            Write-Verbose "Rebuild done in $($swrebuild.Elapsedmilliseconds)ms"
+
+        }
+        $consolidated = Get-Content $idxfile | ConvertFrom-Json
+        $result = $consolidated
+        if($Pattern.length -gt 0) {
+            $result = $result | Where-Object { $_.psobject.properties.value -like "*$Pattern*" }
+        }
+        if($Tag.length -gt 0) {
+            $result = $result | Where-Object Tags -contains $Tag
+        }
+        if($Author.length -gt 0) {
+            $result = $result | Where-Object Author -like '*$Author*'
+        }
+        Select-DefaultView -InputObject $result -Property CommandName, Synopsis
+    }
+}

--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -99,12 +99,6 @@ Finds all commands searching the entire help for "snapshot", rebuilding the inde
             [pscustomobject]$thebase
         }
 
-        function Get-DbaIdxPath() {
-            $docs = [Environment]::GetFolderPath("mydocuments")
-            $idxpath = Join-Path $docs "dbatools-index.json"
-            $idxpath
-        }
-
         function Get-DbaIndex() {
             $dbamodule = Get-Module dbatools
             $allcommands = $dbamodule.ExportedCommands
@@ -122,7 +116,7 @@ Finds all commands searching the entire help for "snapshot", rebuilding the inde
     }
     PROCESS
     {
-        $idxfile = Get-DbaIdxPath
+        $idxfile = Get-ConfigValue -Name 'Path.TagCache' -Fallback "$(Resolve-Path $PSScriptRoot\..)\dbatools-index.json"
         if(!(Test-Path $idxfile) -or $Rebuild) {
             Write-Verbose "Rebuilding index into $idxfile"
             $swrebuild = [system.diagnostics.stopwatch]::startNew()


### PR DESCRIPTION
Fixes #692

Most of this command revolves around what we want to parse and how to parse it. Once that is figured out, it'll be pretty easy to implement. Right now "tag" and "author" are searched into .NOTES, with the simplest of the rule possible: a line starting with "Tags:" and one starting with "Author:".
I'd stick with the basics: we'll need a bit of rewrite here and there for modules but once the good behaviour is promoted with a default template it'll be easy for everybody

TODO: 
- integrating with TE++ for autocompletion of tags
- agreeing on where to put the index file
- adding useful filters (?)

How to test this code: 
- [ ] when the index is not found, it'll be in the "Documents" folder
- [ ] when the index is not found, it is built automatically
- [ ] you can do a full-text search with -Pattern
- [ ] you can search by tag and by author

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works locally

