### PR TITLE
Out-DbaDataTable null value from pipeline handling 

### DIFF
--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -12,6 +12,12 @@ Thanks to Chad Miller, this script is all him. https://gallery.technet.microsoft
 .PARAMETER InputObject
 The object to transform into a DataTable
 	
+.PARAMETER IgnoreNull 
+Use this switch to ignore null rows
+
+.PARAMETER Silent 
+Use this switch to disable any kind of verbose messages
+
 .NOTES
 dbatools PowerShell module (https://dbatools.io)
 Copyright (C) 2016 Chrissy LeMaire
@@ -41,7 +47,9 @@ Similar to above but $dbalist gets piped in
 	[CmdletBinding()]
 	param (
 		[Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-		[AllowNull()][PSObject[]]$InputObject
+		[AllowNull()][PSObject[]]$InputObject,
+		[switch]$IgnoreNull,
+		[switch]$Silent
 	)
 	
 	BEGIN
@@ -84,8 +92,16 @@ Similar to above but $dbalist gets piped in
 	{
 		if (!$InputObject)
 		{
-			Write-Message -level 2 -Message "The InputObject from the pipe is null, ending function..." -silent $false
-			 Continue 
+			if ($IgnoreNull)
+			{
+				Stop-Function -Message "The InputObject from the pipe is null. Skipping." -Continue
+			}
+			else
+			{ 
+				$datarow = $datatable.NewRow()
+				$datatable.Rows.Add($datarow)
+				continue
+			}
 		}
 		foreach ($object in $InputObject)
 		{

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -41,7 +41,7 @@ Similar to above but $dbalist gets piped in
 	[CmdletBinding()]
 	param (
 		[Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-		[PSObject[]]$InputObject
+		[AllowNull()][PSObject[]]$InputObject
 	)
 	
 	BEGIN
@@ -80,9 +80,13 @@ Similar to above but $dbalist gets piped in
 		$datatable = New-Object System.Data.DataTable
 	}
 	
-	PROCESS
-	
+	PROCESS	
 	{
+		if (!$InputObject)
+		{
+			Write-Message -level 2 -Message "The InputObject from the pipe is null, ending function..." -silent $false
+			 Continue 
+		}
 		foreach ($object in $InputObject)
 		{
 			$datarow = $datatable.NewRow()


### PR DESCRIPTION
Fixes #892 

Changes proposed in this pull request:
 -  Added AloowNull() metadata tag and an if to catch nulls instead. 

How to test this code: 
- [ ] $dbatools |  Out-DbaDataTable 
- [ ] then populate $dbatools so it's not null and test again. 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

