### PR TITLE
Remove RecoveryFork check from Test-DbaLsnChain

### DIFF
--- a/internal/Test-DbaLsnChain.ps1
+++ b/internal/Test-DbaLsnChain.ps1
@@ -52,17 +52,7 @@ Checks that the Restore chain in $FilteredFiles is complete and can be fully res
         return $false
         break;
     }
-    #Check all the backups relate to the full backup
-    
-    #Via RecoveryForkID:
-    #Allow for striped fill backups:
-    $RecoveryForkID = ($FullDBAnchor | Select-Object -First 1).RecoveryForkID
-    if (($FilteredRestoreFiles | Where-Object {$_.RecoveryForkID -ne $RecoveryForkID}).count -gt 0)
-    {
-        Write-Warning "$FunctionName - Multiple RecoveryForkIDs found, not supported"
-        return $false
-        break
-    }
+
     #Via LSN chain:
     $CheckPointLSN = ($FullDBAnchor | Select-Object -First 1).CheckPointLSN
     $FullDBLastLSN = ($FullDBAnchor | Select-Object -First 1).LastLSN 


### PR DESCRIPTION
removed test as it was having issues if the db had been restored to a point
earlier in the backup chain. MS documents opaque, so removing until it can
be made reliable and safe

Fixes # 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

