### PR TITLE
Test-ComputerTarget

### DIFF
--- a/bin/typealiases.ps1
+++ b/bin/typealiases.ps1
@@ -1,0 +1,3 @@
+﻿
+[psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("DbaWmConnectionParameter", "sqlcollective.dbatools.parameter.DbaWmConnectionParameter")
+[psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbargx", "sqlcollective.dbatools.Utility.RegexHelper")

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -64,6 +64,7 @@ foreach ($assembly in $assemblies)
 # Load our own custom library
 # Should always come before function imports - 141ms
 $ExecutionContext.InvokeCommand.InvokeScript($false, ([scriptblock]::Create([io.file]::ReadAllText("$PSScriptRoot\bin\library.ps1"))), $null, $null)
+$ExecutionContext.InvokeCommand.InvokeScript($false, ([scriptblock]::Create([io.file]::ReadAllText("$PSScriptRoot\bin\typealiases.ps1"))), $null, $null)
 
 # All internal functions privately available within the toolset - 221ms
 foreach ($function in (Get-ChildItem "$PSScriptRoot\internal\*.ps1"))

--- a/internal/Test-ComputerTarget.ps1
+++ b/internal/Test-ComputerTarget.ps1
@@ -1,0 +1,45 @@
+﻿function Test-ComputerTarget
+{
+    <#
+        .SYNOPSIS
+            Validates whether the input string can be legally used to target a computer.
+        
+        .DESCRIPTION
+            Validates whether the input string can be legally used to target a computer.
+            It will consider:
+            - Names (NETBIOS/dns)
+            - IPv4 Addresses
+            - IPv6 Addresses
+            It will resolve idn names into default ascii names according to the official rules, before rendering judgement.
+        
+        .PARAMETER ComputerName
+            The name to verify
+        
+        .EXAMPLE
+            PS C:\> Test-ComputerTarget -ComputerName 'server1'
+    
+            Will test whether 'server1' is a legal computername (hint: it is)
+    
+        .EXAMPLE
+            PS C:\> "foo", "bar", "foo bar" | Test-ComputerTarget
+    
+            Will test, whether the names passed to it are legal targets.
+            - The first two will pass, the last one will fail
+            - Note that it will only return boolean values, so the order needs to be remembered (due to this, using it by pipeline on more than one object is not really recommended).
+    #>
+    
+    [CmdletBinding()]
+    Param (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [string[]]
+        $ComputerName
+    )
+    
+    Process
+    {
+        foreach ($Computer in $ComputerName)
+        {
+            [sqlcollective.dbatools.Utility.Validation]::IsValidComputerTarget($ComputerName)
+        }
+    }
+}


### PR DESCRIPTION
- Expanded the library, including a lot of the new stuff for the remote management suite, didn't touch existing stuff. So long as it still loads, all is well.
- Added a new file that adds type accelerators (so instead of typing `[sqlcollective.dbatools.Utility.RegexHelper]` I can just type `[dbargx]`)
- Added the file the "things-to-load" in the psm1 file
- Added new internal function `Test-ComputerTarget`, which allows testing for legal names, in a way regular contributors can handle