### PR TITLE
addind LSN and other details to Last* switches

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -194,7 +194,14 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								  a.Type,
 								  a.TotalSizeMB,
 								  a.MediaSetId,
-								  a.Software
+								  a.Software,
+								a.backupsetid,
+		 						 a.position,
+								a.first_lsn,
+								a.database_backup_lsn,
+								a.checkpoint_lsn,
+								a.last_lsn,
+								a.software_major_version
 								FROM (SELECT
 								  RANK() OVER (ORDER BY backupset.backup_start_date DESC) AS 'BackupSetRank',
 								  backupset.database_name AS [Database],
@@ -228,6 +235,12 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 									WHEN 7 THEN 'Virtual Device'
 									ELSE 'Unknown'
 								  END AS DeviceType,
+									backupset.position,
+									backupset.first_lsn,
+									backupset.database_backup_lsn,
+									backupset.checkpoint_lsn,
+									backupset.last_lsn,
+									backupset.software_major_version,
 								  mediaset.software_name AS Software
 								FROM msdb..backupmediafamily AS mediafamily
 								INNER JOIN msdb..backupmediaset AS mediaset


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Adds the hidden properties to the output for the -Last* switches so it can be piped through into restore-dbadatabase using the Trusted switch
 - Some combinations won't work, but they'll get picked up during the restores
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

