### PR TITLE
Connect-SqlServer

### DIFF
--- a/internal/Connect-SqlServer.ps1
+++ b/internal/Connect-SqlServer.ps1
@@ -11,7 +11,7 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 		[System.Management.Automation.PSCredential]$SqlCredential,
 		[switch]$ParameterConnection,
 		[switch]$RegularUser,
-		[string]$ApplicationName
+		[string]$ApplicationName = "dbatools PowerShell module - dbatools.io"
 	)
 	
 	
@@ -21,14 +21,7 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 		if ($ParameterConnection)
 		{
 			$paramserver = New-Object Microsoft.SqlServer.Management.Smo.Server
-			if ($null -ne $ApplicationName)
-			{
-				$paramserver.ConnectionContext.ApplicationName = $ApplicationName
-			}
-			else
-			{
-				$paramserver.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
-			}
+			$paramserver.ConnectionContext.ApplicationName = $ApplicationName
 			$paramserver.ConnectionContext.ConnectionString = $SqlServer.ConnectionContext.ConnectionString
 			
 			if ($SqlCredential.username -ne $null)
@@ -77,14 +70,8 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 	}
 	
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlServer
-	if ('ApplicationName' -in $PsBoundParameters.keys)
-	{
-		$server.ConnectionContext.ApplicationName = $ApplicationName
-	}
-	else
-	{
-		$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
-	}
+	$server.ConnectionContext.ApplicationName = $ApplicationName
+
 	<#
 	 Just realized this will not work because it's SMO ;) We will return to if this is still needed and how to handle it in 1.0.
 	

--- a/internal/Connect-SqlServer.ps1
+++ b/internal/Connect-SqlServer.ps1
@@ -10,7 +10,8 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 		[object]$SqlServer,
 		[System.Management.Automation.PSCredential]$SqlCredential,
 		[switch]$ParameterConnection,
-		[switch]$RegularUser
+		[switch]$RegularUser,
+		[string]$ApplicationName
 	)
 	
 	
@@ -20,7 +21,14 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 		if ($ParameterConnection)
 		{
 			$paramserver = New-Object Microsoft.SqlServer.Management.Smo.Server
-			$paramserver.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
+			if ($null -ne $ApplicationName)
+			{
+				$paramserver.ConnectionContext.ApplicationName = $ApplicationName
+			}
+			else
+			{
+				$paramserver.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
+			}
 			$paramserver.ConnectionContext.ConnectionString = $SqlServer.ConnectionContext.ConnectionString
 			
 			if ($SqlCredential.username -ne $null)
@@ -69,8 +77,14 @@ Internal function that creates SMO server object. Input can be text or SMO.Serve
 	}
 	
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlServer
-	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
-	
+	if ('ApplicationName' -in $PsBoundParameters.keys)
+	{
+		$server.ConnectionContext.ApplicationName = $ApplicationName
+	}
+	else
+	{
+		$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
+	}
 	<#
 	 Just realized this will not work because it's SMO ;) We will return to if this is still needed and how to handle it in 1.0.
 	


### PR DESCRIPTION
Modified to take an applicationname parameter to make life easier when working in single user startup.

Fixes # 

Changes proposed in this pull request:
 - Modified to take an applicationname parameter to make life easier when working in single user startup.

 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

