### PR TITLE
Get db nobackup

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -167,7 +167,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 				continue
 			}
 			
-			if ($Database.Status -ne 'Normal')
+			if ('Normal' -notin ($Database.Status -split ',') )
 			{
 				Write-Warning "Database status not Normal. $dbname skipped."
 				continue

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -121,7 +121,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 		[switch]$LastLog,
 		[switch]$raw
 	)
-	#		[Parameter(ParameterSetName = "NoLast")]
+
 	DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $Credential } }
 	
 	BEGIN
@@ -170,7 +170,6 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 				}
 				elseif ($LastFull -or $LastDiff -or $LastLog)
 				{
-					#$sql = @()
 					
 					if ($databases -eq $null) { $databases = $server.databases.name }
 					
@@ -360,10 +359,8 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 				if (!$last)
 				{
 					Write-Debug $sql
-					Write-Verbose "$FunctionName - Calling sql"
 					$results = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-Object * -ExcludeProperty BackupSetRank, RowError, Rowstate, table, itemarray, haserrors
-					#$results = Invoke-SqlCmd2 -ServerInstance $server -query $sql -as PSObject
-					Write-Verbose "$FunctionName - sql retrieved"
+
 					if ($raw)
 					{
 						write-verbose "$FunctionName - Raw Ouput"

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -184,7 +184,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 					{
 						Write-Verbose "$FunctionName - Processing $database"
 						
-						$sql += "SELECT
+						$tsql += "SELECT
 								  a.BackupSetRank,
 								  a.Server,
 								  a.[Database],
@@ -211,6 +211,7 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								  backupset.backup_start_date AS Start,
 								  backupset.server_name as [server],
 								  backupset.backup_finish_date AS [End],
+								  backupset.is_copy_only,
 								  CAST(DATEDIFF(SECOND, backupset.backup_start_date, backupset.backup_finish_date) AS varchar(4)) + ' ' + 'Seconds' AS Duration,
 								  mediafamily.physical_device_name AS Path,
 								  $BackupSizeColumn,
@@ -252,8 +253,14 @@ Lots of detailed information for all databases on sqlserver2014a and sql2016.
 								WHERE backupset.database_name = '$database'
 								AND (type = '$first'
 								OR type = '$second')) AS a
-								WHERE a.BackupSetRank = 1
-								ORDER BY a.Type;"
+								WHERE a.BackupSetRank = 1 "
+								if ($IgnoreCopyOnly)
+								{
+									$tsql += " and a.is_copy_only='0' "
+								}
+								$tsql += "ORDER BY a.Type;"
+							
+							$sql += $tsql	
 					}
 					
 					$sql = $sql -join "; "

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -224,11 +224,7 @@ Returns databases on multiple instances piped into the function
 			{
 				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}	
 			}
-			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
-			#if ($NoFullBackup -or $NoLogBackup)
-			#{
-				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus')
-			#}
+			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup','SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus'
 
 			foreach ($db in $inputobject)
 			{

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -176,12 +176,12 @@ Returns databases on multiple instances piped into the function
 			{
 				$inputobject = $inputobject | Where-Object {$_.Name -notin $exclude }
 			}
-
+			Write-verbose "dbs  = $($inputobject.count)"
 			if ($NoFullBackup)
 			{
-				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq '01/01/0001 00:00:00'}
+				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq 0}
 			}
-
+			Write-verbose "dbs  = $($inputobject.count)"
 			if ($null -ne $NoFullBackupSince)
 			{
 				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoFullBackupSince}				

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -224,8 +224,12 @@ Returns databases on multiple instances piped into the function
 			{
 				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}	
 			}
-			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup','SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus'
+			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
 
