### PR TITLE
Computermanagement v2

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -450,6 +450,9 @@ namespace Sqlcollective.Dbatools
             /// <param name="Credential">The bad credential that must be punished</param>
             public void AddBadCredential(PSCredential Credential)
             {
+                if (DisableBadCredentialCache)
+                    return;
+
                 if (Credential == null)
                 {
                     WindowsCredentialsAreBad = true;
@@ -458,7 +461,7 @@ namespace Sqlcollective.Dbatools
                 }
 
                 // If previously good credentials have been revoked, better remove them from the list
-                if (Credentials.UserName.ToLower() == Credential.UserName.ToLower())
+                if ((Credentials != null) && (Credentials.UserName.ToLower() == Credential.UserName.ToLower()))
                 {
                     if (Credentials.GetNetworkCredential().Password == Credential.GetNetworkCredential().Password)
                         Credentials = null;

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -311,6 +311,7 @@ namespace Sqlcollective.Dbatools
                 _DisableCredentialAutoRegister = 0;
                 _OverrideExplicitCredential = 0;
                 _DisableCimPersistence = 0;
+                _EnableCredentialFailover = 0;
             }
             #endregion Configuration
 
@@ -718,6 +719,8 @@ namespace Sqlcollective.Dbatools
             public ManagementConnection(string ComputerName)
             {
                 this.ComputerName = ComputerName.ToLower();
+                if (Utility.Validation.IsLocalhost(ComputerName))
+                    CimRM = ManagementConnectionProtocolState.Disabled;
             }
             #endregion Constructors
 
@@ -729,7 +732,11 @@ namespace Sqlcollective.Dbatools
             /// </summary>
             public WSManSessionOptions CimWinRMOptions
             {
-                get { return _CimWinRMOptions; }
+                get
+                {
+                    if (_CimWinRMOptions == null) { return null; }
+                    return new WSManSessionOptions(_CimWinRMOptions); ;
+                }
                 set
                 {
                     cimWinRMSession = null;
@@ -739,9 +746,9 @@ namespace Sqlcollective.Dbatools
             private WSManSessionOptions _CimWinRMOptions;
 
             private CimSession cimWinRMSession;
-            public PSCredential cimWinRMSessionLastCredential;
+            private PSCredential cimWinRMSessionLastCredential;
 
-            private CimSession GetCimWinRMSession(PSCredential Credential, bool ForceReset)
+            private CimSession GetCimWinRMSession(PSCredential Credential)
             {
                 // Prepare the last session if any
                 CimSession tempSession = cimWinRMSession;
@@ -771,12 +778,21 @@ namespace Sqlcollective.Dbatools
                     catch (Exception e)
                     {
                         bool testBadCredential = false;
-                        try { testBadCredential = ((CimException)e.InnerException).MessageId == "HRESULT 0x8007052e"; }
+                        try
+                        {
+                            string tempMessageId = ((CimException)(e.InnerException)).MessageId;
+                            if (tempMessageId ==  "HRESULT 0x8007052e")
+                                testBadCredential = true;
+                            else if (tempMessageId == "HRESULT 0x80070005")
+                                testBadCredential = true;
+                        }
                         catch { }
 
                         if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
                         else { throw e; }
                     }
+
+                    cimWinRMSessionLastCredential = Credential;
                 }
 
                 return tempSession;
@@ -811,17 +827,42 @@ namespace Sqlcollective.Dbatools
             /// <returns>Hopefully a mountainload of CimInstances</returns>
             public object GetCimRMInstance(PSCredential Credential, string Class, string Namespace = @"root\cimv2")
             {
-                
-
-                
-
+                CimSession tempSession;
                 IEnumerable<CimInstance> result = new List<CimInstance>();
-                result = cimWinRMSession.EnumerateInstances(Namespace, Class);
+
+                try
+                {
+                    tempSession = GetCimWinRMSession(Credential);
+                    result = tempSession.EnumerateInstances(Namespace, Class);
+                    result.GetEnumerator().MoveNext();
+                }
+                catch (Exception e)
+                {
+                    bool testBadCredential = false;
+                    try
+                    {
+                        string tempMessageId = ((CimException)e).MessageId;
+                        if (tempMessageId == "HRESULT 0x8007052e")
+                            testBadCredential = true;
+                        else if (tempMessageId == "HRESULT 0x80070005")
+                            testBadCredential = true;
+                    }
+                    catch { }
+
+                    if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
+                    else { throw e; }
+                }
+
                 if (DisableCimPersistence)
                 {
-                    try { cimWinRMSession.Close(); }
+                    try { tempSession.Close(); }
                     catch {  }
                     cimWinRMSession = null;
+                }
+                else
+                {
+                    if (cimWinRMSession != tempSession)
+                        cimWinRMSession = tempSession;
                 }
                 return result;
             }
@@ -836,21 +877,42 @@ namespace Sqlcollective.Dbatools
             /// <returns></returns>
             public object QueryCimRMInstance(PSCredential Credential, string Query, string Dialect = "WQL", string Namespace = @"root\cimv2")
             {
-                WSManSessionOptions options = null;
-                if (CimWinRMOptions == null)
+                CimSession tempSession;
+                IEnumerable<CimInstance> result = new List<CimInstance>();
+
+                try
                 {
-                    options = GetDefaultCimWsmanOptions();
+                    tempSession = GetCimWinRMSession(Credential);
+                    result = tempSession.QueryInstances(Namespace, Dialect, Query);
+                    result.GetEnumerator().MoveNext();
                 }
-                else { options = CimWinRMOptions; }
-                if (Credential != null) { options.AddDestinationCredentials(new CimCredential(PasswordAuthenticationMechanism.Default, Credential.GetNetworkCredential().Domain, Credential.GetNetworkCredential().UserName, Credential.Password)); }
+                catch (Exception e)
+                {
+                    bool testBadCredential = false;
+                    try
+                    {
+                        string tempMessageId = ((CimException)e).MessageId;
+                        if (tempMessageId == "HRESULT 0x8007052e")
+                            testBadCredential = true;
+                        else if (tempMessageId == "HRESULT 0x80070005")
+                            testBadCredential = true;
+                    }
+                    catch { }
 
-                if (cimWinRMSession == null) { cimWinRMSession = CimSession.Create(ComputerName, options); }
+                    if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
+                    else { throw e; }
+                }
 
-                var result = cimWinRMSession.QueryInstances(Namespace, Dialect, Query);
                 if (DisableCimPersistence)
                 {
-                    cimWinRMSession.Close();
+                    try { tempSession.Close(); }
+                    catch { }
                     cimWinRMSession = null;
+                }
+                else
+                {
+                    if (cimWinRMSession != tempSession)
+                        cimWinRMSession = tempSession;
                 }
                 return result;
             }
@@ -860,18 +922,77 @@ namespace Sqlcollective.Dbatools
             /// <summary>
             /// The options ot use when establishing a CIM Session
             /// </summary>
-            public DComSessionOptions CimDCOMOptions
+            public DComSessionOptions CimDComOptions
             {
-                get { return _CimDCOMOptions; }
+                get
+                {
+                    if (_CimDComOptions == null) { return null; }
+                    DComSessionOptions options = new DComSessionOptions();
+                    options.PacketPrivacy = _CimDComOptions.PacketPrivacy;
+                    options.PacketIntegrity = _CimDComOptions.PacketIntegrity;
+                    options.Impersonation = _CimDComOptions.Impersonation;
+                    return options;
+                }
                 set
                 {
-                    _CimDCOMOptions = null;
-                    _CimDCOMOptions = value;
+                    _CimDComOptions = null;
+                    _CimDComOptions = value;
                 }
             }
-            private DComSessionOptions _CimDCOMOptions;
+            private DComSessionOptions _CimDComOptions;
 
-            private CimSession cimDCOMSession;
+            private CimSession cimDComSession;
+            private PSCredential cimDComSessionLastCredential;
+
+            private CimSession GetCimDComSession(PSCredential Credential)
+            {
+                // Prepare the last session if any
+                CimSession tempSession = cimDComSession;
+
+                // If we use different credentials than last time, now's the time to interrupt
+                if (!(cimDComSessionLastCredential == null && Credential == null))
+                {
+                    if (cimDComSessionLastCredential == null || Credential == null)
+                        tempSession = null;
+                    else if (cimDComSessionLastCredential.UserName != Credential.UserName)
+                        tempSession = null;
+                    else if (cimDComSessionLastCredential.GetNetworkCredential().Password != Credential.GetNetworkCredential().Password)
+                        tempSession = null;
+                }
+
+                if (tempSession == null)
+                {
+                    DComSessionOptions options = null;
+                    if (CimWinRMOptions == null)
+                    {
+                        options = GetDefaultCimDcomOptions();
+                    }
+                    else { options = CimDComOptions; }
+                    if (Credential != null) { options.AddDestinationCredentials(new CimCredential(PasswordAuthenticationMechanism.Default, Credential.GetNetworkCredential().Domain, Credential.GetNetworkCredential().UserName, Credential.Password)); }
+
+                    try { tempSession = CimSession.Create(ComputerName, options); }
+                    catch (Exception e)
+                    {
+                        bool testBadCredential = false;
+                        try
+                        {
+                            string tempMessageId = ((CimException)(e.InnerException)).MessageId;
+                            if (tempMessageId == "HRESULT 0x8007052e")
+                                testBadCredential = true;
+                            else if (tempMessageId == "HRESULT 0x80070005")
+                                testBadCredential = true;
+                        }
+                        catch { }
+
+                        if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
+                        else { throw e; }
+                    }
+
+                    cimDComSessionLastCredential = Credential;
+                }
+
+                return tempSession;
+            }
 
             /// <summary>
             /// Returns the default DCom options object
@@ -894,22 +1015,44 @@ namespace Sqlcollective.Dbatools
             /// <param name="Class">The class to query</param>
             /// <param name="Namespace">The namespace to look in (defaults to root\cimv2)</param>
             /// <returns>Hopefully a mountainload of CimInstances</returns>
-            public object GetCimDCOMInstance(PSCredential Credential, string Class, string Namespace = @"root\cimv2")
+            public object GetCimDComInstance(PSCredential Credential, string Class, string Namespace = @"root\cimv2")
             {
-                DComSessionOptions options = null;
-                if (CimDCOMOptions == null)
-                {
-                    options = GetDefaultCimDcomOptions();
-                }
-                else { options = CimDCOMOptions; }
-                if (Credential != null) { options.AddDestinationCredentials(new CimCredential(PasswordAuthenticationMechanism.Default, Credential.GetNetworkCredential().Domain, Credential.GetNetworkCredential().UserName, Credential.Password)); }
+                CimSession tempSession;
+                IEnumerable<CimInstance> result = new List<CimInstance>();
 
-                if (cimDCOMSession == null) { cimDCOMSession = CimSession.Create(ComputerName, options); }
-                var result = cimDCOMSession.EnumerateInstances(Namespace, Class);
+                try
+                {
+                    tempSession = GetCimDComSession(Credential);
+                    result = tempSession.EnumerateInstances(Namespace, Class);
+                    result.GetEnumerator().MoveNext();
+                }
+                catch (Exception e)
+                {
+                    bool testBadCredential = false;
+                    try
+                    {
+                        string tempMessageId = ((CimException)e).MessageId;
+                        if (tempMessageId == "HRESULT 0x8007052e")
+                            testBadCredential = true;
+                        else if (tempMessageId == "HRESULT 0x80070005")
+                            testBadCredential = true;
+                    }
+                    catch { }
+
+                    if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
+                    else { throw e; }
+                }
+
                 if (DisableCimPersistence)
                 {
-                    cimDCOMSession.Close();
-                    cimDCOMSession = null;
+                    try { tempSession.Close(); }
+                    catch { }
+                    cimDComSession = null;
+                }
+                else
+                {
+                    if (cimDComSession != tempSession)
+                        cimDComSession = tempSession;
                 }
                 return result;
             }
@@ -924,20 +1067,42 @@ namespace Sqlcollective.Dbatools
             /// <returns></returns>
             public object QueryCimDCOMInstance(PSCredential Credential, string Query, string Dialect = "WQL", string Namespace = @"root\cimv2")
             {
-                DComSessionOptions options = null;
-                if (CimDCOMOptions == null)
-                {
-                    options = GetDefaultCimDcomOptions();
-                }
-                else { options = CimDCOMOptions; }
-                if (Credential != null) { options.AddDestinationCredentials(new CimCredential(PasswordAuthenticationMechanism.Default, Credential.GetNetworkCredential().Domain, Credential.GetNetworkCredential().UserName, Credential.Password)); }
+                CimSession tempSession;
+                IEnumerable<CimInstance> result = new List<CimInstance>();
 
-                if (cimDCOMSession == null) { cimDCOMSession = CimSession.Create(ComputerName, options); }
-                var result = cimDCOMSession.QueryInstances(Namespace, Dialect, Query);
+                try
+                {
+                    tempSession = GetCimDComSession(Credential);
+                    result = tempSession.QueryInstances(Namespace, Dialect, Query);
+                    result.GetEnumerator().MoveNext();
+                }
+                catch (Exception e)
+                {
+                    bool testBadCredential = false;
+                    try
+                    {
+                        string tempMessageId = ((CimException)e).MessageId;
+                        if (tempMessageId == "HRESULT 0x8007052e")
+                            testBadCredential = true;
+                        else if (tempMessageId == "HRESULT 0x80070005")
+                            testBadCredential = true;
+                    }
+                    catch { }
+
+                    if (testBadCredential) { throw new UnauthorizedAccessException("Invalid credentials!", e); }
+                    else { throw e; }
+                }
+
                 if (DisableCimPersistence)
                 {
-                    cimDCOMSession.Close();
-                    cimDCOMSession = null;
+                    try { tempSession.Close(); }
+                    catch { }
+                    cimDComSession = null;
+                }
+                else
+                {
+                    if (cimDComSession != tempSession)
+                        cimDComSession = tempSession;
                 }
                 return result;
             }
@@ -1838,6 +2003,13 @@ namespace Sqlcollective.Dbatools
                             con.OverrideExplicitCredential = (bool)tempInput.Properties["OverrideExplicitCredential"].Value;
                             con.KnownBadCredentials = (List<PSCredential>)tempInput.Properties["KnownBadCredentials"].Value;
                             con.WindowsCredentialsAreBad = (bool)tempInput.Properties["WindowsCredentialsAreBad"].Value;
+                            con.UseWindowsCredentials = (bool)tempInput.Properties["UseWindowsCredentials"].Value;
+
+                            con.DisableBadCredentialCache = (bool)tempInput.Properties["DisableBadCredentialCache"].Value;
+                            con.DisableCimPersistence = (bool)tempInput.Properties["DisableCimPersistence"].Value;
+                            con.DisableCredentialAutoRegister = (bool)tempInput.Properties["DisableCredentialAutoRegister"].Value;
+                            con.EnableCredentialFailover = (bool)tempInput.Properties["EnableCredentialFailover"].Value;
+
                         }
                         catch
                         {
@@ -2317,6 +2489,8 @@ namespace Sqlcollective.Dbatools
     namespace Utility
     {
         using System.Management.Automation;
+        using System.Net;
+        using System.Net.NetworkInformation;
         using System.Text.RegularExpressions;
 
         /// <summary>
@@ -4551,7 +4725,7 @@ namespace Sqlcollective.Dbatools
             /// <summary>
             /// The Version of the dbatools Library. Used to compare with import script to determine out-of-date libraries
             /// </summary>
-            public readonly static Version LibraryVersion = new Version(1, 0, 0, 5);
+            public readonly static Version LibraryVersion = new Version(1, 0, 1, 6);
         }
 
         /// <summary>
@@ -4559,6 +4733,50 @@ namespace Sqlcollective.Dbatools
         /// </summary>
         public static class Validation
         {
+            /// <summary>
+            /// Tests whether a given string is the local host.
+            /// Does NOT use DNS resolution, DNS aliases will NOT be recognized!
+            /// </summary>
+            /// <param name="Name">The name to test for being local host</param>
+            /// <returns>Whether the name is localhost</returns>
+            public static bool IsLocalhost(string Name)
+            {
+                #region Handle IP Addresses
+                try
+                {
+                    IPAddress tempAddress;
+                    IPAddress.TryParse(Name, out tempAddress);
+                    if (IPAddress.IsLoopback(tempAddress))
+                        return true;
+
+                    foreach (NetworkInterface netInterface in NetworkInterface.GetAllNetworkInterfaces())
+                    {
+                        IPInterfaceProperties ipProps = netInterface.GetIPProperties();
+                        foreach (UnicastIPAddressInformation addr in ipProps.UnicastAddresses)
+                        {
+                            if (tempAddress.ToString() == addr.Address.ToString())
+                                return true;
+                        }
+                    }
+                }
+                catch { }
+                #endregion Handle IP Addresses
+
+                #region Handle Names
+                try
+                {
+                    if (Name.ToLower() == "localhost")
+                        return true;
+                    if (Name.ToLower() == Environment.MachineName.ToLower())
+                        return true;
+                    if (Name.ToLower() == (Environment.MachineName + "." + Environment.GetEnvironmentVariable("USERDNSDOMAIN")).ToLower())
+                        return true;
+                }
+                catch { }
+                #endregion Handle Names
+                return false;
+            }
+
             /// <summary>
             /// Tests whether a given string is a recommended instance name. Recommended names musst be legal, nbot on the ODBC list and not on the list of words likely to become reserved keywords in the future.
             /// </summary>
@@ -4698,6 +4916,7 @@ namespace Sqlcollective.Dbatools
 '@
     #endregion Source Code
     
+    #region Add Code
     try
     {
         $paramAddType = @{
@@ -4741,10 +4960,11 @@ aka "The guy who made most of The Library that Failed to import"
         throw
         #endregion Warning
     }
+    #endregion Add Code
 }
 
 #region Version Warning
-$LibraryVersion = New-Object System.Version(1, 0, 0, 5)
+$LibraryVersion = New-Object System.Version(1, 0, 1, 6)
 if ($LibraryVersion -ne ([Sqlcollective.Dbatools.Utility.UtilityHost]::LibraryVersion))
 {
     Write-Warning @"

--- a/bin/typealiases.ps1
+++ b/bin/typealiases.ps1
@@ -15,3 +15,5 @@ try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators
 catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbasize", "sqlcollective.dbatools.Utility.Size") }
 catch { }
+try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbavalidate", "Sqlcollective.Dbatools.Utility.Validation") }
+catch { }

--- a/functions/Get-DbaCmConnection.ps1
+++ b/functions/Get-DbaCmConnection.ps1
@@ -1,0 +1,68 @@
+﻿function Get-DbaCmConnection
+{
+    <#
+        .SYNOPSIS
+            Retrieves windows management connections from the cache
+        
+        .DESCRIPTION
+            Retrieves windows management connections from the cache
+        
+        .PARAMETER ComputerName
+            The computername to ComputerName for.
+        
+        .PARAMETER UserName
+            Username on credentials to look for. Will not find connections using the default windows credentials.
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            PS C:\> Get-DbaCmConnection
+            
+            List all cached connections.
+        
+        .EXAMPLE
+            PS C:\> Get-DbaCmConnection sql2014
+            
+            List the cached connection - if any - to the server sql2014.
+        
+        .EXAMPLE
+            PS C:\> Get-DbaCmConnection -UserName "*charles*"
+            
+            List all cached connection that use a username containing "charles" as default or override credentials.
+    #>
+    
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Alias('Filter')]
+        [String[]]
+        $ComputerName = "*",
+        
+        [String]
+        $UserName = "*",
+        
+        [switch]
+        $Silent
+    )
+    
+    Begin
+    {
+        Write-Message -Level InternalComment -Message "Starting"
+        Write-Message -Level Verbose -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
+    }
+    Process
+    {
+        foreach ($name in $ComputerName)
+        {
+            Write-Message -Level VeryVerbose -Message "Processing search. ComputerName: '$name' | Username: '$UserName'"
+            ([sqlcollective.dbatools.Connection.ConnectionHost]::Connections.Values | Where-Object { ($_.ComputerName -like $name) -and ($_.Credentials.UserName -like $UserName) })
+        }
+    }
+    End
+    {
+        Write-Message -Level InternalComment -Message "Ending"
+    }
+}

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -1,0 +1,321 @@
+﻿function Get-DbaCmObject
+{
+    <#
+        .SYNOPSIS
+            Retrieves Wmi/Cim-Style information from computers.
+        
+        .DESCRIPTION
+            This function centralizes all requests for information retrieved from Get-WmiObject or Get-CimInstance.
+            It uses different protocols as available in this order:
+            - Cim over WinRM
+            - Cim over DCOM
+            - Wmi
+            - Wmi over PowerShell Remoting
+            It remembers channels that didn't work and will henceforth avoid them. It remembers invalid credentials and will avoid reusing them.
+            Much of its behavior can be configured using Test-DbaWmConnection.
+        
+        .PARAMETER ClassName
+            The name of the class to retrieve.
+        
+        .PARAMETER ComputerName
+            The computer(s) to connect to. Defaults to localhost.
+        
+        .PARAMETER Credential
+            Credentials to use. Invalid credentials will be stored in a credentials cache and not be reused.
+        
+        .PARAMETER Namespace
+            The namespace of the class to use.
+        
+        .PARAMETER DoNotUse
+            Connection Protocols that should not be used.
+    
+        .PARAMETER Force
+            Overrides some checks that might otherwise halt execution as a precaution
+            - Ignores timeout on bad connections
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            PS C:\> Get-DbaCmObject win32_OperatingSystem
+        
+            Retrieves the common operating system informations from the local computer.
+        
+        .EXAMPLE
+            PS C:\> Get-DbaCmObject -Computername "sql2014" -ClassName Win32_OperatingSystem -Credential $cred -DoNotUse CimRM
+        
+            Retrieves the common operating system informations from the server sql2014.
+            It will use the credewntials stored in $cred to connect, unless they are known to not work, in which case they will default to windows credentials (unless another default has been set).
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Class")]
+    Param (
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Class")]
+        [Alias('Class')]
+        [string]
+        $ClassName,
+        
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+        [string]
+        $Query,
+        
+        [Parameter(ValueFromPipeline = $true)]
+        [sqlcollective.dbatools.Parameter.DbaCmConnectionParameter[]]
+        $ComputerName = $env:COMPUTERNAME,
+        
+        [System.Management.Automation.PSCredential]
+        $Credential,
+        
+        [string]
+        $Namespace = "root\cimv2",
+        
+        [sqlcollective.dbatools.Connection.ManagementConnectionType[]]
+        $DoNotUse = "None",
+        
+        [switch]
+        $Force,
+        
+        [switch]
+        $SilentlyContinue,
+        
+        [switch]
+        $Silent
+    )
+    
+    Begin
+    {
+        #region Configuration Values
+        $disable_cache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.All' -Fallback $false
+        $disable_badcredentialcache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.BadCredentialList' -Fallback $false
+        
+        $disable_CimRM = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.CimRM' -Fallback $false
+        $disable_CimDCOM = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.CimDCOM' -Fallback $false
+        $disable_WMI = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.WMI' -Fallback $false
+        $disable_PowerShellRemoting = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.PowerShellRemoting' -Fallback $false
+        
+        Write-Message -Level Verbose -Message "Configuration loaded | Cache disabled: $disable_cache | Bad Credential Cache disabled: $disable_badcredentialcache | CimRM disabled: $disable_CimRM | CimDCOM disabled: $disable_CimDCOM | Wmi disabled: $disable_WMI | PowerShellRemoting disabled: $disable_PowerShellRemoting"
+        #endregion Configuration Values
+        
+        $ParSet = $PSCmdlet.ParameterSetName
+    }
+    Process
+    {
+        :main foreach ($connectionObject in $ComputerName)
+        {
+            if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret input: $($connectionObject.Input)" -Category InvalidArgument -Target $connectionObject.Input -Continue -SilentlyContinue:$SilentlyContinue }
+            
+            # Since all connection caching runs using lower-case strings, making it lowercase here simplifies things.
+            $computer = $connectionObject.Connection.ComputerName.ToLower()
+            
+            Write-Message -Message "[$computer] Retrieving Management Information" -Level VeryVerbose -Target $computer
+            
+            $connection = $connectionObject.Connection
+            
+            # Ensure using the right credentials
+            try { $cred = $connection.GetCredential($Credential, $PSBoundParameters.ContainsKey("Credential")) }
+            catch
+            {
+                $message = "Bad credentials! "
+                if ($Credential) { $message += "The credentials for $($Credential.UserName) are known to not work. " }
+                else { $message += "The windows credentials are known to not work. " }
+                if ($connection.EnableCredentialFailover -or $connection.OverrideExplicitCredential) { $message += "The connection is configured to use credentials that are known to be good, but none have been registered yet. " }
+                elseif ($connection.Credentials) { $message += "Working credentials are known for $($connection.Credentials.UserName), however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
+                elseif ($connection.UseWindowsCredentials) { $message += "The windows credentials are known to work, however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
+                $message += $_.Exception.Message
+                Stop-Function -Message $message -InnerErrorRecord $_ -Target $connection -Continue
+            }
+            
+            # Create list of excluded connection types (Duplicates don't matter)
+            $excluded = @()
+            foreach ($item in $DoNotUse) { $excluded += $item }
+            if ($disable_CimRM) { $excluded += "CimRM" }
+            if ($disable_CimDCOM) { $excluded += "CimDCOM" }
+            if ($disable_WMI) { $excluded += "Wmi" }
+            if ($disable_PowerShellRemoting) { $excluded += "PowerShellRemoting" }
+            
+            :sub while ($true)
+            {
+                try { $conType = $connection.GetConnectionType(($excluded -join ","), $Force) }
+                catch
+                {
+                    if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                    Stop-Function -Message "[$computer] Could not find a valid connection protocol, interrupting execution now" -Target $computer -Category OpenError -Continue -ContinueLabel "main" -SilentlyContinue:$SilentlyContinue -InnerErrorRecord $_
+                }
+                
+                switch ($conType.ToString())
+                {
+                    #region CimRM
+                    "CimRM"
+                    {
+                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM"
+                        try
+                        {
+                            switch ($ParSet)
+                            {
+                                "Class" { $connection.GetCimRMInstance($cred, $ClassName, $Namespace) }
+                                "Query" { $connection.QueryCimRMInstance($cred, $Query, "WQL", $Namespace) }
+                            }
+                            
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Success!"
+                            $connection.ReportSuccess('CimRM')
+                            if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                            continue main
+                        }
+                        catch
+                        {
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Failed!"
+                            if ($Session) { Remove-CimSession -CimSession $Session }
+                            
+                            if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException")
+                            {
+                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+                                $connection.AddBadCredential($cred)
+                                if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            elseif ($_.Exception.InnerException.MessageId -eq "HRESULT 0x80338000")
+                            {
+                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            else
+                            {
+                                $connection.ReportFailure('CimRM')
+                                $excluded += "CimRM"
+                                continue sub
+                            }
+                        }
+                    }
+                    #endregion CimRM
+                    
+                    #region CimDCOM
+                    "CimDCOM"
+                    {
+                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM"
+                        try
+                        {
+                            switch ($ParSet)
+                            {
+                                "Class" { $connection.GetCimDCOMInstance($cred, $ClassName, $Namespace) }
+                                "Query" { $connection.QueryCimDCOMInstance($cred, $Query, "WQL", $Namespace) }
+                            }
+                            
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Success!"
+                            $connection.ReportSuccess('CimDCOM')
+                            if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                            continue main
+                        }
+                        catch
+                        {
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Failed!"
+                            if ($Session) { Remove-CimSession -CimSession $Session }
+                            
+                            if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException")
+                            {
+                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+                                $connection.AddBadCredential($cred)
+                                if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            elseif ($_.Exception.InnerException.MessageId -eq "HRESULT 0x80338000")
+                            {
+                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            else
+                            {
+                                $connection.ReportFailure('CimDCOM')
+                                $excluded += "CimDCOM"
+                                continue sub
+                            }
+                        }
+                    }
+                    #endregion CimDCOM
+                    
+                    #region Wmi
+                    "Wmi"
+                    {
+                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI"
+                        try
+                        {
+                            $parameters = @{
+                                ComputerName = $computer
+                                Credential = $cred
+                                ClassName = $ClassName
+                                ErrorAction = 'Stop'
+                            }
+                            if ($PSBoundParameters.ContainsKey("Namespace")) { $parameters["Namespace"] = $Namespace }
+                            Get-WmiObject @parameters
+                            
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Success!"
+                            $connection.ReportSuccess('Wmi')
+                            if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                            continue main
+                        }
+                        catch
+                        {
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Failed!"
+                            
+                            if ($_.CategoryInfo.Reason -eq "UnauthorizedAccessException")
+                            {
+                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+                                $connection.AddBadCredential($cred)
+                                if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            elseif ($_.CategoryInfo.Category -eq "InvalidType")
+                            {
+                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+                            }
+                            else
+                            {
+                                $connection.ReportFailure('Wmi')
+                                $excluded += "Wmi"
+                                continue sub
+                            }
+                        }
+                    }
+                    #endregion Wmi
+                    
+                    #region PowerShell Remoting
+                    "PowerShellRemoting"
+                    {
+                        try
+                        {
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting"
+                            $scp_string = "Get-WmiObject -Class $ClassName -ErrorAction Stop"
+                            if ($PSBoundParameters.ContainsKey("Namespace")) { $scp_string += " -Namespace $Namespace" }
+                            
+                            $parameters = @{
+                                ScriptBlock = ([System.Management.Automation.ScriptBlock]::Create($scp_string))
+                                ComputerName = $ComputerName
+                                ErrorAction = 'Stop'
+                            }
+                            if ($Credential) { $parameters["Credential"] = $Credential }
+                            Invoke-Command @parameters
+                            
+                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting - Success!"
+                            $connection.ReportSuccess('PowerShellRemoting')
+                            if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+                            continue main
+                        }
+                        catch
+                        {
+                            # Will always consider authenticated, since any call with credentials to a server that doesn't exist will also carry invalid credentials error.
+                            # There simply is no way to differentiate between actual authentication errors and server not reached
+                            $connection.ReportFailure('PowerShellRemoting')
+                            $excluded += "PowerShellRemoting"
+                            continue sub
+                        }
+                    }
+                    #endregion PowerShell Remoting
+                }
+            }
+        }
+    }
+    End
+    {
+        
+    }
+}

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -112,7 +112,7 @@
             $connection = $connectionObject.Connection
             
             # Ensure using the right credentials
-            try { $cred = $connection.GetCredential($Credential, $PSBoundParameters.ContainsKey("Credential")) }
+            try { $cred = $connection.GetCredential($Credential) }
             catch
             {
                 $message = "Bad credentials! "
@@ -158,6 +158,7 @@
                             
                             Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Success!"
                             $connection.ReportSuccess('CimRM')
+                            $connection.AddGoodCredential($cred)
                             if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
                             continue main
                         }
@@ -202,6 +203,7 @@
                             
                             Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Success!"
                             $connection.ReportSuccess('CimDCOM')
+                            $connection.AddGoodCredential($cred)
                             if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
                             continue main
                         }
@@ -249,6 +251,7 @@
                             
                             Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Success!"
                             $connection.ReportSuccess('Wmi')
+                            $connection.AddGoodCredential($cred)
                             if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
                             continue main
                         }
@@ -297,6 +300,7 @@
                             
                             Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting - Success!"
                             $connection.ReportSuccess('PowerShellRemoting')
+                            $connection.AddGoodCredential($cred)
                             if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
                             continue main
                         }

--- a/functions/New-DbaCmConnection.ps1
+++ b/functions/New-DbaCmConnection.ps1
@@ -1,0 +1,176 @@
+﻿function New-DbaCmConnection
+{
+    <#
+        .SYNOPSIS
+            Generates a connection object for use in remote computer management.
+        
+        .DESCRIPTION
+            Generates a connection object for use in remote computer management.
+            Those objects are used for the purpose of cim/wmi queries, caching which protocol worked, optimizing performance and minimizing authentication errors.
+    
+            New-DbaCmConnection will create a NEW object and overwrite any existing ones for the specified computer.
+            Furthermore, information stored in the input beyond the computername will be discarded in favor of the new settings.
+    
+            Unless the connection cache has been disabled, all connections will automatically be registered in the cache, so no further action is necessary.
+            The output is primarily for information purposes, however it may be used to pass objects and circumvent the cache with those.
+    
+            NOTE: Generally, this function need not be used, as a first connection to a computer using any connecting function such as "Get-DbaCmObject" will automatically register a new default connection for it.
+            This function exists to be able to preconfigure connections.
+        
+        .PARAMETER ComputerName
+            The computer to build the connection object for.
+        
+        .PARAMETER Credential
+            The credential to register.
+        
+        .PARAMETER UseWindowsCredentials
+            Whether using the default windows credentials is legit.
+            Not setting this will not exclude using windows credentials, but only not pre-confirm them as working.
+        
+        .PARAMETER OverrideExplicitCredential
+            Setting this will enable the credential override.
+            The override will cause the system to ignore explicitly specified credentials, so long as known, good credentials are available.
+        
+        .PARAMETER DisabledConnectionTypes
+            Exlicitly disable connection types.
+            These types will then not be used for connecting to the computer.
+        
+        .PARAMETER DisableBadCredentialCache
+            Will prevent the caching of credentials if set to true.
+        
+        .PARAMETER DisableCimPersistence
+            Will prevent Cim-Sessions to be reused.
+        
+        .PARAMETER DisableCredentialAutoRegister
+            Will prevent working credentials from being automatically cached
+    
+        .PARAMETER EnableCredentialFailover
+            Will enable automatic failing over to known to work credentials, when using bad credentials.
+            By default, passing bad credentials will cause the Computer Management functions to interrupt with a warning (Or exception if in silent mode).
+        
+        .PARAMETER WindowsCredentialsAreBad
+            Will prevent the windows credentials of the currently logged on user from being used for the remote connection.
+        
+        .PARAMETER CimWinRMOptions
+            Specify a set of options to use when connecting to the target computer using CIM over WinRM.
+            Use 'New-CimSessionOption' to create such an object.
+        
+        .PARAMETER CimDCOMOptions
+            Specify a set of options to use when connecting to the target computer using CIM over DCOM.
+            Use 'New-CimSessionOption' to create such an object.
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            New-DbaCmConnection -ComputerName sql2014 -UseWindowsCredentials -OverrideExplicitCredential -DisabledConnectionTypes CimRM
+    
+            Returns a new configuration object for connecting to the computer sql2014.
+            - The current user credentials are set as valid
+            - The connection is configured to ignore explicit credentials (so all connections use the windows credentials)
+            - The connections will not try using CIM over WinRM
+            Unless caching is globally disabled, this is automatically stored in the connection cache and will be applied automatically.
+            In that (the default) case, the output is for information purposes only and need not be used.
+    
+        .EXAMPLE
+            Get-Content computers.txt | New-DbaCmConnection -Credential $cred -CimWinRMOptions $options -DisableBadCredentialCache -OverrideExplicitCredential
+    
+            Gathers a list of computers from a text file, then creates and registers connections for each of them, setting them to ...
+            - use the credentials stored in $cred
+            - use the opzions stored in $options when connecting using CIM over WinRM
+            - not store credentials that are known to not work
+            - to ignore explicitly specified credentials
+            Essentially, this configures all connections to those computers to prefer failure with the specified credentials over using alternative credentials.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    Param (
+        [Parameter(ValueFromPipeline = $true)]
+        [sqlcollective.dbatools.Parameter.DbaCmConnectionParameter[]]
+        $ComputerName = $env:COMPUTERNAME,
+        
+        [Parameter(ParameterSetName = "Credential")]
+        [PSCredential]
+        $Credential,
+        
+        [Parameter(ParameterSetName = "Windows")]
+        [switch]
+        $UseWindowsCredentials,
+        
+        [switch]
+        $OverrideExplicitCredential,
+        
+        [SqlCollective.Dbatools.Connection.ManagementConnectionType]
+        $DisabledConnectionTypes = 'None',
+        
+        [switch]
+        $DisableBadCredentialCache,
+        
+        [switch]
+        $DisableCimPersistence,
+        
+        [switch]
+        $DisableCredentialAutoRegister,
+        
+        [switch]
+        $EnableCredentialFailover,
+        
+        [Parameter(ParameterSetName = "Credential")]
+        [switch]
+        $WindowsCredentialsAreBad,
+        
+        [Microsoft.Management.Infrastructure.Options.WSManSessionOptions]
+        $CimWinRMOptions,
+        
+        [Microsoft.Management.Infrastructure.Options.DComSessionOptions]
+        $CimDCOMOptions,
+        
+        [switch]
+        $Silent
+    )
+    
+    begin
+    {
+        Write-Message -Level InternalComment -Message "Starting execution"
+        Write-Message -Level Verbose -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
+        
+        $disable_cache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.All' -Fallback $false
+    }
+    process
+    {
+        foreach ($connectionObject in $ComputerName)
+        {
+            if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret computername input: $($connectionObject.InputObject)" -Category InvalidArgument -Target $connectionObject.InputObject -Continue }
+            Write-Message -Level VeryVerbose -Message "Processing computer: $($connectionObject.Connection.ComputerName)" -Target $connectionObject.Connection
+            
+            $connection = New-Object -TypeName Sqlcollective.Dbatools.Connection.ManagementConnection -ArgumentList $connectionObject.Connection.ComputerName
+            if (Was-Bound "Credential") { $connection.Credentials = $Credential }
+            if (Was-Bound "UseWindowsCredentials")
+            {
+                $connection.Credentials = $null
+                $connection.UseWindowsCredentials = $UseWindowsCredentials
+            }
+            if (Was-Bound "OverrideExplicitCredential") { $connection.OverrideExplicitCredential = $OverrideExplicitCredential }
+            if (Was-Bound "DisabledConnectionTypes") { $connection.DisabledConnectionTypes = $DisabledConnectionTypes }
+            if (Was-Bound "DisableBadCredentialCache") { $connection.DisableBadCredentialCache = $DisableBadCredentialCache }
+            if (Was-Bound "DisableCimPersistence") { $connection.DisableCimPersistence = $DisableCimPersistence }
+            if (Was-Bound "DisableCredentialAutoRegister") { $connection.DisableCredentialAutoRegister = $DisableCredentialAutoRegister }
+            if (Was-Bound "EnableCredentialFailover") { $connection.DisableCredentialAutoRegister = $EnableCredentialFailover }
+            if (Was-Bound "WindowsCredentialsAreBad") { $connection.WindowsCredentialsAreBad = $WindowsCredentialsAreBad }
+            if (Was-Bound "CimWinRMOptions") { $connection.CimWinRMOptions = $CimWinRMOptions }
+            if (Was-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
+            
+            if (-not $disable_cache)
+            {
+                Write-Message -Level Verbose -Message "Writing connection to cache"
+                [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$connectionObject.Connection.ComputerName] = $connection
+            }
+            else { Write-Message -Level Verbose -Message "Skipping writing to cache, since the cache has been disabled!" }
+            $connection
+        }
+    }
+    end
+    {
+        Write-Message -Level InternalComment -Message "Stopping execution"
+    }
+}

--- a/functions/Remove-DbaCmConnection.ps1
+++ b/functions/Remove-DbaCmConnection.ps1
@@ -1,0 +1,64 @@
+﻿function Remove-DbaCmConnection
+{
+    <#
+        .SYNOPSIS
+            Removes connection objects from the connection cache used for remote computer management.
+        
+        .DESCRIPTION
+            Removes connection objects from the connection cache used for remote computer management.
+        
+        .PARAMETER ComputerName
+            The computer whose connection to remove.
+            Accepts both text as well as the output of Get-DbaCmConnection.
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            Remove-DbaCmConnection -ComputerName sql2014
+    
+            Removes the cached connection to the server sql2014 from the cache.
+    
+        .EXAMPLE
+            Get-DbaCmConnection | Remove-DbaCmConnection
+    
+            Clears the entire connection cache.
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [Sqlcollective.Dbatools.Parameter.DbaCmConnectionParameter[]]
+        $ComputerName,
+        
+        [switch]
+        $Silent
+    )
+    
+    Begin
+    {
+        Write-Message -Level InternalComment -Message "Starting"
+        Write-Message -Level Verbose -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
+    }
+    Process
+    {
+        foreach ($connectionObject in $ComputerName)
+        {
+            if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret computername input: $($connectionObject.InputObject)" -Category InvalidArgument -Target $connectionObject.InputObject -Continue }
+            Write-Message -Level VeryVerbose -Message "Removing from connection cache: $($connectionObject.Connection.ComputerName)" -Target $connectionObject.Connection.ComputerName
+            if ([sqlcollective.dbatools.Connection.ConnectionHost]::Connections.ContainsKey($connectionObject.Connection.ComputerName))
+            {
+                $null = [sqlcollective.dbatools.Connection.ConnectionHost]::Connections.Remove($connectionObject.Connection.ComputerName)
+                Write-Message -Level Verbose -Message "Successfully removed $($connectionObject.Connection.ComputerName)" -Target $connectionObject.Connection.ComputerName
+            }
+            else
+            {
+                Write-Message -Level Verbose -Message "Not found: $($connectionObject.Connection.ComputerName)" -Target $connectionObject.Connection.ComputerName
+            }
+        }
+    }
+    End
+    {
+        Write-Message -Level InternalComment -Message "Ending"
+    }
+}

--- a/functions/Set-DbaCmConnection.ps1
+++ b/functions/Set-DbaCmConnection.ps1
@@ -1,0 +1,286 @@
+﻿function Set-DbaCmConnection
+{
+    <#
+        .SYNOPSIS
+            Configures a connection object for use in remote computer management.
+        
+        .DESCRIPTION
+            Configures a connection object for use in remote computer management.
+            This function will either create new records for computers that have no connection registered so far, or it will configure existing connections if already present.
+    
+            As such it can be handy in making bulk-edits on connections or manually adjusting some settings.
+        
+        .PARAMETER ComputerName
+            The computer to build the connection object for.
+        
+        .PARAMETER Credential
+            The credential to register.
+        
+        .PARAMETER UseWindowsCredentials
+            Whether using the default windows credentials is legit.
+            Not setting this will not exclude using windows credentials, but only not pre-confirm them as working.
+        
+        .PARAMETER OverrideExplicitCredential
+            Setting this will enable the credential override.
+            The override will cause the system to ignore explicitly specified credentials, so long as known, good credentials are available.
+        
+        .PARAMETER DisabledConnectionTypes
+            Exlicitly disable connection types.
+            These types will then not be used for connecting to the computer.
+        
+        .PARAMETER DisableBadCredentialCache
+            Will prevent the caching of credentials if set to true.
+        
+        .PARAMETER DisableCimPersistence
+            Will prevent Cim-Sessions to be reused.
+        
+        .PARAMETER DisableCredentialAutoRegister
+            Will prevent working credentials from being automatically cached
+    
+        .PARAMETER EnableCredentialFailover
+            Will enable automatic failing over to known to work credentials, when using bad credentials.
+            By default, passing bad credentials will cause the Computer Management functions to interrupt with a warning (Or exception if in silent mode).
+        
+        .PARAMETER WindowsCredentialsAreBad
+            Will prevent the windows credentials of the currently logged on user from being used for the remote connection.
+        
+        .PARAMETER CimWinRMOptions
+            Specify a set of options to use when connecting to the target computer using CIM over WinRM.
+            Use 'New-CimSessionOption' to create such an object.
+        
+        .PARAMETER CimDCOMOptions
+            Specify a set of options to use when connecting to the target computer using CIM over DCOM.
+            Use 'New-CimSessionOption' to create such an object.
+        
+        .PARAMETER AddBadCredential
+            Adds credentials to the bad credential cache.
+            These credentials will not be used when connecting to the target remote computer.
+        
+        .PARAMETER RemoveBadCredential
+            Removes credentials from the bad credential cache.
+        
+        .PARAMETER ClearBadCredential
+            Clears the cache of credentials that didn't worked.
+            Will be applied before adding entries to the credential cache.
+        
+        .PARAMETER ClearCredential
+            Clears the cache of credentials that worked.
+            Will be applied before adding entries to the credential cache.
+        
+        .PARAMETER ResetCredential
+            Resets all credential-related caches:
+            - Clears bad credential cache
+            - Removes last working credential
+            - Un-Confirms the windows credentials as working
+            - Un-Confirms the windows credentials as not working
+            Automatically implies the parameters -ClearCredential and -ClearBadCredential. Using them together is redundant.
+            Will be applied before adding entries to the credential cache.
+        
+        .PARAMETER ResetConnectionStatus
+            Restores all connection stati to default, as if no connection protocol had ever been tested.
+        
+        .PARAMETER ResetConfiguration
+            Restores the configuration back to system default.
+            Configuration elements are the basic behavior controlling settings, such as whether to cache bad credentials, etc.
+            These can be configured globally using the dbatools configuration system and overridden locally on a per-connection basis.
+            For a list of all available settings, use "Get-DbaConfig -Module ComputerManagement".
+            Note: Does not apply to globally overridden protocols to connect over.
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            Get-DbaCmConnection sql2014 | Set-DbaCmConnection -ClearBadCredential -UseWindowsCredentials
+    
+            Retrieves the already existing connection to sql2014, removes the list of not working credentials and configures it to default to the credentials of the logged on user.
+            
+        .EXAMPLE
+            Get-DbaCmConnection | Set-DbaCmConnection -RemoveBadCredential $cred
+    
+            Removes the credentials stored in $cred from all connections' list of "known to not work" credentials.
+            Handy to update changes in privilege.
+    
+        .EXAMPLE
+            Get-DbaCmConnection | Export-Clixml .\connections.xml
+    
+            Import-Clixml .\connections.xml | Set-DbaCmConnection -ResetConfiguration
+    
+            At first, the current cached connections are stored in an xml file.
+            At a later time - possibly in the profile when starting the console again - those connections are imported again and applied again to the connection cache.
+            In this example, the configuration settings will also be reset, since after reimport those will be set to explicit, rather than deriving them from the global settings.
+            In many cases, using the default settings is desirable. For specific settings, use New-DbaCmConnection as part of the profile in order to explicitly configure a connection.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Credential')]
+    Param (
+        [Parameter(ValueFromPipeline = $true)]
+        [sqlcollective.dbatools.Parameter.DbaCmConnectionParameter[]]
+        $ComputerName = $env:COMPUTERNAME,
+        
+        [Parameter(ParameterSetName = "Credential")]
+        [PSCredential]
+        $Credential,
+        
+        [Parameter(ParameterSetName = "Windows")]
+        [switch]
+        $UseWindowsCredentials,
+        
+        [switch]
+        $OverrideExplicitCredential,
+        
+        [SqlCollective.Dbatools.Connection.ManagementConnectionType]
+        $DisabledConnectionTypes = 'None',
+        
+        [switch]
+        $DisableBadCredentialCache,
+        
+        [switch]
+        $DisableCimPersistence,
+        
+        [switch]
+        $DisableCredentialAutoRegister,
+        
+        [switch]
+        $EnableCredentialFailover,
+        
+        [Parameter(ParameterSetName = "Credential")]
+        [switch]
+        $WindowsCredentialsAreBad,
+        
+        [Microsoft.Management.Infrastructure.Options.WSManSessionOptions]
+        $CimWinRMOptions,
+        
+        [Microsoft.Management.Infrastructure.Options.DComSessionOptions]
+        $CimDCOMOptions,
+        
+        [System.Management.Automation.PSCredential[]]
+        $AddBadCredential,
+        
+        [System.Management.Automation.PSCredential[]]
+        $RemoveBadCredential,
+        
+        [switch]
+        $ClearBadCredential,
+        
+        [switch]
+        $ClearCredential,
+        
+        [switch]
+        $ResetCredential,
+        
+        [switch]
+        $ResetConnectionStatus,
+        
+        [switch]
+        $ResetConfiguration,
+        
+        [switch]
+        $Silent
+    )
+    
+    begin
+    {
+        Write-Message -Level InternalComment -Message "Starting execution"
+        Write-Message -Level Verbose -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
+        
+        $disable_cache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.All' -Fallback $false
+    }
+    process
+    {
+        foreach ($connectionObject in $ComputerName)
+        {
+            if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret computername input: $($connectionObject.InputObject)" -Category InvalidArgument -Target $connectionObject.InputObject -Continue }
+            Write-Message -Level VeryVerbose -Message "Processing computer: $($connectionObject.Connection.ComputerName)"
+            
+            $connection = $connectionObject.Connection
+            
+            if ($ResetConfiguration)
+            {
+                Write-Message -Level Verbose -Message "Resetting the configuration to system default"
+                
+                $connection.RestoreDefaultConfiguration()
+            }
+            
+            if ($ResetConnectionStatus)
+            {
+                Write-Message -Level Verbose -Message "Resetting the connection status"
+                
+                $connection.CimRM = 'Unknown'
+                $connection.CimDCOM = 'Unknown'
+                $connection.Wmi = 'Unknown'
+                $connection.PowerShellRemoting = 'Unknown'
+                
+                $connection.LastCimRM = New-Object System.DateTime(0)
+                $connection.LastCimDCOM = New-Object System.DateTime(0)
+                $connection.LastWmi = New-Object System.DateTime(0)
+                $connection.LastPowerShellRemoting = New-Object System.DateTime(0)
+            }
+            
+            if ($ResetCredential)
+            {
+                Write-Message -Level Verbose -Message "Resetting credentials"
+                
+                $connection.KnownBadCredentials.Clear()
+                $connection.Credentials = $null
+                $connection.UseWindowsCredentials = $false
+                $connection.WindowsCredentialsAreBad = $false
+            }
+            else
+            {
+                if ($ClearBadCredential)
+                {
+                    Write-Message -Level Verbose -Message "Clearing bad credentials"
+                    
+                    $connection.KnownBadCredentials.Clear()
+                    $connection.WindowsCredentialsAreBad = $false
+                }
+                
+                if ($ClearCredential)
+                {
+                    Write-Message -Level Verbose -Message "Clearing credentials"
+                    
+                    $connection.Credentials = $null
+                    $connection.UseWindowsCredentials = $false
+                }
+            }
+            
+            foreach ($badCred in $RemoveBadCredential)
+            {
+                $connection.RemoveBadCredential($badCred)
+            }
+            
+            foreach ($badCred in $AddBadCredential)
+            {
+                $connection.AddBadCredential($badCred)
+            }
+            
+            if (Was-Bound "Credential") { $connection.Credentials = $Credential }
+            if ($UseWindowsCredentials)
+            {
+                $connection.Credentials = $null
+                $connection.UseWindowsCredentials = $UseWindowsCredentials
+            }
+            if (Was-Bound "OverrideExplicitCredential") { $connection.OverrideExplicitCredential = $OverrideExplicitCredential }
+            if (Was-Bound "DisabledConnectionTypes") { $connection.DisabledConnectionTypes = $DisabledConnectionTypes }
+            if (Was-Bound "DisableBadCredentialCache") { $connection.DisableBadCredentialCache = $DisableBadCredentialCache }
+            if (Was-Bound "DisableCimPersistence") { $connection.DisableCimPersistence = $DisableCimPersistence }
+            if (Was-Bound "DisableCredentialAutoRegister") { $connection.DisableCredentialAutoRegister = $DisableCredentialAutoRegister }
+            if (Was-Bound "EnableCredentialFailover") { $connection.DisableCredentialAutoRegister = $EnableCredentialFailover }
+            if (Was-Bound "WindowsCredentialsAreBad") { $connection.WindowsCredentialsAreBad = $WindowsCredentialsAreBad }
+            if (Was-Bound "CimWinRMOptions") { $connection.CimWinRMOptions = $CimWinRMOptions }
+            if (Was-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
+            
+            if (-not $disable_cache)
+            {
+                Write-Message -Level Verbose -Message "Writing connection to cache"
+                [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$connectionObject.Connection.ComputerName] = $connection
+            }
+            else { Write-Message -Level Verbose -Message "Skipping writing to cache, since the cache has been disabled!" }
+            $connection
+        }
+    }
+    end
+    {
+        Write-Message -Level InternalComment -Message "Stopping execution"
+    }
+}

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -1,0 +1,367 @@
+﻿function Test-DbaCmConnection
+{
+    <#
+        .SYNOPSIS
+            Tests over which paths a computer can be managed.
+        
+        .DESCRIPTION
+            Tests over which paths a computer can be managed.
+            
+            This function tries out the connectivity for:
+            - Cim over WinRM
+            - Cim over DCOM
+            - Wmi
+            - PowerShellRemoting
+            Results will be written to the connectivity cache and will cause Get-DbaCmObject and Invoke-DbaCmMethod to connect using the way most likely to succeed.
+            This way, it is likely the other commands will take less time to execute. These other's too cache their results, in order to dynamically update connection statistics.
+            
+            This function ignores global configuration settings limiting which protocols may be used.
+        
+        .PARAMETER ComputerName
+            The computer to test against.
+        
+        .PARAMETER Credential
+            The credentials to use when running the test.
+            Bad credentials are automatically cached as non-working, a behavior that can be disabled by the 'Cache.Management.Disable.BadCredentialList' configuration.
+        
+        .PARAMETER Type
+            The connection protocol types to test.
+            By default, all types are tested.
+            Note that this function will ignore global configurations limiting the types of connections available and test all connections specified here instead.
+            
+            Available connection protocol types:
+            "CimRM", "CimDCOM", "Wmi", "PowerShellRemoting"
+        
+        .PARAMETER Force
+            Overrides safeguards and "do you really want to do this" kinds of issues.
+            - Will force a test to proceed on a known bad credential
+        
+        .PARAMETER Silent
+            Replaces user friendly yellow warnings with bloody red exceptions of doom!
+            Use this if you want the function to throw terminating errors you want to catch.
+        
+        .EXAMPLE
+            PS C:\> Test-DbaCmConnection -ComputerName sql2014
+        
+            Performs a full-spectrum connection test against the computer sql2014.
+            The results will be reported and registered, future calls from Get-DbaCmObject will thus recognize the results and optimize the query.
+        
+        .EXAMPLE
+            PS C:\> Test-DbaCmConnection -ComputerName sql2014 -Credential $null -Type CimDCOM, CimRM
+        
+            This test will run a connectivity test against the computer sql2014
+            - It will use windows authentication of the current user
+            - It will only test Cim over DCOM and Cim over WinRM
+        
+            The results will be reported and registered, future calls from Get-DbaCObject will thus recognize the results and optimize the query.
+        
+        .EXAMPLE
+            PS C:\> Test-DbaCmConnection -ComputerName sql2014 -Credential $cred -ClearCache
+        
+            Performs a full-spectrum connection test against the computer sql2014 using the credentials stored in $cred.
+            Before doing so it will discard all previous results and settings.
+            The results will be reported and registered, future calls from Get-DbaWmObject will thus recognize the results and optimize the query.
+        
+        .NOTES
+            This function should not be called from within dbatools. It is meant as a tool for users only.
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter(ValueFromPipeline = $true)]
+        [Sqlcollective.Dbatools.Parameter.DbaCmConnectionParameter[]]
+        $ComputerName = $env:COMPUTERNAME,
+        
+        [System.Management.Automation.PSCredential]
+        $Credential,
+        
+        [sqlcollective.dbatools.Connection.ManagementConnectionType[]]
+        $Type = @("CimRM", "CimDCOM", "Wmi", "PowerShellRemoting"),
+        
+        [switch]
+        $Force,
+        
+        [sqlcollective.dbatools.Connection.ManagementConnectionType[]]
+        $DisableConnectionType,
+        
+        [switch]
+        $Silent
+    )
+    
+    Begin
+    {
+        #region Configuration Values
+        $disable_cache = Get-DbaConfigValue -Name "ComputerManagement.Cache.Disable.All" -Fallback $false
+        $disable_badcredentialcache = Get-DbaConfigValue -Name "ComputerManagement.Cache.Disable.BadCredentialList" -Fallback $false
+        #endregion Configuration Values
+        
+        #region Helper Functions
+        function Test-ConnectionCimRM
+        {
+            [CmdletBinding()]
+            Param (
+                [Sqlcollective.Dbatools.Parameter.DbaCmConnectionParameter]
+                $ComputerName,
+                
+                [System.Management.Automation.PSCredential]
+                $Credential
+            )
+            
+            try
+            {
+                $os = $ComputerName.Connection.GetCimRMInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
+                
+                New-Object PSObject -Property @{
+                    Success = "Success"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+            catch
+            {
+                if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException")
+                {
+                    New-Object PSObject -Property @{
+                        Success = "Error"
+                        Timestamp = Get-Date
+                        Authenticated = $false
+                    }
+                }
+                else
+                {
+                    New-Object PSObject -Property @{
+                        Success = "Error"
+                        Timestamp = Get-Date
+                        Authenticated = $true
+                    }
+                }
+            }
+        }
+        
+        function Test-ConnectionCimDCOM
+        {
+            [CmdletBinding()]
+            Param (
+                [Sqlcollective.Dbatools.Parameter.DbaCmConnectionParameter]
+                $ComputerName,
+                
+                [System.Management.Automation.PSCredential]
+                $Credential
+            )
+            
+            try
+            {
+                $os = $ComputerName.Connection.GetCimDComInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
+                
+                New-Object PSObject -Property @{
+                    Success = "Success"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+            catch
+            {
+                if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException")
+                {
+                    New-Object PSObject -Property @{
+                        Success = "Error"
+                        Timestamp = Get-Date
+                        Authenticated = $false
+                    }
+                }
+                else
+                {
+                    New-Object PSObject -Property @{
+                        Success = "Error"
+                        Timestamp = Get-Date
+                        Authenticated = $true
+                    }
+                }
+            }
+        }
+        
+        function Test-ConnectionWmi
+        {
+            [CmdletBinding()]
+            Param (
+                [string]
+                $ComputerName,
+                
+                [System.Management.Automation.PSCredential]
+                $Credential
+            )
+            
+            try
+            {
+                $os = Get-WmiObject -ComputerName $ComputerName -Credential $Credential -Class Win32_OperatingSystem -ErrorAction Stop
+                New-Object PSObject -Property @{
+                    Success = "Success"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+            catch [System.UnauthorizedAccessException]
+            {
+                New-Object PSObject -Property @{
+                    Success = "Error"
+                    Timestamp = Get-Date
+                    Authenticated = $false
+                }
+            }
+            catch
+            {
+                New-Object PSObject -Property @{
+                    Success = "Error"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+        }
+        
+        function Test-ConnectionPowerShellRemoting
+        {
+            [CmdletBinding()]
+            Param (
+                [string]
+                $ComputerName,
+                
+                [System.Management.Automation.PSCredential]
+                $Credential
+            )
+            
+            try
+            {
+                $parameters = @{
+                    ScriptBlock = { Get-WmiObject -Class Win32_OperatingSystem -ErrorAction Stop }
+                    ComputerName = $ComputerName
+                }
+                if ($Credential) { $parameters["Credential"] = $Credential }
+                $os = Invoke-Command @parameters
+                
+                New-Object PSObject -Property @{
+                    Success = "Success"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+            catch
+            {
+                # Will always consider authenticated, since any call with credentials to a server that doesn't exist will also carry invalid credentials error.
+                # There simply is no way to differentiate between actual authentication errors and server not reached
+                New-Object PSObject -Property @{
+                    Success = "Error"
+                    Timestamp = Get-Date
+                    Authenticated = $true
+                }
+            }
+        }
+        #endregion Helper Functions
+    }
+    Process
+    {
+        foreach ($ConnectionObject in $ComputerName)
+        {
+            if (-not $ConnectionObject.Success) { Stop-Function -Message "Failed to interpret input: $($ConnectionObject.Input)" -Category InvalidArgument -Target $ConnectionObject.Input -Continue}
+            
+            $Computer = $ConnectionObject.Connection.ComputerName.ToLower()
+            Write-Message -Level VeryVerbose -Message "[$Computer] Testing management connection"
+            
+            #region Setup connection object
+            $con = $ConnectionObject.Connection
+            #endregion Setup connection object
+            
+            #region Handle credentials
+            $BadCredentialsFound = $false
+            if ($con.DisableBadCredentialCache) { $con.KnownBadCredentials.Clear() }
+            elseif ($con.IsBadCredential($Credential) -and (-not $Force))
+            {
+                Stop-Function -Message "[$Computer] The credentials supplied are on the list of known bad credentials, skipping. Use -Force to override this." -Continue -Category InvalidArgument -Target $Computer
+            }
+            elseif ($con.IsBadCredential($Credential) -and $Force)
+            {
+                $con.RemoveBadCredential($Credential)
+            }            
+            #endregion Handle credentials
+            
+            #region Connectivity Tests
+            :types foreach ($ConnectionType in $Type)
+            {
+                switch ($ConnectionType)
+                {
+                    #region CimRM
+                    "CimRM"
+                    {
+                        Write-Message -Level Verbose -Message "[$Computer] Testing management access using Cim over WinRM"
+                        $res = Test-ConnectionCimRM -ComputerName $con -Credential $Credential
+                        $con.LastCimRM = $res.Timestamp
+                        $con.CimRM = $res.Success
+                        Write-Message -Level VeryVerbose -Message "[$Computer] Cim over WinRM Results | Success: $($res.Success), Authentication: $($res.Authenticated)"
+                        
+                        if (-not $res.Authenticated)
+                        {
+                            Write-Message -Level Important -Message "[$Computer] The credentials supplied proved to be invalid. Skipping further tests"
+                            $con.AddBadCredential($Credential)
+                            break types
+                        }
+                    }
+                    #endregion CimRM
+                    
+                    #region CimDCOM
+                    "CimDCOM"
+                    {
+                        Write-Message -Level Verbose -Message "[$Computer] Testing management access using Cim over DCOM"
+                        $res = Test-ConnectionCimDCOM -ComputerName $con -Credential $Credential
+                        $con.LastCimDCOM = $res.Timestamp
+                        $con.CimDCOM = $res.Success
+                        Write-Message -Level VeryVerbose -Message "[$Computer] Cim over DCOM Results | Success: $($res.Success), Authentication: $($res.Authenticated)"
+                        
+                        if (-not $res.Authenticated)
+                        {
+                            Write-Message -Level Important -Message "[$Computer] The credentials supplied proved to be invalid. Skipping further tests"
+                            $con.AddBadCredential($Credential)
+                            break types
+                        }
+                    }
+                    #endregion CimDCOM
+                    
+                    #region Wmi
+                    "Wmi"
+                    {
+                        Write-Message -Level Verbose -Message "[$Computer] Testing management access using Wmi"
+                        $res = Test-ConnectionWmi -ComputerName $Computer -Credential $Credential
+                        $con.LastWmi = $res.Timestamp
+                        $con.Wmi = $res.Success
+                        Write-Message -Level VeryVerbose -Message "[$Computer] Wmi Results | Success: $($res.Success), Authentication: $($res.Authenticated)"
+                        
+                        if (-not $res.Authenticated)
+                        {
+                            Write-Message -Level Important -Message "[$Computer] The credentials supplied proved to be invalid. Skipping further tests"
+                            $con.AddBadCredential($Credential)
+                            break types
+                        }
+                    }
+                    #endregion Wmi
+                    
+                    #region PowerShell Remoting
+                    "PowerShellRemoting"
+                    {
+                        Write-Message -Level Verbose -Message "[$Computer] Testing management access using PowerShell Remoting"
+                        $res = Test-ConnectionPowerShellRemoting -ComputerName $Computer -Credential $Credential
+                        $con.LastPowerShellRemoting = $res.Timestamp
+                        $con.PowerShellRemoting = $res.Success
+                        Write-Message -Level VeryVerbose -Message "[$Computer] PowerShell Remoting Results | Success: $($res.Success)"
+                    }
+                    #endregion PowerShell Remoting
+                }
+            }
+            #endregion Connectivity Tests
+            
+            if (-not $disable_cache) { [sqlcollective.dbatools.Connection.ConnectionHost]::Connections[$Computer] = $con }
+            $con
+        }
+    }
+    End
+    {
+        
+    }
+}
+

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -233,6 +233,7 @@
                 $parameters = @{
                     ScriptBlock = { Get-WmiObject -Class Win32_OperatingSystem -ErrorAction Stop }
                     ComputerName = $ComputerName
+                    ErrorAction = 'Stop'
                 }
                 if ($Credential) { $parameters["Credential"] = $Credential }
                 $os = Invoke-Command @parameters

--- a/internal/configurations/computermanagement.handler.ps1
+++ b/internal/configurations/computermanagement.handler.ps1
@@ -1,0 +1,174 @@
+﻿#region ComputerManagement.Cache.Disable.All
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::DisableCache = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Disable.All' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Disable.All
+
+#region ComputerManagement.Cache.Disable.BadCredentialList
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::DisableBadCredentialCache = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Disable.BadCredentialList' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Disable.BadCredentialList
+
+#region ComputerManagement.Cache.Disable.CredentialAutoRegister
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::DisableCredentialAutoRegister = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Disable.CredentialAutoRegister' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Disable.CredentialAutoRegister
+
+#region ComputerManagement.Cache.Force.OverrideExplicitCredential
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::OverrideExplicitCredential = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Force.OverrideExplicitCredential' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Force.OverrideExplicitCredential
+
+#region ComputerManagement.BadConnectionTimeout
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.TimeSpan")
+    {
+        $Result.Message = "Not a TimeSpan: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::BadConnectionTimeout = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.BadConnectionTimeout' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.BadConnectionTimeout
+
+#region ComputerManagement.Cache.Disable.CimPersistence
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::DisableCimPersistence = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Disable.CimPersistence' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Disable.CimPersistence
+
+#region ComputerManagement.Cache.Enable.CredentialFailover
+$ScriptBlock = {
+    Param (
+        $Value
+    )
+    
+    $Result = New-Object PSOBject -Property @{
+        Success = $True
+        Message = ""
+    }
+    
+    if ($Value.GetType().FullName -ne "System.Boolean")
+    {
+        $Result.Message = "Not a Boolean: $Value"
+        $Result.Success = $False
+        return $Result
+    }
+    
+    [sqlcollective.dbatools.Connection.ConnectionHost]::EnableCredentialFailover = $Value
+    
+    return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Enable.CredentialFailover' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Cache.Enable.CredentialFailover

--- a/internal/configurations/computermanagement.ps1
+++ b/internal/configurations/computermanagement.ps1
@@ -1,0 +1,31 @@
+﻿<#
+This is designed for all things that control how anything that caches acts
+#>
+
+# Sets the default timeout on bad connections
+Set-DbaConfig -Name 'ComputerManagement.BadConnectionTimeout' -Value (New-TimeSpan -Minutes 15) -Default -DisableHandler -Description 'The timeout used on bad computer management connections. When a connection using a protocol fails, it will not be reattempted for this timespan.'
+
+# Disable the management cache entire
+Set-DbaConfig -Name 'ComputerManagement.Cache.Disable.All' -Value $false -Default -DisableHandler -Description 'Globally disables all caching done by the Computer Management functions'
+
+# Disables the caching of bad credentials, which is kept in order to avoid reusing them
+Set-DbaConfig -Name 'ComputerManagement.Cache.Disable.BadCredentialList' -Value $false -Default -DisableHandler -Description 'Disables the caching of bad credentials. dbatools caches bad logon credentials for wmi/cim and will not reuse them.'
+
+# Disables reuse of CIM Sessions
+Set-DbaConfig -Name 'ComputerManagement.Cache.Disable.CimPersistence' -Value $false -Default -DisableHandler -Description 'Disables the reuse of Cim Sessions. Setting this config to "true" will hurt Computer Management Performance, but may be necessary in some rare cases'
+
+# Disables automatic caching of working credentials
+Set-DbaConfig -Name 'ComputerManagement.Cache.Disable.CredentialAutoRegister' -Value $false -Default -DisableHandler -Description 'Disables the automatic registration of working credentials. dbatools will caches the last working credential when connecting using wmi/cim and will use those rather than using known bad credentials'
+
+# Enables automatic failover of credentials. If enabled, CM will use known-to-work credentials in case of non-working credentials
+Set-DbaConfig -Name 'ComputerManagement.Cache.Enable.CredentialFailover' -Value $false -Default -DisableHandler -Description 'Enables automatically failing over to known to work credentials, when specified credentials will not work.'
+
+# Force-Overrides explicit credentials with cached-as-working credentials
+Set-DbaConfig -Name 'ComputerManagement.Cache.Force.OverrideExplicitCredential' -Value $false -Default -DisableHandler -Description 'Enabling this will force the use of the last credentials known to work, rather than even trying explicit credentials.'
+
+# Disables or enables globally which Remote Management channels can be used
+Set-DbaConfig -Name 'ComputerManagement.Type.Disable.CimRM' -Value $false -Default -DisableHandler -Description 'Globally disables all connections using Cim over WinRM'
+Set-DbaConfig -Name 'ComputerManagement.Type.Disable.CimDCOM' -Value $false -Default -DisableHandler -Description 'Globally disables all connections using Cim over DCOM'
+Set-DbaConfig -Name 'ComputerManagement.Type.Disable.WMI' -Value $true -Default -DisableHandler -Description 'Globally disables all connections using WMI'
+Set-DbaConfig -Name 'ComputerManagement.Type.Disable.PowerShellRemoting' -Value $true -Default -DisableHandler -Description 'Globally disables all connections using PowerShell Remoting'
+#TODO: Implement Handler for type validation


### PR DESCRIPTION
Alright, now after a long wait, here's the second iteration of the computer management framework.

This implements automatic connection caching, lots of customization, up to four paths to reach your target, credential management and lots of pre-validation and good performance (at least in my tests so far).

Caveat:
 - It currently can only retrieve classes or invoke queries.
 - It _cannot_ list namespace contents
 - it _cannot_ invoke methods
Not because I don't want to do this, but because I'd like the basic framework to have some mileage before I start into adding still more onto it. Complexity-creep is what's delayed this to the current point.

I fully expect to get back to these points before long - I know it to be not complex, but as I wrote, I'd prefer some more testing and live use before I add more complexity to it.