### PR TITLE
Get-DbaBackupHistory - added back fix for emailed issue

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -159,9 +159,13 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 				if ($last)
 				{
 					if ($databases -eq $null) { $databases = $server.databases.name }
-					Get-DbaBackupHistory -SqlServer $server -LastFull -Databases $databases -raw:$raw
-					Get-DbaBackupHistory -SqlServer $server -LastDiff -Databases $databases -raw:$raw
-					Get-DbaBackupHistory -SqlServer $server -LastLog -Databases $databases -raw:$raw
+					
+					foreach ($db in $databases)
+					{
+						Get-DbaBackupHistory -SqlServer $server -LastFull -Databases $db -raw:$raw
+						Get-DbaBackupHistory -SqlServer $server -LastDiff -Databases $db -raw:$raw
+						Get-DbaBackupHistory -SqlServer $server -LastLog -Databases $db -raw:$raw
+					}
 				}
 				elseif ($LastFull -or $LastDiff -or $LastLog)
 				{


### PR DESCRIPTION
User emailed saying that all of the backup history files were combined when -Last was used. This was the fix. @Stuart-Moore, please check.