### PR TITLE
Remove-DbaBackup, fixes #970

### DIFF
--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -13,11 +13,11 @@ backups have been archived to your archive location before removal.
 Also included is the ability to remove empty folders as part of this cleanup activity.
 
 .PARAMETER Path
-Name of the base level folder to search for backup files. 
+Name of the base level folder to search for backup files.
 Deletion of backup files will be recursive from this location.
 
 .PARAMETER BackupFileExtension
-Extension of the backup files you wish to remove (typically bak or log)
+Extension of the backup files you wish to remove (typically bak, trn or log)
 
 .PARAMETER RetentionPeriod
 Retention period for backup files. Correct format is ##U.
@@ -29,23 +29,26 @@ d = days
 w = weeks
 m = months
 
-Formatting Examples: 
+Formatting Examples:
 '48h' = 48 hours
 '7d' = 7 days
 '4w' = 4 weeks
 '1m' = 1 month
 
 .PARAMETER CheckArchiveBit
-Check the archive bit on files before deletion
+Checks the archive bit before deletion. If the file is "ready for archiving" (which translates to "it has not been backed up yet") it won't be removed
 
 .PARAMETER RemoveEmptyBackupFolder
 Remove any empty folders after the cleanup process is complete.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+.PARAMETER WhatIf
+Shows what would happen if the command were to run. No actions are actually performed.
+
+.PARAMETER Confirm
+Prompts you for confirmation before executing any changing operations within the command.
 
 .NOTES
 Tags: Storage, DisasterRecovery, Backup
@@ -77,10 +80,10 @@ The cmdlet will remove '*.trn' files from 'C:\MSSQL\SQL Backup\' and all subdire
 
 .EXAMPLE
 Remove-DbaBackup -Path 'C:\MSSQL\SQL Backup\' -BackupFileExtension trn -RetentionPeriod 48h -WhatIf
- 
+
 Same as example #1, but using the WhatIf parameter. The WhatIf parameter will allow the cmdlet show you what it will do, without actually doing it.
 In this case, no trn files will be deleted. Instead, the cmdlet will output what it will do when it runs. This is a good preventatitive measure
-especially when you are first configuring the cmdlet calls. 
+especially when you are first configuring the cmdlet calls.
 
 .EXAMPLE
 Remove-DbaBackup -Path 'C:\MSSQL\Backup\' -BackupFileExtension bak -RetentionPeriod 7d -CheckArchiveBit
@@ -96,28 +99,30 @@ It will also remove any backup folders that no longer contain backup files.
 
 
 #>
