### PR TITLE
Fixed Write-Message ErrorRecord parameter

### DIFF
--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -146,7 +146,7 @@
         if ($Silent) { Write-Error -Message $record -Category $ErrorRecord.CategoryInfo.Category -TargetObject $Target -Exception $Exception -ErrorId "dbatools_$FunctionName" -ErrorAction Continue }
         else { $null = Write-Error -Message $record -Category $ErrorRecord.CategoryInfo.Category -TargetObject $Target -Exception $Exception -ErrorId "dbatools_$FunctionName" -ErrorAction Continue 2>&1 }
         
-        [sqlcollective.dbatools.dbaSystem.DebugHost]::WriteErrorEntry($Error[0], $FunctionName, $timestamp, $Message)
+        [sqlcollective.dbatools.dbaSystem.DebugHost]::WriteErrorEntry($ErrorRecord, $FunctionName, $timestamp, $Message)
     }
     #endregion Handle Errors
     


### PR DESCRIPTION
Would throw an exception due to bad input handling when passing an exception to log