### PR TITLE
Fix For Restore of brand new db fails when use ReuseSourceFolderStructure option

### DIFF
--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -152,9 +152,9 @@ Function Restore-DBFromFilteredArray
 			foreach ($File in ($RestorePoints.Files.filelist.PhysicalName | Sort-Object -Unique))
 			{
 				write-verbose "File = $file"
-				if ((Test-SqlPath -Path $File -SqlServer:$SqlServer -SqlCredential:$SqlCredential) -ne $true)
+				if ((Test-SqlPath -Path (Split-Path -Path $File -Parent) -SqlServer:$SqlServer -SqlCredential:$SqlCredential) -ne $true)
 					{
-					if ((New-DbaSqlDirectory -Path $File -SqlServer:$SqlServer -SqlCredential:$SqlCredential).Created -ne $true)
+					if ((New-DbaSqlDirectory -Path (Split-Path -Path $File -Parent) -SqlServer:$SqlServer -SqlCredential:$SqlCredential).Created -ne $true)
 					{
 						write-Warning  "$FunctionName - Destination File $File does not exist, and could not be created on $SqlServer"
 
@@ -162,7 +162,7 @@ Function Restore-DBFromFilteredArray
 					}
 					else
 					{
-						Write-Verbose "$FunctionName - Destination File $Fil  created on $SqlServer"
+						Write-Verbose "$FunctionName - Destination File $File  created on $SqlServer"
 					}
 				}
 				else


### PR DESCRIPTION
Fixes#
Fix for the issue https://github.com/sqlcollaborative/dbatools/issues/1159

Changes:
Changed Restore-DBFromFilteredArray.ps1. Lines 155 & 157 to use Folder name only for the check instead of the file name.

How to test this code:
Please follow instruction in issue https://github.com/sqlcollaborative/dbatools/issues/1159