### PR TITLE
Restore-SqlBackupFromDirectory: Example has wrong param name (servername)

### DIFF
--- a/functions/Restore-SqlBackupFromDirectory.ps1
+++ b/functions/Restore-SqlBackupFromDirectory.ps1
@@ -68,7 +68,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 https://dbatools.io/Restore-SqlBackupFromDirectory
 
 .EXAMPLE   
-Restore-SqlBackupFromDirectory -ServerName sqlcluster -Path \\fileserver\share\sqlbackups\SQLSERVER2014A
+Restore-SqlBackupFromDirectory -SqlServer sqlcluster -Path \\fileserver\share\sqlbackups\SQLSERVER2014A
 
 Description
 


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - change doc example param to name in the 

How to test this code: 
- [ ] Look at example, make sure param matches the one that exists. 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

