### PR TITLE
Get dbatempdbusage fix

### DIFF
--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -9,15 +9,19 @@
 	
     .PARAMETER SqlInstance
     The SQL Instance you are querying against.
+
     .PARAMETER SqlCredential
     If you want to use alternative credentials to connect to the server.
+
     .PARAMETER Detailed
     Returns additional information from the DMVs, such as:
     -- program_name running the session.
     -- login_time of the session.
+    -- SQL Command used to return the data
 	
     .PARAMETER WhatIf
 	Shows what would happen if the command were to run. No actions are actually performed.
+
 	.PARAMETER Confirm 
 	Prompts you for confirmation before executing any changing operations within the command.
 	
@@ -132,6 +136,7 @@ WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.in
                     LoginTime = $TempdbUsage.LoginTime
                     LastRequestStartTime = $TempdbUsage.LastRequestStartTime
                     LastRequestEndTime = $TempdbUsage.LastRequestEndTime
+                    SQLCommand = $QueryText
                 } | Select-DefaultView -ExcludeProperty OriginalLoginName,
                                                         NTDomain,
                                                         NTUserName,
@@ -139,7 +144,8 @@ WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.in
                                                         ProgramName,
                                                         LoginTime,
                                                         LastRequestStartTime,
-                                                        LastRequestEndTime 
+                                                        LastRequestEndTime
+                                                        SQLCommand
 		}
 	}
 }

--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -79,16 +79,16 @@ SELECT SERVERPROPERTY('MachineName') AS ComputerName,
        ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName, 
        SERVERPROPERTY('ServerName') AS SqlInstance, 
        t.session_id AS Spid, 
-       /*r.command*/'' AS StatementCommand, 
-       /*r.start_time*/'' AS StartTime, 
+       r.command AS StatementCommand, 
+       r.start_time AS StartTime, 
        t.user_objects_alloc_page_count * 8 AS UserObjectAllocatedSpace, 
        t.user_objects_dealloc_page_count * 8 AS UserObjectDeallocatedSpace, 
        t.internal_objects_alloc_page_count * 8 AS InternalObjectAllocatedSpace, 
        t.internal_objects_dealloc_page_count * 8 AS InternalObjectDeallocatedSpace, 
-       /*r.reads*/0 AS RequestedReads, 
-       /*r.writes*/0 AS RequestedWrites, 
-       /*r.logical_reads*/1 AS RequestedLogicalReads, 
-       /*r.cpu_time*/1 AS RequestedCPUTime, 
+       r.reads AS RequestedReads, 
+       r.writes AS RequestedWrites, 
+       r.logical_reads AS RequestedLogicalReads, 
+       r.cpu_time AS RequestedCPUTime, 
        s.is_user_process AS IsUserProcess, 
        s.[status] AS Status, 
        DB_NAME(r.database_id) AS [Database], 
@@ -103,7 +103,7 @@ SELECT SERVERPROPERTY('MachineName') AS ComputerName,
        s.last_request_end_time AS LastRequestedEndTime 
 FROM sys.dm_db_session_space_usage AS t 
 INNER JOIN sys.dm_exec_sessions AS s ON s.session_id = t.session_id 
-/*INNER JOIN sys.dm_exec_requests AS r ON r.session_id = s.session_id*/ 
+INNER JOIN sys.dm_exec_requests AS r ON r.session_id = s.session_id
 WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.internal_objects_alloc_page_count + t.internal_objects_dealloc_page_count > 0
 "@
 			

