### PR TITLE
Fix issue 1008 - Add SizeMB property to default of Get-DbaDatabase

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -135,36 +135,36 @@ Returns databases on multiple instances piped into the function
             }
 
             if ($NoUserDb) {
-                $inputobject = $server.Databases | Where-Object { $_.IsSystemObject }
+                $inputobject = $server.Databases | Where-Object IsSystemObject
             }
 
             if ($NoSystemDb) {
-                $inputobject = $server.Databases | Where-Object { $_.IsSystemObject -eq $false }
+                $inputobject = $server.Databases | Where-Object IsSystemObject -eq $false
             }
 
             if ($databases) {
-                $inputobject = $server.Databases | Where-Object { $_.Name -in $databases }
+                $inputobject = $server.Databases | Where-Object Name -in $databases
             }
 
             if ($status) {
-                $inputobject = $server.Databases | Where-Object { $_.Status -eq $status }
+                $inputobject = $server.Databases | Where-Object Status -eq $status
             }
 
             if ($Owner) {
-                $inputobject = $server.Databases | Where-Object { $_.Owner -in $Owner }
+                $inputobject = $server.Databases | Where-Object Owner -in $Owner
             }
 
             switch ($Access) {
-                "ReadOnly" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly } }
-                "ReadWrite" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly -eq $false } }
+                "ReadOnly" { $inputobject = $server.Databases | Where-Object ReadOnly }
+                "ReadWrite" { $inputobject = $server.Databases | Where-Object ReadOnly -eq $false }
             }
 
             if ($Encrypted) {
-                $inputobject = $server.Databases | Where-Object { $_.EncryptionEnabled }
+                $inputobject = $server.Databases | Where-Object EncryptionEnabled
             }
 
             if ($RecoveryModel) {
-                $inputobject = $server.Databases | Where-Object { $_.RecoveryModel -eq $RecoveryModel }
+                $inputobject = $server.Databases | Where-Object RecoveryModel -eq $RecoveryModel
             }
 
             # I forgot the pretty way to do this
@@ -173,7 +173,7 @@ Returns databases on multiple instances piped into the function
             }
 
             if ($exclude) {
-                $inputobject = $inputobject | Where-Object {$_.Name -notin $exclude }
+                $inputobject = $inputobject | Where-Object Name -notin $exclude
             }
 
             if ($NoFullBackup -or $NoFullBackupSince) {
@@ -196,10 +196,10 @@ Returns databases on multiple instances piped into the function
             }
 
             if ($null -ne $NoFullBackupSince) {
-                $inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoFullBackupSince}
+                $inputobject = $inputobject | Where-Object LastBackupdate -lt $NoFullBackupSince
             }
             elseif ($null -ne $NoLogBackupSince) {
-                $inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}
+                $inputobject = $inputobject | Where-Object LastBackupdate -lt $NoLogBackupSince
             }
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'RecoveryModel', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
 

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -199,7 +199,7 @@ Returns databases on multiple instances piped into the function
             elseif ($null -ne $NoLogBackupSince) {
                 $inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}
             }
-            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'RecoveryModel', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
 
             if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
                 $defaults += ('Notes')

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -1,5 +1,5 @@
 function Get-DbaDatabase {
-<#
+    <#
 .SYNOPSIS
 Gets SQL Database information for each database that is present in the target instance(s) of SQL Server.
 
@@ -47,6 +47,9 @@ Returns databases without a Log backup recorded by SQL Server. Will indicate tho
 
 .PARAMETER NoLogBackupSince
 DateTime value. Returns list of SQL Server databases that haven't had a Log backup since the passed iin DateTime
+
+.PARAMETER Switch
+Use this switch to disable any kind of verbose messages
 
 .NOTES
 Author: Garry Bargsley (@gbargsley), http://blog.garrybargsley.com
@@ -107,7 +110,8 @@ Returns databases on multiple instances piped into the function
         [switch]$NoFullBackup,
         [datetime]$NoFullBackupSince,
         [switch]$NoLogBackup,
-        [datetime]$NoLogBackupSince
+        [datetime]$NoLogBackupSince,
+        [switch]$Silent
     )
 
     DynamicParam { if ($SqlInstance) { return Get-ParamSqlDatabases -SqlServer $SqlInstance[0] -SqlCredential $SqlCredential } }
@@ -117,8 +121,7 @@ Returns databases on multiple instances piped into the function
         $exclude = $psboundparameters.Exclude
 
         if ($NoUserDb -and $NoSystemDb) {
-            Write-Warning "You cannot specify both NoUserDb and NoSystemDb"
-            continue
+            Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue -Silent $Silent
         }
     }
 
