### PR TITLE
Add CopyDestination switch to Test-DbaLastBackup

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -300,7 +300,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 							{
 								try 
 								{
-									New-Item -Path ("{0}\{1}" -f $copyPath,$Prefix) -ItemType Directory | Out-Null
+									$null = New-Item -Path ("{0}\{1}" -f $copyPath,$Prefix) -ItemType Directory -ErrorAction Stop
 								}
 								catch
 								{
@@ -313,7 +313,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 								$sourcefile = Join-AdminUnc -servername $sourceserver.netname -filepath $lastbackup.Path 
 								$destdirectory = Join-AdminUnc -servername $destserver.netname -filepath $copyPath
 								$destfile = ("{0}\{1}\{2}" -f $destdirectory,$Prefix,$lastbackup.path.split('\')[-1])
-								Copy-Item -Path $sourcefile -Destination $destfile
+								Copy-Item -Path $sourcefile -Destination $destfile -ErrorAction Stop
 								$lastbackup.path = $destfile
 								$lastbackup.fullname = $destfile
 							}
@@ -468,7 +468,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 								Write-Message -Level Verbose -Message "Removing backup file from $destination"
 								try 
 								{
-									Remove-item $($lastbackup.fullname)
+									Remove-item $($lastbackup.fullname) -ErrorAction Stop
 								}
 								catch
 								{
@@ -479,7 +479,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 								{
 									try
 									{
-										Remove-item -Path $tempFolder
+										Remove-item -Path $tempFolder -ErrorAction Stop
 									}
 									catch
 									{

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -294,6 +294,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 							$fileexists = "Skipped"
 							$restoreresult = "Destination backup not on shared location."
 							$dbccresult = "Skipped"
+							$copyDestination = $false
 						}
 						elseif ((Test-SqlPath -SqlServer $destserver -path $copyPath)) 
 						{
@@ -337,8 +338,9 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 					}
 					elseif ($CopyDestination) {
 						Write-Message -Level Verbose -Message "Ignoring CopyDestination flag, using UNC path."
+						$CopyDestination = $false
 					}
-
+					
 					#if ($null -eq $lastbackup)
 					if(!($lastbackup | Where-Object {$_.type -eq 'Full'}))
 					{

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -57,6 +57,9 @@ Skip DBCC CHECKTABLE
 .PARAMETER NoDrop
 Do not drop newly created test database
 
+.PARAMETER CopyDestination
+Will copy the backup file to the destination default backup location.
+
 .PARAMETER MaxMB
 Do not restore databases larger than MaxMB
 
@@ -117,7 +120,12 @@ Skips the DBCC CHECKTABLE check. This can help speed up the tests but makes it l
 Test-DbaLastBackup -SqlServer sql2016 -DataDirectory E:\bigdrive -LogDirectory L:\bigdrive -MaxMB 10240
 
 Restores data and log files to alternative locations and only restores databases that are smaller than 10 GB
-	
+
+.EXAMPLE 
+Test-DbaLastBackup -SqlServer sql2014 -Destination sql2016 -CopyDestination
+
+Copies the backup files for sql2014 databases to sql2016 default backup locations and then attempts restore from there.
+
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	Param (

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -272,7 +272,14 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 					if($lastbackup[0].Path.StartsWith('\\') -eq $false -and $CopyDestination -eq $true) 
 					{
 						Write-Message -Level Verbose -Message "Copying backup to destination server"
-						if ((Test-SqlPath -SqlServer $destserver -path $destserver.BackupDirectory) -eq $true) 
+						if($destserver.BackupDirectory.StartsWith('\\') -eq $false)
+						{
+							Write-Message -Level Verbose -Message "Destination backup directory is not UNC and source does not match destination."
+							$fileexists = "Skipped"
+							$restoreresult = "Destination backup not on shared location."
+							$dbccresult = "Skipped"
+						}
+						elseif ((Test-SqlPath -SqlServer $destserver -path $destserver.BackupDirectory) -eq $true) 
 						{
 							if((Test-SqlPath -SqlServer $destserver -path ("{0}\{1}" -f $destserver.BackupDirectory,$Prefix)) -eq $false)
 							{


### PR DESCRIPTION
Fixes #1067 

Changes proposed in this pull request:
 - Added CopyDestination switch that will copy the backup file from the local backup path to the destination servers default backup location
 - Added CopyDestination to help section, parameter definition and example
 - 

How to test this code: 
- [ ] Server1 backups up to a non UNC path, server2 backup directory is UNC path, use CopyDestination to copy backup file to destination path and restore from there.
`Test-DbaLastBackup -SqlInstance Server1 -Destination Server2 -CopyDestination` 
- [ ] Server1 backups up to UNC path, CopyDestination switch is set but will be ignored.
`Test-DbaLastBackup -SqlInstance Server1 -Destination Server2 -CopyDestination` 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

