### PR TITLE
Get-DbaSpn, accomodate get-dbaadobject

### DIFF
--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -21,6 +21,9 @@ User credential to connect to the remote servers or active directory.
 .PARAMETER ByAccount
 Shows all SPNs registered by the specified AccountName otherwise, only results will be shown for the specified ComputerName (which is localhost by default)
 
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages
+
 .NOTES
 Tags: SPN
 Author: Drew Furgiuele (@pittfurg), http://www.port1433.com
@@ -49,15 +52,16 @@ Get-DbaSpn -ServerName SQLSERVERA,SQLSERVERB -Credential (Get-Credential)
 
 Returns a custom object with SearchTerm (ServerName) and the SPNs that were found for multiple computers
 #>
-    [cmdletbinding()]
+	[cmdletbinding()]
 	param (
-        [Parameter(Mandatory = $false,ValueFromPipeline = $true)]
-        [string[]]$ComputerName = $env:COMPUTERNAME,
-        [Parameter(Mandatory = $false)]
+		[Parameter(Mandatory = $false,ValueFromPipeline = $true)]
+		[string[]]$ComputerName = $env:COMPUTERNAME,
+		[Parameter(Mandatory = $false)]
 		[string[]]$AccountName,
 		[switch]$ByAccount,
 		[Parameter(Mandatory = $false)]
-        [PSCredential]$Credential
+		[PSCredential]$Credential,
+		[switch]$Silent
 	)
 	begin
 	{
@@ -72,7 +76,7 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 				}
 				catch
 				{
-					Write-Message -Message "AD lookup failure. This may be because the domain cannot be resolved for the SQL Server service account ($serviceAccount)." -Level Warning
+					Write-Message -Message "AD lookup failure. This may be because the domain cannot be resolved for the SQL Server service account ($Account)." -Level Warning
 					continue
 				}
 				if ($Result.Count -gt 0)

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#FlowControl,Pipeline#
 function Get-DbaSpn
 {
 <#
@@ -15,15 +16,15 @@ The servers you want to return set SPNs for. This is defaulted automatically to 
 The accounts you want to retrieve set SPNs for.
 
 .PARAMETER Credential
-User credential to connect to the remote servers or active directory. This is a required parameter.
-	
+User credential to connect to the remote servers or active directory.
+
 .PARAMETER ByAccount
 Shows all SPNs registered by the specified AccountName otherwise, only results will be shown for the specified ComputerName (which is localhost by default)
 
 .NOTES
 Tags: SPN
 Author: Drew Furgiuele (@pittfurg), http://www.port1433.com
-	
+
 dbatools PowerShell module (https://dbatools.io)
 Copyright (C) 2016 Chrissy LeMaire
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -39,7 +40,7 @@ Get-DbaSpn -ServerName SQLSERVERA -Credential (Get-Credential)
 Returns a custom object with SearchTerm (ServerName) and the SPNs that were found
 
 .EXAMPLE
-Get-DbaSpn -AccountName doamain\account -Credential (Get-Credential)
+Get-DbaSpn -AccountName domain\account -Credential (Get-Credential)
 
 Returns a custom object with SearchTerm (domain account) and the SPNs that were found
 
@@ -64,48 +65,31 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 			
 			ForEach ($account in $AccountName)
 			{
-				$ogaccount = $account
-				if ($account -like "*\*")
-				{
-					Write-Verbose "Account name ($account) provided in in domain\user format, stripping out domain info."
-					$account = ($account.split("\"))[1]
-				}
-				if ($account -like "*@*")
-				{
-					Write-Verbose "Account name ($account) provided in in user@domain format, stripping out domain info."
-					$account = ($account.split("@"))[0]
-				}
-				
-				$root = ([ADSI]"LDAP://RootDSE").defaultNamingContext
-				$adsearch = New-Object System.DirectoryServices.DirectorySearcher
-				
-				if ($Credential)
-				{
-					$domain = New-Object System.DirectoryServices.DirectoryEntry -ArgumentList ("LDAP://" + $root), $($Credential.UserName), $($Credential.GetNetworkCredential().password)
-				}
-				else
-				{
-					$domain = New-Object System.DirectoryServices.DirectoryEntry -ArgumentList ("LDAP://" + $root)
-				}
-				
-				$adsearch.SearchRoot = $domain
-				$adsearch.Filter = $("(&(samAccountName={0}))" -f $account)
-				
-				Write-Verbose "Looking for account $account..."
-				
+				Write-Message -Message "Looking for account $account..." -Level Verbose
 				try
 				{
-					$Result = $adsearch.FindOne()
+					$Result = Get-DbaADObject -ADObject $account -Type User -Credential $Credential -Silent
 				}
 				catch
 				{
-					Write-Warning "AD lookup failure. This may be because the hostname ($computer) was not resolvable within the domain ($domain) or the SQL Server service account ($serviceaccount) couldn't be found in domain."
+					Write-Message -Message "AD lookup failure. This may be because the domain cannot be resolved for the SQL Server service account ($serviceAccount)." -Level Warning
+					continue
+				}
+				if ($Result.Count -gt 0)
+				{
+					try {
+						$results = $Result.GetUnderlyingObject()
+						$spns = $results.Properties.servicePrincipalName
+					} catch {
+						Write-Message -Message "The SQL Service account ($serviceAccount) has been found, but you don't have enough permission to inspect its SPNs" -Level Warning
+						continue
+					}
+				} else {
+					Write-Message -Message "The SQL Service account ($serviceAccount) has not been found" -Level Warning
 					continue
 				}
 				
-				$properties = $result.Properties
-				
-				foreach ($spn in $result.Properties.serviceprincipalname)
+				foreach ($spn in $spns)
 				{
 					if ($spn -match "\:")
 					{
@@ -123,8 +107,8 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 						}
 					}
 					[pscustomobject] @{
-						Input = $ogaccount
-						AccountName = $ogaccount
+						Input = $account
+						AccountName = $account
 						ServiceClass = "MSSQLSvc" # $serviceclass
 						Port = $port
 						SPN = $spn
@@ -143,18 +127,18 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 			{
 				if ($computer.EndsWith('$'))
 				{
-					Write-Verbose "$computer is an account name. Processing as account."
+					Write-Message -Message "$computer is an account name. Processing as account." -Level Verbose
 					Process-Account -AccountName $computer -ByAccount:$true
 					continue
 				}
 			}
 			
-			Write-Verbose "Getting SQL Server SPN for $computer"
+			Write-Message -Message "Getting SQL Server SPN for $computer" -Level Verbose
 			$spns = Test-DbaSpn -ComputerName $computer -Credential $Credential
 			
 			$sqlspns = 0
 			$spncount = $spns.count
-			Write-Verbose "Calculated $spncount SQL SPN entries that should exist for $computer"
+			Write-Message -Message "Calculated $spncount SQL SPN entries that should exist for $computer" -Level Verbose
 			foreach ($spn in $spns | Where-Object { $_.IsSet -eq $true })
 			{
 				$sqlspns++
@@ -183,7 +167,7 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 					}
 				}
 			}
-			Write-Verbose "Found $sqlspns set SQL SPN entries for $computer"
+			Write-Message -Message "Found $sqlspns set SQL SPN entries for $computer" -Level Verbose
 		}
 		
 		if ($AccountName)


### PR DESCRIPTION
Fixes #936

Additional PRs in the next few days to make every spn cmdlet use get-dbaadobject

While rewriting it, I used the new messaging system and spotted a few inconsintencies between the documented use of parameters and their mandatory usage.

Also, can anyone vouch for the usage of computername with the ending $ ? 
What's the whole deal behind Process-Account and the ByAccount switch ??
I can't figure out both what ByAccount changes in the flow AND why is it there in the first place, but I may be tired

