### PR TITLE
New-DbaDatabaseSnapshot not always honoring $Credential

### DIFF
--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -273,12 +273,7 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 							$CustomFileStructure[$fg.Name] += @{ 'name' = $file.name; 'filename' = $fname }
 						}
 					}
-                    #Use default constructor and set Parent + Credentials, in order to honor $Credential
-					$SnapDB = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database
-                    #Server connection using credentials was created above
-                    $SnapDB.Parent = $server
-                    $SnapDB.Name = $SnapName
-
+					$SnapDB = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database -ArgumentList $server, $Snapname
 					$SnapDB.DatabaseSnapshotBaseName = $db.Name
 					foreach ($fg in $CustomFileStructure.Keys)
 					{

--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -273,7 +273,12 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 							$CustomFileStructure[$fg.Name] += @{ 'name' = $file.name; 'filename' = $fname }
 						}
 					}
-					$SnapDB = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database -ArgumentList $instance, $Snapname
+                    #Use default constructor and set Parent + Credentials, in order to honor $Credential
+					$SnapDB = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database
+                    #Server connection using credentials was created above
+                    $SnapDB.Parent = $server
+                    $SnapDB.Name = $SnapName
+
 					$SnapDB.DatabaseSnapshotBaseName = $db.Name
 					foreach ($fg in $CustomFileStructure.Keys)
 					{


### PR DESCRIPTION
Fixes #1070 

Using the 2-parameter version of the
Microsoft.SqlServer.Management.Smo.Database constructor was causing it
not to honor the $Credential parameter, and instead used the
credentials of the session running New-DbaDatabaseSnapshot. This caused
a failure if the account running the cmdlet did not have permission to
connect to $instance