### PR TITLE
Get-DbaSpn and Test-DbaSpn, fixed parameter inconsistencies

### DIFF
--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -18,9 +18,6 @@ The accounts you want to retrieve set SPNs for.
 .PARAMETER Credential
 User credential to connect to the remote servers or active directory.
 
-.PARAMETER ByAccount
-Shows all SPNs registered by the specified AccountName otherwise, only results will be shown for the specified ComputerName (which is localhost by default)
-
 .PARAMETER Silent
 Use this switch to disable any kind of verbose messages
 
@@ -55,17 +52,16 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 	[cmdletbinding()]
 	param (
 		[Parameter(Mandatory = $false,ValueFromPipeline = $true)]
-		[string[]]$ComputerName = $env:COMPUTERNAME,
+		[string[]]$ComputerName,
 		[Parameter(Mandatory = $false)]
 		[string[]]$AccountName,
-		[switch]$ByAccount,
 		[Parameter(Mandatory = $false)]
 		[PSCredential]$Credential,
 		[switch]$Silent
 	)
 	begin
 	{
-		Function Process-Account ($AccountName, $ByAccount) {
+		Function Process-Account ($AccountName) {
 			
 			ForEach ($account in $AccountName)
 			{
@@ -119,12 +115,15 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 					}
 				}
 			}
-			continue
+		}
+		if ($ComputerName.Count -eq 0 -and $AccountName.Count -eq 0) {
+			$ComputerName = @($env:COMPUTERNAME)
 		}
 	}
 	
 	process
 	{	
+		
 		foreach ($computer in $ComputerName)
 		{
 			if ($computer)
@@ -132,7 +131,7 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 				if ($computer.EndsWith('$'))
 				{
 					Write-Message -Message "$computer is an account name. Processing as account." -Level Verbose
-					Process-Account -AccountName $computer -ByAccount:$true
+					Process-Account -AccountName $computer
 					continue
 				}
 			}
@@ -178,7 +177,7 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 		{
 			foreach ($account in $AccountName)
 			{
-				Process-Account -AccountName $account -ByAccount:$ByAccount
+				Process-Account -AccountName $account
 			}
 		}
 	}

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -26,10 +26,6 @@ The server name you want to discover any SQL Server instances on. This parameter
 .PARAMETER Credential
 The credential you want to use to connect to the remote server and active directory.
 
-.PARAMETER Domain
-If your server resides on a different domain than what your current session is authenticated against, you can specify a domain here. This
-parameter is optional.
-
 .PARAMETER Silent
 Use this switch to disable any kind of verbose messages
 
@@ -61,11 +57,11 @@ Connects to multiple computers (SQLSERVERA, SQLSERVERB) and queries WMI for all 
 It will then take each SPN it generates and query Active Directory to make sure the SPNs are set.
 
 .EXAMPLE
-Test-DbaSpn -ComputerName SQLSERVERC -Domain domain.something -Credential (Get-Credential)
+Test-DbaSpn -ComputerName SQLSERVERC -Credential (Get-Credential)
 
 Connects to a computer (SQLSERVERC) on a specified and queries WMI for all SQL instances and return "required" SPNs. 
 It will then take each SPN it generates and query Active Directory to make sure the SPNs are set. Note that the credential you pass must
-have be a valid login with appropriate rights on the domain you specify
+have be a valid login with appropriate rights on the domain
 
 #>
 	[cmdletbinding()]
@@ -75,7 +71,6 @@ have be a valid login with appropriate rights on the domain you specify
 		[Parameter(Mandatory = $false)]
 		[PSCredential]$Credential,
 		[Parameter(Mandatory = $false)]
-		[string]$Domain,
 		[switch]$Silent
 	)
 	begin {
@@ -97,27 +92,6 @@ have be a valid login with appropriate rights on the domain you specify
 			
 			$ipaddr = $resolved.IPAddress
 			$hostentry = $resolved.DNSHostEntry
-			
-			if (!$domain)
-			{
-				$domain = $resolved.domain
-				if ($computer -notmatch "\.")
-				{
-					$computer = $resolved.DNSHostEntry
-				}
-			}
-			else
-			{
-				if ($computer -notmatch "\.")
-				{
-					if ($computer -match "\\")
-					{
-						$computer = $computer.Split("\")[0]
-						
-					}
-					$computer = "$computer.$domain"
-				}
-			}
 			
 			Write-Message -Message "Resolved ComputerName to FQDN: $computer" -Level Verbose
 			


### PR DESCRIPTION
Get-DbaSpn and Test-DbaSpn behave better now as per observations made in #1053 and #1052 

PS: please test this before releasing as the entire pipeline with the other cmdlets has not been verified accurately