### PR TITLE
Fixed datetime bug

### DIFF
--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -134,8 +134,8 @@
     # Since it's internal, I set it to always silent. Will show up in tests, but not bother the end users with a reminder over something they didn't do.
     Test-DbaDeprecation -DeprecatedOn "1.0.0.0" -Parameter "Warning" -CustomMessage "The parameter -Warning has been deprecated and will be removed on release 1.0.0.0. Please use '-Level Warning' instead." -Silent $true
     
-    $timestamp = Get-Date -Format "HH:mm:ss"
-    $NewMessage = "[$FunctionName][$timestamp] $Message"
+    $timestamp = Get-Date
+    $NewMessage = "[$FunctionName][$($timestamp.ToString("HH:mm:ss"))] $Message"
     
     #region Handle Errors
     if ($ErrorRecord)


### PR DESCRIPTION
Fixes the bad timestamp behavior.
Was converting straight to string, rather than only expressing it as such in the message, causing issues in some locales.
Now it's a true datetime object all the way, eliminating this.