### PR TITLE
Copy-DbaQueryStore copy status output

### DIFF
--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -138,7 +138,15 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
 
                 Write-Message -Message "Executing Set-DbaQueryStoreConfig" -Level Verbose
                 # Set the Query Store configuration through the Set-DbaQueryStoreConfig function
-                Set-DbaQueryStoreConfig -SqlInstance $destinationServer -SqlCredential $DestinationSqlCredential -Databases $($db.name) -State $SourceQSConfig.ActualState -FlushInterval $SourceQSConfig.FlushInterval -CollectionInterval $SourceQSConfig.CollectionInterval -MaxSize $SourceQSConfig.MaxSize -CaptureMode $SourceQSConfig.CaptureMode -CleanupMode $SourceQSConfig.CleanupMode -StaleQueryThreshold $SourceQSConfig.StaleQueryThreshold
+                Set-DbaQueryStoreConfig -SqlInstance $destinationServer -SqlCredential $DestinationSqlCredential `
+                    -Databases $($db.name) `
+                    -State $SourceQSConfig.ActualState `
+                    -FlushInterval $SourceQSConfig.FlushInterval `
+                    -CollectionInterval $SourceQSConfig.CollectionInterval `
+                    -MaxSize $SourceQSConfig.MaxSize `
+                    -CaptureMode $SourceQSConfig.CaptureMode `
+                    -CleanupMode $SourceQSConfig.CleanupMode `
+                    -StaleQueryThreshold $SourceQSConfig.StaleQueryThreshold
             }
         }
     }

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -115,7 +115,7 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $desetServer -NoSystemDb
+            $dbs = Get-DbaDatabase -SqlInstance $destServer -NoSystemDb
 
             if ($DestinationDatabase.count -gt 0) {
                 $dbs = $dbs | Where-Object { $DestinationDatabase -contains $_.Name }

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -130,7 +130,7 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
             }
 
             foreach ($db in $dbs) {
-                Write-Message -Message "Processing destination database: $db on $destinationServer" -Verbose
+                Write-Message -Message "Processing destination database: $db on $destinationServer" -Level Verbose
 
                 if ($db.IsAccessible -eq $false) {
                     Stop-Function -Message "The database $db on server $destinationServer is not accessible. Skipping database." -Continue

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -69,7 +69,7 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [object[]]$Source,
+        [object]$Source,
         [System.Management.Automation.PSCredential]$SourceSqlCredential,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [object]$SourceDatabase,

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -130,15 +130,15 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
             }
 
             foreach ($db in $dbs) {
-                Write-Message -Message "Processing destination database: $db on $destination" -Verbose
+                Write-Message -Message "Processing destination database: $db on $destinationServer" -Verbose
 
                 if ($db.IsAccessible -eq $false) {
-                    Stop-Function -Message "The database $db on server $destination is not accessible. Skipping database." -Continue
+                    Stop-Function -Message "The database $db on server $destinationServer is not accessible. Skipping database." -Continue
                 }
 
                 Write-Message -Message "Executing Set-DbaQueryStoreConfig" -Level Verbose
                 # Set the Query Store configuration through the Set-DbaQueryStoreConfig function
-                Set-DbaQueryStoreConfig -SqlInstance $Destination -SqlCredential $DestinationSqlCredential -Databases $($db.name) -State $SourceQSConfig.ActualState -FlushInterval $SourceQSConfig.FlushInterval -CollectionInterval $SourceQSConfig.CollectionInterval -MaxSize $SourceQSConfig.MaxSize -CaptureMode $SourceQSConfig.CaptureMode -CleanupMode $SourceQSConfig.CleanupMode -StaleQueryThreshold $SourceQSConfig.StaleQueryThreshold
+                Set-DbaQueryStoreConfig -SqlInstance $destinationServer -SqlCredential $DestinationSqlCredential -Databases $($db.name) -State $SourceQSConfig.ActualState -FlushInterval $SourceQSConfig.FlushInterval -CollectionInterval $SourceQSConfig.CollectionInterval -MaxSize $SourceQSConfig.MaxSize -CaptureMode $SourceQSConfig.CaptureMode -CleanupMode $SourceQSConfig.CleanupMode -StaleQueryThreshold $SourceQSConfig.StaleQueryThreshold
             }
         }
     }

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -115,7 +115,7 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = $destServer.Databases | Where-Object { $_.IsSystemObject -eq $false }
+            $dbs = Get-DbaDatabase -SqlInstance $desetServer -NoSystemDb
 
             if ($DestinationDatabase.count -gt 0) {
                 $dbs = $dbs | Where-Object { $DestinationDatabase -contains $_.Name }

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -87,20 +87,19 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
         Write-Message -Message "Connecting to source: $Source" -Level Verbose
         try {
             $sourceServer = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
-
         }
         catch {
             Stop-Function -Message "Can't connect to $Source." -InnerErrorRecord $_ -Target $Source
         }
-
-        # Grab the Query Store configuration from the SourceDatabase through the Get-DbaQueryStoreConfig function
-        $SourceQSConfig = Get-DbaQueryStoreConfig -SqlServer $sourceServer -Databases $SourceDatabase
     }
 
     PROCESS {
         if (Test-FunctionInterrupt) {
 			return
 		}
+        # Grab the Query Store configuration from the SourceDatabase through the Get-DbaQueryStoreConfig function
+        $SourceQSConfig = Get-DbaQueryStoreConfig -SqlInstance $sourceServer -Databases $SourceDatabase
+
         if (!$DestinationDatabase -and !$Exclude -and !$AllDatabases) {
             Stop-Function -Message "You must specify databases to execute against using either -DestinationDatabase, -Exclude or -AllDatabases" -Continue
         }

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -1,5 +1,5 @@
-Function Copy-DbaQueryStoreConfig {
-<#
+function Copy-DbaQueryStoreConfig {
+    <#
 .SYNOPSIS
 Copies the configuration of a Query Store enabled database and sets the copied configuration on other databases.
 	
@@ -24,11 +24,14 @@ The target server where the databases reside on which you want to enfore the cop
 .PARAMETER DestinationDatabase
 The databases that will recieve a copy of the Query Store configuration of the SourceDatabase.
 
-.PARAMETER AllDatabases
-Set copied Query Store configuration on all databases on the destination server.	
-	
 .PARAMETER Exclude
 Copy Query Store configuration for all but these specific databases.
+
+.PARAMETER AllDatabases
+Set copied Query Store configuration on all databases on the destination server.	
+
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages
 
 .PARAMETER WhatIf
 Shows what would happen if the command were to run
@@ -75,7 +78,8 @@ Copy the Query Store configuration of the AdventureWorks database in the ServerA
         [System.Management.Automation.PSCredential]$DestinationSqlCredential,
         [object[]]$DestinationDatabase,
         [object[]]$Exclude,
-        [switch]$AllDatabases
+        [switch]$AllDatabases,
+        [switch]$Silent
     )
 	
     BEGIN {


### PR DESCRIPTION
Changes proposed in this pull request:
 - Applied standards (format, cameCase, messaging system)
 - Added call to `Get-DbaDatabase` instead of SMO
 - Adjusted Source to be a single object instead of an array object
 - Added copy status object
 - Null-ed the output from `Set-DbaQueryStoreConfig` so it does not output.
 - Added logic if the source and destination server are the same to skip the source database provided, no need to apply QueryStore config to the same database.

How to test this code: 
- [ ] Need SQL Server 2016 instance (one or multiple)
- [ ] Enable/Adjust QueryStore configuration for a given database (can be to just turn it on or adjust property)
- [ ] Run `Copy-DbaQueryStoreConfigu -Source YourSource -SourceDatabase YourSourceDatabase -Destination YourDestination -DestinationDatabase ASingleDatabase`
- [ ] Run `Copy-DbaQueryStoreConfigu -Source YourSource -SourceDatabase YourSourceDatabase -Destination YourDestination -DestinationDatabase 'Database1','Database2'`
- [ ] Run `Copy-DbaQueryStoreConfigu -Source YourSource -SourceDatabase YourSourceDatabase -Destination YourDestination -Exclude 'Database5','Database8','Database3'`
- [ ] Run `Copy-DbaQueryStoreConfigu -Source YourSource -SourceDatabase YourSourceDatabase -Destination YourDestination -AllDatabases`
- [ ] In each run above confirm the output copy object is as expected.
- [ ] Confirm on each run that the given configuration was copied properly.

A few samples of expected output:
![image](https://cloud.githubusercontent.com/assets/11204251/25812901/68fdf676-33dd-11e7-8266-2e193c92f1a6.png)

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2016