--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -1,5 +1,4 @@
-﻿Function Get-DbaTempdbUsage
-{
+Function Get-DbaTempdbUsage {
     <#
     .SYNOPSIS
     Gets Tempdb usage for running queries.
@@ -12,20 +11,14 @@
 
     .PARAMETER SqlCredential
     If you want to use alternative credentials to connect to the server.
-
-    .PARAMETER Detailed
-    Returns additional information from the DMVs, such as:
-    -- program_name running the session.
-    -- login_time of the session.
-    -- SQL Command used to return the data
 	
     .PARAMETER WhatIf
 	Shows what would happen if the command were to run. No actions are actually performed.
 
-	.PARAMETER Confirm 
+    .PARAMETER Confirm 
 	Prompts you for confirmation before executing any changing operations within the command.
 	
-	.PARAMETER Silent
+    .PARAMETER Silent
 	Use this switch to disable any kind of verbose messages
 	
     .NOTES
@@ -40,112 +33,61 @@
     Get-DbaTempdbUsage -SqlInstance localhost\SQLDEV2K14
 	
 	Gets tempdb usage for localhost\SQLDEV2K14
-    .EXAMPLE
-    Get-DbaTempdbUsage -SqlInstance localhost\SQLDEV2K14 -Detailed
-	
-	Gets detailed tempdb usage for localhost\SQLDEV2K14
     #>
 	[CmdletBinding()]
-	Param (
+	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[object[]]$SqlInstance,
 		[System.Management.Automation.PSCredential]$SqlCredential,
-		[switch]$Detailed,
 		[switch]$Silent
 	)
 	
-	PROCESS
-	{
-		foreach ($instance in $SqlInstance)
-		{
-			try
-			{
+	process {
+		foreach ($instance in $SqlInstance) {
+			try {
 				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
 			}
-			catch
-			{
+			catch {
 				Stop-Function -Message "Failed to connect to: $instance" -Continue -Target $Instance
 			}
 			
-			if ($server.VersionMajor -le 9)
-			{
-				Stop-Function -Message "This function is only supported in SQL Server 2008 or higher."
-				continue
+			if ($server.VersionMajor -le 9) {
+				Stop-Function -Message "This function is only supported in SQL Server 2008 or higher." -Continue
 			}
-
-            $QueryText = @"
-SELECT SERVERPROPERTY('MachineName') AS ComputerName, 
-       ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName, 
-       SERVERPROPERTY('ServerName') AS SqlInstance, 
-       t.session_id AS Spid, 
-       r.command AS StatementCommand, 
-       r.start_time AS StartTime, 
-       t.user_objects_alloc_page_count * 8 AS UserObjectAllocatedSpace, 
-       t.user_objects_dealloc_page_count * 8 AS UserObjectDeallocatedSpace, 
-       t.internal_objects_alloc_page_count * 8 AS InternalObjectAllocatedSpace, 
-       t.internal_objects_dealloc_page_count * 8 AS InternalObjectDeallocatedSpace, 
-       r.reads AS RequestedReads, 
-       r.writes AS RequestedWrites, 
-       r.logical_reads AS RequestedLogicalReads, 
-       r.cpu_time AS RequestedCPUTime, 
-       s.is_user_process AS IsUserProcess, 
-       s.[status] AS Status, 
-       DB_NAME(r.database_id) AS [Database], 
-       s.login_name AS LoginName, 
-       s.original_login_name AS OriginalLoginName, 
-       s.nt_domain AS NTDomain, 
-       s.nt_user_name AS NTUserName, 
-       s.[host_name] AS HostName, 
-       s.[program_name] AS ProgramName, 
-       s.login_time AS LoginTime, 
-       s.last_request_start_time AS LastRequestedStartTime, 
-       s.last_request_end_time AS LastRequestedEndTime 
-FROM sys.dm_db_session_space_usage AS t 
-INNER JOIN sys.dm_exec_sessions AS s ON s.session_id = t.session_id 
-INNER JOIN sys.dm_exec_requests AS r ON r.session_id = s.session_id
-WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.internal_objects_alloc_page_count + t.internal_objects_dealloc_page_count > 0
-"@
 			
-			$TempdbUsage = $server.ConnectionContext.ExecuteWithResults($sql).Tables
-
-                [PSCustomObject]@{
-                    ComputerName = $TempdbUsage.ComputerName
-                    InstanceName = $TempdbUsage.InstanceName
-                    SQLInstance = $TempdbUsage.SqlInstance
-                    Spid = $TempdbUsage.Spid
-                    StatementCommand = $TempdbUsage.StatementCommand
-                    StartTime = $TempdbUsage.StartTime
-                    UserObjectAllocatedSpace = $TempdbUsage.UserObjectAllocatedSpace
-                    UserObjectDeallocatedSpace = $TempdbUsage.UserObjectDeallocatedSpace
-                    InternalObjectAllocatedSpace = $TempdbUsage.InternalObjectAllocatedSpace
-                    InternalObjectDeallocatedSpace = $TempdbUsage.InternalObjectDeallocatedSpace
-                    RequestedReads = $TempdbUsage.RequestedReads
-                    RequestedWrites = $TempdbUsage.RequestedWrites
-                    RequestedLogicalReads = $TempdbUsage.RequestedLogicalReads
-                    RequestedCPUTime = $TempdbUsage.RequestedCPUTime
-                    IsUserProcess = $TempdbUsage.IsUserProcess
-                    Status = $TempdbUsage.Status
-                    Database = $TempdbUsage.Database
-                    LoginName = $TempdbUsage.LoginName
-                    OriginalLoginName = $TempdbUsage.OriginalLoginName
-                    NTDomain = $TempdbUsage.NTDomain
-                    NTUserName = $TemdbUsage.NTUserName
-                    HostName = $TempdbUsage.HostName
-                    ProgramName = $TempdbUsage.ProgramName
-                    LoginTime = $TempdbUsage.LoginTime
-                    LastRequestStartTime = $TempdbUsage.LastRequestStartTime
-                    LastRequestEndTime = $TempdbUsage.LastRequestEndTime
-                    SQLCommand = $QueryText
-                } | Select-DefaultView -ExcludeProperty OriginalLoginName,
-                                                        NTDomain,
-                                                        NTUserName,
-                                                        HostName,
-                                                        ProgramName,
-                                                        LoginTime,
-                                                        LastRequestStartTime,
-                                                        LastRequestEndTime
-                                                        SQLCommand
+			$sql = "SELECT SERVERPROPERTY('MachineName') AS ComputerName, 
+							       ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName, 
+							       SERVERPROPERTY('ServerName') AS SqlInstance, 
+							       t.session_id AS Spid, 
+							       r.command AS StatementCommand, 
+							       r.start_time AS StartTime, 
+							       t.user_objects_alloc_page_count * 8 AS UserObjectAllocatedSpace, 
+							       t.user_objects_dealloc_page_count * 8 AS UserObjectDeallocatedSpace, 
+							       t.internal_objects_alloc_page_count * 8 AS InternalObjectAllocatedSpace, 
+							       t.internal_objects_dealloc_page_count * 8 AS InternalObjectDeallocatedSpace, 
+							       r.reads AS RequestedReads, 
+							       r.writes AS RequestedWrites, 
+							       r.logical_reads AS RequestedLogicalReads, 
+							       r.cpu_time AS RequestedCPUTime, 
+							       s.is_user_process AS IsUserProcess, 
+							       s.[status] AS Status, 
+							       DB_NAME(r.database_id) AS [Database], 
+							       s.login_name AS LoginName, 
+							       s.original_login_name AS OriginalLoginName, 
+							       s.nt_domain AS NTDomain, 
+							       s.nt_user_name AS NTUserName, 
+							       s.[host_name] AS HostName, 
+							       s.[program_name] AS ProgramName, 
+							       s.login_time AS LoginTime, 
+							       s.last_request_start_time AS LastRequestedStartTime, 
+							       s.last_request_end_time AS LastRequestedEndTime 
+							FROM sys.dm_db_session_space_usage AS t 
+							INNER JOIN sys.dm_exec_sessions AS s ON s.session_id = t.session_id 
+							INNER JOIN sys.dm_exec_requests AS r ON r.session_id = s.session_id
+							WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.internal_objects_alloc_page_count + t.internal_objects_dealloc_page_count > 0"
+			
+			$server.ConnectionContext.ExecuteWithResults($sql).Tables
 		}
 	}
 }


### PR DESCRIPTION
Fixes #984  

Changes proposed in this pull request:
 - Takes the proposed changes from #984 and includes them in. Unable to verify when the columns were added to the DMVs since MS changed from MSDN to docs, so requires further testing.

How to test this code: 
- [ ] Run the code on a SQL Server prior to 2012 and ensure that no errors occur.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

