### PR TITLE
Restore position

### DIFF
--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -253,6 +253,7 @@
 					$Device = New-Object -TypeName Microsoft.SqlServer.Management.Smo.BackupDeviceItem
 					$Device.Name = $RestoreFile.BackupPath
 					$Device.devicetype = "File"
+					$Restore.FileNumber = $RestoreFile.Position
 					$Restore.Devices.Add($device)
 				}
 				Write-Verbose "$FunctionName - Performing restore action"
@@ -312,27 +313,34 @@
 					$RestoreDirectory = ((Split-Path $Restore.RelocateFiles.PhysicalFileName) | sort-Object -unique) -join ','
 					$RestoredFile = (Split-Path $Restore.RelocateFiles.PhysicalFileName -Leaf) -join ','
 				}
-				[PSCustomObject]@{
-                    SqlInstance = $SqlServer
-                    DatabaseName = $DatabaseName
-                    DatabaseOwner = $server.ConnectionContext.TrueLogin
-					NoRecovery = $restore.NoRecovery
-					WithReplace = $ReplaceDatabase
-					RestoreComplete  = $RestoreComplete
-                    BackupFilesCount = $RestoreFiles.Count
-                    RestoredFilesCount = $RestoreFiles[0].Filelist.PhysicalName.count
-                    BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
-                    CompressedBackupSizeMB = ($RestoreFiles | measure-object -property CompressedBackupSizeMb -Sum).sum
-                    BackupFile = $RestoreFiles.BackupPath -join ','
-					RestoredFile = $RestoredFile
-					RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
-					RestoreDirectory = $RestoreDirectory
-					BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
-					CompressedBackupSize = ($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum
-                    TSql = $script  
-					BackupFileRaw = $RestoreFiles
-					ExitError = $ExitError				
-                } | Select-DefaultView -ExcludeProperty BackupSize, CompressedBackupSize, ExitError, BackupFileRaw, RestoredFileFull 
+				if (!$ScriptOnly)
+				{
+					[PSCustomObject]@{
+						SqlInstance = $SqlServer
+						DatabaseName = $DatabaseName
+						DatabaseOwner = $server.ConnectionContext.TrueLogin
+						NoRecovery = $restore.NoRecovery
+						WithReplace = $ReplaceDatabase
+						RestoreComplete  = $RestoreComplete
+						BackupFilesCount = $RestoreFiles.Count
+						RestoredFilesCount = $RestoreFiles[0].Filelist.PhysicalName.count
+						BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
+						CompressedBackupSizeMB = ($RestoreFiles | measure-object -property CompressedBackupSizeMb -Sum).sum
+						BackupFile = $RestoreFiles.BackupPath -join ','
+						RestoredFile = $RestoredFile
+						RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
+						RestoreDirectory = $RestoreDirectory
+						BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
+						CompressedBackupSize = ($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum
+						Script = $script  
+						BackupFileRaw = $RestoreFiles
+						ExitError = $ExitError				
+					} | Select-DefaultView -ExcludeProperty BackupSize, CompressedBackupSize, ExitError, BackupFileRaw, RestoredFileFull 
+				} 
+				else
+				{
+					$script
+				}
 				while ($Restore.Devices.count -gt 0)
 				{
 					$device = $restore.devices[0]

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -56,7 +56,7 @@
 			$Server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential	
 		}
 		catch {
-			$server.ConnectionContext.Disconnect()
+
 			Write-Warning "$FunctionName - Cannot connect to $SqlServer" 
 			break
 


### PR DESCRIPTION
﻿Fixes # 

Changes proposed in this pull request:
 - File positions work properly
 - Output change
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

