### PR TITLE
Get-DbaBackupHistory - return only last diff instead of all, and log backups after the last diff

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -168,10 +168,15 @@ Function Get-DbaBackupHistory {
 					$logdb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$Raw -LastLog
 					
 					if ($logdb) {
-						$alldb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$Raw
-						$alldb | Where-Object { $_.FirstLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Full' }
-						$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -ne 'Full' -and $_.Type -ne 'Log' }
-						$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Log' }
+						$alldb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$Raw 
+						$alldb | Where-Object { $_.FirstLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Full' } 
+						$diff = $alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -ne 'Full' -and $_.Type -ne 'Log' } | Sort-Object Start -Descending | Select-Object -First 1
+						$diff
+						if($diff) {
+							$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.lastlsn -ge $diff.lastlsn -and $_.Type -eq 'Log'}
+						} else {
+							$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Log'}
+						}
 					}
 					else{
 						Get-DbaBackupHistory -SqlServer $server -Databases $db -LastFull -raw:$Raw


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - for -last switch return only one differential backup (was returning all)
 - for -last switch return log backups after the differential if there is one
 - 

How to test this code: 
- [ ] Get-DbaBackupHistory -SqlServer server1 -Databases db1 -last
- db1 in full recovery mode, returns last chain of backups, 1 full, 1 differential and any log backups since that diff.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