+			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince)
+			{
+				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus')
+			}
 			foreach ($db in $inputobject)
 			{
 			

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -92,7 +92,9 @@ Returns databases on multiple instances piped into the function
 		[string]$Access,
 		[parameter(ParameterSetName = "RecoveryModel")]
 		[ValidateSet('Full', 'Simple', 'BulkLogged')]
-		[string]$RecoveryModel
+		[string]$RecoveryModel,
+		[switch]$NoFullBackup, 
+		[datetime]$NoFullBackupSince = (get-date('01/01/0001 00:00:00'))
 	)
 	
 	DynamicParam { if ($SqlInstance) { return Get-ParamSqlDatabases -SqlServer $SqlInstance[0] -SqlCredential $SqlCredential } }
@@ -173,6 +175,11 @@ Returns databases on multiple instances piped into the function
 			if ($exclude)
 			{
 				$inputobject = $inputobject | Where-Object {$_.Name -notin $exclude }
+			}
+
+			if ($NoFullBackup)
+			{
+				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq '01/01/0001 00:00:00'}
 			}
 			
 			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -225,34 +225,35 @@ Returns databases on multiple instances piped into the function
 				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}	
 			}
 			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
-			if ($NoFullBackup -or $NoLogBackup)
-			{
+			#if ($NoFullBackup -or $NoLogBackup)
+			#{
 				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus')
-			}
+			#}
 
 			foreach ($db in $inputobject)
 			{
-				
-				if ($NoFullBackup -or $NoFullBackup)
-				{				
-					$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {(New-TimeSpan -Start $db.LastBackupdate).Tostring()}
-					$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {$SinceFull.split('.')[0..($SinceFull.split('.').count - 2)] -join ' days ' }
+			
+				$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {(New-TimeSpan -Start $db.LastBackupdate).Tostring()}
+				$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {$SinceFull.split('.')[0..($SinceFull.split('.').count - 2)] -join ' days ' }
 
-					$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()}
-					$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {$SinceDiff.split('.')[0..($SinceDiff.split('.').count - 2)] -join ' days ' }
+				$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()}
+				$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {$SinceDiff.split('.')[0..($SinceDiff.split('.').count - 2)] -join ' days ' }
 
-					$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
-					$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
-					$BackupStatus = ""
+				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
+				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
+				$BackupStatus = ""
+				if ($NoFullBackup -or $NoFullBackupSince)
+				{		
 					if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object{$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) )
 					{
 						$BackupStatus = "Only CopyOnly backups"
 					}	
-					Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
-					Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
-					Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
-					Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $BackupStatus
-				}					
+				}	
+				Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
+				Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
+				Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
+				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $BackupStatus
+	
 				Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName
 				Add-Member -InputObject $db -MemberType NoteProperty InstanceName -value $server.ServiceName
 				Add-Member -InputObject $db -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -228,7 +228,7 @@ Returns databases on multiple instances piped into the function
 
 			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince)
 			{
-				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus')
+				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Notes')
 			}
 			foreach ($db in $inputobject)
 			{
@@ -241,18 +241,18 @@ Returns databases on multiple instances piped into the function
 
 				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
 				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
-				$BackupStatus = ""
+				$Notes = $null
 				if ($NoFullBackup -or $NoFullBackupSince)
 				{		
 					if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object{$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) )
 					{
-						$BackupStatus = "Only CopyOnly backups"
+						$Notes = "Only CopyOnly backups"
 					}	
 				}	
 				Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
 				Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
 				Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
