### PR TITLE
Create PSScriptAnalzyer rules file

### DIFF
--- a/bin/PSScriptAnalyzerRules.psd1
+++ b/bin/PSScriptAnalyzerRules.psd1
@@ -1,0 +1,24 @@
+@{
+    IncludeRules = @(
+                    'PSAvoidUsingCmdletAliases',
+                    'PSAvoidUsingWriteHost',
+                    'PSAvoidDefaultValueSwitchParameter',
+                    'PSReservedCmdletChar',
+                    'PSReservedParams',
+                    'PSAvoidUsingUserNameAndPassWordParams',
+                    'PSAvoidUsingPlaintTextForPassword',
+                    'PSAvoidUsingWMICmdlet',
+                    'PSAvoidUsingWriteHost',
+                    'PSMisleadingBacktick',
+                    'PSMissingModuleMainifestField',
+                    'PSPossibleIncorrectComparisonWithNull',
+                    'PSUseApprovedVerbs',
+                    'PSUseOutputTypeCorrectly',
+                    'PSShouldProcess',
+                    'PSUserToExportFieldsInManifest',
+                    'PSUseSingularNouns',
+                    'PSAvoidUsingInvokeExpression',
+                    'PSUseShouldProcessForStateChangingFunctions',
+                    'PSUseDeclaredVarsMoreThanAssignments'
+                    )
+}


### PR DESCRIPTION
Rules file that will be used with contributors wanting to use VS Code mostly, but can be used for those just wanting to run `Invoke-ScriptAnalzyer` against their PS1.

Changes proposed in this pull request:
 - Just adding a rules file to the bin directory

How to test this code: 

```powershell
Invoke-ScriptAnalzyer -Path C:\GitHub\dbatools\functions\Backup-DbaDatabase.ps1 -Settings C:\GitHub\dbatools\bin\PSScritpAnalzyerRules.psd1
```