### PR TITLE
Small fixes

### DIFF
--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -62,9 +62,7 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
 		[Switch]$IgnoreLimit,
 		[switch]$Silent
 	)
-	
-	END
-	{
+
 		try
 		{
 			$server = Connect-SqlServer -SqlServer $SqlInstance -SqlCredential $SqlCredential
@@ -110,5 +108,5 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
 		Write-Message -Level Debug -Message $sql
 		Write-Message -Level Verbose -Message "Starting Log retrieval"
 		Invoke-SqlCmd2 -ServerInstance $server.name -Credential $SqlCredential -Query $sql -Database $Database
-	}
+
 }

--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -94,7 +94,12 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
 		else
 		{
 			#Warn if more than 0.5GB of live log. Dodgy conversion as SMO returns the value in an unhelpful format :(
-			if ($server.databases[$Database].LogFiles.usedspace/1000 -ge 500) # this will cause enumeration and needs to be addressed
+			$SqlSizeCheck = "select 
+								sum(FileProperty(sf.name,'spaceused')*8/1024) as 'SizeMb'
+								from sys.sysfiles sf
+								where CONVERT(INT,sf.status & 0x40) / 64=1"	
+			$TransLogSize = Invoke-SqlCmd2 -ServerInstance $server.name -Credential $SqlCredential -Query $SqlSizeCheck -Database $Database
+			if ($TransLogSize.SizeMb -ge 500) 
 			{
 				Stop-Function -Message "$Database has more than 0.5 Gb of live log data, returning this may have an impact on the database and the calling system. If you wish to proceed please rerun with the -IgnoreLimit switch"
 				return
@@ -104,6 +109,6 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
 		$sql = "select * from fn_dblog(NULL,NULL)"
 		Write-Message -Level Debug -Message $sql
 		Write-Message -Level Verbose -Message "Starting Log retrieval"
-		Invoke-SqlCmd2 -ServerInstance $server -Query $sql -Database $Database
+		Invoke-SqlCmd2 -ServerInstance $server.name -Credential $SqlCredential -Query $sql -Database $Database
 	}
 }


### PR DESCRIPTION
Moved Invoke-SqlCmd2 away from SMO and push in credentials
Removed Enumeration for getting transction log size (query should be safe -ge 2000)

Fixes # 

Changes proposed in this pull request:
 - Moved Invoke-SqlCmd2 away from SMO and push in credentials
 - Removed Enumeration for getting transction log size (query should be safe -ge 2000)
  

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

