### PR TITLE
Files modified to work under single user startup

### DIFF
--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -90,11 +90,19 @@ Gets a list of all .bak files on the \\nas\sql share and reads the headers using
 	{
 		$LoopCnt = 1
 		$FunctionName = $FunctionName = (Get-PSCallstack)[0].Command
-		Write-Verbose "$FunctionName - Connecting to $SqlServer"
+
 		try
 		{
-			$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential -ErrorVariable ConnectError
-			
+			if ($sqlServer -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject])
+			{
+					Write-Verbose "$FunctionName - Connecting to $SqlServer"
+					$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential -ErrorVariable ConnectError
+			}
+			else
+			{
+				Write-Verbose "$FunctionName - Reusing connection to $SqlServer"
+				$server = $sqlServer
+			}
 		}
 		catch
 		{

--- a/internal/Get-SqlDefaultPaths.ps1
+++ b/internal/Get-SqlDefaultPaths.ps1
@@ -16,8 +16,25 @@ Internal function. Returns the default data and log paths for SQL Server. Needed
 		[System.Management.Automation.PSCredential]$SqlCredential
 	)
 	
-	$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
-	
+	try 
+	{
+		if ($sqlServer -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject])
+		{
+			Write-verbose "$FunctionName - Opening SQL Server connection"
+			$NewConnection = $True
+			$Server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential	
+		}
+		else
+		{
+			Write-Verbose "$FunctionName - reusing SMO connection"
+			$server = $SqlServer
+		}
+	}
+	catch {
+
+		Write-Warning "$FunctionName - Cannot connect to $SqlServer" 
+		break
+	}
 	switch ($filetype) { "mdf" { $filetype = "data" } "ldf" { $filetype = "log" } }
 	
 	if ($filetype -eq "log")

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -22,25 +22,36 @@ Takes path, checks for validity. Scans for usual backup file
         
         Write-Verbose "$FunctionName - Starting"
         Write-Verbose "$FunctionName - Checking Path"
-        Try 
-        {
-            $srv = Connect-SQLServer -SqlServer $SqlServer -SqlCredential $SqlCredential
-        }
-        Catch
-        {
-            Write-Warning "$FunctionName - Cannot connect to $sqlServer" -WarningAction stop
-        }
+		try 
+		{
+			if ($sqlServer -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject])
+			{
+				Write-verbose "$FunctionName - Opening SQL Server connection"
+				$NewConnection = $True
+				$Server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential	
+			}
+			else
+			{
+				Write-Verbose "$FunctionName - reusing SMO connection"
+				$server = $SqlServer
+			}
+		}
+		catch {
+
+			Write-Warning "$FunctionName - Cannot connect to $SqlServer" 
+			break
+		}
 
         if ($Path[-1] -ne "\")
         {
             $Path = $Path + "\"
         }
-        If (!(Test-SqlPath -SQLServer $sqlserver -SqlCredential $SqlCredential -path $path))
+        If (!(Test-SqlPath -SQLServer $server -SqlCredential $SqlCredential -path $path))
         {
             Write-warning "$FunctionName - SQLServer $sqlserver cannot access $path"
         }
         $query = "EXEC master.sys.xp_dirtree '$Path',1,1;"
-        $queryResult = Invoke-Sqlcmd2 -ServerInstance $sqlServer -Credential $SqlCredential -Database tempdb -Query $query
+        $queryResult = Invoke-Sqlcmd2 -ServerInstance $server -Credential $SqlCredential -Database tempdb -Query $query
         #$queryresult
         $dirs = $queryResult | where-object { $_.file -eq 0 }
         $Results = @()


### PR DESCRIPTION
If SMO connection passed in, reuse it so we only have one connection

Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

