### PR TITLE
Fix Copy-SqlLogin requiring SA

### DIFF
--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -270,7 +270,9 @@ Limitations: Does not support Application Roles yet
 							}
 						}
 						
-						try { $hashedpass = $sourceserver.ConnectionContext.ExecuteScalar($sql) }
+						try { 
+							$hashedpass = $sourceserver.ConnectionContext.ExecuteScalar($sql) 
+						}
 						catch {
 							$hashedpassdt = $sourceserver.databases['master'].ExecuteWithResults($sql)
 							$hashedpass = $hashedpassdt.Tables[0].Rows[0].Item(0)

--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -139,13 +139,10 @@ Limitations: Does not support Application Roles yet
 	
 	DynamicParam { if ($source) { return Get-ParamSqlLogins -SqlServer $source -SqlCredential $SourceSqlCredential } }
 	
-	BEGIN
-	{
+	BEGIN {
 		
-		Function Copy-Login
-		{
-			foreach ($sourcelogin in $sourceserver.logins)
-			{
+		Function Copy-Login {
+			foreach ($sourcelogin in $sourceserver.logins) {
 				
 				$username = $sourcelogin.name
 				if ($Logins -ne $null -and $Logins -notcontains $username) { continue }
@@ -155,70 +152,55 @@ Limitations: Does not support Application Roles yet
 				
 				$currentlogin = $sourceserver.ConnectionContext.truelogin
 				
-				if ($currentlogin -eq $username -and $force)
-				{
-					If ($Pscmdlet.ShouldProcess("console", "Stating $username is skipped because it is performing the migration."))
-					{
+				if ($currentlogin -eq $username -and $force) {
+					If ($Pscmdlet.ShouldProcess("console", "Stating $username is skipped because it is performing the migration.")) {
 						Write-Warning "Cannot drop login performing the migration. Skipping"
 					}
 					continue
 				}
 
-				if(($destserver.LoginMode -ne [Microsoft.SqlServer.Management.Smo.ServerLoginMode]::Mixed) -and ($sourcelogin.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin))
-				{ 
+				if(($destserver.LoginMode -ne [Microsoft.SqlServer.Management.Smo.ServerLoginMode]::Mixed) -and ($sourcelogin.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin)) { 
 					Write-Warning "$Destination does not have Mixed Mode enabled. $username is an SqlLogin so it needs mixed mode enabled. Enable this after the migration completes."				 
 				}
 				
 				$userbase = ($username.Split("\")[0]).ToLower()
 				
-				if ($servername -eq $userbase -or $username.StartsWith("NT "))
-				{
-					if ($sourceserver.netname -ne $destserver.netname)
-					{
-						If ($Pscmdlet.ShouldProcess("console", "Stating $username was skipped because it is a local machine name."))
-						{
+				if ($servername -eq $userbase -or $username.StartsWith("NT ")) {
+					if ($sourceserver.netname -ne $destserver.netname) {
+						If ($Pscmdlet.ShouldProcess("console", "Stating $username was skipped because it is a local machine name.")) {
 							Write-Warning "$username was skipped because it is a local machine name."
 						}
 						continue
 					}
-					else
-					{
-						If ($Pscmdlet.ShouldProcess("console", "Stating local login $username since the source and destination server reside on the same machine."))
-						{
+					else {
+						If ($Pscmdlet.ShouldProcess("console", "Stating local login $username since the source and destination server reside on the same machine.")) {
 							Write-Output "Copying local login $username since the source and destination server reside on the same machine."
 						}
 					}
 				}
 				
-				if (($login = $destserver.Logins.Item($username)) -ne $null -and !$force)
-				{
-					If ($Pscmdlet.ShouldProcess("console", "Stating $username is skipped because it exists at destination."))
-					{
+				if (($login = $destserver.Logins.Item($username)) -ne $null -and !$force) {
+					If ($Pscmdlet.ShouldProcess("console", "Stating $username is skipped because it exists at destination.")) {
 						Write-Warning "$username already exists in destination. Use -Force to drop and recreate."
 					}
 					continue
 				}
 				
-				if ($login -ne $null -and $force)
-				{
-					if ($username -eq $destserver.ServiceAccount)
-					{
+				if ($login -ne $null -and $force) {
+					if ($username -eq $destserver.ServiceAccount) {
 						Write-Warning "$username is the destination service account. Skipping drop."
 						continue
 					}
 					
-					If ($Pscmdlet.ShouldProcess($destination, "Dropping $username"))
-					{
+					If ($Pscmdlet.ShouldProcess($destination, "Dropping $username")) {
 						# Kill connections, delete user
 						Write-Output "Attempting to migrate $username"
 						Write-Output "Force was specified. Attempting to drop $username on $destination"
-						try
-						{
+						try {
 							
 							$owneddbs = $destserver.Databases | Where { $_.Owner -eq $username }
 							
-							foreach ($owneddb in $owneddbs)
-							{
+							foreach ($owneddb in $owneddbs) {
 								Write-Output "Changing database owner for $($owneddb.name) from $username to sa"
 								$owneddb.SetOwner('sa')
 								$owneddb.Alter()
@@ -226,8 +208,7 @@ Limitations: Does not support Application Roles yet
 							
 							$ownedjobs = $destserver.JobServer.Jobs | Where { $_.OwnerLoginName -eq $username }
 							
-							foreach ($ownedjob in $ownedjobs)
-							{
+							foreach ($ownedjob in $ownedjobs) {
 								Write-Output "Changing job owner for $($ownedjob.name) from $username to sa"
 								$ownedjob.set_OwnerLoginName('sa')
 								$ownedjob.Alter()
@@ -239,8 +220,7 @@ Limitations: Does not support Application Roles yet
 							
 							Write-Output "Successfully dropped $username on $destination"
 						}
-						catch
-						{
+						catch {
 							$ex = $_.Exception.Message
 							if ($ex -ne $null) { $ex.trim() }
 							Write-Error "Could not drop $username`: $ex"
@@ -250,8 +230,7 @@ Limitations: Does not support Application Roles yet
 					}
 				}
 				
-				If ($Pscmdlet.ShouldProcess($destination, "Adding SQL login $username"))
-				{
+				If ($Pscmdlet.ShouldProcess($destination, "Adding SQL login $username")) {
 					Write-Output "Attempting to add $username to $destination"
 					$destlogin = New-Object Microsoft.SqlServer.Management.Smo.Login($destserver, $username)
 					Write-Output "Setting $username SID to source username SID"
@@ -261,8 +240,7 @@ Limitations: Does not support Application Roles yet
 					Write-Output "Setting login language to $($sourcelogin.Language)"
 					$destlogin.Language = $sourcelogin.Language
 					
-					if ($destserver.databases[$defaultdb] -eq $null)
-					{
+					if ($destserver.databases[$defaultdb] -eq $null) {
 						Write-Warning "$defaultdb does not exist on destination. Setting defaultdb to master."
 						$defaultdb = "master"
 					}
@@ -277,18 +255,15 @@ Limitations: Does not support Application Roles yet
 					$destlogin.PasswordExpirationEnabled = $sourcelogin.PasswordExpirationEnabled
 					
 					# Attempt to add SQL Login User
-					if ($sourcelogin.LoginType -eq "SqlLogin")
-					{
+					if ($sourcelogin.LoginType -eq "SqlLogin") {
 						$destlogin.LoginType = "SqlLogin"
 						$sourceloginname = $sourcelogin.name
 						
-						switch ($sourceserver.versionMajor)
-						{
+						switch ($sourceserver.versionMajor) {
 							0 { $sql = "SELECT convert(varbinary(256),password) as hashedpass FROM master.dbo.syslogins WHERE loginname='$sourceloginname'" }
 							8 { $sql = "SELECT convert(varbinary(256),password) as hashedpass FROM dbo.syslogins WHERE name='$sourceloginname'" }
 							9 { $sql = "SELECT convert(varbinary(256),password_hash) as hashedpass FROM sys.sql_logins where name='$sourceloginname'" }
-							default
-							{
+							default {
 								$sql = "SELECT CAST(CONVERT(varchar(256), CAST(LOGINPROPERTY(name,'PasswordHash') 
 						AS varbinary (256)), 1) AS nvarchar(max)) as hashedpass FROM sys.server_principals
 						WHERE principal_id = $($sourcelogin.id)"
@@ -296,28 +271,23 @@ Limitations: Does not support Application Roles yet
 						}
 						
 						try { $hashedpass = $sourceserver.ConnectionContext.ExecuteScalar($sql) }
-						catch
-						{
+						catch {
 							$hashedpassdt = $sourceserver.databases['master'].ExecuteWithResults($sql)
 							$hashedpass = $hashedpassdt.Tables[0].Rows[0].Item(0)
 						}
 						
-						if ($hashedpass.gettype().name -ne "String")
-						{
+						if ($hashedpass.gettype().name -ne "String") {
 							$passtring = "0x"; $hashedpass | % { $passtring += ("{0:X}" -f $_).PadLeft(2, "0") }
 							$hashedpass = $passtring
 						}
 						
-						try
-						{
+						try {
 							$destlogin.Create($hashedpass, [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::IsHashed)
 							$destlogin.refresh()
 							Write-Output "Successfully added $username to $destination"
 						}
-						catch
-						{
-							try
-							{
+						catch {
+							try {
 								$sid = "0x"; $sourcelogin.sid | % { $sid += ("{0:X}" -f $_).PadLeft(2, "0") }
 								$sqlfailsafe = "CREATE LOGIN [$username] WITH PASSWORD = $hashedpass HASHED, SID = $sid, 
 												DEFAULT_DATABASE = [$defaultdb], CHECK_POLICY = $checkpolicy, 
@@ -327,8 +297,7 @@ Limitations: Does not support Application Roles yet
 								$destlogin = $destserver.logins[$username]
 								Write-Output "Successfully added $username to $destination"
 							}
-							catch
-							{
+							catch {
 								Write-Warning "Failed to add $username to $destination`: $_"
 								Write-Exception $_
 								continue
@@ -336,21 +305,18 @@ Limitations: Does not support Application Roles yet
 						}
 					}
 					# Attempt to add Windows User
-					elseif ($sourcelogin.LoginType -eq "WindowsUser" -or $sourcelogin.LoginType -eq "WindowsGroup")
-					{
+					elseif ($sourcelogin.LoginType -eq "WindowsUser" -or $sourcelogin.LoginType -eq "WindowsGroup") {
 						Write-Output "Adding as login type $($sourcelogin.LoginType)"
 						$destlogin.LoginType = $sourcelogin.LoginType
 						Write-Output "Setting language as $($sourcelogin.Language)"
 						$destlogin.Language = $sourcelogin.Language
 						
-						try
-						{
+						try {
 							$destlogin.Create()
 							$destlogin.Refresh()
 							Write-Output "Successfully added $username to $destination"
 						}
-						catch
-						{
+						catch {
 							Write-Warning "Failed to add $username to $destination"
 							Write-Exception $_
 							continue
@@ -358,25 +324,21 @@ Limitations: Does not support Application Roles yet
 					}
 					
 					# This script does not currently support certificate mapped or asymmetric key users.
-					else
-					{
+					else {
 						Write-Warning "$($sourcelogin.LoginType) logins not supported. $($sourcelogin.name) skipped."
 						continue
 					}
 					
-					if ($sourcelogin.IsDisabled)
-					{
+					if ($sourcelogin.IsDisabled) {
 						try { $destlogin.Disable() }
 						catch { Write-Warning "$username disabled on source, but could not be disabled on destination."; Write-Exception $_ }
 					}
-					if ($sourcelogin.DenyWindowsLogin)
-					{
+					if ($sourcelogin.DenyWindowsLogin) {
 						try { $destlogin.DenyWindowsLogin = $true }
 						catch { Write-Warning "$username denied login on source, but could not be denied login on destination."; Write-Exception $_ }
 					}
 				}
-				If ($Pscmdlet.ShouldProcess($destination, "Updating SQL login $username permissions"))
-				{
+				If ($Pscmdlet.ShouldProcess($destination, "Updating SQL login $username permissions")) {
 					Update-SqlPermissions -sourceserver $sourceserver -sourcelogin $sourcelogin -destserver $destserver -destlogin $destlogin
 				}
 				
@@ -398,16 +360,14 @@ Limitations: Does not support Application Roles yet
 		}
 		
 		Write-Output "Attempting to connect to SQL Servers.."
-		$sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
+		$sourceserver = Connect-DbaSqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
 		$source = $sourceserver.DomainInstanceName
 		
-		if ($Destination.length -gt 0)
-		{
-			$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
+		if ($Destination.length -gt 0) {
+			$destserver = Connect-DbaSqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 			$destination = $destserver.DomainInstanceName
 			
-			if ($sourceserver.versionMajor -gt 10 -and $destserver.versionMajor -lt 11)
-			{
+			if ($sourceserver.versionMajor -gt 10 -and $destserver.versionMajor -lt 11) {
 				throw "SQL login migration from SQL Server version $($sourceserver.versionMajor) to $($destserver.versionMajor) not supported. Halting."
 			}
 			
@@ -417,8 +377,7 @@ Limitations: Does not support Application Roles yet
 		$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
 		$started = Get-Date
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing time started message"))
-		{
+		If ($Pscmdlet.ShouldProcess("console", "Showing time started message")) {
 			Write-Output "Migration started: $started"
 		}
 		
@@ -426,46 +385,38 @@ Limitations: Does not support Application Roles yet
 		$Logins = $psboundparameters.Logins
 		$Exclude = $psboundparameters.Exclude
 		
-		if ($Logins.length -eq 0)
-		{
+		if ($Logins.length -eq 0) {
 			$Logins = $sourceserver.logins.name
 		}
 		
-		if ($psboundparameters.Logins -gt 0)
-		{
+		if ($psboundparameters.Logins -gt 0) {
 			$loginparms += @{ 'Logins' = $logins }
 		}
 		
-		if ($psboundparameters.Exclude -gt 0)
-		{
+		if ($psboundparameters.Exclude -gt 0) {
 			$loginparms += @{ 'Exclude' = $exclude }
 		}
 		
 		return $serverparms
 	}
 	
-	PROCESS
-	{
-		if ($pipelogin.Length -gt 0)
-		{
+	PROCESS {
+		if ($pipelogin.Length -gt 0) {
 			$Source = $pipelogin[0].parent.name
 			$logins = $pipelogin.name
 		}
 		
-		if ($SyncOnly)
-		{
+		if ($SyncOnly) {
 			Sync-SqlLoginPermissions -Source $Source -Destination $Destination $loginparms
 			return
 		}
 		
-		if ($OutFile)
-		{
+		if ($OutFile) {
 			Export-SqlLogin -SqlServer $source -FilePath $OutFile $loginparms
 			return
 		}
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing migration attempt message"))
-		{
+		If ($Pscmdlet.ShouldProcess("console", "Showing migration attempt message")) {
 			Write-Output "Attempting Login Migration"
 		}
 		
@@ -475,28 +426,23 @@ Limitations: Does not support Application Roles yet
 		$destsa = $destserver.Logins | Where-Object { $_.id -eq 1 }
 		$saname = $sa.name
 		
-		if ($saname -ne $destsa.name -and $SyncSaName -eq $true)
-		{
+		if ($saname -ne $destsa.name -and $SyncSaName -eq $true) {
 			Write-Output "Changing sa username to match source ($saname)"
-			If ($Pscmdlet.ShouldProcess($destination, "Changing sa username to match source ($saname)"))
-			{
+			If ($Pscmdlet.ShouldProcess($destination, "Changing sa username to match source ($saname)")) {
 				$destsa.Rename($saname)
 				$destsa.alter()
 			}
 		}
 	}
 	
-	END
-	{
+	END {
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message"))
-		{
+		If ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
 			Write-Output "Login migration completed: $(Get-Date)"
 			$totaltime = ($elapsed.Elapsed.toString().Split(".")[0])
 			$sourceserver.ConnectionContext.Disconnect()
 			
-			if ($Destination.length -gt 0)
-			{
+			if ($Destination.length -gt 0) {
 				$destserver.ConnectionContext.Disconnect()
 			}
 			

--- a/functions/Copy-SqlLogin.ps1
+++ b/functions/Copy-SqlLogin.ps1
@@ -362,11 +362,11 @@ Limitations: Does not support Application Roles yet
 		}
 		
 		Write-Output "Attempting to connect to SQL Servers.."
-		$sourceserver = Connect-DbaSqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
+		$sourceserver = Connect-SqlServer -RegularUser -SqlServer $Source -SqlCredential $SourceSqlCredential
 		$source = $sourceserver.DomainInstanceName
 		
 		if ($Destination.length -gt 0) {
-			$destserver = Connect-DbaSqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
+			$destserver = Connect-SqlServer -RegularUser -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 			$destination = $destserver.DomainInstanceName
 			
 			if ($sourceserver.versionMajor -gt 10 -and $destserver.versionMajor -lt 11) {


### PR DESCRIPTION
Fixes #157 

Changes proposed in this pull request:
 - Formatting changes around braces (vast majority of the changes) via `\n\s+{` replaced with ` {`
 - Switching invoke of Connect-SqlServer to Connect-DbaSqlServer which does not assume you need SA

How to test this code: 
- Create  a security admin on both boxes.
```
CREATE LOGIN [securityadmintest] WITH PASSWORD=N'STRONGPASSWORDHERE=', DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english], CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF
GO
ALTER SERVER ROLE [securityadmin] ADD MEMBER [securityadmintest]
GO
```
- Invoke Copy-SqlLogin with both source and destination credentials.
`Copy-SqlLogin -Source sql2014 -Destination sql2016 -SourceSqlCredential $(get-credential) -DestinationSqlCredential $(get-credential)`

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

