### PR TITLE
improve test for existing Cimsession

### DIFF
--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -149,7 +149,7 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 					CurrentUsage = $null
 				} | Select-DefaultView -Property ComputerName, AutoPageFile
 			}
-			if ( $CIMsession ) { Remove-CimSession $CIMsession }
+			if ( $CIMsession.TestConnection() ) { Remove-CimSession $CIMsession }
 		}
 	}
 }

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -149,7 +149,7 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 					CurrentUsage = $null
 				} | Select-DefaultView -Property ComputerName, AutoPageFile
 			}
-			if ( $CIMsession.TestConnection() ) { Remove-CimSession $CIMsession }
+			if ( [void]$CIMsession.TestConnection() ) { Remove-CimSession $CIMsession }
 		}
 	}
 }


### PR DESCRIPTION
Fixes #976

Changes proposed in this pull request:
 - instead of checking for the existence of $cimsession, now the connection is tested

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

