### PR TITLE
Fix find dbaagentjob

### DIFF
--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -117,7 +117,7 @@ Returns all agent job(s) that are named exactly Mybackup
 	)
 	begin
 	{
-		if ($Failed, $Name, $StepName, $LastUsed, $Disabled, $Disabled, $NoSchedule, $NoEmailNotification, $Category, $Owner, $Exclude -notcontains $true)
+		if ($Failed, [boolean]$Name, [boolean]$StepName, $LastUsed, $Disabled, $NoSchedule, $NoEmailNotification, [boolean]$Category, [boolean]$Owner, [boolean]$Exclude -notcontains $true)
 		{
 			Write-Warning "At least one search term must be specified"
 			continue


### PR DESCRIPTION
Converted string parameter values to boolean to prevent write-warning when one of these paramaters is used and none of the swith-paramters is.

Hope I followed the right steps, since this is my 1st experience on github and my 1st pull request.

Kind regards,

Cees