### PR TITLE
Restore-DbaDatabase remote file handling take 1

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -9,11 +9,15 @@ Upon bein passed a list of potential backups files this command will scan the fi
 backup sets. It will then filter those files down to a set that can perform the requested restore, checking that we have a 
 full restore chain to the point in time requested by the caller.
 
+The function defaults to working on a remote instance. This means that all paths passed in must be relative to the remote instance.
+XpDirTree will be used to perform the file scans
+
+
 Various means can be used to pass in a list of files to be considered. The default is to non recursively scan the folder
 passed in. 
 
 .PARAMETER SqlServer
-The SQL Server instance. 
+The SQL Server instance to restore to.
 
 .PARAMETER SqlCredential
 Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
@@ -42,10 +46,12 @@ want to perform more complex rename operations then please use the FileMapping p
 This will apply to all file move options, except for FileMapping
 
 .PARAMETER UseDestinationDefaultDirectories
-Switch that tells the restore to use the default Data and Log locations on the target server
+Switch that tells the restore to use the default Data and Log locations on the target server. If the don't exist, 
+the function will try to create them
 
 .PARAMETER RestoreTime
-Specify a DateTime object to which you want the database restored to. Default is to the latest point available 
+Specify a DateTime object to which you want the database restored to. Default is to the latest point  available 
+in the specified backups
 
 .PARAMETER MaintenanceSolutionBackup
 Switch to indicate the backup files are in a folder structure as created by Ola Hallengreen's maintenance scripts.
@@ -62,7 +68,7 @@ A string which will be prefixed to the start of the restore Database's Name
 Useful if restoring a copy to the same sql sevrer for testing.
 
 .PARAMETER NoRecovery
-Indicates if the database should be recovered after last restore. Default is to recover
+Indicates if the databases should be recovered after last restore. Default is to recover
 
 .PARAMETER WithReplace
 Switch indicated is the restore is allowed to replace an existing database.

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -276,7 +276,7 @@ folder for those file types as defined on the target instance.
 							}
 							else
 							{
-								Write-Warning "$FunctionName - $p cannot be access by $SqlServer"
+								Write-Warning "$FunctionName - $p cannot be access by $SqlServer" -WarningAction Stop
 							}
 						}
 						else
@@ -327,7 +327,7 @@ folder for those file types as defined on the target instance.
 							}
 							else
 							{
-								Write-Warning "$FunctionName - $($FileTmp.FullName) cannot be access by $SqlServer"
+								Write-Warning "$FunctionName - $($FileTmp.FullName) cannot be access by $SqlServer" -WarningAction stop
 							}
 
 						}
@@ -340,8 +340,7 @@ folder for those file types as defined on the target instance.
 							#Most likely incoming from Get-DbaBackupHistory
 							if($Filetmp.Server -ne $SqlServer -and $FileTmp.Full -notlike '\\\\*')
 							{
-								Write-Warning "$FunctionName - Backups from a different server and on a local drive, can't access"
-								Continue
+								Write-Warning "$FunctionName - Backups from a different server and on a local drive, can't access" -WarningAction stop
 							}
 						}
 						if ($FileTmp.FullName -notmatch '\.\w{3}\Z' )
@@ -358,7 +357,7 @@ folder for those file types as defined on the target instance.
 							}
 							else
 							{
-								Write-Warning "$FunctionName - $($FileTmp.FullName) cannot be access by $SqlServer"
+								Write-Warning "$FunctionName - $($FileTmp.FullName) cannot be accessed by $SqlServer"
 							}
 
 						}

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -37,7 +37,7 @@ Takes path, checks for validity. Scans for usual backup file
         }
         If (!(Test-SqlPath -SQLServer $sqlserver -SqlCredential $SqlCredential -path $path))
         {
-            Write-warning "$FunctionName - SQLServer $sqlserver cannot access $path" -WarningAction stop
+            Write-warning "$FunctionName - SQLServer $sqlserver cannot access $path"
         }
         $query = "EXEC master.sys.xp_dirtree '$Path',1,1;"
         $queryResult = Invoke-Sqlcmd2 -ServerInstance $sqlServer -Credential $SqlCredential -Database tempdb -Query $query

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -257,8 +257,8 @@
 				else
 				{
 					Write-Progress -id 1 -activity "Restoring $DbName to ServerName" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
-					$Restore.sqlrestore($Server)
 					$script = $restore.Script($Server)
+					$Restore.sqlrestore($Server)
 					Write-Progress -id 1 -activity "Restoring $DbName to $ServerName" -status "Complete" -Completed
 					
 				}

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -26,7 +26,8 @@
 		[System.Management.Automation.PSCredential]$SqlCredential,
 		[switch]$UseDestinationDefaultDirectories,
 		[switch]$ReuseSourceFolderStructure,
-		[switch]$Force
+		[switch]$Force,
+		[string]$RestoredDatababaseNamePrefix
 	)
     
 	    Begin
@@ -101,14 +102,14 @@
 
  		$RestorePoints  = @()
         $if = $InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Database'} | Group-Object FirstLSN
-		$RestorePoints  += @([PSCustomObject]@{order=[int64]1;'Files' = $if.group})
+		$RestorePoints  += @([PSCustomObject]@{order=[Decimal]1;'Files' = $if.group})
         $if = $InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Database Differential'}| Group-Object FirstLSN
 		if ($if -ne $null){
-			$RestorePoints  += @([PSCustomObject]@{order=[int64]2;'Files' = $if.group})
+			$RestorePoints  += @([PSCustomObject]@{order=[Decimal]2;'Files' = $if.group})
 		}
 		foreach ($if in ($InternalFiles | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log'} | Group-Object FirstLSN))
  		{
-   			$RestorePoints  += [PSCustomObject]@{order=[int64]($if.Name); 'Files' = $if.group}
+   			$RestorePoints  += [PSCustomObject]@{order=[Decimal]($if.Name); 'Files' = $if.group}
 		}
 		$SortedRestorePoints = $RestorePoints | Sort-object -property order
 		foreach ($RestorePoint in $SortedRestorePoints)


### PR DESCRIPTION
Also snuck in:

if multiple dbs passed in and DatabaseName set, makes no sense stops
Added RestoredDatababaseNamePrefix parameter, as with the remote limitations people may
want to restore back to teh same instance for testing, so this is a quick way of avoiding
name collision

fixes #754

Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

