### PR TITLE
Historyfix

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -164,24 +164,22 @@ Function Get-DbaBackupHistory {
 			if ($last) {
 				if ($databases -eq $null) { $databases = $server.databases.name }
 				
-				foreach ($db in $databases) {
-					$logdb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$Raw -LastLog
-					
-					if ($logdb) {
-						$alldb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$Raw 
-						$alldb | Where-Object { $_.FirstLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Full' } 
-						$diff = $alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -ne 'Full' -and $_.Type -ne 'Log' } | Sort-Object Start -Descending | Select-Object -First 1
-						$diff
-						if($diff) {
-							$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.lastlsn -ge $diff.lastlsn -and $_.Type -eq 'Log'}
-						} else {
-							$alldb | Where-Object { $_.DatabaseBackupLsn -eq $logdb.DatabaseBackupLsn -and $_.Type -eq 'Log'}
-						}
-					}
-					else{
-						Get-DbaBackupHistory -SqlServer $server -Databases $db -LastFull -raw:$Raw
-					}
-				}
+                foreach ($db in $databases) {
+
+
+                    #Get the full and build upwards
+					$allbackups = @()
+                    $allbackups += $Fulldb = Get-DbaBackupHistory -SqlServer $server -Databases $db -LastFull -raw:$Raw
+                    $Allbackups += $DiffDB = Get-DbaBackupHistory -SqlServer $server -Databases $db -LastDiff -raw:$Raw
+                    if ($null -ne $diffdb) {
+                        $TLogStartLSN = $diffdb.FirstLsn
+                    }
+                    else {
+                        $TLogStartLSN = $fulldb.FirstLsn
+                    }
+                    $Allbackups += $Logdb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$raw | Where-object {$_.Type -eq 'Log' -and $_.FirstLSN -gt $TLogstartLSN }
+                    $Allbackups | Sort-Object FirstLSN
+                }
 				continue
 			}
 			

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -269,7 +269,6 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 						Stop-Function -Message "$dbname does not exist on $source." -Continue
 					}
 					
-					#$lastbackup = Get-DbaBackupHistory -SqlServer $sourceserver -Databases $dbname -LastFull -IgnoreCopyOnly:$ignorecopyonly
 					$lastbackup = Get-DbaBackupHistory -SqlServer $sourceserver -Databases $dbname -Last -IgnoreCopyOnly:$ignorecopyonly
 					
 					if ($CopyFile) {


### PR DESCRIPTION
Fixes # 1164

Changes proposed in this pull request:
 -  Works the other way round to last implementation.
 - First the last full, then work upwards
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

