### PR TITLE
Get-DbaSqlBuildReference, fixes #1057

### DIFF
--- a/functions/Get-DbaSqlBuildReference.ps1
+++ b/functions/Get-DbaSqlBuildReference.ps1
@@ -159,7 +159,12 @@ Integrate with other commandlets to have builds checked for all your registered 
 	{
 		foreach ($instance in $SqlInstance)
 		{
-			$Detected = Resolve-DbaSqlBuild -Build $instance.Version.ToString()
+			try {
+				$null = $instance.Version.ToString()
+			} catch {
+				Stop-Function -Message "Failed to connect to: $instance" -Continue -Silent $Silent -Target $instance
+			}
+			$Detected = Resolve-DbaSqlBuild  $instance.Version.ToString()
 			
 			[PSCustomObject]@{
 				SqlInstance = $instance.DomainInstanceName


### PR DESCRIPTION
errors out better when users don't read the manual

Fixes #1057

Changes proposed in this pull request:
 - tests if the pipelined input is something we can use or skip it
