### PR TITLE
Improvements to datatable functions

### DIFF
--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -18,9 +18,6 @@ Use this switch to ignore null rows
 .PARAMETER TimeSpanType
 Sets what type to convert TimeSpan into before creating the datatable. Options are Ticks, TotalDays, TotalHours, TotalMinutes, TotalSeconds, TotalMilliseconds and String.
 
-.PARAMETER Silent 
-Use this switch to disable any kind of verbose messages
-
 .NOTES
 dbatools PowerShell module (https://dbatools.io)
 Copyright (C) 2016 Chrissy LeMaire
@@ -54,14 +51,28 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
 #>	
 	[CmdletBinding()]
 	param (
-		[Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        # Input object to process
+		[Parameter(Position = 0,
+                   Mandatory = $true,
+                   ValueFromPipeline = $true)]
 		[AllowNull()]
 		[PSObject[]]$InputObject,
-		[switch]$IgnoreNull,
-        [ValidateSet("Ticks", "TotalDays", "TotalHours", "TotalMinutes", "TotalSeconds", "TotalMilliseconds", "String")]
-        [string]$TimeSpanType = "TotalMilliseconds",		
-        [switch]$Silent
         
+        # What to convert TimeSpan to
+        [Parameter(Position = 1)]
+        [ValidateSet("Ticks",
+                     "TotalDays",
+                     "TotalHours",
+                     "TotalMinutes",
+                     "TotalSeconds",
+                     "TotalMilliseconds",
+                     "String")]
+        [ValidateNotNullOrEmpty()]
+        [string]$TimeSpanType = "TotalMilliseconds",		
+        
+        # Ignore null rows
+        [Parameter(Position = 2)]
+		[switch]$IgnoreNull    
 	)
 	
 	BEGIN

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -12,11 +12,14 @@ Thanks to Chad Miller, this is based on his script. https://gallery.technet.micr
 .PARAMETER InputObject
 The object to transform into a DataTable
 	
+.PARAMETER TimeSpanType
+Sets what type to convert TimeSpan into before creating the datatable. Options are Ticks, TotalDays, TotalHours, TotalMinutes, TotalSeconds, TotalMilliseconds and String.
+
 .PARAMETER IgnoreNull 
 Use this switch to ignore null rows
 
-.PARAMETER TimeSpanType
-Sets what type to convert TimeSpan into before creating the datatable. Options are Ticks, TotalDays, TotalHours, TotalMinutes, TotalSeconds, TotalMilliseconds and String.
+.PARAMETER Silent 
+Use this switch to disable any kind of verbose messages
 
 .NOTES
 dbatools PowerShell module (https://dbatools.io)
@@ -71,8 +74,10 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
         [string]$TimeSpanType = "TotalMilliseconds",		
         
         # Ignore null rows
-        [Parameter(Position = 2)]
-		[switch]$IgnoreNull    
+		[switch]$IgnoreNull,
+        
+
+        [switch]$Silent   
 	)
 	
 	BEGIN

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -53,6 +53,7 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
 
 #>	
 	[CmdletBinding()]
+    [OutputType([System.Object[]])]
 	param (
         # Input object to process
 		[Parameter(Position = 0,
@@ -189,7 +190,6 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
                             # this is where the table columns are generated
                             if ($property.value -isnot [System.DBNull]) {
                                 # Check if property is a ScriptProperty, then resolve it while calling ConvertType. (otherwise we dont get the proper type)
-                                # Debug, remove when done
                                 Write-Verbose "Attempting to get type from property $($property.Name)"
                                 If ($property.MemberType -eq 'ScriptProperty') {
                                     try {
@@ -250,7 +250,6 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
 			        }
 
 			        $datatable.Rows.Add($datarow)
-                    # Row added.
                     # If this is the first non-null object then the columns has just been created.
                     # Set variable to false to skip creating columns from now on.
                     if ($ShouldCreateCollumns) {

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -126,17 +126,11 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
             # Ticks are more accurate but I think milliseconds are more useful most of the time.
             if ($type -eq 'System.TimeSpan') {
                 $special = $true
-                # Debug, remove when done
-                # Write-Verbose "Found match: $type (special)"
                 if ($timespantype -eq 'String') {
-                    # Debug, remove when done
-                    # Write-Verbose "Converting TimeSpan to string"
                     $value = $value.ToString()
                     $type = 'System.String'
                 }
                 else {
-                    # Debug, remove when done
-                    # Write-Verbose "Converting TimeSpan to $timespantype (Int64)"
                     # Lets use Int64 for all other types than string.
                     # We could match the type more closely with the timespantype but that can be added in the future if needed.
                     $value = $value.$timespantype
@@ -144,8 +138,6 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
                 }
             }
             elseif (!$types.Contains($type)) {
-                # Debug, remove when done
-                # Write-Verbose "Did not find match: $type"
                 # All types which are not found in the array will be converted into strings.
                 # In this way we dont ignore it completely and it will be clear in the end why it looks as it does.
                 $type = 'System.String'
@@ -169,115 +161,103 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
 		if (!$InputObject) {
 			if ($IgnoreNull) {
                 # If the object coming down the pipeline is null and the IgnoreNull parameter is set, ignore it.
-				#Stop-Function -Message "The InputObject from the pipe is null. Skipping." -Continue
-                Write-Message -Message "The InputObject from the pipe is null. Skipping." -Silent:$Silent -Warning
-                #Continue
+				Write-Message -Message "The InputObject from the pipe is null. Skipping." -Silent:$Silent -Warning
 			}
 			else {
                 # If the object coming down the pipeline is null, add an empty row and then skip to next.
 				$datarow = $datatable.NewRow()
 				$datatable.Rows.Add($datarow)
-				#continue
 			}
 		} else {
 		    foreach ($object in $InputObject) {
-            if (!$object) {
-                if ($IgnoreNull) {
-                # If the object in the array is null and the IgnoreNull parameter is set, ignore it.
-				#Stop-Function -Message "Object in array is null. Skipping." -SilentlyContinue
-                Write-Message -Message "Object in array is null. Skipping." -Silent:$Silent -Warning
-                #Continue
-			    }
-			    else {
-                    # If the object in the array is null, add an empty row and then skip to next.
-				    $datarow = $datatable.NewRow()
-				    $datatable.Rows.Add($datarow)
-				    #continue
-			    }
-            } else {
-                $datarow = $datatable.NewRow()
-			    foreach ($property in $object.PsObject.get_properties()) {
-                    # The converted variable will get the result from the ConvertType function and used for type and value conversion when adding to the datatable.
-                    $converted = @{}
-				    if ($ShouldCreateCollumns) {
-                        # this is where the table columns are generated
-                        if ($property.value -isnot [System.DBNull]) {
-                            # Check if property is a ScriptProperty, then resolve it while calling ConvertType. (otherwise we dont get the proper type)
-                            # Debug, remove when done
-                            Write-Verbose "Attempting to get type from property $($property.Name)"
-                            If ($property.MemberType -eq 'ScriptProperty') {
+                if (!$object) {
+                    if ($IgnoreNull) {
+                        # If the object in the array is null and the IgnoreNull parameter is set, ignore it.
+				        Write-Message -Message "Object in array is null. Skipping." -Silent:$Silent -Warning
+                    }
+			        else {
+                        # If the object in the array is null, add an empty row and then skip to next.
+				        $datarow = $datatable.NewRow()
+				        $datatable.Rows.Add($datarow)
+			        }
+                } else {
+                    $datarow = $datatable.NewRow()
+			        foreach ($property in $object.PsObject.get_properties()) {
+                        # The converted variable will get the result from the ConvertType function and used for type and value conversion when adding to the datatable.
+                        $converted = @{}
+				        if ($ShouldCreateCollumns) {
+                            # this is where the table columns are generated
+                            if ($property.value -isnot [System.DBNull]) {
+                                # Check if property is a ScriptProperty, then resolve it while calling ConvertType. (otherwise we dont get the proper type)
                                 # Debug, remove when done
-                                # Write-Verbose "Converting Script Property"
-                                # Write-Verbose "Value: $($property.Value)"
-                                # Write-Verbose "Points to: $($object.($property.Name))"
-                                try {
-                                    $converted = ConvertType -type ($object.($property.Name).GetType().ToString()) -value $property.value -timespantype $TimeSpanType
-                                } catch {
-                                    # Ends up here when the type is not possible to get so the call to ConvertType fails.
-                                    # In that case we make a string out of it. (in this scenario its often that a script property points to a null value so we can't get the type)
-                                    $converted = @{
-                                        type='System.String'
-                                        Value=$property.value
-                                        Special=$false
+                                Write-Verbose "Attempting to get type from property $($property.Name)"
+                                If ($property.MemberType -eq 'ScriptProperty') {
+                                    try {
+                                        $converted = ConvertType -type ($object.($property.Name).GetType().ToString()) -value $property.value -timespantype $TimeSpanType
+                                    } catch {
+                                        # Ends up here when the type is not possible to get so the call to ConvertType fails.
+                                        # In that case we make a string out of it. (in this scenario its often that a script property points to a null value so we can't get the type)
+                                        $converted = @{
+                                            type='System.String'
+                                            Value=$property.value
+                                            Special=$false
+                                        }
+                                    }
+                                    # We need to check if the type returned by ConvertType is a special type.
+                                    # In that case we add it to the $specialColumns variable for future reference.
+                                    if ($converted.special) {
+                                        $specialColumns.Add($property.Name, $object.($property.Name).GetType().ToString())
+                                    }
+                                } else {
+                                    $converted = ConvertType -type $property.TypeNameOfValue -value $property.value -timespantype $TimeSpanType
+                                    # We need to check if the type returned by ConvertType is a special type.
+                                    # In that case we add it to the $specialColumns variable for future reference.
+                                    if ($converted.special) {
+                                        $specialColumns.Add($property.Name, $property.TypeNameOfValue)
                                     }
                                 }
-                                # We need to check if the type returned by ConvertType is a special type.
-                                # In that case we add it to the $specialColumns variable for future reference.
-                                if ($converted.special) {
-                                    $specialColumns.Add($property.Name, $object.($property.Name).GetType().ToString())
+				            }
+					        $column = New-Object System.Data.DataColumn
+					        $column.ColumnName = $property.Name.ToString()
+					        $column.DataType = [System.Type]::GetType($converted.type)
+					        $datatable.Columns.Add($column)
+                        } 
+                        else {
+                            # This is where we end up if the columns has been created in the data table.
+                            # We still need to check for special columns again, to make sure that the value is converted properly.
+                            if ($property.value -isnot [System.DBNull]) {
+                                if ($specialColumns.Keys -contains $property.Name) {
+                                    $converted = ConvertType -type $specialColumns.($property.Name) -value $property.Value -timespantype $TimeSpanType
                                 }
-                            } else {
-                                $converted = ConvertType -type $property.TypeNameOfValue -value $property.value -timespantype $TimeSpanType
-                                # We need to check if the type returned by ConvertType is a special type.
-                                # In that case we add it to the $specialColumns variable for future reference.
+				            }
+                        }
+
+				        if ($property.value.length -gt 0) {
+					        if ($property.value.ToString() -eq 'System.Object[]') {
+						        $datarow.Item($property.Name) = $property.value -join ", "
+					        }
+					        else {
+                                # If the typename was a special typename we want to use the value returned from ConvertType instead.
+                                # We might get error if we try to change the value for $property.value if it is read-only. That's why we use $converted.value instead.
                                 if ($converted.special) {
-                                    $specialColumns.Add($property.Name, $property.TypeNameOfValue)
+						            $datarow.Item($property.Name) = $converted.value
                                 }
-                            }
-				        }
-					    $column = New-Object System.Data.DataColumn
-					    $column.ColumnName = $property.Name.ToString()
-					    $column.DataType = [System.Type]::GetType($converted.type)
-					    $datatable.Columns.Add($column)
-                    } 
-                    else {
-                        # This is where we end up if the columns has been created in the data table.
-                        # We still need to check for special columns again, to make sure that the value is converted properly.
-                        if ($property.value -isnot [System.DBNull]) {
-                            if ($specialColumns.Keys -contains $property.Name) {
-                                $converted = ConvertType -type $specialColumns.($property.Name) -value $property.Value -timespantype $TimeSpanType
-                            }
-				        }
+                                else {
+                                    $datarow.Item($property.Name) = $property.value
+                                }
+					        }		
+                        }
+			        }
+
+			        $datatable.Rows.Add($datarow)
+                    # Row added.
+                    # If this is the first non-null object then the columns has just been created.
+                    # Set variable to false to skip creating columns from now on.
+                    if ($ShouldCreateCollumns) {
+                        $ShouldCreateCollumns = $false
                     }
-
-				    if ($property.value.length -gt 0) {
-					    if ($property.value.ToString() -eq 'System.Object[]') {
-						    $datarow.Item($property.Name) = $property.value -join ", "
-					    }
-					    else {
-                            # If the typename was a special typename we want to use the value returned from ConvertType instead.
-                            # We might get error if we try to change the value for $property.value if it is read-only. That's why we use $converted.value instead.
-                            if ($converted.special) {
-						        $datarow.Item($property.Name) = $converted.value
-                            }
-                            else {
-                                $datarow.Item($property.Name) = $property.value
-                            }
-					    }		
-                    }
-			    }
-
-            
-
-			    $datatable.Rows.Add($datarow)
-                # Row added.
-                # If this is the first non-null object then the columns has just been created.
-                # Set variable to false to skip creating columns from now on.
-                if ($ShouldCreateCollumns) {
-                    $ShouldCreateCollumns = $false
                 }
-            }
-		}
+		    }
         }
 	}
 	

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -127,16 +127,16 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
             if ($type -eq 'System.TimeSpan') {
                 $special = $true
                 # Debug, remove when done
-                Write-Verbose "Found match: $type (special)"
+                # Write-Verbose "Found match: $type (special)"
                 if ($timespantype -eq 'String') {
                     # Debug, remove when done
-                    Write-Verbose "Converting TimeSpan to string"
+                    # Write-Verbose "Converting TimeSpan to string"
                     $value = $value.ToString()
                     $type = 'System.String'
                 }
                 else {
                     # Debug, remove when done
-                    Write-Verbose "Converting TimeSpan to $timespantype (Int64)"
+                    # Write-Verbose "Converting TimeSpan to $timespantype (Int64)"
                     # Lets use Int64 for all other types than string.
                     # We could match the type more closely with the timespantype but that can be added in the future if needed.
                     $value = $value.$timespantype
@@ -145,7 +145,7 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
             }
             elseif (!$types.Contains($type)) {
                 # Debug, remove when done
-                Write-Verbose "Did not find match: $type"
+                # Write-Verbose "Did not find match: $type"
                 # All types which are not found in the array will be converted into strings.
                 # In this way we dont ignore it completely and it will be clear in the end why it looks as it does.
                 $type = 'System.String'
@@ -207,9 +207,9 @@ Creates a DataTable with the running processes and converts any TimeSpan propert
                         Write-Verbose "Attempting to get type from property $($property.Name)"
                         If ($property.MemberType -eq 'ScriptProperty') {
                             # Debug, remove when done
-                            Write-Verbose "Converting Script Property"
-                            Write-Verbose "Value: $($property.Value)"
-                            Write-Verbose "Points to: $($object.($property.Name))"
+                            # Write-Verbose "Converting Script Property"
+                            # Write-Verbose "Value: $($property.Value)"
+                            # Write-Verbose "Points to: $($object.($property.Name))"
                             try {
                                 $converted = ConvertType -type ($object.($property.Name).GetType().ToString()) -value $property.value -timespantype $TimeSpanType
                             } catch {

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -118,26 +118,46 @@ This is a good example of the type conversion in action. All process properties 
 #>	
 	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
 	param (
-		[Parameter(Mandatory = $true)]
+		[Parameter(Position = 0,
+                   Mandatory = $true)]
 		[Alias("ServerInstance", "SqlInstance")]
+        [ValidateNotNull()]
 		[object]$SqlServer,
+
+        [Parameter(Position = 1)]
+        [ValidateNotNull()]
 		[Alias("Credential")]
 		[System.Management.Automation.PSCredential]$SqlCredential,
-		[Parameter(ValueFromPipeline = $true)]
+        
+		[Parameter(Position = 2,
+                   Mandatory = $true,
+                   ValueFromPipeline = $true)]
 		[Alias("DataTable")]
+        [ValidateNotNull()]
 		[object]$InputObject,
-		[string]$Schema = 'dbo',
-		[Parameter(Mandatory = $true)]
+        
+        [Parameter(Position = 3,
+                   Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
 		[string]$Table,
+
+        [Parameter(Position = 4)]
+        [ValidateNotNullOrEmpty()]
+		[string]$Schema = 'dbo',
+        
+        [ValidateNotNull()]
 		[int]$BatchSize = 50000,
+
+        [ValidateNotNull()]
 		[int]$NotifyAfter = 5000,
+
+        [switch]$AutoCreateTable,
 		[switch]$NoTableLock,
 		[switch]$CheckConstraints,
 		[switch]$FireTriggers,
 		[switch]$KeepIdentity,
 		[switch]$KeepNulls,
 		[switch]$Truncate,
-		[switch]$AutoCreateTable,
 		[switch]$Silent
 	)
 	

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -373,33 +373,6 @@ This is a good example of the type conversion in action. All process properties 
 						$columnvalue = $InputObject.$sqlcolumnname
 					}
 					
-					# bigint, float, and datetime are more accurate, but it didn't work
-					# as often as it should have, so we'll just go for a smaller datatype
-					
-					# also, if anyone wants to add support for using the datatable datatypes
-					# to make the table creation more accurate, please do
-                    
-                    # don't mind if I do :) /John
-					
-                    <# Removed to make place for PS to SQL type conversion /John
-					    if ([int64]::TryParse($columnvalue, [ref]0) -eq $true)
-					    {
-						    $sqldatatype = "varchar(50)"
-					    }
-					    elseif ([double]::TryParse($columnvalue, [ref]0) -eq $true)
-					    {
-						    $sqldatatype = "varchar(50)"
-					    }
-					    elseif ([datetime]::TryParse($columnvalue, [ref]0) -eq $true)
-					    {
-						    $sqldatatype = "varchar(50)"
-					    }
-					    else
-					    {
-						    $sqldatatype = "varchar(MAX)"
-					    }
-                    #>                  
-                    
                     # PS to SQL type conversion
                     # If data type exists in hash table, use the corresponding SQL type
                     # Else, fallback to nvarchar
@@ -412,19 +385,11 @@ This is a good example of the type conversion in action. All process properties 
                         $sqldatatype = "nvarchar(MAX)"
                     }
                     
-                    # Debug, remove when done
-                    #Write-Verbose "Column: $sqlcolumnname"
-                    #Write-Verbose "PS datatype: $($column.DataType)"
-                    #Write-Verbose "SQL datatype: $($sqldatatype)"
-					
 					$sqldatatypes += "[$sqlcolumnname] $sqldatatype"
 				}
 				
 				$sql = "BEGIN CREATE TABLE $fqtn ($($sqldatatypes -join ' NULL,')) END"
 				
-                # Debug, remove when done
-                #Write-Verbose "SQL: $sql"
-
 				Write-Message -Level Debug -Message $sql
 				
 				if ($Pscmdlet.ShouldProcess($SqlServer, "Creating table $fqtn"))

--- a/tests/Out-DbaDataTable.Tests.ps1
+++ b/tests/Out-DbaDataTable.Tests.ps1
@@ -1,23 +1,5 @@
-﻿<#
-Invoke-Pester .\Out-DbaDataTable.tests.ps1 -CodeCoverage @{Path = '.\..\functions\Out-DbaDataTable.ps1'}
-#>
-
-# to be able to get code coverage from pester
-$basepath = Split-Path $MyInvocation.MyCommand.Path -Parent
-Import-Module C:\git\dbatools -Force
-# Need to import the Out-DbaDataTable.ps1 separately to get CodeCoverage to work with Pester
-Import-Module "$basepath\..\functions\Out-DbaDataTable.ps1" -Force -ErrorAction Stop
-# Need to import Test-DbaDeprecation as well to avoid getting error during Pester tests
-Import-Module "$basepath\..\internal\Test-DbaDeprecation.ps1" -Force -ErrorAction Stop
-# Need to import Write-Message as well to avoid getting error during Pester tests
-Import-Module "$basepath\..\internal\Write-Message.ps1" -Force -ErrorAction Stop
-
-
-
-
-Import-Module C:\git\dbatools -Force
+﻿
 Describe "Testing data table output when using a complex object" {
-    # Prepare object for testing
     $obj = New-Object -TypeName psobject -Property @{
         guid = [system.guid]'32ccd4c4-282a-4c0d-997c-7b5deb97f9e0'
         timespan = New-TimeSpan -Start 2016-10-30 -End 2017-04-30
@@ -35,7 +17,6 @@ Describe "Testing data table output when using a complex object" {
     }
     
     Add-Member -InputObject $obj -MemberType NoteProperty -Name myobject -Value $innedobj
-    # Run the command to get output to run tests on
     $result = Out-DbaDataTable -InputObject $obj
 
     Context "Property: guid" {
@@ -163,7 +144,6 @@ Describe "Testing data table output when using a complex object" {
 }
 
 Describe "Testing input parameters" {
-    # Prepare object for testing
     $obj = New-Object -TypeName psobject -Property @{
         timespan = New-TimeSpan -Start 2017-01-01 -End 2017-01-02
     }

--- a/tests/Out-DbaDataTable.Tests.ps1
+++ b/tests/Out-DbaDataTable.Tests.ps1
@@ -1,0 +1,126 @@
+﻿
+
+Describe "Testing data table output when using a complex object" {
+    $obj = New-Object -TypeName psobject -Property @{
+        guid = [system.guid]'32ccd4c4-282a-4c0d-997c-7b5deb97f9e0'
+        timespan = New-TimeSpan -Start 2016-10-30 -End 2017-04-30
+        datetime = Get-Date -Year 2016 -Month 10 -Day 30 -Hour 5 -Minute 52 -Second 0 -Millisecond 0
+        char = [System.Char]'T'
+        true = $true
+        false = $false
+        null = [bool]$null
+        string = "it's a boy!"
+        UInt64 = [System.UInt64]123456
+    }
+    $result = Out-DbaDataTable -InputObject $obj
+
+    Context "Property: guid" {
+        It 'Has a column called "guid"' {
+            $result.Columns.ColumnName.Contains('guid') | Should Be $true 
+        }
+        It 'Has a [guid] data type on the column "guid"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'guid' | Select-Object -ExpandProperty 'DataType' | Should Be 'guid'
+        }
+        It 'Has the following guid: "32ccd4c4-282a-4c0d-997c-7b5deb97f9e0"' {
+            $result.guid | Should Be '32ccd4c4-282a-4c0d-997c-7b5deb97f9e0'
+        }
+    }
+
+    Context "Property: timespan" {
+        It 'Has a column called "timespan"' {
+            $result.Columns.ColumnName.Contains('timespan') | Should Be $true 
+        }
+        It 'Has a [long] data type on the column "timespan"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'timespan' | Select-Object -ExpandProperty 'DataType' | Should Be 'long'
+        }
+        It "Has the following timespan: 15724800000" {
+            $result.timespan | Should Be 15724800000
+        }
+    }
+
+    Context "Property: datetime" {
+        It 'Has a column called "datetime"' {
+            $result.Columns.ColumnName.Contains('datetime') | Should Be $true 
+        }
+        It 'Has a [datetime] data type on the column "datetime"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'datetime' | Select-Object -ExpandProperty 'DataType' | Should Be 'datetime'
+        }
+        It "Has the following datetime: 2016-10-30 05:52:00.000" {
+            $date = Get-Date -Year 2016 -Month 10 -Day 30 -Hour 5 -Minute 52 -Second 0 -Millisecond 0
+            $result.datetime -eq $date | Should Be $true
+        }
+    }
+
+    Context "Property: char" {
+        It 'Has a column called "char"' {
+            $result.Columns.ColumnName.Contains('char') | Should Be $true 
+        }
+        It 'Has a [char] data type on the column "char"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'char' | Select-Object -ExpandProperty 'DataType' | Should Be 'char'
+        }
+        It "Has the following char: T" {
+            $result.char | Should Be "T"
+        }
+    }
+
+    Context "Property: true" {
+        It 'Has a column called "true"' {
+            $result.Columns.ColumnName.Contains('true') | Should Be $true 
+        }
+        It 'Has a [bool] data type on the column "true"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'true' | Select-Object -ExpandProperty 'DataType' | Should Be 'bool'
+        }
+        It "Has the following bool: true" {
+            $result.true | Should Be $true
+        }
+    }
+
+    Context "Property: false" {
+        It 'Has a column called "false"' {
+            $result.Columns.ColumnName.Contains('false') | Should Be $true 
+        }
+        It 'Has a [bool] data type on the column "false"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'false' | Select-Object -ExpandProperty 'DataType' | Should Be 'bool'
+        }
+        It "Has the following bool: false" {
+            $result.false | Should Be $false
+        }
+    }
+
+    Context "Property: null" {
+        It 'Has a column called "null"' {
+            $result.Columns.ColumnName.Contains('null') | Should Be $true 
+        }
+        It 'Has a [bool] data type on the column "null"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'null' | Select-Object -ExpandProperty 'DataType' | Should Be 'bool'
+        }
+        It "Has the following bool: false" {
+            $result.null | Should Be $false #should actually be $null but its hard to compare :)
+        }
+    }
+
+    Context "Property: string" {
+        It 'Has a column called "string"' {
+            $result.Columns.ColumnName.Contains('string') | Should Be $true 
+        }
+        It 'Has a [string] data type on the column "string"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'string' | Select-Object -ExpandProperty 'DataType' | Should Be 'string'
+        }
+        It "Has the following string: it's a boy!" {
+            $result.string | Should Be "it's a boy!"
+        }
+    }
+
+    Context "Property: UInt64" {
+        It 'Has a column called "UInt64"' {
+            $result.Columns.ColumnName.Contains('UInt64') | Should Be $true 
+        }
+        It 'Has a [string] data type on the column "UInt64"' {
+            $result.Columns | Where-Object -Property 'ColumnName' -eq 'UInt64' | Select-Object -ExpandProperty 'DataType' | Should Be 'UInt64'
+        }
+        It "Has the following number: 123456" {
+            $result.UInt64 | Should Be 123456
+        }
+    }
+
+}

--- a/tests/Out-DbaDataTable.Tests.ps1
+++ b/tests/Out-DbaDataTable.Tests.ps1
@@ -1,6 +1,9 @@
-﻿
+﻿<#
+Invoke-Pester .\Out-DbaDataTable.tests.ps1 -CodeCoverage @{Path = '.\..\functions\Out-DbaDataTable.ps1'}
+#>
 
 Describe "Testing data table output when using a complex object" {
+    # Prepare object for testing
     $obj = New-Object -TypeName psobject -Property @{
         guid = [system.guid]'32ccd4c4-282a-4c0d-997c-7b5deb97f9e0'
         timespan = New-TimeSpan -Start 2016-10-30 -End 2017-04-30
@@ -12,6 +15,7 @@ Describe "Testing data table output when using a complex object" {
         string = "it's a boy!"
         UInt64 = [System.UInt64]123456
     }
+    # Run the command to get output to run tests on
     $result = Out-DbaDataTable -InputObject $obj
 
     Context "Property: guid" {
@@ -123,4 +127,36 @@ Describe "Testing data table output when using a complex object" {
         }
     }
 
+}
+
+Describe "Testing input parameters" {
+    # Prepare object for testing
+    $obj = New-Object -TypeName psobject -Property @{
+        timespan = New-TimeSpan -Start 2017-01-01 -End 2017-01-02
+    }
+    
+    Context "Verifying TimeSpanType" {
+        It "Should return '1.00:00:00' when String is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType String).Timespan | Should Be '1.00:00:00'
+        }
+        It "Should return 864000000000 when Ticks is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType Ticks).Timespan | Should Be 864000000000
+        }
+        It "Should return 1 when TotalDays is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalDays).Timespan | Should Be 1
+        }
+        It "Should return 24 when TotalHours is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalHours).Timespan | Should Be 24
+        }
+        It "Should return 86400000 when TotalMilliseconds is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalMilliseconds).Timespan | Should Be 86400000
+        }
+        It "Should return 1440 when TotalMinutes is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalMinutes).Timespan | Should Be 1440
+        }
+        It "Should return 86400 when TotalSeconds is used" {
+            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalSeconds).Timespan | Should Be 86400
+        }
+        # add tests to verify data types depending on TimeSpanType
+    }
 }


### PR DESCRIPTION
Improvements to Out-DbaDataTable and Write-DbaDatatable

Changes proposed in this pull request:

Out-DbaDataTable
- Added timespan conversion and support for other special types which can easily be added in the future
- Improved parameter validation
- Improved performance (should now be similar to the original function)
- Improved handling of null values
- Added pester tests

Write-DbaDataTable
- Improved parameter validation
- Removed debug comments

How to test this code: 
- [ ] Use complex objects with properties with a large variance of datatypes (get-process is a good example)
- [ ] The pester test has a good example of an object which can be used for both functions for testing

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

