### PR TITLE
Fixed ussue #1134

### DIFF
--- a/functions/Get-SqlServerKey.ps1
+++ b/functions/Get-SqlServerKey.ps1
@@ -120,7 +120,7 @@ Gets SQL Server versions, editions and product keys for all instances listed wit
 			if ([Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.RegisteredServers") -eq $null)
 			{ throw "Can't load CMS assemblies. You must have SQL Server Management Studio installed to use the -SqlCms switch." }
 			
-			Write-Output "Gathering SQL Servers names from Central Management Server"
+            Write-Verbose "Gathering SQL Servers names from Central Management Server"
 			$server = Connect-SqlServer -SqlServer $SqlCms -SqlCredential $SqlCredential
 			$sqlconnection = $server.ConnectionContext.SqlConnectionObject
 			


### PR DESCRIPTION
Changed Write-Output to Write-Verbose.

Fixes #1134

How to test this code: 
The following command should no longer output any string to the pipeline:
Get-SqlServerKey -SqlCms localhost

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database
