### PR TITLE
Write-DbaDataTable and Out-DbaDataTable enhancements

### DIFF
--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -60,32 +60,69 @@ Similar to above but $dbalist gets piped in
 			param ($type)
 			
 			$types = @(
-				'System.Boolean',
-				'System.Byte[]',
-				'System.Byte',
-				'System.Char',
-				'System.Datetime',
-				'System.Decimal',
-				'System.Double',
-				'System.Guid',
-				'System.Int16',
-				'System.Int32',
-				'System.Int64',
-				'System.Single',
-				'System.UInt16',
-				'System.UInt32',
-				'System.UInt64')
-			
-			if ($types -contains $type)
+                'Int32',    
+                'UInt32',   
+                'Int16',    
+                'UInt16',   
+                'Int64',    
+                'UInt64',   
+                'Decimal',  
+                'Single',   
+                'Double',   
+                'Byte',     
+                'SByte',    
+                'Boolean',
+                'Bool',
+                'String',   
+                'DateTime',
+                'Guid',
+                'Char',
+                'int',  
+                'long',
+                'System.Int32',    
+                'System.UInt32',   
+                'System.Int16',    
+                'System.UInt16',   
+                'System.Int64',    
+                'System.UInt64',   
+                'System.Decimal',  
+                'System.Single',   
+                'System.Double',   
+                'System.Byte',     
+                'System.SByte',    
+                'System.Boolean',
+                'System.String',   
+                'System.DateTime',
+                'System.Guid',
+                'System.Char'
+                )
+
+            # some types require conversion to be stored in a database
+            $specialtypes = @{
+                'System.TimeSpan' = 'System.String'
+                'TimeSpan'        = 'System.String'
+            }
+
+            if ($specialtypes.keys -contains $type) 
+            {
+                # Debug, remove when done
+                #Write-Verbose "Found match: $type (special)"
+                return $specialtypes[$type]
+            }
+            elseif ($types -contains $type)
 			{
+                # Debug, remove when done
+                #Write-Verbose "Found match: $type"
 				return $type
 			}
 			else
 			{
+                # Debug, remove when done
+                #Write-Warning "Did not find match: $type"
 				return 'System.String'
 			}
 		}
-		
+	
 		$datatable = New-Object System.Data.DataTable
 	}
 	
@@ -114,14 +151,22 @@ Similar to above but $dbalist gets piped in
 					$column = New-Object System.Data.DataColumn
 					$column.ColumnName = $property.Name.ToString()
 					
-					if ($property.value)
-					{
+                    # Even if property value is $false or $null we need to check the type
+                    # Commenting out this if statement. Can't see the benefit after the other changes, but I could be missing something. /John
+					#if ($property.value)
+					#{
 						if ($property.value -isnot [System.DBNull])
 						{
-							$type = Get-Type $property.TypeNameOfValue
+                            # Check if property is a ScriptProperty, then resolve it before checking type
+                            If ($property.MemberType -eq 'ScriptProperty') {
+                                $type = Get-Type ($object.($property.Name).GetType().ToString())
+                            } else {
+                                $type = Get-Type $property.TypeNameOfValue
+                            }
+                            
 							$column.DataType = [System.Type]::GetType($type)
 						}
-					}
+					#}
 					$datatable.Columns.Add($column)
 				}
 				


### PR DESCRIPTION
Changes proposed in this pull request:
Updated Write-DbaDataTable and Out-DbaDataTable with features from Write-ObjectToSQL.

Out-DbaDataTable
- Added more data types
- Added special data types for situations where the type does not fit into a table very well without type conversion, like the TimeSpan object
- Added logic for resolving script properties before type is checked
- Removed check for property value before evaluating type, since it should not be needed anymore

Write-DbaDataTable
- Added hash table for type conversion between PowerShell and SQL Server data types
- Updated help message to suggest user to use Out-DbaDataTable if wrong type of input object is used
- Function now converts data types much better than before when creating target table. No more varchar where it shouldn't be (except for timespan which is special).
- Replaced varchar with nvarchar when creating target table
- Strings are now converted into nvarchar(MAX) since there is no way of knowing how long the strings will be from the pipeline (or further down the DataTable)
- Added example showing the type conversion in action (hint: the process object has a lot of properties)
- Left some commented out verbose logging in there for now. Should be removed later

How to test this code: 
- Use the examples as test. The latest example in Write-DbaDataTable provides a good test for type conversion.
- The following object is also a good test to use (and to make sure that the converted types in SQL are correct):
$obj = New-Object -TypeName psobject -Property @{
    guid = [system.guid]::NewGuid()
    timespan = New-TimeSpan -Start 2017-01-01 -End 2017-01-02
    datetime = Get-Date
    char = [System.Char]'Z'
    true = $true
    false = $false
    null = [bool]$null
    string = "some text"
    UInt64 = [System.UInt64]123456
}

Tested on Windows 10 and SQL Server 2014.
