### PR TITLE
Improve resolve-dbanetworkname

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -102,6 +102,7 @@
         catch
         {
           $Computer = $OGComputer
+          $ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
         }
       }
 			

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -1,258 +1,248 @@
 ﻿Function Resolve-DbaNetworkName
 {
-<#
-.SYNOPSIS
-Returns information about the network connection of the target computer including NetBIOS name, IP Address, domain name and fully qualified domain name (FQDN).
+  <#
+      .SYNOPSIS
+      Returns information about the network connection of the target computer including NetBIOS name, IP Address, domain name and fully qualified domain name (FQDN).
 
-.DESCRIPTION
-Retrieves the IPAddress, ComputerName from one computer.
-The object can be used to take action against its name or IPAddress.
+      .DESCRIPTION
+      Retrieves the IPAddress, ComputerName from one computer.
+      The object can be used to take action against its name or IPAddress.
 
-First ICMP is used to test the connection, and get the connected IPAddress.
+      First ICMP is used to test the connection, and get the connected IPAddress.
 
-If your local Powershell version is not higher than 2, WMI is tried to get the computername.
-If not, CIM is used, first via WinRM, and if not successful, via DCOM.
+      If your local Powershell version is not higher than 2, WMI is tried to get the computername.
+      If not, CIM is used, first via WinRM, and if not successful, via DCOM.
 
-.PARAMETER ComputerName
-The Server that you're connecting to.
-This can be the name of a computer, a SMO object, an IP address or a SQL Instance.
+      .PARAMETER ComputerName
+      The Server that you're connecting to.
+      This can be the name of a computer, a SMO object, an IP address or a SQL Instance.
 
-.PARAMETER Credential
-Credential object used to connect to the SQL Server as a different user
+      .PARAMETER Credential
+      Credential object used to connect to the SQL Server as a different user
 
-.PARAMETER Turbo
-Resolves without accessing the serer itself. Faster but may be less accurate.
+      .PARAMETER Turbo
+      Resolves without accessing the serer itself. Faster but may be less accurate.
 
-.NOTES
-Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+      .NOTES
+      Author: Klaas Vandenberghe ( @PowerDBAKlaas )
 
-dbatools PowerShell module (https://dbatools.io)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+      dbatools PowerShell module (https://dbatools.io)
+      Copyright (C) 2016 Chrissy LeMaire
+      This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+      You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
 
-.LINK
- https://dbatools.io/Resolve-DbaNetworkName
+      .LINK
+      https://dbatools.io/Resolve-DbaNetworkName
 
-.EXAMPLE
-Resolve-DbaNetworkName -ComputerName ServerA
+      .EXAMPLE
+      Resolve-DbaNetworkName -ComputerName ServerA
 
-Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for ServerA
+      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for ServerA
 	
-.EXAMPLE
-Resolve-DbaNetworkName -SqlServer sql2016\sqlexpress
+      .EXAMPLE
+      Resolve-DbaNetworkName -SqlServer sql2016\sqlexpress
 
-Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress
+      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress
 	
-.EXAMPLE
-Resolve-DbaNetworkName -SqlServer sql2016\sqlexpress, sql2014
+      .EXAMPLE
+      Resolve-DbaNetworkName -SqlServer sql2016\sqlexpress, sql2014
 
-Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress and sql2014
+      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress and sql2014
 
-Get-SqlRegisteredServerName -SqlServer sql2014 | Resolve-DbaNetworkName
+      Get-SqlRegisteredServerName -SqlServer sql2014 | Resolve-DbaNetworkName
 	
-Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-SqlRegisteredServerName
-#>
-	[CmdletBinding()]
-	param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
-		[object]$ComputerName,
-		[PsCredential]$Credential,
-		[Alias("FastParrot")]
-		[switch]$Turbo
-	)
-	
-	PROCESS
-	{
-		foreach ( $Computer in $ComputerName )
-		{
-			$conn = $ipaddress = $CIMsession = $null
+      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-SqlRegisteredServerName
+  #>
+  [CmdletBinding()]
+  param (
+    [parameter(Mandatory, ValueFromPipeline)]
+    [Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlServer')]
+    [object]$ComputerName = $env:COMPUTERNAME,
+    [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
+    [Alias("FastParrot")]
+    [switch]$Turbo
+  )
+  BEGIN
+  {
+    $functionName = (Get-PSCallstack)[0].Command
+  }
+  PROCESS
+  {
+    foreach ( $Computer in $ComputerName )
+    {
+      $conn = $ipaddress = $CIMsession = $null
 			
-			if ( $Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server] )
-			{
-				$Computer = $Computer.NetName
-			}
+      if ( $Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server] )
+      {
+        $Computer = $Computer.NetName
+      }
 			
-			$OGComputer = $Computer
+      $OGComputer = $Computer
 			
-			if ($Computer -eq "localhost" -or $Computer -eq ".")
-			{
-				$Computer = $env:COMPUTERNAME
-			}
+      if ($Computer -eq 'localhost' -or $Computer -eq '.')
+      {
+        $Computer = $env:COMPUTERNAME
+      }
 			
-			$Computer = $Computer.Split('\')[0]
-			Write-Verbose "Connecting to server $Computer"
+      $Computer = $Computer.Split('\')[0]
+      Write-Verbose "$functionName - Connecting to server $Computer"
 			
-			try
-			{
-				$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
-			}
-			catch
-			{
-				try
-				{
-					$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
-					$Computer = "$Computer.$env:USERDNSDOMAIN"
-				}
-				catch
-				{
-					$Computer = $OGComputer
-				}
-			}
+      try
+      {
+        $ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
+      }
+      catch
+      {
+        try
+        {
+          $ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+          $Computer = "$Computer.$env:USERDNSDOMAIN"
+        }
+        catch
+        {
+          $Computer = $OGComputer
+        }
+      }
 			
-			if ($Turbo)
-			{
-				try
-				{
-					$fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
-				}
-				catch
-				{
-					try
-					{
-						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
-					}
-					catch
-					{
-						throw "DNS name does not exist"
-					}
-				}
+      if ($Turbo)
+      {
+        try
+        {
+          $fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
+        }
+        catch
+        {
+          try
+          {
+            $fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+          }
+          catch
+          {
+            throw "$functionName - DNS name does not exist"
+          }
+        }
 				
-				if ($fqdn -notmatch "\.")
-				{
-					$dnsdomain = $env:USERDNSDOMAIN.ToLower()
-					$fqdn = "$fqdn.$dnsdomain"
-				}
+        if ($fqdn -notmatch "\.")
+        {
+          $dnsdomain = $env:USERDNSDOMAIN.ToLower()
+          $fqdn = "$fqdn.$dnsdomain"
+        }
 				
-				$hostname = $fqdn.Split(".")[0]
+        $hostname = $fqdn.Split(".")[0]
 				
-				[PSCustomObject]@{
-					InputName = $OGComputer
-					ComputerName = $hostname.ToUpper()
-					DNSHostname = $hostname
-					IPAddress = $ipaddress
-					Domain = $fqdn.Replace("$hostname.", "")
-					FQDN = $fqdn
-				}
-				return
-			}
+        [PSCustomObject]@{
+          InputName = $OGComputer
+          ComputerName = $hostname.ToUpper()
+          DNSHostname = $hostname
+          IPAddress = $ipaddress
+          Domain = $fqdn.Replace("$hostname.", "")
+          FQDN = $fqdn
+        }
+        return
+      }
 			
-			if ( $ipaddress )
-			{
-			    Write-Verbose "IP Address from $Computer is $ipaddress"
-			}
-			else
-			{
-				Write-Warning "No IP Address returned from Computer $Computer"
-			}
-			if ( $host.Version.Major -gt 2 )
-			{
-				Write-Verbose "Your PowerShell Version is $($host.Version.Major)"
-				try
-				{
-					Write-Verbose "Getting computer information from server $Computer via CIM (WSMan)"
-					if ($Credential)
-					{
-						$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
-					}
-					else
-					{
-						$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue
-					}
+      if ( $ipaddress )
+      {
+          Write-Verbose "$functionName - IP Address from $Computer is $ipaddress"
+      }
+      else
+      {
+        Write-Warning "$functionName - No IP Address returned from Computer $Computer"
+      }
+      if ( $host.Version.Major -gt 2 )
+      {
+        Write-Verbose "$functionName - Your PowerShell Version is $($host.Version.Major)"
+        try
+        {
+          Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (WSMan)"
+          if ($Credential)
+          {
+            $CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
+          }
+          else
+          {
+            $CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue
+          }
 					
-					$conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
-				}
-				catch
-				{
-					Write-Verbose "No WSMan connection to $Computer"
-				}
-				if ( !$conn )
-				{
-					try
-					{
-						Write-Verbose "Getting computer information from server $Computer via CIM (DCOM)"
-						$sessionoption = New-CimSessionOption -Protocol DCOM
-						if ($Credential)
-						{
-							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
+          $conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
+        }
+        catch
+        {
+          Write-Verbose "$functionName - No WSMan connection to $Computer"
+        }
+        if ( !$conn )
+        {
+          try
+          {
+            Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (DCOM)"
+            $sessionoption = New-CimSessionOption -Protocol DCOM
+            if ($Credential)
+            {
+              $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
 							
-						}
-						else
-						{
-							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
-						}
+            }
+            else
+            {
+              $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
+            }
 						
-						$conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
-					}
-					catch
-					{
-						Write-Warning "No DCOM connection for CIM to $Computer"
-					}
-				}
-			    if ( !$conn )
-			    {
-				    Write-Verbose "Getting computer information from server $Computer via WMI (DCOM)"
-					
-					if ($Credential)
-					{
-						$conn = Get-WmiObject -ComputerName $Computer -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -ErrorAction SilentlyContinue -Credential $Credential
-					}
-					else
-					{
-						$conn = Get-WmiObject -ComputerName $Computer -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -ErrorAction SilentlyContinue
-					}
-				}
-				
-				if (!$conn)
-				{
-					Write-Verbose "Cim and Wmi both failed. Defaulting to .NET"
-					try
-					{
-						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
-						$hostname = $fqdn.Split(".")[0]
+            $conn = Get-CimInstance -Query "Select Name, Caption, DNSHostName, Domain FROM Win32_computersystem" -CimSession $CIMsession
+          }
+          catch
+          {
+            Write-Warning "$functionName - No DCOM connection for CIM to $Computer"
+          }
+        }
+
+        if (!$conn)
+        {
+          Write-Verbose "$functionName - No CIM from $Computer. Defaulting to .NET"
+          try
+          {
+            $fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+            $hostname = $fqdn.Split(".")[0]
 						
-						$conn = [PSCustomObject]@{
-							Name = $Computer
-							DNSHostname = $hostname
-							Domain = $fqdn.Replace("$hostname.", "")
-						}
-					}
-					catch
-					{
-						# ouch, no dice
-					}
-				}
-			}
+            $conn = [PSCustomObject]@{
+              Name = $Computer
+              DNSHostname = $hostname
+              Domain = $fqdn.Replace("$hostname.", "")
+            }
+          }
+          catch
+          {
+            # ouch, no dice
+          }
+        }
+      }
 			
 			
-			try
-			{
-				Write-Verbose "Resolving $($conn.DNSHostname) using GetHostEntry"
-				$hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
-			}
-			catch
-			{
-				Write-Verbose "GetHostEntry failed"
-			}
+      try
+      {
+        Write-Verbose "$functionName - Resolving $($conn.DNSHostname) using GetHostEntry"
+        $hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
+      }
+      catch
+      {
+        Write-Verbose "$functionName - GetHostEntry failed"
+      }
 			
-			$fqdn = "$($conn.DNSHostname).$($conn.Domain)"
-			if ($fqdn -eq ".")
-			{
-				Write-Verbose "No full FQDN found. Setting to null"
-				$fqdn = $null
-			}
+      $fqdn = "$($conn.DNSHostname).$($conn.Domain)"
+      if ($fqdn -eq ".")
+      {
+        Write-Verbose "$functionName - No full FQDN found. Setting to null"
+        $fqdn = $null
+      }
 			
-			[PSCustomObject]@{
-				InputName = $OGComputer
-				ComputerName = $conn.Name
-				IPAddress = $ipaddress
-				DNSHostName = $conn.DNSHostname
-				Domain = $conn.Domain
-				DNSHostEntry = $hostentry
-				FQDN = $fqdn
-			}
-		}
-	}
+      [PSCustomObject]@{
+        InputName = $OGComputer
+        ComputerName = $conn.Name
+        IPAddress = $ipaddress
+        DNSHostName = $conn.DNSHostname
+        Domain = $conn.Domain
+        DNSHostEntry = $hostentry
+        FQDN = $fqdn
+      }
+    }
+  }
 }

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -92,15 +92,19 @@
 			{
 				try
 				{
+					Write-Verbose "Resolving $Computer using GetHostEntry"
 					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+					Write-Verbose "Resolving $ipaddress using GetHostByAddress"
 					$fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
 				}
 				catch
 				{
 					try
 					{
-						$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+						Write-Verbose "Resolving $Computer and IP using GetHostEntry"
+						$resolved = [System.Net.Dns]::GetHostEntry($Computer)
+						$ipaddress = $resolved.AddressList[0].IPAddressToString
+						$fqdn = $resolved.HostName
 					}
 					catch
 					{

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -59,8 +59,8 @@
     [parameter(Mandatory, ValueFromPipeline)]
     [Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlServer')]
     [object]$ComputerName = $env:COMPUTERNAME,
-    [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
-    [Alias("FastParrot")]
+    [System.Management.Automation.Credential()]$Credential,
+    [Alias('FastParrot')]
     [switch]$Turbo
   )
   BEGIN

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -161,11 +161,11 @@
           if ( $Credential )
           {
             $CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
-            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession
+            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession -ErrorAction SilentlyContinue
           }
           else
           {
-            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -ComputerName $Computer
+            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -ComputerName $Computer -ErrorAction SilentlyContinue
           }
         }
         catch

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -120,6 +120,7 @@
           catch
           {
             Write-Warning "$functionName - DNS name does not exist"
+            continue
           }
         }
 				

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -213,6 +213,7 @@
           catch
           {
             Write-Warning "$functionName - No .NET information from $Computer"
+            continue
           }
         }
       }

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -54,198 +54,205 @@
 	
       Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-SqlRegisteredServerName
   #>
-  [CmdletBinding()]
-  param (
-    [parameter(Mandatory, ValueFromPipeline)]
-    [Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlServer')]
-    [object]$ComputerName = $env:COMPUTERNAME,
-    [System.Management.Automation.Credential()]$Credential,
-    [Alias('FastParrot')]
-    [switch]$Turbo
-  )
-  BEGIN
-  {
-    $functionName = (Get-PSCallstack)[0].Command
-  }
-  PROCESS
-  {
-    foreach ( $Computer in $ComputerName )
-    {
-      $conn = $ipaddress = $CIMsession = $null
+	[CmdletBinding()]
+	param (
+		[parameter(Mandatory, ValueFromPipeline)]
+		[Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlServer')]
+		[object]$ComputerName = $env:COMPUTERNAME,
+		[System.Management.Automation.Credential()]
+		$Credential,
+		[Alias('FastParrot')]
+		[switch]$Turbo
+	)
+	BEGIN
+	{
+		$functionName = (Get-PSCallstack)[0].Command
+	}
+	PROCESS
+	{
+		foreach ($Computer in $ComputerName)
+		{
+			$conn = $ipaddress = $CIMsession = $null
 			
-      if ( $Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server] )
-      {
-        $Computer = $Computer.NetName
-      }
+			if ($Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server])
+			{
+				$Computer = $Computer.NetName
+			}
 			
-      $OGComputer = $Computer
+			$OGComputer = $Computer
 			
-      if ($Computer -eq 'localhost' -or $Computer -eq '.')
-      {
-        $Computer = $env:COMPUTERNAME
-      }
+			if ($Computer -eq 'localhost' -or $Computer -eq '.')
+			{
+				$Computer = $env:COMPUTERNAME
+			}
 			
-      $Computer = $Computer.Split('\')[0]
-      Write-Verbose "$functionName - Connecting to server $Computer"
+			$Computer = $Computer.Split('\')[0]
 			
-      try
-      {
-        $ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
-      }
-      catch
-      {
-        try
-        {
-          $ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
-          $Computer = "$Computer.$env:USERDNSDOMAIN"
-        }
-        catch
-        {
-          $Computer = $OGComputer
-          $ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-        }
-      }
-			
-      if ($Turbo)
-      {
-        try
-        {
-          $fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
-        }
-        catch
-        {
-          try
-          {
-            $fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
-          }
-          catch
-          {
-            Write-Warning "$functionName - DNS name does not exist"
-            continue
-          }
-        }
+			if ($Turbo)
+			{
+				try
+				{
+					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+					$fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
+				}
+				catch
+				{
+					try
+					{
+						$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+					}
+					catch
+					{
+						Write-Warning "$functionName - DNS name does not exist"
+						continue
+					}
+				}
 				
-        if ($fqdn -notmatch "\.")
-        {
-          $dnsdomain = $env:USERDNSDOMAIN.ToLower()
-          $fqdn = "$fqdn.$dnsdomain"
-        }
+				if ($fqdn -notmatch "\.")
+				{
+					$dnsdomain = $env:USERDNSDOMAIN.ToLower()
+					$fqdn = "$fqdn.$dnsdomain"
+				}
 				
-        $hostname = $fqdn.Split(".")[0]
+				$hostname = $fqdn.Split(".")[0]
 				
-        [PSCustomObject]@{
-          InputName = $OGComputer
-          ComputerName = $hostname.ToUpper()
-          IPAddress = $ipaddress
-          DNSHostname = $hostname
-          Domain = $fqdn.Replace("$hostname.", "")
-          DNSHostEntry = $fqdn
-          FQDN = $fqdn
-        }
-        return
-      }
+				[PSCustomObject]@{
+					InputName = $OGComputer
+					ComputerName = $hostname.ToUpper()
+					IPAddress = $ipaddress
+					DNSHostname = $hostname
+					Domain = $fqdn.Replace("$hostname.", "")
+					DNSHostEntry = $fqdn
+					FQDN = $fqdn
+				}
+				return
+			}
 			
-      if ( $ipaddress )
-      {
-          Write-Verbose "$functionName - IP Address from $Computer is $ipaddress"
-      }
-      else
-      {
-        Write-Warning "$functionName - No IP Address returned from Computer $Computer"
-      }
-      if ( $host.Version.Major -gt 2 )
-      {
-        Write-Verbose "$functionName - Your PowerShell Version is $($host.Version.Major)"
-        try
-        {
-          Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (WSMan)"
-          if ( $Credential )
-          {
-            $CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
-            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession -ErrorAction SilentlyContinue
-          }
-          else
-          {
-            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -ComputerName $Computer -ErrorAction SilentlyContinue
-          }
-        }
-        catch
-        {
-          Write-Verbose "$functionName - No WSMan connection to $Computer"
-        }
-        if ( !$conn )
-        {
-          try
-          {
-            Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (DCOM)"
-            $sessionoption = New-CimSessionOption -Protocol DCOM
-            if ( $Credential )
-            {
-              $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
+			Write-Verbose "$functionName - Connecting to server $Computer"
+			
+			try
+			{
+				$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
+			}
+			catch
+			{
+				try
+				{
+					$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+					$Computer = "$Computer.$env:USERDNSDOMAIN"
+				}
+				catch
+				{
+					$Computer = $OGComputer
+					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+				}
+			}
+			
+			if ($ipaddress)
+			{
+				Write-Verbose "$functionName - IP Address from $Computer is $ipaddress"
+			}
+			else
+			{
+				Write-Warning "$functionName - No IP Address returned from Computer $Computer"
+				Write-Warning "$functionName - Using pure .NET to resolve"
+				return (Resolve-DbaNetworkName -ComputerName $Computer -Turbo)
+			}
+			
+			if ($host.Version.Major -gt 2)
+			{
+				Write-Verbose "$functionName - Your PowerShell Version is $($host.Version.Major)"
+				try
+				{
+					Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (WSMan)"
+					if ($Credential)
+					{
+						$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
+						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession -ErrorAction SilentlyContinue
+					}
+					else
+					{
+						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -ComputerName $Computer -ErrorAction SilentlyContinue
+					}
+				}
+				catch
+				{
+					Write-Verbose "$functionName - No WSMan connection to $Computer"
+				}
+				if (!$conn)
+				{
+					try
+					{
+						Write-Verbose "$functionName - Getting computer information from server $Computer via CIM (DCOM)"
+						$sessionoption = New-CimSessionOption -Protocol DCOM
+						if ($Credential)
+						{
+							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
 							
-            }
-            else
-            {
-              $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
-            }
+						}
+						else
+						{
+							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
+						}
 						
-            $conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession
-          }
-          catch
-          {
-            Write-Warning "$functionName - No DCOM connection for CIM to $Computer"
-          }
-        }
-
-        if ( !$conn )
-        {
-          Write-Verbose "$functionName - No CIM from $Computer. Getting HostName via .NET"
-          try
-          {
-            $fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
-            $hostname = $fqdn.Split(".")[0]
+						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession
+					}
+					catch
+					{
+						Write-Warning "$functionName - No DCOM connection for CIM to $Computer"
+					}
+				}
+				
+				if (!$conn)
+				{
+					Write-Verbose "$functionName - No CIM from $Computer. Getting HostName via .NET"
+					try
+					{
+						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+						$hostname = $fqdn.Split(".")[0]
 						
-            $conn = [PSCustomObject]@{
-              Name = $Computer
-              DNSHostname = $hostname
-              Domain = $fqdn.Replace("$hostname.", "")
-            }
-          }
-          catch
-          {
-            Write-Warning "$functionName - No .NET information from $Computer"
-            continue
-          }
-        }
-      }
+						$conn = [PSCustomObject]@{
+							Name = $Computer
+							DNSHostname = $hostname
+							Domain = $fqdn.Replace("$hostname.", "")
+						}
+					}
+					catch
+					{
+						Write-Warning "$functionName - No .NET information from $Computer"
+						continue
+					}
+				}
+			}
 			
 			
-      try
-      {
-        Write-Verbose "$functionName - Resolving $($conn.DNSHostname) using GetHostEntry"
-        $hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
-      }
-      catch
-      {
-        Write-Warning "$functionName - GetHostEntry failed"
-      }
+			try
+			{
+				Write-Verbose "$functionName - Resolving $($conn.DNSHostname) using GetHostEntry"
+				$hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
+			}
+			catch
+			{
+				Write-Warning "$functionName - GetHostEntry failed"
+			}
 			
-      $fqdn = "$($conn.DNSHostname).$($conn.Domain)"
-      if ($fqdn -eq ".")
-      {
-        Write-Verbose "$functionName - No full FQDN found. Setting to null"
-        $fqdn = $null
-      }
+			$fqdn = "$($conn.DNSHostname).$($conn.Domain)"
+			if ($fqdn -eq ".")
+			{
+				Write-Verbose "$functionName - No full FQDN found. Setting to null"
+				$fqdn = $null
+			}
 			
-      [PSCustomObject]@{
-        InputName = $OGComputer
-        ComputerName = $conn.Name
-        IPAddress = $ipaddress
-        DNSHostName = $conn.DNSHostname
-        Domain = $conn.Domain
-        DNSHostEntry = $hostentry
-        FQDN = $fqdn
-      }
-    }
-  }
+			[PSCustomObject]@{
+				InputName = $OGComputer
+				ComputerName = $conn.Name
+				IPAddress = $ipaddress
+				DNSHostName = $conn.DNSHostname
+				Domain = $conn.Domain
+				DNSHostEntry = $hostentry
+				FQDN = $fqdn
+			}
+		}
+	}
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - added $functionname
 - improved Verbose messages
 - add default $env:COMPUTERNAME
 - removed WMI check

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