-				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $BackupStatus
+				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
 	
 				Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName
 				Add-Member -InputObject $db -MemberType NoteProperty InstanceName -value $server.ServiceName

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -179,7 +179,7 @@ Returns databases on multiple instances piped into the function
 			Write-verbose "dbs  = $($inputobject.count)"
 			if ($NoFullBackup)
 			{
-				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq 0}
+				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq 0 -or (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | ?{$_.IsCopyOnly}).count )}
 			}
 			Write-verbose "dbs  = $($inputobject.count)"
 			if ($null -ne $NoFullBackupSince)

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -179,7 +179,11 @@ Returns databases on multiple instances piped into the function
 			Write-verbose "dbs  = $($inputobject.count)"
 			if ($NoFullBackup)
 			{
-				$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq 0 -or (((@($_.EnumBackupSets()).count -eq @($_.EnumBackupSets() | Where-Object {$_.IsCopyOnly}).count) -and $_.RecoveryModel -in ('Full','BulkLogged')))}
+				$dabs = (Get-DbaBackuphistory -SqlServer $server -lastfull -ignorecopyonly).Database
+				Write-Verbose "Got dabs"
+				$inputobject = $inputObject  | where-object {$_.name -notin $dabs}
+				Write-verbose "past filter"
+				#$inputobject = $inputobject | Where-Object {$_.LastBackupDate -eq 0 -or (((@($_.EnumBackupSets()).count -eq @($_.EnumBackupSets() | Where-Object {$_.IsCopyOnly}).count) -and $_.RecoveryModel -in ('Full','BulkLogged')))}
 			}
 			Write-verbose "dbs  = $($inputobject.count)"
 			if ($null -ne $NoFullBackupSince)
@@ -187,29 +191,33 @@ Returns databases on multiple instances piped into the function
 				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoFullBackupSince}				
 			}
 			
-			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup', 'SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus'
+			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup','SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus'
 			foreach ($db in $inputobject)
 			{
-				$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {(New-TimeSpan -Start $db.LastBackupdate).Tostring()}
-                $SinceFull = if ($db.LastBackupdate -eq 0) {""} else {$SinceFull.split('.')[0..($SinceFull.split('.').count - 2)] -join ' days ' }
+				#if ($NoFullBackup)
+				#{				
+					$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {(New-TimeSpan -Start $db.LastBackupdate).Tostring()}
+					$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {$SinceFull.split('.')[0..($SinceFull.split('.').count - 2)] -join ' days ' }
 
-				$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()}
-                $SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {$SinceDiff.split('.')[0..($SinceDiff.split('.').count - 2)] -join ' days ' }
+					$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()}
+					$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {$SinceDiff.split('.')[0..($SinceDiff.split('.').count - 2)] -join ' days ' }
 
-				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
-                $SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
-				$BackupStatus = ""
-				if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object{$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) )
-				{
-					$BackupStatus = "Only CopyOnly backups"
-				}							
+					$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
+					$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
+					$BackupStatus = ""
+					if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object{$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) )
+					{
+						$BackupStatus = "Only CopyOnly backups"
+					}	
+					Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
+					Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
+					Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
+					Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $BackupStatus
+					#$defaults = $defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Backupstatus')
+				#}					
 				Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName
 				Add-Member -InputObject $db -MemberType NoteProperty InstanceName -value $server.ServiceName
 				Add-Member -InputObject $db -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
-				Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
-				Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
-				Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
-				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $BackupStatus
 				Select-DefaultView -InputObject $db -Property $defaults
 				
 			}

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -228,19 +228,11 @@ Returns databases on multiple instances piped into the function
 
 			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince)
 			{
-				$defaults += ('SinceFull', 'SinceDiff', 'SinceLog', 'Notes')
+				$defaults += ('Notes')
 			}
 			foreach ($db in $inputobject)
 			{
 			
-				$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {(New-TimeSpan -Start $db.LastBackupdate).Tostring()}
-				$SinceFull = if ($db.LastBackupdate -eq 0) {""} else {$SinceFull.split('.')[0..($SinceFull.split('.').count - 2)] -join ' days ' }
-
-				$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()}
-				$SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {""} else {$SinceDiff.split('.')[0..($SinceDiff.split('.').count - 2)] -join ' days ' }
-
-				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {(New-TimeSpan -Start $db.LastLogBackupDate).Tostring()}
-				$SinceLog = if ($db.LastLogBackupDate -eq 0) {""} else {$SinceLog.split('.')[0..($SinceLog.split('.').count - 2)] -join ' days ' }
 				$Notes = $null
 				if ($NoFullBackup -or $NoFullBackupSince)
 				{		
@@ -249,9 +241,6 @@ Returns databases on multiple instances piped into the function
 						$Notes = "Only CopyOnly backups"
 					}	
 				}	
