### PR TITLE
Back restore pipe

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -506,7 +506,6 @@ folder for those file types as defined on the target instance.
 		}
 
 		$AllFilteredFiles = $BackupFiles | Get-FilteredRestoreFile -SqlServer $SqlServer -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory
-
 		Write-Verbose "$FunctionName - $($AllFilteredFiles.count) dbs to restore"
 		
 		if ($AllFilteredFiles.count -gt 1 -and $DatabaseName -ne '')

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -277,7 +277,7 @@ folder for those file types as defined on the target instance.
 					$f = $f.FullName
 				}
 				
-				if ($f.Gettype -is [string])
+				if ($f -is [string])
 				{
 					if ($f.StartsWith("\\") -eq $false -and  $islocal -ne $true)
 					{

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -256,7 +256,7 @@ folder for those file types as defined on the target instance.
 				Write-Verbose "$FunctionName - Trust Database Backup History Set"
 				if ("BackupPath" -notin $f.PSobject.Properties.name)
 				{
-					$f = $f | Select-Object *, @{Name="BackupPath";Expression={$_.FullName}}
+						$f = $f | Select-Object *, @{Name="BackupPath";Expression={$_.FullName}}
 				}
 				if ("DatabaseName" -notin $f.PSobject.Properties.name)
 				{
@@ -266,17 +266,8 @@ folder for those file types as defined on the target instance.
 				{
 					$f = $f | Select-Object *,  @{Name="Type";Expression={"Full"}}
 				}
-				if ($f.BackupPath.count -gt 1)
-				{
-					foreach ($p in $f.backupPath)
-					{
-						$BackupFiles += $tf | Select-Object *,@{Name="Fullname";Expression={$p}}, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
-					}	
-				}
-				else
-				{
-						$BackupFiles += $tf | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
-				}
+
+					$BackupFiles += $F | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
 			}
 			else
 			{
@@ -510,7 +501,7 @@ folder for those file types as defined on the target instance.
 		}
 
 		$AllFilteredFiles = $BackupFiles | Get-FilteredRestoreFile -SqlServer $SqlServer -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory
-		
+
 		Write-Verbose "$FunctionName - $($AllFilteredFiles.count) dbs to restore"
 		
 		if ($AllFilteredFiles.count -gt 1 -and $DatabaseName -ne '')

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -257,7 +257,6 @@ folder for those file types as defined on the target instance.
 				if ("BackupPath" -notin $f.PSobject.Properties.name)
 				{
 					$f = $f | Select-Object *, @{Name="BackupPath";Expression={$_.FullName}}
-					
 				}
 				if ("DatabaseName" -notin $f.PSobject.Properties.name)
 				{
@@ -267,8 +266,17 @@ folder for those file types as defined on the target instance.
 				{
 					$f = $f | Select-Object *,  @{Name="Type";Expression={"Full"}}
 				}
-				
-				$BackupFiles += $f | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
+				if ($f.BackupPath.count -gt 1)
+				{
+					foreach ($p in $f.backupPath)
+					{
+						$BackupFiles += $tf | Select-Object *,@{Name="Fullname";Expression={$p}}, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
+					}	
+				}
+				else
+				{
+						$BackupFiles += $tf | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
+				}
 			}
 			else
 			{

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -105,7 +105,7 @@ It allows the user to say that they trust that the output from those commands is
 read portion of the process. This means a faster process, but at the risk of not knowing till halfway through the restore 
 that something is wrong with a file.
 
-.PARAMETERT XpNoRecurse
+.PARAMETER XpNoRecurse
 If specified, prevents the XpDirTree process from recursing (it's default behaviour)
 
 .PARAMETER Confirm

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -194,7 +194,8 @@ folder for those file types as defined on the target instance.
 		[switch]$ReuseSourceFolderStructure,
 		[string]$DestinationFilePrefix = '',
 		[string]$RestoredDatababaseNamePrefix,
-		[switch]$TrustDbBackupHistory
+		[switch]$TrustDbBackupHistory,
+		[switch]$XpNoRecurse
 	)
 	BEGIN
 	{
@@ -321,7 +322,7 @@ folder for those file types as defined on the target instance.
 							}
 							else
 							{
-								$BackupFiles += Get-XPDirTreeRestoreFile -Path $p -SqlServer $SqlServer -SqlCredential $SqlCredential
+								$BackupFiles += Get-XPDirTreeRestoreFile -Path $p -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
 							}
 						}
 						elseif ((Get-Item $p -ErrorAction SilentlyContinue).PSIsContainer -ne $true)
@@ -371,7 +372,7 @@ folder for those file types as defined on the target instance.
 							Write-Verbose "$FunctionName - File object"
 							if ($FileTmp.PsIsContainer)
 							{
-								$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential
+								$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
 							}
 							else
 							{
@@ -404,7 +405,7 @@ folder for those file types as defined on the target instance.
 
 								foreach ($dir in $Filetmp.path){
 									Write-Verbose "$FunctionName - it's a folder, passing to Get-XpDirTree - $($dir)"
-									$BackupFiles += Get-XPDirTreeRestoreFile -Path $dir -SqlServer $SqlServer -SqlCredential $SqlCredential
+									$BackupFiles += Get-XPDirTreeRestoreFile -Path $dir -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
 								}
 							}
 							elseif ([bool]($FileTmp.FullName -match '\.\w{3}\Z' ))

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -104,12 +104,17 @@ This switch can be used when piping the output of Get-DbaBackupHistory or Backup
 It allows the user to say that they trust that the output from those commands is correct, and skips the file header
 read portion of the process. This means a faster process, but at the risk of not knowing till halfway through the restore 
 that something is wrong with a file.
-	
+
+.PARAMETERT XpNoRecurse
+If specified, prevents the XpDirTree process from recursing (it's default behaviour)
+
 .PARAMETER Confirm
 Prompts to confirm certain actions
 	
 .PARAMETER WhatIf
 Shows what would happen if the command would execute, but does not actually perform the command
+
+.
 
 .NOTES
 Tags: DisasterRecovery, Backup, Restore
@@ -194,8 +199,7 @@ folder for those file types as defined on the target instance.
 		[switch]$ReuseSourceFolderStructure,
 		[string]$DestinationFilePrefix = '',
 		[string]$RestoredDatababaseNamePrefix,
-		[switch]$TrustDbBackupHistory,
-		[switch]$XpNoRecurse
+		[switch]$TrustDbBackupHistory
 	)
 	BEGIN
 	{
@@ -322,7 +326,7 @@ folder for those file types as defined on the target instance.
 							}
 							else
 							{
-								$BackupFiles += Get-XPDirTreeRestoreFile -Path $p -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
+								$BackupFiles += Get-XPDirTreeRestoreFile -Path $p -SqlServer $SqlServer -SqlCredential $SqlCredential
 							}
 						}
 						elseif ((Get-Item $p -ErrorAction SilentlyContinue).PSIsContainer -ne $true)
@@ -372,7 +376,7 @@ folder for those file types as defined on the target instance.
 							Write-Verbose "$FunctionName - File object"
 							if ($FileTmp.PsIsContainer)
 							{
-								$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
+								$BackupFiles += Get-XPDirTreeRestoreFile -Path $FileTmp.Fullname -SqlServer $SqlServer -SqlCredential $SqlCredential
 							}
 							else
 							{
@@ -405,7 +409,7 @@ folder for those file types as defined on the target instance.
 
 								foreach ($dir in $Filetmp.path){
 									Write-Verbose "$FunctionName - it's a folder, passing to Get-XpDirTree - $($dir)"
-									$BackupFiles += Get-XPDirTreeRestoreFile -Path $dir -SqlServer $SqlServer -SqlCredential $SqlCredential -XpNoRecurse:$XpNoRecurse
+									$BackupFiles += Get-XPDirTreeRestoreFile -Path $dir -SqlServer $SqlServer -SqlCredential $SqlCredential
 								}
 							}
 							elseif ([bool]($FileTmp.FullName -match '\.\w{3}\Z' ))

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -267,7 +267,7 @@ folder for those file types as defined on the target instance.
 					$f = $f | Select-Object *,  @{Name="Type";Expression={"Full"}}
 				}
 