-	[CmdletBinding(SupportsShouldProcess=$true)]
-	Param (
-		[parameter(Mandatory = $true,HelpMessage="Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
-		[Alias("BackupFolder")]
-		[ValidateScript({Test-Path $_ -PathType 'Container'})]
-		[string]$Path,
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param (
+        [parameter(Mandatory = $true,HelpMessage="Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
+        [Alias("BackupFolder")]
+        [ValidateScript({Test-Path $_ -PathType 'Container'})]
+        [string]$Path,
 
-		[parameter(Mandatory = $true,HelpMessage="Backup File extension to remove (ex. bak, trn, dif)")]
-		[string]$BackupFileExtension ,
+        [parameter(Mandatory = $true,HelpMessage="Backup File extension to remove (ex. bak, trn, dif)")]
+        [string]$BackupFileExtension ,
 
-		[parameter(Mandatory = $true,HelpMessage="Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
-		[string]$RetentionPeriod ,
-
-		[parameter(Mandatory = $false)]
-		[switch]$CheckArchiveBit = $false ,
+        [parameter(Mandatory = $true,HelpMessage="Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
+        [string]$RetentionPeriod ,
 
         [parameter(Mandatory = $false)]
-		[switch]$RemoveEmptyBackupFolder = $false
-	)
+        [switch]$CheckArchiveBit = $false ,
 
-	BEGIN
-	{
+        [parameter(Mandatory = $false)]
+        [switch]$RemoveEmptyBackupFolder = $false,
+
+        [switch]$Silent
+    )
+
+    BEGIN
+    {
         ### Local Functions
         function Convert-UserFriendlyRetentionToDatetime
         {
@@ -126,14 +131,14 @@ It will also remove any backup folders that no longer contain backup files.
                 [string]$UserFriendlyRetention
             )
 
-            <# 
+            <#
             Convert a user friendly retention value into a datetime.
-            The last character of the string will indicate units (validated) 
+            The last character of the string will indicate units (validated)
             Valid units are: (h = hours, d = days, w = weeks, m = months)
 
             The preceeding characters are the value and must be an integer (validated)
-    
-            Examples: 
+
+            Examples:
                 '48h' = 48 hours
                 '7d' = 7 days
                 '4w' = 4 weeks
@@ -142,10 +147,10 @@ It will also remove any backup folders that no longer contain backup files.
 
             [int]$Length = ($UserFriendlyRetention).Length
             $Value = ($UserFriendlyRetention).Substring(0,$Length-1)
-            $Units = ($UserFriendlyRetention).Substring($Length-1,1)   
+            $Units = ($UserFriendlyRetention).Substring($Length-1,1)
 
             # Validate that $Units is an accepted unit of measure
-            if ( $Units -notin @('h','d','w','m') ){
+            if ( $Units -notin @('h','d','w','m') ) {
                 throw "RetentionPeriod '$UserFriendlyRetention' units invalid! See Get-Help for correct formatting and examples."
             }
 
@@ -161,97 +166,76 @@ It will also remove any backup folders that no longer contain backup files.
                 'w' { $UnitString = 'Weeks'; [datetime]$ReturnDatetime = (Get-Date).AddDays(-$Value*7) }
                 'm' { $UnitString = 'Months';[datetime]$ReturnDatetime = (Get-Date).AddMonths(-$Value) }
             }
-            Write-Verbose "Retention set to '$Value' $UnitString. Retention date/time '$ReturnDatetime'"
             $ReturnDatetime
         }
-
-        function Get-EmptyBackupFolder 
-        {
-            [cmdletbinding()]
-            param (
-                [string]$BaseLocation
-            )
-            Get-ChildItem -Path $BaseLocation -Recurse | Where-Object {$_.PSIsContainer -eq $true -and (Get-ChildItem -Path $_.FullName) -eq $null}
-        }
-
 
         # Validations
         # Ensure BackupFileExtension does not begin with a .
         if ($BackupFileExtension -match "^[.]") {
-            Write-Warning "Parameter -BackupFileExtension begins with a period '$BackupFileExtension'. A period is automatically prepended to -BackupFileExtension and need not be passed in."
-        } 
+            Write-Message -Message "Parameter -BackupFileExtension begins with a period '$BackupFileExtension'. A period is automatically prepended to -BackupFileExtension and need not be passed in." -Warning
+        }
 
-        # Initialize stuff
-        $Start = Get-Date
-	}
-	PROCESS
-	{
-		# Process stuff
-        Write-Output ("Started at $Start")
-        Write-Output ("Removing backups from $Path")
-
+    }
+    PROCESS
+    {
+        # Process stuff
+        Write-Message -Message "Started" -Level 3 -Silent $Silent
+        Write-Message -Message "Removing backups from $Path" -Level 3 -Silent $Silent
         # Convert Retention Value to an actual DateTime
         try {
             $RetentionDate = Convert-UserFriendlyRetentionToDatetime -UserFriendlyRetention $RetentionPeriod
-            Write-Output "Backup Retention Date set to $RetentionDate"
+            Write-Message -Message "Backup Retention Date set to $RetentionDate" -Level 5 -Silent $Silent
         } catch {
             throw $_
         }
 
-        # Generate list of files that are to be removed
-        $FilesToDelete = Get-ChildItem "$Path" -Filter "*.$BackupFileExtension" -Recurse | `
-            Where-Object {$_.LastWriteTime -lt $RetentionDate}
-            
         # Filter out unarchived files if -CheckArchiveBit parameter is used
         if ($CheckArchiveBit.IsPresent) {
-            Write-Output 'Removing only archived files'
-            $FilesToDelete = $FilesToDelete | Where-Object {$_.attributes -notmatch "Archive"} 
+            Write-Message -Message "Removing only archived files" -Level 5 -Silent $Silent
+            Filter DbaArchiveBitFilter {
+                If ($_.Attributes -notmatch "Archive") {
+                    $_
+                }
+            }
+        } else {
+            Filter DbaArchiveBitFilter {
+                $_
+            }
         }
-        
-        # Perform the deletion or show which file will be deleted if WhatIf is used
-        foreach ($file in $filestodelete) { 
-            If ($Pscmdlet.ShouldProcess( $(($file.FullName).Replace($file.Name, '')), "Removing backup file '$($file.name)'")) {
+        # Enumeration may take a while. Without resorting to "esoteric" file listing facilities
+        # and given we need to fetch at least the LastWriteTime, let's just use "streaming" processing
+        # here to avoid issues like described in #970
+        Get-ChildItem $Path -Filter "*.$BackupFileExtension" -Recurse | `
+            Where-Object LastWriteTime -lt $RetentionDate | DbaArchiveBitFilter | Foreach-Object `
+        {
+            $file = $_
+            if ($PSCmdlet.ShouldProcess($file.Directory.FullName, "Removing backup file $($file.Name)")) {
                 try {
-                    Write-Output "Removing backup file '$($file.FullName)'"
-                    $file.FullName | Remove-Item -Force
+                    $file
+                    $file | Remove-Item -Force
                 } catch {
                     throw $_
                 }
             }
         }
- 
-        # Cleanup empty backup folders. Using a DO/WHILE loop to force it to go through the logic at least once so we can display WhatIf if we need to
-        do {
-            if ($RemoveEmptyBackupFolder.IsPresent) {
-                # Get the empty backup folders
-                $EmptyBackupFolder = Get-EmptyBackupFolder -BaseLocation $Path
-
-                foreach ($folder in $EmptyBackupFolder) {
-                    if ($Pscmdlet.ShouldProcess($Path, "Removing empty folder '.$(($folder.FullName).Replace($Path,''))")) {
-                        try {
-                            Write-Output "Removing empty folder '$($folder.FullName)'"
-                            $folder.FullName | Remove-Item -Force
-                        } catch {
-                            throw $_
-                        }
+        Write-Message -Message "File Cleaning ended" -Level 3 -Silent $Silent
+        # Cleanup empty backup folders.
+        if ($RemoveEmptyBackupFolder.IsPresent) {
+            Write-Message -Message "Removing empty folders" -Level 3 -Silent $Silent
+            Get-ChildItem -Directory -Path $Path -Recurse | Foreach-Object { $_.FullName } | Sort-Object -Descending | `
+                Where-Object { @( Get-ChildItem -Force $_ ).Count -eq 0 } | Foreach-Object `
+            {
+                $FolderPath = $_
+                if ($PSCmdlet.ShouldProcess($Path, "Removing empty folder .$($FolderPath.Replace($Path, ''))")) {
+                    try {
+                        $FolderPath
+                        $FolderPath | Remove-Item
+                    } catch {
+                        throw $_
                     }
                 }
             }
-            # Refresh the empty folders. This will allow us to recursively clean them up
-            $EmptyBackupFolder = Get-EmptyBackupFolder -BaseLocation $Path
-          
-        } while ($RemoveEmptyBackupFolder.IsPresent -and !$WhatIfPreference -and $EmptyBackupFolder)
-	}
-
-	END
-	{
-        # End cleanup
-		if ($Pscmdlet.ShouldProcess($env:computername, "Showing final message"))
-		{
-			$End = Get-Date
-			Write-Output "Finished at $End"
-			$Duration = $End - $start
-			Write-Output "Script Duration: $Duration"
-		} 
-	}
+            Write-Message -Message "Removed empty folders" -Level 3 -Silent $Silent
+        }
+    }
 }


### PR DESCRIPTION
Fixes #970 

Changes proposed in this pull request:
 - avoid long waits to build up file lists, everything is pipelined, so concurrent alteration of the underlying filestructure are less likely to impact the command itself
 - new logging subsystem
 - returns the removed files and directory fullnames for empty folder removals
- avoids top-down recursion when removing empty folders (which ultimately was the reason behind the relative slowness described)


tl;dr: on 302k files nested into 5k dirs on a local SSD the process passed from 20min to 6min

 
