### PR TITLE
Remove obsolete condition on Restore-SqlBackupFromDirectory

### DIFF
--- a/functions/Restore-SqlBackupFromDirectory.ps1
+++ b/functions/Restore-SqlBackupFromDirectory.ps1
@@ -221,7 +221,7 @@ All user databases contained within \\fileserver\share\sqlbackups\SQLSERVERA wil
 		$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
 		$server.ConnectionContext.StatementTimeout = 0
 		
-		if ($server.versionMajor -lt 8 -and $server.versionMajor -lt 8)
+		if ($server.versionMajor -lt 8)
 		{
 			throw "This script can only be run on SQL Server 2000 and above. Quitting."
 		}


### PR DESCRIPTION
Restore-SqlBackupFromDirectory function have twice identical condition
on a IF statement. So one is removed.