-					$BackupFiles += $F | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
+				$BackupFiles += $F | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
 			}
 			else
 			{

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -43,23 +43,26 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
     End
     {
 
-        $tmpInternalFiles = @()
-        foreach ($row in $InternalFiles)
-        {
-            if ($row.FullName.Count -gt 1){
-                foreach ($filename in $row.FullName)
-                {
-                    $newIF  = $row | select *
-                    $NewIf.fullName = $filename.ToString()
-                    $NewIf.BackupPath = $filename.ToString()
-                    $tmpInternalFiles += $NewIf
-                }
-            }
-        }
-        $InternalFiles = $tmpInternalFiles    
+   
         if ($TrustDbBackupHistory)
         {
             Write-Verbose "$FunctionName - Trusted backup history"
+
+            $tmpInternalFiles = @()
+            foreach ($row in $InternalFiles)
+            {
+                if ($row.FullName.Count -gt 1){
+                    foreach ($filename in $row.FullName)
+                    {
+                        $newIF  = $row | select *
+                        $NewIf.fullName = $filename.ToString()
+                        $NewIf.BackupPath = $filename.ToString()
+                        $tmpInternalFiles += $NewIf
+                    }
+                }
+            }
+            $InternalFiles = $tmpInternalFiles 
+
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Full'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Database"}},  @{Name="BackupType";Expression={"1"}}
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Log'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Transaction Log"}},  @{Name="BackupType";Expression={"2"}}
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Differential'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Database Differential"}},  @{Name="BackupType";Expression={"5"}}
@@ -70,7 +73,6 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
     		Write-Verbose "$FunctionName - Read File headers (Read-DBABackupHeader)"		
 			$AllSQLBackupdetails = $InternalFiles | ForEach{if($_.fullname -ne $null){$_.Fullname}else{$_}} | Read-DBAbackupheader -sqlserver $SQLSERVER -SqlCredential $SqlCredential
         }
-		
 		Write-Verbose "$FunctionName - $($AllSQLBackupdetails.count) Files to filter"
         $Databases = $AllSQLBackupdetails  | Group-Object -Property Servername, DatabaseName
         Write-Verbose "$FunctionName - $(($Databases | Measure-Object).count) database to process"

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -42,7 +42,21 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
     }
     End
     {
-    
+
+            $tmpInternalFiles = @()
+            foreach ($row in $InternalFiles)
+            {
+                if ($row.FullName.Count -gt 1){
+                    foreach ($filename in $row.FullName)
+                    {
+                        $newIF  = $row | select *
+                        $NewIf.fullName = $filename.ToString()
+                        $NewIf.BackupPath = $filename.ToString()
+                        $tmpInternalFiles += $NewIf
+                    }
+                }
+            }
+            $InternalFiles = $tmpInternalFiles    
         if ($TrustDbBackupHistory)
         {
             Write-Verbose "$FunctionName - Trusted backup history"

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -43,20 +43,20 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
     End
     {
 
-            $tmpInternalFiles = @()
-            foreach ($row in $InternalFiles)
-            {
-                if ($row.FullName.Count -gt 1){
-                    foreach ($filename in $row.FullName)
-                    {
-                        $newIF  = $row | select *
-                        $NewIf.fullName = $filename.ToString()
-                        $NewIf.BackupPath = $filename.ToString()
-                        $tmpInternalFiles += $NewIf
-                    }
+        $tmpInternalFiles = @()
+        foreach ($row in $InternalFiles)
+        {
+            if ($row.FullName.Count -gt 1){
+                foreach ($filename in $row.FullName)
+                {
+                    $newIF  = $row | select *
+                    $NewIf.fullName = $filename.ToString()
+                    $NewIf.BackupPath = $filename.ToString()
+                    $tmpInternalFiles += $NewIf
                 }
             }
-            $InternalFiles = $tmpInternalFiles    
+        }
+        $InternalFiles = $tmpInternalFiles    
         if ($TrustDbBackupHistory)
         {
             Write-Verbose "$FunctionName - Trusted backup history"

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -7,7 +7,6 @@ Internal Function to get SQL Server backfiles from a specified folder using xp_d
 Takes path, checks for validity. Scans for usual backup file 
 .PARAMETER Path
 .PARAMETER 
-
 #>
     [CmdletBinding()]
     Param (
@@ -16,8 +15,7 @@ Takes path, checks for validity. Scans for usual backup file
         [parameter(Mandatory = $true)]
         [Alias("ServerInstance", "SqlInstance")]
         [object]$SqlServer,
-        [System.Management.Automation.PSCredential]$SqlCredential,
-        [Switch]$XpNoRecurse
+        [System.Management.Automation.PSCredential]$SqlCredential
     )
        
         $FunctionName =(Get-PSCallstack)[0].Command
@@ -47,14 +45,12 @@ Takes path, checks for validity. Scans for usual backup file
         $dirs = $queryResult | where-object { $_.file -eq 0 }
         $Results = @()
               $Results += $queryResult | where-object { $_.file -eq 1 } | Select-Object @{Name="FullName";Expression={$PATH+$_."Subdirectory"}}
-        if ($XpNoRecurse -eq $false)      
-        { 
-            ForEach ($d in $dirs) 
-            {
-                $fullpath = "$path$($d.Subdirectory)"
-                Write-Verbose "Enumerating subdirectory '$fullpath'"
-                $Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlServer $SqlServer -SqlCredential $SqlCredential
-            }
+  
+        ForEach ($d in $dirs) 
+        {
+            $fullpath = "$path$($d.Subdirectory)"
+            Write-Verbose "Enumerating subdirectory '$fullpath'"
+            $Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlServer $SqlServer -SqlCredential $SqlCredential
         }
         return $Results
     

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -7,6 +7,7 @@ Internal Function to get SQL Server backfiles from a specified folder using xp_d
 Takes path, checks for validity. Scans for usual backup file 
 .PARAMETER Path
 .PARAMETER 
+
 #>
     [CmdletBinding()]
     Param (
@@ -15,7 +16,8 @@ Takes path, checks for validity. Scans for usual backup file
         [parameter(Mandatory = $true)]
         [Alias("ServerInstance", "SqlInstance")]
         [object]$SqlServer,
-        [System.Management.Automation.PSCredential]$SqlCredential
+        [System.Management.Automation.PSCredential]$SqlCredential,
+        [Switch]$XpNoRecurse
     )
        
         $FunctionName =(Get-PSCallstack)[0].Command
@@ -45,12 +47,14 @@ Takes path, checks for validity. Scans for usual backup file
         $dirs = $queryResult | where-object { $_.file -eq 0 }
         $Results = @()
               $Results += $queryResult | where-object { $_.file -eq 1 } | Select-Object @{Name="FullName";Expression={$PATH+$_."Subdirectory"}}
-  
-        ForEach ($d in $dirs) 
-        {
-            $fullpath = "$path$($d.Subdirectory)"
-            Write-Verbose "Enumerating subdirectory '$fullpath'"
-            $Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlServer $SqlServer -SqlCredential $SqlCredential
+        if ($XpNoRecurse -eq $false)      
+        { 
+            ForEach ($d in $dirs) 
+            {
+                $fullpath = "$path$($d.Subdirectory)"
+                Write-Verbose "Enumerating subdirectory '$fullpath'"
+                $Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlServer $SqlServer -SqlCredential $SqlCredential
+            }
         }
         return $Results
     

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -73,7 +73,7 @@ Function Restore-DBFromFilteredArray
 			$DestinationLogDirectory = Get-SqlDefaultPaths $Server log
 		}
 
-		If ($DbName -in $Server.databases.name -and $ScriptOnly -eq $false)
+		If ($DbName -in $Server.databases.name -and $ScriptOnly -eq $false -and $VerfiyOnly -eq $false)
 		{
 			If ($ReplaceDatabase -eq $true)
 			{	


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Piping from Backup-DBADatabase to restore-DbaDatabase didn't work with multiple backup files (either filecount -gt 1 or multiple paths). It does now
 - This particular pipe only works with TrustedDbBackupHistory
 - @ClaudioESSilva found an issue with dropping to XpDirTree functionality. Bad comparison in Restore-DbaDatabase, now fixed
- @ClaudioESSilva asked for the ability to stop Get-XpDirTreeRestoreFile from recursing. XpNoRecurse switch now available.

How to test this code: 
- [ ] $f = Get-DbaDatabase -SqlInstance localhost\sqlexpress2016 -Databases FGtest |
Backup-DbaDatabase -BackupDirectory C:\dbatools\backups\ -FileCount 8 | 
Restore-DbaDatabase -SqlServer localhost\sqlexpress2016 -DestinationDataDirectory C:\dbatools -OutputScriptOnly -verbose -TrustDbBackupHistory
- [ ] Restore-DbaDatabase -SqlServer localhost\sqlexpress2016 -path C:\dbatools\olapipe -OutputScriptOnly -verbose -XpDirTree -XpNoRecurse

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

