### PR TITLE
Fixed arrays of paths and XPdir issue

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -267,6 +267,8 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 										ELSE NULL
 									  END AS Type,
 									  backupset.media_set_id AS MediaSetId,
+									  mediafamily.media_family_id as mediafamilyid,
+		   							  backupset.backup_set_id as backupsetid,
 									  CASE mediafamily.device_type
 										WHEN 2 THEN 'Disk'
 										WHEN 102 THEN 'Permanent Disk  Device'

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -212,6 +212,8 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 									ELSE NULL
 								  END AS Type,
 								  backupset.media_set_id AS MediaSetId,
+								  mediafamily.media_family_id as mediafamilyid,
+		   						  backupset.backup_set_id as backupsetid,
 								  CASE mediafamily.device_type
 									WHEN 2 THEN 'Disk'
 									WHEN 102 THEN 'Permanent Disk  Device'
@@ -331,7 +333,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 					else
 					{	
 						write-verbose "$FunctionName - Grouped output"
-						$GroupedResults  = $results | Group-Object -Property mediasetid
+						$GroupedResults  = $results | Group-Object -Property backupsetid
 						$GroupResults = @()
 						foreach ($group in $GroupedResults){
 							$GroupResults += [PSCustomObject]@{
@@ -346,7 +348,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								Path = $group.Group.Path
 								TotalSizeMb = ($group.group.TotalSizeMb | measure-object  -Sum).sum
 								Type = $group.Group[0].Type
-								MediaSetID = $group.Group[0].MediaSetId
+								BackupSetupId = $group.Group[0].BackupSetId
 								DeviceType = $group.Group[0].DeviceType
 								Software = $group.Group[0].Software
 								FullName =  $group.Group.Path

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -318,10 +318,10 @@ folder for those file types as defined on the target instance.
 				Write-Verbose "$FunctionName : Files passed in $($Path.count)"
 				Foreach ($FileTmp in $Path)
 				{
-					Write-Verbose "Type - $($FileTmp.GetType()), length =$($FileTmp.length)"
+					Write-Verbose "$FunctionName - Type - $($FileTmp.GetType()), length =$($FileTmp.length)"
 					if($FileTmp -is [System.Io.FileInfo] -and $isLocal -eq $False )
 					{
-						Write-Verbose "File object"
+						Write-Verbose "$FunctionName - File object"
 						if ($FileTmp.PsIsContainer)
 						{
 							$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential
@@ -354,15 +354,18 @@ folder for those file types as defined on the target instance.
 						}
 						if ([bool]($FileTmp.FullName -notmatch '\.\w{3}\Z' ))
 						{
-							Write-Verbose "$FunctionName - it's file"
-							$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential
+
+							foreach ($dir in $Filetmp.path){
+															Write-Verbose "$FunctionName - it's a folder, passing to Get-XpDirTree - $($dir)"
+								$BackupFiles += Get-XPDirTreeRestoreFile -Path $dir -SqlServer $SqlServer -SqlCredential $SqlCredential
+							}
 						}
 						elseif ([bool]($FileTmp.FullName -match '\.\w{3}\Z' ))
 						{
 							Write-Verbose "$FunctionName - it's folder"
 							ForEach ($ft in $Filetmp.FullName)
 							{			
-								Write-Verbose "$FunctionName - Piped files Testing $($ft)"					
+								Write-Verbose "$FunctionName - Piped files Test-SqlPath $($ft)"					
 								if (Test-SqlPath -Path $ft -SqlServer $SqlServer -SqlCredential $SqlCredential)
 								{
 									$BackupFiles += $ft

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -44,7 +44,7 @@ Takes path, checks for validity. Scans for usual backup file
         #$queryresult
         $dirs = $queryResult | where-object { $_.file -eq 0 }
         $Results = @()
-              $Results += $queryResult | where-object { $_.file -eq 1 } | Select @{Name="FullName";Expression={$PATH+$_."Subdirectory"}}
+              $Results += $queryResult | where-object { $_.file -eq 1 } | Select-Object @{Name="FullName";Expression={$PATH+$_."Subdirectory"}}
   
         ForEach ($d in $dirs) 
         {

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -87,13 +87,13 @@
 					}
 					catch
 					{
-						Write-Verbose "$FunctionName - No processes to kill"
+						Write-Verbose "$FunctionName - No processes to kill in $DbName"
 					}
 				} 
 			}
 			else
 			{
-				Write-Warning "$FunctionName - Database exists and will not be overwritten without the WithReplace switch"
+				Write-Warning "$FunctionName - Database $DbName exists and will not be overwritten without the WithReplace switch"
 				break
 			}
 
@@ -121,7 +121,7 @@
 					{
 					if ((New-DbaSqlDirectory -Path $File -SqlServer:$SqlServer -SqlCredential:$SqlCredential).Created -ne $true)
 					{
-						write-Warning  "$FunctionName - Destination File $File does not exist, and could not be created on $SqlServer" -WarningAction stop
+						write-Warning  "$FunctionName - Destination File $File does not exist, and could not be created on $SqlServer"
 
 						return
 					}
@@ -140,7 +140,7 @@
 		{
 			$RestoreFiles = $RestorePoint.files
 			$RestoreFileNames = $RestoreFiles.BackupPath -join '`n ,'
-			Write-verbose "$FunctionName - Restoring backup starting at order $($RestorePoint.order) - LSN $($RestoreFiles[0].FirstLSN) in $($RestoreFiles[0].BackupPath)"
+			Write-verbose "$FunctionName - Restoring $Dbname backup starting at order $($RestorePoint.order) - LSN $($RestoreFiles[0].FirstLSN) in $($RestoreFiles[0].BackupPath)"
 			$LogicalFileMoves = @()
 
 			if ($Restore.RelocateFiles.count -gt 0)
@@ -194,7 +194,7 @@
 				$LogicalFileMovesString = $LogicalFileMoves -join ", `n"
 
 
-				Write-Verbose "$FunctionName - Beginning Restore"
+				Write-Verbose "$FunctionName - Beginning Restore of $Dbname"
 				$percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
 					Write-Progress -id 1 -activity "Restoring $dbname to $servername" -percentcomplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
 				}
@@ -205,7 +205,7 @@
 				if ($RestoreTime -gt (Get-Date))
 				{
 						$restore.ToPointInTime = $null
-						Write-Verbose "$FunctionName - restoring to latest point in time"
+						Write-Verbose "$FunctionName - restoring $DbName to latest point in time"
 
 				}
 				elseif ($RestoreFiles[0].RecoveryModel -ne 'Simple')
@@ -329,8 +329,8 @@
 						RestoredFile = $RestoredFile
 						RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
 						RestoreDirectory = $RestoreDirectory
-						BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
-						CompressedBackupSize = if([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSize')){($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum}else{0}
+						BackupSize =  ($RestoreFiles | measure-object -property BackupSize -Sum).sum
+						CompressedBackupSize = if([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSize')){($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum}else{$null}
 						Script = $script  
 						BackupFileRaw = $RestoreFiles
 						ExitError = $ExitError				

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -330,7 +330,7 @@
 						RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
 						RestoreDirectory = $RestoreDirectory
 						BackupSize = ($RestoreFiles | measure-object -property BackupSize -Sum).sum
-						CompressedBackupSize = ($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum
+						CompressedBackupSize = if([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSize')){($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum}else{0}
 						Script = $script  
 						BackupFileRaw = $RestoreFiles
 						ExitError = $ExitError				


### PR DESCRIPTION
﻿Fixes issue with Get-XpDirectory being passed arrays

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

