### PR TITLE
Dba backup the return

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -114,7 +114,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 			
 			if ($BackupDirectory.count -gt 1)
 			{
-				Write-Verbose "$FunctionName - Multiple Backup Directories"
+				Write-Verbose "$FunctionName - Multiple Backup Directories, striping"
 				$Filecount = $BackupDirectory.count
 			}
 			
@@ -250,7 +250,6 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 						}
 						else {
 							$FinaLBackupPath += "$path\$BackupFileName.$suffix"
-							Write-Verbose "$FunctionName - t= $path\$BackupFileName.$suffix"
 						}
 					}
 					else
@@ -261,8 +260,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 							$FailReasons += $FailReason
 							Write-Warning "$FunctionName - $FailReason"
 						}
-						$FinaLBackupPath += "$path\$BackupFileName.$suffix"
-						Write-Verbose "$FunctionName - q= $path\$BackupFileName.$suffix"
+						$FinalBackupPath += "$path\$BackupFileName.$suffix"
 					}
 				}
 			}
@@ -325,20 +323,6 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 					Write-Exception $_
 					$BackupComplete = $false
 				}
-		
-			
-	<#			[PSCustomObject]@{
-					SqlInstance = $server.name
-					DatabaseName = $($Database.Name)
-					BackupComplete = $BackupComplete
-					BackupFilesCount = $filecount
-					BackupFile = (split-path $backup.Devices.name -leaf)
-					BackupFolder = (split-path $backup.Devices.name)
-					BackupPath = ($backup.Devices.name)
-					Script = $Tsql
-					Notes = $FailReasons -join (',')
-				} 
-			} else {#>
 			}
 			[PSCustomObject]@{
 					SqlInstance = $server.name
@@ -357,30 +341,3 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 		}
 	}
 }
-
-<#
-
-[int]$FileCount = 1,
-[switch]$CreateFolder,
-
-.PARAMETER FileCount
-Number of files to stripe each backup across if a single BackupDirectory is provided.
-
-File Names with be suffixed with x-of-y to enable identifying striped sets, where y is the number of files in the set and x is from 1 to you
-
-.PARAMETER CreateFolder
-Switch to indicate that a folder should be created under each folder for each database if it doesn't already existing
-Folders are created by the Sql Instance, and checks will be made for write permissions
-
-.EXAMPLE
-Backup-DbaDatabase -SqlInstance Server1 -Databases HR,Finance -Type Full -BackupDirectory \\server2\backups,\\server3\backups -CreateFolder
-
-This will perform a full Copy Only database backup on the databases HR and Finance on SQL Server Instance Server1 striping the files across the 2 fileshares, creaing folders 
-for each database
-
-.EXAMPLE
-Get-DbaDatabase -SqlInstance localhost\sqlexpress2016 -Status Normal -Exclude tempdb | Backup-DbaDatabase -SqlInstance localhost\sqlexpress2016 -Type diff -BackupDirectory d:\backups,e:\backups -CreateFolder
-
-Backs up every database in a normal start on localhost\sqlexpress2016, striping the backups across d:\backups and e:\backups for improved performance. Each DB has it's own folder under each of the backup paths
-
-#>

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -151,12 +151,17 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 			Write-Warning "You must specify a server and database or pipe some databases"
 			continue
 		}
+		if ($DatabaseCollection.Count -eq 0)
+		{
+			Write-Warning "The databases specified do not exist on $SqlInstance"
+			continue	
+		}
 		if ($DatabaseCollection.count -gt 1 -and $BackupFileName -ne '')
 		{
 			Write-Warning "$FunctionName - 1 BackupFile specified, but more than 1 database." -WarningAction stop
 			break
 		}
-		Write-Verbose "$FunctionName - $($DatabaseCollection.count) database to backup"
+		Write-Verbose "$FunctionName - $($DatabaseCollection.count) databases to backup"
 		
 		ForEach ($Database in $databasecollection)
 		{

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -141,6 +141,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 				$PipeDbs += $tdb.name
 			}
 		}
+
 	}
 	END
 	{


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Striping is back either by file count in a single folder or across multiple directories
 - Appears to be remote/local safe (all path checks done via SQL Server)
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