@@ -128,8 +131,7 @@ Returns databases on multiple instances piped into the function
                 $server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
             }
             catch {
-                Write-Warning "Failed to connect to: $instance"
-                continue
+                Stop-Function -Message "Failed to connect to: $instance" -Continue -Silent $Silent
             }
 
             if ($NoUserDb) {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -1,5 +1,4 @@
-FUNCTION Get-DbaDatabase
-{
+function Get-DbaDatabase {
 <#
 .SYNOPSIS
 Gets SQL Database information for each database that is present in the target instance(s) of SQL Server.
@@ -7,7 +6,7 @@ Gets SQL Database information for each database that is present in the target in
 .DESCRIPTION
  The Get-DbaDatabase command gets SQL database information for each database that is present in the target instance(s) of
  SQL Server. If the name of the database is provided, the command will return only the specific database information.
-	
+
 .PARAMETER SqlInstance
 SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and recieve pipeline input to allow the function
 to be executed against multiple SQL Server instances.
@@ -20,9 +19,9 @@ Returns all SQL Server System databases from the SQL Server instance(s) executed
 
 .PARAMETER NoSystemDb
 Returns SQL Server user databases from the SQL Server instance(s) executed against.
-	
+
 .PARAMETER Status
-Returns SQL Server databases in the status passed to the function.  Could include Emergency, Online, Offline, Recovering, Restoring, Standby or Suspect 
+Returns SQL Server databases in the status passed to the function.  Could include Emergency, Online, Offline, Recovering, Restoring, Standby or Suspect
 statuses of databases from the SQL Server instance(s) executed against.
 
 .PARAMETER Access
@@ -58,7 +57,7 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.	
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
 https://dbatools.io/Get-DbaDatabase
@@ -74,181 +73,153 @@ Returns only the system databases on the local default SQL Server instance
 .EXAMPLE
 Get-DbaDatabase -SqlServer localhost -NoSystemDb
 Returns only the user databases on the local default SQL Server instance
-	
+
 .EXAMPLE
 'localhost','sql2016' | Get-DbaDatabase
 Returns databases on multiple instances piped into the function
 
 #>
-	[CmdletBinding(DefaultParameterSetName = "Default")]
-	Param (
-		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-		[Alias("ServerInstance", "SqlServer")]
-		[object[]]$SqlInstance,
-		[System.Management.Automation.PSCredential]$SqlCredential,
-		[Alias("SystemDbOnly")]
-		[parameter(ParameterSetName = "NoUserDb")]
-		[switch]$NoUserDb,
-		[Alias("UserDbOnly")]
-		[parameter(ParameterSetName = "NoSystemDb")]
-		[switch]$NoSystemDb,
-		[parameter(ParameterSetName = "DbBackuOwner")]
-		[string[]]$Owner,
-		[parameter(ParameterSetName = "Encrypted")]
-		[switch]$Encrypted,
-		[parameter(ParameterSetName = "Status")]
-		[ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
-		[string]$Status,
-		[parameter(ParameterSetName = "Access")]
-		[ValidateSet('ReadOnly', 'ReadWrite')]
-		[string]$Access,
-		[parameter(ParameterSetName = "RecoveryModel")]
-		[ValidateSet('Full', 'Simple', 'BulkLogged')]
-		[string]$RecoveryModel,
-		[switch]$NoFullBackup, 
-		[datetime]$NoFullBackupSince,
-		[switch]$NoLogBackup, 
-		[datetime]$NoLogBackupSince
-	)
-	
-	DynamicParam { if ($SqlInstance) { return Get-ParamSqlDatabases -SqlServer $SqlInstance[0] -SqlCredential $SqlCredential } }
-	
-	BEGIN
-	{
-		$databases = $psboundparameters.Databases
-		$exclude = $psboundparameters.Exclude
-		
-		if ($NoUserDb -and $NoSystemDb)
-		{
-			Write-Warning "You cannot specify both NoUserDb and NoSystemDb"
-			continue
-		}
-	}
-	
-	PROCESS
-	{
-		foreach ($instance in $SqlInstance)
-		{
-			try
-			{
-				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
-			}
-			catch
-			{
-				Write-Warning "Failed to connect to: $instance"
-				continue
-			}
-			
-			if ($NoUserDb)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.IsSystemObject }
-			}
-			
-			if ($NoSystemDb)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.IsSystemObject -eq $false }
-			}
-			
-			if ($databases)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.Name -in $databases }
-			}
-			
-			if ($status)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.Status -eq $status }
-			}
-			
-			if ($Owner)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.Owner -in $Owner }
-			}
-			
-			switch ($Access)
-			{
-				"ReadOnly" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly } }
-				"ReadWrite" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly -eq $false } }
-			}
-			
-			if ($Encrypted)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.EncryptionEnabled }
-			}
-			
-			if ($RecoveryModel)
-			{
-				$inputobject = $server.Databases | Where-Object { $_.RecoveryModel -eq $RecoveryModel }
-			}
-			
-			# I forgot the pretty way to do this
-			if (!$NoUserDb -and !$NoSystemDb -and !$databases -and !$status -and !$Owner -and !$Access -and !$Encrypted -and !$RecoveryModel)
-			{
-				$inputobject = $server.Databases
-			}
-			
-			if ($exclude)
-			{
-				$inputobject = $inputobject | Where-Object {$_.Name -notin $exclude }
-			}
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    Param (
+        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [Alias("ServerInstance", "SqlServer")]
+        [object[]]$SqlInstance,
+        [System.Management.Automation.PSCredential]$SqlCredential,
+        [Alias("SystemDbOnly")]
+        [parameter(ParameterSetName = "NoUserDb")]
+        [switch]$NoUserDb,
+        [Alias("UserDbOnly")]
+        [parameter(ParameterSetName = "NoSystemDb")]
+        [switch]$NoSystemDb,
+        [parameter(ParameterSetName = "DbBackuOwner")]
+        [string[]]$Owner,
+        [parameter(ParameterSetName = "Encrypted")]
+        [switch]$Encrypted,
+        [parameter(ParameterSetName = "Status")]
+        [ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
+        [string]$Status,
+        [parameter(ParameterSetName = "Access")]
+        [ValidateSet('ReadOnly', 'ReadWrite')]
+        [string]$Access,
+        [parameter(ParameterSetName = "RecoveryModel")]
+        [ValidateSet('Full', 'Simple', 'BulkLogged')]
+        [string]$RecoveryModel,
+        [switch]$NoFullBackup,
+        [datetime]$NoFullBackupSince,
+        [switch]$NoLogBackup,
+        [datetime]$NoLogBackupSince
+    )
 
-			if ($NoFullBackup -or $NoFullBackupSince)
-			{
-				if($NoFullBackup)
-				{
-					$dabs = (Get-DbaBackuphistory -SqlServer $server -LastFull -IgnoreCopyOnly).Database
-				}
-				else
-				{
-					$dabs = (Get-DbaBackuphistory -SqlServer $server -LastFull -IgnoreCopyOnly -Since $NoFullBackupSince).Database
-				}
-				$inputobject = $inputObject  | where-object {$_.name -notin $dabs -and $_.name -ne 'tempdb'}
-			}
-			if ($NoLogBackup -or $NoLogBackupSince)
-			{
-				if($NoLogBackup)
-				{
-					$dabs = (Get-DbaBackuphistory -SqlServer $server -LastLog -IgnoreCopyOnly).Database
-				}
-				else
-				{
-					$dabs = (Get-DbaBackuphistory -SqlServer $server -LastLog -IgnoreCopyOnly -Since $NoLogBackupSince).Database
-				}
-				$inputobject = $inputObject  | where-object {$_.name -notin $dabs -and $_.name -ne 'tempdb' -and $_.RecoveryModel -ne 'simple'}
-			}
+    DynamicParam { if ($SqlInstance) { return Get-ParamSqlDatabases -SqlServer $SqlInstance[0] -SqlCredential $SqlCredential } }
 
-			if ($null -ne $NoFullBackupSince)
-			{
-				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoFullBackupSince}				
-			}
-			elseif ($null -ne $NoLogBackupSince)
-			{
-				$inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}	
-			}
-			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance','Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
+    BEGIN {
+        $databases = $psboundparameters.Databases
+        $exclude = $psboundparameters.Exclude
 
-			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince)
-			{
-				$defaults += ('Notes')
-			}
-			foreach ($db in $inputobject)
-			{
-			
-				$Notes = $null
-				if ($NoFullBackup -or $NoFullBackupSince)
-				{		
-					if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object{$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) )
-					{
-						$Notes = "Only CopyOnly backups"
-					}	
-				}	
-				Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
-	
-				Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName
-				Add-Member -InputObject $db -MemberType NoteProperty InstanceName -value $server.ServiceName
-				Add-Member -InputObject $db -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
-				Select-DefaultView -InputObject $db -Property $defaults
-				
-			}
-		}
-	}
+        if ($NoUserDb -and $NoSystemDb) {
+            Write-Warning "You cannot specify both NoUserDb and NoSystemDb"
+            continue
+        }
+    }
+
+    PROCESS {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Write-Warning "Failed to connect to: $instance"
+                continue
+            }
+
+            if ($NoUserDb) {
+                $inputobject = $server.Databases | Where-Object { $_.IsSystemObject }
+            }
+
+            if ($NoSystemDb) {
+                $inputobject = $server.Databases | Where-Object { $_.IsSystemObject -eq $false }
+            }
+
+            if ($databases) {
+                $inputobject = $server.Databases | Where-Object { $_.Name -in $databases }
+            }
+
+            if ($status) {
+                $inputobject = $server.Databases | Where-Object { $_.Status -eq $status }
+            }
+
+            if ($Owner) {
+                $inputobject = $server.Databases | Where-Object { $_.Owner -in $Owner }
+            }
+
+            switch ($Access) {
+                "ReadOnly" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly } }
+                "ReadWrite" { $inputobject = $server.Databases | Where-Object { $_.ReadOnly -eq $false } }
+            }
+
+            if ($Encrypted) {
+                $inputobject = $server.Databases | Where-Object { $_.EncryptionEnabled }
+            }
+
+            if ($RecoveryModel) {
+                $inputobject = $server.Databases | Where-Object { $_.RecoveryModel -eq $RecoveryModel }
+            }
+
+            # I forgot the pretty way to do this
+            if (!$NoUserDb -and !$NoSystemDb -and !$databases -and !$status -and !$Owner -and !$Access -and !$Encrypted -and !$RecoveryModel) {
+                $inputobject = $server.Databases
+            }
+
+            if ($exclude) {
+                $inputobject = $inputobject | Where-Object {$_.Name -notin $exclude }
+            }
+
+            if ($NoFullBackup -or $NoFullBackupSince) {
+                if ($NoFullBackup) {
+                    $dabs = (Get-DbaBackuphistory -SqlServer $server -LastFull -IgnoreCopyOnly).Database
+                }
+                else {
+                    $dabs = (Get-DbaBackuphistory -SqlServer $server -LastFull -IgnoreCopyOnly -Since $NoFullBackupSince).Database
+                }
+                $inputobject = $inputObject  | where-object {$_.name -notin $dabs -and $_.name -ne 'tempdb'}
+            }
+            if ($NoLogBackup -or $NoLogBackupSince) {
+                if ($NoLogBackup) {
+                    $dabs = (Get-DbaBackuphistory -SqlServer $server -LastLog -IgnoreCopyOnly).Database
+                }
+                else {
+                    $dabs = (Get-DbaBackuphistory -SqlServer $server -LastLog -IgnoreCopyOnly -Since $NoLogBackupSince).Database
+                }
+                $inputobject = $inputObject  | where-object {$_.name -notin $dabs -and $_.name -ne 'tempdb' -and $_.RecoveryModel -ne 'simple'}
+            }
+
+            if ($null -ne $NoFullBackupSince) {
+                $inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoFullBackupSince}
+            }
+            elseif ($null -ne $NoLogBackupSince) {
+                $inputobject = $inputobject | Where-Object {$_.LastBackupdate -lt $NoLogBackupSince}
+            }
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'RecoveryModel', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
+
+            if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
+                $defaults += ('Notes')
+            }
+            foreach ($db in $inputobject) {
+
+                $Notes = $null
+                if ($NoFullBackup -or $NoFullBackupSince) {
+                    if	(@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object {$_.IsCopyOnly}).count -and (@($db.EnumBackupSets()).count -gt 0) ) {
+                        $Notes = "Only CopyOnly backups"
+                    }
+                }
+                Add-Member -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
+
+                Add-Member -InputObject $db -MemberType NoteProperty ComputerName -value $server.NetName
+                Add-Member -InputObject $db -MemberType NoteProperty InstanceName -value $server.ServiceName
+                Add-Member -InputObject $db -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
+                Select-DefaultView -InputObject $db -Property $defaults
+
+            }
+        }
+    }
 }

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -126,12 +126,14 @@ Returns databases on multiple instances piped into the function
     }
 
     PROCESS {
+        if (Test-FunctionInterrupt) { return }
+
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
             }
             catch {
-                Stop-Function -Message "Failed to connect to: $instance" -Continue -Silent $Silent
+                Stop-Function -Message "Failed to connect to: $instance" -InnerErrorRecord $_ -Target $instance -Continue -Silent $Silent
             }
 
             if ($NoUserDb) {


### PR DESCRIPTION
Fixes #1008 

Changes proposed in this pull request:
 - Added "SizeMB" to the default view, the Size property defaults to MB units
 - Added messaging functions (Stop-Function) where appropriate to replace Write-Warning
 - Cleaned up where-object to remove `$_.property` references, makes it easier to read

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers
