### PR TITLE
Piping between Backup-DbaDataBase and Restore-DbaDatabase now works

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -365,7 +365,8 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 					BackupPath = ($FinalBackupPath | Sort-Object -Unique)
 					Script = $script
 					Notes = $failures -join (',')
-			}
+					FullName = ($FinalBackupPath | Sort-Object -Unique)
+			} | Select-DefaultView -ExcludeProperty FullName
 			$BackupFileName = $null
 		}
 	}


### PR DESCRIPTION
﻿Fixes # 

Changes proposed in this pull request:
 - Can now pipe from Backup-DbaDataBase to Restore-DbaDatabase
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

