### PR TITLE
fixes issue #968 - set-dbaspconfigure: Properly show current run config value(old value) when using -WhatIf

### DIFF
--- a/functions/Set-DbaSpConfigure.ps1
+++ b/functions/Set-DbaSpConfigure.ps1
@@ -117,7 +117,7 @@ Returns information on the action that would be performed. No actual change will
 				Stop-Function -Message "Value out of range for $configs (min: $minValue - max $maxValue)" -Continue
 			}
 			
-			If ($Pscmdlet.ShouldProcess($SqlInstance, "Adjusting server configuration $configs from $currentValue to $value."))
+			If ($Pscmdlet.ShouldProcess($SqlInstance, "Adjusting server configuration $configs from $currentRunValue to $value."))
 			{
 				try
 				{


### PR DESCRIPTION
Fixes #

Fix to properly show Current Run Config Value(old value) when using -WhatIf switch

Changes proposed in this pull request:

return `$currentRunValue` as opposed to`$currentValue`

Should show

```
Set-DbaSpConfigure -SqlServer localhost -configs ScanForStartupProcedures -value 1 -WhatIf 

What if: Performing the operation "Adjusting server configuration ScanForStartupProcedures from 0 to 1." on target "localhost".
```

How to test this code:

[`Set-DbaSpConfigure -SqlServer localhost -configs ScanForStartupProcedures -value 1 -WhatIf `]
[ ]

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ X ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

