### PR TITLE
New function to collect system details on the DBAtools workstation

### DIFF
--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -39,7 +39,8 @@ This will show MORE DETAILED information about the computer where DBAtools is be
 #>
     Param (
         #[string]$ComputerName = "$ENV:COMPUTERNAME",
-        [switch]$Detailed
+        [switch]$Detailed,
+        [switch]$Clip
     )
     
     try
@@ -91,16 +92,38 @@ This will show MORE DETAILED information about the computer where DBAtools is be
 
     if ($Detailed -eq $true)
         {
+            if($Clip -eq $true)
+            {
+            Write-Output ""   
+            Write-Output "Detailed information about the workstation is collected and copied to the clipboard; you can paste it elsewhere."
+            Write-Output "" 
+
             $localinfo | clip  
+
+            }
+            else {
             return $localinfo
+            }  
+            
             
             #may be add all environment variables back using Get-ChildItem Env: ?
+            #Also Fred recommended a function to collect diagnostic data from memory and log (but can also be implemented here as a switch)
         }
     else {
-
+            
             $BasicLocalInfo = $localinfo | Select-Object OSVersion, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin, isPowerShellISE
+            
+            if($Clip -eq $true)
+            {
+            Write-Output "" 
+            Write-Output "Basic information about the workstation is collected and copied to the clipboard; you can paste it elsewhere."
+            Write-Output "" 
             $BasicLocalInfo | clip
+            }
+            else {
             return $BasicLocalInfo
+            }
+            
     }
 
 }

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -69,7 +69,7 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         }
 
         $localinfo.DbaToolsVersion = (Get-Module dbatools).Version.ToString()
