### PR TITLE
Copy-SqlDatabaseMail Removed -Silent from write-message

### DIFF
--- a/functions/Copy-SqlDatabaseMail.ps1
+++ b/functions/Copy-SqlDatabaseMail.ps1
@@ -188,7 +188,7 @@ Shows what would happen if the command were executed.
 				
 				if ($pscmdlet.ShouldProcess($destination, "Migrating account $accountName")) {
 					try {
-						Write-Message -Message "Copying mail account $accountName" -Level Verbose -Silent $Silent
+						Write-Message -Message "Copying mail account $accountName" -Level Verbose
 						$sql = $account.Script() | Out-String
 						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
 						Write-Message -Message $sql -Level Debug


### PR DESCRIPTION
Missed removing -silent from write-message before it got merged.

Changes proposed in this pull request:
 - Just missed removing a silent parameter from Write-Message before previous PR got merged.