-				Add-Member -InputObject $db -MemberType NoteProperty SinceFull -value $SinceFull
-				Add-Member -InputObject $db -MemberType NoteProperty SinceDiff -value $SinceDiff
-				Add-Member -InputObject $db -MemberType NoteProperty SinceLog -value $SinceLog
 				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
 	
 				Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -544,7 +544,7 @@ folder for those file types as defined on the target instance.
 			{
 				try
 				{
-					$FilteredFiles | Restore-DBFromFilteredArray -SqlServer $SqlServer -DBName $databasename -SqlCredential $SqlCredential -RestoreTime $RestoreTime -DestinationDataDirectory $DestinationDataDirectory -DestinationLogDirectory $DestinationLogDirectory -NoRecovery:$NoRecovery -TrustDbBackupHistory:$TrustDbBackupHistory -Replace:$WithReplace -ScriptOnly:$OutputScriptOnly -FileStructure $FileMapping -VerifyOnly:$VerifyOnly -UseDestinationDefaultDirectories:$UseDestinationDefaultDirectories -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -DestinationFilePrefix $DestinationFilePrefix
+					$FilteredFiles | Restore-DBFromFilteredArray -SqlServer $SqlServer -DBName $databasename -SqlCredential $SqlCredential -RestoreTime $RestoreTime -DestinationDataDirectory $DestinationDataDirectory -DestinationLogDirectory $DestinationLogDirectory -NoRecovery:$NoRecovery -TrustDbBackupHistory:$TrustDbBackupHistory -ReplaceDatabase:$WithReplace -ScriptOnly:$OutputScriptOnly -FileStructure $FileMapping -VerifyOnly:$VerifyOnly -UseDestinationDefaultDirectories:$UseDestinationDefaultDirectories -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -DestinationFilePrefix $DestinationFilePrefix
 					
 					$Completed = 'successfully'
 				}

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -512,10 +512,17 @@ folder for those file types as defined on the target instance.
 				}
 			}
 		}
-
-		$AllFilteredFiles = $BackupFiles | Get-FilteredRestoreFile -SqlServer $SqlServer -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory
+		#$BackupFiles 
+		#return
+		Write-Verbose "$FunctionName - sorting uniquely"
+		$AllFilteredFiles = $BackupFiles | sort-object -property fullname -unique | Get-FilteredRestoreFile -SqlServer $SqlServer -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory
+		
 		Write-Verbose "$FunctionName - $($AllFilteredFiles.count) dbs to restore"
 		
+		#$AllFilteredFiles
+		#return
+		
+
 		if ($AllFilteredFiles.count -gt 1 -and $DatabaseName -ne '')
 		{
 			Write-Warning "$FunctionName -  DatabaseName parameter and multiple database restores is not compatible "

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -268,6 +268,7 @@ folder for those file types as defined on the target instance.
 				Write-Verbose "$FunctionName - Trust Database Backup History Set"
 				if ("BackupPath" -notin $f.PSobject.Properties.name)
 				{
+						Write-Verbose "$FunctionName - adding BackupPath - $($_.Fullname)"
 						$f = $f | Select-Object *, @{Name="BackupPath";Expression={$_.FullName}}
 				}
 				if ("DatabaseName" -notin $f.PSobject.Properties.name)
@@ -280,6 +281,7 @@ folder for those file types as defined on the target instance.
 				}
 
 				$BackupFiles += $F | Select-Object *, @{Name="ServerName";Expression={$_.SqlInstance}}, @{Name="BackupStartDate";Expression={$_.Start}}
