### PR TITLE
Fixed edge case with LSNs

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -223,6 +223,7 @@ folder for those file types as defined on the target instance.
         
         foreach ($f in $path)
         {
+            Write-Verbose "type = $($f.gettype())"
             if ($f -is [string])
             {
                 Write-Verbose "$FunctionName : Paths passed in" 
@@ -245,7 +246,12 @@ folder for those file types as defined on the target instance.
                     else 
                     {
                         Write-Verbose "$FunctionName : Standard Directory"
+                        $FileCheck = $BackFiles.Count()
                         $BackupFiles += Get-DirectoryRestoreFile -Path $p
+                        if ((($BackupFiles.count)-$FileCheck) -eq 0)
+                        {
+                            $BackupFiles += Get-OlaHRestoreFile -Path $p
+                        }
                     }
                 }
             } 

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -246,7 +246,7 @@ folder for those file types as defined on the target instance.
                     else 
                     {
                         Write-Verbose "$FunctionName : Standard Directory"
-                        $FileCheck = $BackFiles.Count()
+                        $FileCheck = $BackupFiles.count
                         $BackupFiles += Get-DirectoryRestoreFile -Path $p
                         if ((($BackupFiles.count)-$FileCheck) -eq 0)
                         {

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -103,18 +103,18 @@ Function Restore-DBFromFilteredArray
 
  		$RestorePoints  = @()
         $if = $InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Database'} | Group-Object FirstLSN
-		$RestorePoints  += @([PSCustomObject]@{order=1;'Files' = $if.group})
+		$RestorePoints  += @([PSCustomObject]@{order=[int64]1;'Files' = $if.group})
         $if = $InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Database Differential'}| Group-Object FirstLSN
-		$RestorePoints  += @([PSCustomObject]@{order=2;'Files' = $if.group})
+		$RestorePoints  += @([PSCustomObject]@{order=[int64]2;'Files' = $if.group})
   		foreach ($if in ($InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log'} | Group-Object FirstLSN))
  		{
-   			$RestorePoints  += [PSCustomObject]@{order=$if.Name; 'Files' = $if.group}
+   			$RestorePoints  += [PSCustomObject]@{order=[int64]($if.Name); 'Files' = $if.group}
 		}
 		foreach ($RestorePoint in ($RestorePoints | Sort-object -property order))
 		{
 			$RestoreFiles = $RestorePoint.files
 			$RestoreFileNames = $RestoreFiles.BackupPath -join '`n ,'
-			Write-verbose "$FunctionName - Restoring backup starting at LSN $($RestoreFiles[0].FirstLSN) in $($RestoreFiles[0].BackupPath)"
+			Write-verbose "$FunctionName - Restoring backup starting at order $($RestorePoint.order) - LSN $($RestoreFiles[0].FirstLSN) in $($RestoreFiles[0].BackupPath)"
 			$LogicalFileMoves = @()
 			if ($Restore.RelocateFiles.count -gt 0)
 			{

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -280,7 +280,7 @@ Function Restore-DBFromFilteredArray
 					NoRecovery = $restore.NoRecovery
 					WithReplace = $ReplaceDatabase
 					RestoreComplete  = $RestoreComplete
-                    BackupFilesCount = $RestoreFiles.Length
+                    BackupFilesCount = $RestoreFiles.Count
                     RestoredFilesCount = $RestoreFiles[0].Filelist.PhysicalName.count
                     BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
                     CompressedBackupSizeMB = ($RestoreFiles | measure-object -property CompressedBackupSizeMb -Sum).sum

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -288,9 +288,9 @@ Function Restore-DBFromFilteredArray
                     BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
                     CompressedBackupSizeMB = ($RestoreFiles | measure-object -property CompressedBackupSizeMb -Sum).sum
                     BackupFile = $RestoreFiles.BackupPath -join ','
-					RestoredFile = (Split-Path $RestoreFiles[0].Filelist.PhysicalName -Leaf) -join ','
+					RestoredFile = (Split-Path $Restore.RelocateFiles.PhysicalFileName -Leaf) -join ','
 					RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
-					RestoreDirectory = ((Split-Path $RestoreFiles[0].Filelist.PhysicalName) | sort-Object -unique) -join ','
+					RestoreDirectory = ((Split-Path $Restore.RelocateFiles.PhysicalFileName) | sort-Object -unique) -join ','
 					BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
 					CompressedBackupSize = ($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum
                     TSql = $script  

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -81,9 +81,7 @@ Function Restore-DBFromFilteredArray
 					try
 					{
 						Write-Verbose "$FunctionName - Set $DbName single_user to kill processes"
-						#Stop-DbaProcess -SqlServer $Server -Databases $Dbname -WarningAction continue
-						
-						#Invoke-SQLcmd2 -ServerInstance:$SqlServer -Credential:$SqlCredential -query "Alter database $DbName set single_user with rollback immediate;Alter database $DbName set Multi_user with rollback immediate;" -database master
+						Stop-DbaProcess -SqlServer $Server -Databases $Dbname -WarningAction Silentlycontinue
 						Invoke-SQLcmd2 -ServerInstance:$SqlServer -Credential:$SqlCredential -query "Alter database $DbName set offline with rollback immediate; Alter database $DbName set online with rollback immediate" -database master
 
 					}

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -288,13 +288,15 @@ Function Restore-DBFromFilteredArray
                     BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
                     CompressedBackupSizeMB = ($RestoreFiles | measure-object -property CompressedBackupSizeMb -Sum).sum
                     BackupFile = $RestoreFiles.BackupPath -join ','
-					RestoredFile = $RestoreFiles[0].Filelist.PhysicalName -join ','
+					RestoredFile = (Split-Path $RestoreFiles[0].Filelist.PhysicalName -Leaf) -join ','
+					RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
+					RestoreDirectory = ((Split-Path $RestoreFiles[0].Filelist.PhysicalName) | sort-Object -unique) -join ','
 					BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
 					CompressedBackupSize = ($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum
                     TSql = $script  
 					BackupFileRaw = $RestoreFiles
 					ExitError = $ExitError				
-                } | Select-DefaultView -ExcludeProperty BackupSize, CompressedBackupSize, ExitError, BackupFileRaw 
+                } | Select-DefaultView -ExcludeProperty BackupSize, CompressedBackupSize, ExitError, BackupFileRaw, RestoredFileFull 
 				while ($Restore.Devices.count -gt 0)
 				{
 					$device = $restore.devices[0]


### PR DESCRIPTION
And added drop through if user specifies path to OlaH style
backups but forgets the switch.

Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