-        $localinfo.ModuleBase = (Get-Module dbatools).ModuleBase.ToString()
+        $localinfo.ModuleBase = (Get-Module dbatools).ModuleBase.ToString() -replace "\\users\\\w+\\","\users\...\"
         $localinfo.CLR = $PSVersionTable.CLRVersion.ToString()
      
         $smo = (([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -52,10 +52,10 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         $localinfo = @{ } | Select-Object OSVersion, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin, isPowerShellISE
         
         $localinfo.OSversion = [environment]::OSVersion.Version.ToString() 
-        $OsVersion = (Get-CimInstance Win32_OperatingSystem).Caption.ToString()
+        $OsVersion = (Get-CimInstance CIM_OperatingSystem).Caption.ToString()
         $localinfo.OSversion = $OsVersion + "(" + $localinfo.OSversion + ")"
         
-        $localinfo.OsArchitecture = (Get-CimInstance Win32_OperatingSystem).OSArchitecture.ToString()
+        $localinfo.OsArchitecture = (Get-CimInstance CIM_OperatingSystem).OSArchitecture.ToString()
 
         $localinfo.PowerShellVersion = $PSVersionTable.PSversion.ToString()
 

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -1,0 +1,106 @@
+#Function Get-DbatoolsEnvironmentInfo
+Function Get-DbaDiagnosticInfo
+{
+<#
+.SYNOPSIS
+Collects information about environment where DBAtools is being executed from.
+
+.DESCRIPTION
+Collects information about environment where DBAtools is being executed from. The information will be helpful for troubleshooting issues reported by users.
+    
+
+.PARAMETER Detailed
+Capture detailed information.
+
+.NOTES 
+Original Author: Chrissy LeMaire
+
+dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+Copyright (C) 2016 Chrissy LeMaire
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+.LINK
+https://dbatools.io/Get-DbaDiagnosticInfo
+
+.EXAMPLE
+Get-DbaDiagnosticInfo
+
+This will collect basic information about the computer where DBAtools is being executed from. It will then show the information in the conslole and at the same time COPY it. After running the cmdlet just paste it where ever you are reporting the issue: GitHub issues, email, or SQLcommunity slack channel etc.
+
+.EXAMPLE   
+Get-DbatoolsEnvironmentInfo -Detailed
+
+This will show MORE DETAILED information about the computer where DBAtools is being executed from.
+    
+#>
+    Param (
+        #[string]$ComputerName = "$ENV:COMPUTERNAME",
+        [switch]$Detailed
+    )
+    
+    try
+    {
+        
+        # #Write-Verbose "Collecting information about the computer where DBAtools is excuted from"
+
+        Write-Verbose "Getting local enivornment information"
+        $localinfo = @{ } | Select-Object Windows, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin
+        
+        $localinfo.Windows = [environment]::OSVersion.Version.ToString() 
+        $OsVersion = (Get-WmiObject Win32_OperatingSystem).Caption.ToString()
+        $localinfo.Windows = $OsVersion + "(" + $localinfo.Windows + ")"
+        
+        $localinfo.OsArchitecture = (Get-WmiObject Win32_OperatingSystem).OSArchitecture.ToString()
+
+        $localinfo.PowerShellVersion = $PSVersionTable.PSversion.ToString()
+
+        #If([Environment]::Is64BitProcess -eq $True) #Works on Powershell 3.0/.Net 4 and above
+        If($env:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
+            $localinfo.PowerShellArchitecture = "64-bit PowerShell"
+        }
+        else{
+            $localinfo.PowerShellArchitecture = "32-bit PowreShell"
+        }
+
+        $localinfo.DbaToolsVersion = (Get-Module dbatools -ListAvailable).Version.ToString()
+        $localinfo.ModuleBase = (Get-Module dbatools -ListAvailable).ModuleBase.ToString()
+        $localinfo.CLR = $PSVersionTable.CLRVersion.ToString()
+     
+        $smo = (([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]
+        $localinfo.SMO = $smo.TrimStart("Version=")
+        
+        $localinfo.DomainUser = $env:computername -ne $env:USERDOMAIN
+        $localinfo.RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+
+                
+        #$localinfo
+    }
+    
+    catch
+    {
+        Write-Warning "Can't collect info"
+        $_.Exception.Message
+        return
+        # break
+    }
+
+    if ($Detailed -eq $true)
+        {
+            $localinfo | clip  
+            return $localinfo
+            
+            #may be add all environment variables back using Get-ChildItem Env: ?
+        }
+    else {
+
+            $BasicLocalInfo = $localinfo | Select-Object Windows, PowerShell, CLR, SMO, RunAsAdmin 
+            $BasicLocalInfo | clip
+            return $BasicLocalInfo
+    }
+
+}

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -51,10 +51,10 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         $localinfo = @{ } | Select-Object OSVersion, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin, isPowerShellISE
         
         $localinfo.OSversion = [environment]::OSVersion.Version.ToString() 
-        $OsVersion = (Get-WmiObject Win32_OperatingSystem).Caption.ToString()
+        $OsVersion = (Get-CimInstance Win32_OperatingSystem).Caption.ToString()
         $localinfo.OSversion = $OsVersion + "(" + $localinfo.OSversion + ")"
         
-        $localinfo.OsArchitecture = (Get-WmiObject Win32_OperatingSystem).OSArchitecture.ToString()
+        $localinfo.OsArchitecture = (Get-CimInstance Win32_OperatingSystem).OSArchitecture.ToString()
 
         $localinfo.PowerShellVersion = $PSVersionTable.PSversion.ToString()
 

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -65,7 +65,7 @@ This will show MORE DETAILED information about the computer where DBAtools is be
             $localinfo.PowerShellArchitecture = "64-bit PowerShell"
         }
         else{
-            $localinfo.PowerShellArchitecture = "32-bit PowreShell"
+            $localinfo.PowerShellArchitecture = "32-bit PowerShell"
         }
 
         $localinfo.DbaToolsVersion = (Get-Module dbatools).Version.ToString()

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -59,7 +59,8 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         $localinfo.PowerShellVersion = $PSVersionTable.PSversion.ToString()
 
         #If([Environment]::Is64BitProcess -eq $True) #Works on Powershell 3.0/.Net 4 and above
-        If($env:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
+        #$env:PROCESSOR_ARCHITECTURE -eq 'AMD64' 
+        If([Intptr]::Size -eq 8) {
             $localinfo.PowerShellArchitecture = "64-bit PowerShell"
         }
         else{

--- a/functions/Get-DbaDiagnosticInfo.ps1
+++ b/functions/Get-DbaDiagnosticInfo.ps1
@@ -1,4 +1,3 @@
-#Function Get-DbatoolsEnvironmentInfo
 Function Get-DbaDiagnosticInfo
 {
 <#
@@ -49,11 +48,11 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         # #Write-Verbose "Collecting information about the computer where DBAtools is excuted from"
 
         Write-Verbose "Getting local enivornment information"
-        $localinfo = @{ } | Select-Object Windows, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin
+        $localinfo = @{ } | Select-Object OSVersion, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin, isPowerShellISE
         
-        $localinfo.Windows = [environment]::OSVersion.Version.ToString() 
+        $localinfo.OSversion = [environment]::OSVersion.Version.ToString() 
         $OsVersion = (Get-WmiObject Win32_OperatingSystem).Caption.ToString()
-        $localinfo.Windows = $OsVersion + "(" + $localinfo.Windows + ")"
+        $localinfo.OSversion = $OsVersion + "(" + $localinfo.OSversion + ")"
         
         $localinfo.OsArchitecture = (Get-WmiObject Win32_OperatingSystem).OSArchitecture.ToString()
 
@@ -67,8 +66,8 @@ This will show MORE DETAILED information about the computer where DBAtools is be
             $localinfo.PowerShellArchitecture = "32-bit PowreShell"
         }
 
-        $localinfo.DbaToolsVersion = (Get-Module dbatools -ListAvailable).Version.ToString()
-        $localinfo.ModuleBase = (Get-Module dbatools -ListAvailable).ModuleBase.ToString()
+        $localinfo.DbaToolsVersion = (Get-Module dbatools).Version.ToString()
+        $localinfo.ModuleBase = (Get-Module dbatools).ModuleBase.ToString()
         $localinfo.CLR = $PSVersionTable.CLRVersion.ToString()
      
         $smo = (([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]
@@ -76,7 +75,7 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         
         $localinfo.DomainUser = $env:computername -ne $env:USERDOMAIN
         $localinfo.RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
-
+        $localinfo.isPowerShellISE = [Environment]::CommandLine -match 'ise.exe'  
                 
         #$localinfo
     }
@@ -98,7 +97,7 @@ This will show MORE DETAILED information about the computer where DBAtools is be
         }
     else {
 
-            $BasicLocalInfo = $localinfo | Select-Object Windows, PowerShell, CLR, SMO, RunAsAdmin 
+            $BasicLocalInfo = $localinfo | Select-Object OSVersion, OsArchitecture,PowerShellVersion, PowerShellArchitecture, DbaToolsVersion, ModuleBase, CLR, SMO, DomainUser, RunAsAdmin, isPowerShellISE
             $BasicLocalInfo | clip
             return $BasicLocalInfo
     }

--- a/tests/Get-DbaDiagnosticInfo.Tests.ps1
+++ b/tests/Get-DbaDiagnosticInfo.Tests.ps1
@@ -1,0 +1,87 @@
+﻿
+## Thank you Warren http://ramblingcookiemonster.github.io/Testing-DSC-with-Pester-and-AppVeyor/
+
+if(-not $PSScriptRoot) {
+	$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+}
+
+$Verbose = @{}
+if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master") {
+	$Verbose.add("Verbose", $true)
+}
+
+
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace('.Tests.', '.')
+Import-Module "$PSScriptRoot\..\functions\$sut" -Force
+Import-Module PSScriptAnalyzer
+## Added PSAvoidUsingPlainTextForPassword as credential is an object and therefore fails. We can ignore any rules here under special circumstances agreed by admins :-)
+$rules = Get-ScriptAnalyzerRule | Where-Object{$_.RuleName -notin ('PSAvoidUsingPlainTextForPassword') }
+$name = $sut.Split('.')[0]
+
+Describe 'Script Analyzer Tests' {
+	Context "Testing $name for Standard Processing" {
+		foreach ($rule in $rules) { 
+			$index = $rules.IndexOf($rule)
+			It "passes the PSScriptAnalyzer Rule number $index - $rule	" {
+				(Invoke-ScriptAnalyzer -Path "$PSScriptRoot\..\functions\$sut" -IncludeRule $rule.RuleName).Count | Should Be 0 
+			}
+		}
+	}
+}
+
+## Load the command
+$ModuleBase = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# For tests in .\Tests subdirectory
+if ((Split-Path $ModuleBase -Leaf) -eq 'Tests')
+{
+	$ModuleBase = Split-Path $ModuleBase -Parent
+}
+
+# Handles modules in version directories
+$leaf = Split-Path $ModuleBase -Leaf
+$parent = Split-Path $ModuleBase -Parent
+$parsedVersion = $null
+if ([System.Version]::TryParse($leaf, [ref]$parsedVersion)) {
+	$ModuleName = Split-Path $parent -Leaf
+}
+else {
+	$ModuleName = $leaf
+}
+
+# Removes all versions of the module from the session before importing
+Get-Module $ModuleName | Remove-Module
+
+# Because ModuleBase includes version number, this imports the required version
+# of the module
+$null = Import-Module $ModuleBase\$ModuleName.psd1 -PassThru -ErrorAction Stop
+
+
+
+###############
+
+## Validate functionality. 
+<#
+
+Describe $name {
+    It "tries to get Powershell version" {
+        $true | Should Be $false
+    }
+
+
+
+    It "tries to get Windows Version" {
+        $true | Should Be $false
+    }
+
+    It "tries to determine if Powershell is running in Adminstrator mode" {
+        $true | Should Be $false
+    }
+
+    It "tries to get DBAtools version" {
+        $true | Should Be $false
+    }
+
+    
+
+#>

--- a/tests/Get-DbaDiagnosticInfo.Tests.ps1
+++ b/tests/Get-DbaDiagnosticInfo.Tests.ps1
@@ -108,7 +108,8 @@ Describe $name {
 			Assert-MockCalled Get-CimInstance -Times 2 -Exactly
 			
 		} #end It block
-
+	
+	} -Tag "Unit Tests"
 		Context "Checking Output of the function " {
 					
 					It 'Should not return null or Empty' {
@@ -127,8 +128,8 @@ Describe $name {
 					$localInfo.RunAsAdmin             | should Not BeNullOrEmpty
 					$localInfo.isPowerShellISE        | should Not BeNullOrEmpty
 			} #end It block
-		}
+		} -Tag "Operational Tests"
 		
-	}
+	
     
 }


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - New function to collect system details on the DBAtools workstation 
 - 
 - 

How to test this code: 
- [Get-DbaDiagnosticInfo ] 
- [ Get-DbaDiagnosticInfo -Detailed] 

Has been tested on minimum requirements:
- [X]  Powershell 3
- [X]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

