### PR TITLE
Fix last backup order

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -188,7 +188,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								  a.MediaSetId,
 								  a.Software
 								FROM (SELECT
-								  RANK() OVER (ORDER BY backupset.media_set_id DESC) AS 'BackupSetRank',
+								  RANK() OVER (ORDER BY backupset.backup_start_date DESC) AS 'BackupSetRank',
 								  '$servername' AS Server,
 								  backupset.database_name AS [Database],
 								  backupset.user_name AS Username,


### PR DESCRIPTION
- If the most recent backup is done to an existing and older backup
media set id, when runing the function the output shows not the most
recent regarding date time but the most recent regarding the higher
backupset.media_set_id.

I will add more info into PR