+				$str = ($BackUpFiles | select Fullname) -join ',' 
 			}
 			else
 			{
@@ -449,7 +451,6 @@ folder for those file types as defined on the target instance.
 	}
 	END
 	{
-
 
 		try
 		{

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -76,13 +76,15 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
     		Write-Verbose "$FunctionName - Read File headers (Read-DBABackupHeader)"		
 			$AllSQLBackupdetails = $InternalFiles | ForEach{if($_.fullname -ne $null){$_.Fullname}else{$_}} | Read-DBAbackupheader -sqlserver $SQLSERVER -SqlCredential $SqlCredential
         }
+
 		Write-Verbose "$FunctionName - $($AllSQLBackupdetails.count) Files to filter"
         $Databases = $AllSQLBackupdetails  | Group-Object -Property Servername, DatabaseName
         Write-Verbose "$FunctionName - $(($Databases | Measure-Object).count) database to process"
 		
 		foreach ($Database in $Databases){
+
             $Results = @()
-            Write-Verbose "$FunctionName - Find Newest Full backup"
+            Write-Verbose "$FunctionName - Find Newest Full backup - $($_.$DatabaseName)"
             $ServerName, $databaseName = $Database.Name.split(',')
             $SQLBackupdetails = $AllSQLBackupdetails | Where-Object {$_.ServerName -eq $ServerName -and $_.DatabaseName -eq $DatabaseName.trim()}
             $Fullbackup = $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq 'Database' -and $_.BackupStartDate -lt $RestoreTime} | Sort-Object -Property BackupStartDate -descending | Select-Object -First 1

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -46,7 +46,7 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
    
         if ($TrustDbBackupHistory)
         {
-            Write-Verbose "$FunctionName - Trusted backup history"
+            Write-Verbose "$FunctionName - Trusted backup history loop"
 
             $tmpInternalFiles = @()
             foreach ($row in $InternalFiles)
@@ -60,13 +60,16 @@ Tnen find the T-log backups needed to bridge the gap up until the RestorePoint
                         $tmpInternalFiles += $NewIf
                     }
                 }
+                else
+                {
+                    $tmpInternalFiles += $row
+                }
             }
             $InternalFiles = $tmpInternalFiles 
 
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Full'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Database"}},  @{Name="BackupType";Expression={"1"}}
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Log'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Transaction Log"}},  @{Name="BackupType";Expression={"2"}}
             $allsqlBackupDetails += $InternalFiles | Where-Object {$_.Type -eq 'Differential'} | select-object *,  @{Name="BackupTypeDescription";Expression={"Database Differential"}},  @{Name="BackupType";Expression={"5"}}
-
         }
         else
         {

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -73,7 +73,7 @@ Function Restore-DBFromFilteredArray
 			$DestinationLogDirectory = Get-SqlDefaultPaths $Server log
 		}
 
