### PR TITLE
Bugfix for Error Record Category

### DIFF
--- a/internal/Stop-Function.ps1
+++ b/internal/Stop-Function.ps1
@@ -111,7 +111,7 @@
     $timestamp = Get-Date
     
     $Exception = New-Object System.Exception($Message, $InnerErrorRecord.Exception)
-    if (-not $PSBoundParameters.ContainsKey("Category") -and ($PSBoundParameters.ContainsKey("InnerErrorRecord"))) { $Category = $InnerErrorRecord.CategoryInfo.Category }
+    if ((-not $PSBoundParameters.ContainsKey("Category")) -and ($PSBoundParameters.ContainsKey("InnerErrorRecord")) -and ($InnerErrorRecord.CategoryInfo.Category)) { $Category = $InnerErrorRecord.CategoryInfo.Category }
     $record = New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools_$FunctionName", $Category, $Target)
     
     # Manage Debugging


### PR DESCRIPTION
The input validation was not sufficient, causing the function to resolve to a bad error category, when ...
 - An inner error record was provided
 - That error record would not contain a proper CategoryInfo
A new validation condition is applied, ensuring that only when a valid categoryinfo property is on the record it will be used to override the default