### PR TITLE
Backup dbadatabase compression

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -58,6 +58,9 @@ If not set, function will use the Server's default setting for compression
 .PARAMETER Checksum
 If switch enabled the backup checksum will be calculated
 
+.PARAMETER Verfiy
+If switch enabled, the backup with be verified by running a RESTORE VERIFYONLY against the Sql Instance
+
 .PARAMETER DatabaseCollection
 Internal parameter
 

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -58,7 +58,7 @@ If not set, function will use the Server's default setting for compression
 .PARAMETER Checksum
 If switch enabled the backup checksum will be calculated
 
-.PARAMETER Verfiy
+.PARAMETER Verify
 If switch enabled, the backup with be verified by running a RESTORE VERIFYONLY against the Sql Instance
 
 .PARAMETER DatabaseCollection

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -402,7 +402,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 										FullName = ($FinalBackupPath | Sort-Object -Unique)
 										FileList = $FileList
 										SoftwareVersionMajor = $server.VersionMajor
-								}  | Restore-DbaDatabase -SqlServer $server.name -SqlCredential $SqlCredential -DatabaseName DbaVerifyOnly -VerifyOnly
+								}  | Restore-DbaDatabase -SqlServer $server -SqlCredential $SqlCredential -DatabaseName DbaVerifyOnly -VerifyOnly
 						if ($verifiedResult[0] -eq "Verify successful")
 						{
 							$VerifiedDesc = $verifiedResult[0]

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -93,7 +93,7 @@ Gets a list of all .bak files on the \\nas\sql share and reads the headers using
 		Write-Verbose "$FunctionName - Connecting to $SqlServer"
 		try
 		{
-			$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $Credential -ErrorVariable ConnectError
+			$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential -ErrorVariable ConnectError
 			
 		}
 		catch

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -200,7 +200,14 @@ folder for those file types as defined on the target instance.
 	{
 		#Don't like nulls
 		$islocal = $false
-		$base = $SqlServer.Split("\")[0]
+		if ($base -is [string])
+		{
+			$base = $SqlServer.Split("\")[0]
+		}
+		else
+		{
+			$base = $SqlServer.name.Split("\")[0]
+		}
 		
 		if ($base -eq "." -or $base -eq "localhost" -or $base -eq $env:computername -or $base -eq "127.0.0.1")
 		{


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 Backup-DbaDatabase now supports
 - Compression
    - -lt 2008 - go away
    - -eq 2008
       - -eq Enterprise - Let's do it
       - -ne Enterprise - go away
    - -ge 2008R2 - let's do it
    -like '*express*' - go away
 - Checksum
- Verfiy

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