-		If ($DbName -in $Server.databases.name -and $ScriptOnly -eq $false -and $VerfiyOnly -eq $false)
+		If ($DbName -in $Server.databases.name -and ($ScriptOnly -eq $false -or $VerfiyOnly -eq $false))
 		{
 			If ($ReplaceDatabase -eq $true)
 			{	
@@ -181,8 +181,9 @@ Function Restore-DBFromFilteredArray
 					{
 						$DestinationLogDirectory = $DestinationLogDirectory.Substring(0,($DestinationLogDirectory.length -1))
 					}
-					foreach ($File in $RestoreFiles[0].Filelist)
+					foreach ($File in $RestoreFiles.Filelist)
 			        {
+						Write-Verbose "$FunctionName - Moving $($File.PhysicalName)"
                         $MoveFile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
                         $MoveFile.LogicalFileName = $File.LogicalName
                         if ($File.Type -eq 'L' -and $DestinationLogDirectory -ne '')
@@ -216,7 +217,7 @@ Function Restore-DBFromFilteredArray
                     break
 				} 
 				$LogicalFileMovesString = $LogicalFileMoves -join ", `n"
-
+				Write-Verbose "$FunctionName - $LogicalFileMovesString"
 
 				Write-Verbose "$FunctionName - Beginning Restore of $Dbname"
 				$percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
@@ -259,7 +260,7 @@ Function Restore-DBFromFilteredArray
 					}
 				Write-Verbose "$FunctionName - restore action = $Action"
 				$restore.Action = $Action 
-				if ($RestorePoint -eq $RestorePoints[-1] -and $NoRecovery -ne $true)
+				if ($RestorePoint -eq $SortedRestorePoints[-1] -and $NoRecovery -ne $true)
 				{
 					#Do recovery on last file
 					Write-Verbose "$FunctionName - Doing Recovery on last file"

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -190,7 +190,8 @@ Function Restore-DBFromFilteredArray
                         {
                             $MoveFile.PhysicalFileName = $DestinationLogDirectory + '\' + $DestinationFilePrefix + (split-path $file.PhysicalName -leaf)					
                         }
-                        else {
+                        else 
+						{
                             $MoveFile.PhysicalFileName = $DestinationDataDirectory + '\' + $DestinationFilePrefix + (split-path $file.PhysicalName -leaf)	
 							Write-verbose "$FunctionName - Moving $($file.PhysicalName) to $($MoveFile.PhysicalFileName) "
                         }

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -192,6 +192,7 @@ Function Restore-DBFromFilteredArray
                         }
                         else {
                             $MoveFile.PhysicalFileName = $DestinationDataDirectory + '\' + $DestinationFilePrefix + (split-path $file.PhysicalName -leaf)	
+							Write-verbose "$FunctionName - Moving $($file.PhysicalName) to $($MoveFile.PhysicalFileName) "
                         }
                         $LogicalFileMoves += "Relocating $($MoveFile.LogicalFileName) to $($MoveFile.PhysicalFileName)"
 						$null = $Restore.RelocateFiles.Add($MoveFile)
@@ -348,13 +349,13 @@ Function Restore-DBFromFilteredArray
 						RestoreComplete  = $RestoreComplete
 						BackupFilesCount = $RestoreFiles.Count
 						RestoredFilesCount = $RestoreFiles[0].Filelist.PhysicalName.count
-						BackupSizeMB = ($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum
+						BackupSizeMB = if([bool]($RestoreFiles.PSobject.Properties.name -match 'BackupSizeMb')){($RestoreFiles | measure-object -property BackupSizeMb -Sum).sum}else{$null}
 						CompressedBackupSizeMB = if([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSizeMb')){($RestoreFiles | measure-object -property CompressedBackupSizeMB -Sum).sum}else{$null}
 						BackupFile = $RestoreFiles.BackupPath -join ','
 						RestoredFile = $RestoredFile
 						RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
 						RestoreDirectory = $RestoreDirectory
-						BackupSize =  ($RestoreFiles | measure-object -property BackupSize -Sum).sum
+						BackupSize =  if([bool]($RestoreFiles.PSobject.Properties.name -match 'BackupSize')){($RestoreFiles | measure-object -property BackupSize -Sum).sum}else{$null}
 						CompressedBackupSize = if([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSize')){($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum}else{$null}
 						Script = $script  
 						BackupFileRaw = $RestoreFiles


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 -  NoFullBackup switch added to Get-DbaDatabase to get list of Dbs with no anchoring full backup
 - NoFullBackupSince parameter added to Get-DbaDatabase to get a list of dbs with no full backup since passed in date 
 - Get-DbaBackupHistory - Improved performance of running Last* queries across lots of dbs using  partitioning and only running the query once. Still support 2005+ as before
- Get-DbaBackupHistory - Since parameter now works across the paramters

How to test this code: 
- [ ] Get-DbaDatabase -SqlInstance sql2005 -NoFullBackup
- [ ] Get-DbaDatabase -SqlInstance sql2005 -NoFullBackupSince (Get-Date).AddDays(-7)
And the reason I did this initially:
- [ ] Get-DbaDatabase -SqlInstance sql2005 -NoFullBackup | Backup-DbaDatabase -NoCopyOnly

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [x ] All examples work as advertised
- [x ] Does not contain template content
- [x ] Does not contain excessive/unnecessary amounts of comments
- [x ] Works remotely
- [x ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [x ] Works with named instances
- [x ] Works with clustered instances
- [x ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x ] No un-handled errors which stop the command working with multiple servers

