### PR TITLE
Copy-SQLdatabase fixes

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -428,7 +428,7 @@ Backs up AdventureWorks2014 to sql2016's C:\temp folder
 					$BackupComplete = $true
 					$Filelist = @()
 					$FileList += $server.Databases[$dbname].FileGroups.Files | Select-Object @{Name="FileType";Expression={"D"}}, @{Name="LogicalName";Expression={$_.Name}}, @{Name="PhysicalName";Expression={$_.FileName}}
-					$FileList += $server.Databases[$dbname].LofFiles | Select-Object @{Name="FileType";Expression={"L"}}, @{Name="LogicalName";Expression={$_.Name}}, @{Name="PhysicalName";Expression={$_.FileName}}
+					$FileList += $server.Databases[$dbname].LogFiles | Select-Object @{Name="FileType";Expression={"L"}}, @{Name="LogicalName";Expression={$_.Name}}, @{Name="PhysicalName";Expression={$_.FileName}}
 					$Verified = $false
 					if ($Verify)
 					{

--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -376,11 +376,11 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			{
 				try
 				{
-					Write-Warning "Breaking mirror for $dbname"
+					Write-Message -Level Warning -Message  "Breaking mirror for $dbname"
 					$database.ChangeMirroringState([Microsoft.SqlServer.Management.Smo.MirroringOption]::Off)
 					$database.Alter()
 					$database.Refresh()
-					Write-Warning "Could not break mirror for $dbname. Skipping."
+					Write-Message -Level Warning -Message "Could not break mirror for $dbname. Skipping."
 					
 				}
 				catch
@@ -517,16 +517,16 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 					}
 					catch
 					{
-						Write-Warning "Start-BitsTransfer did not succeed. Now attempting with Copy-Item - no progress bar will be shown."
+						Write-Message -Level Warning -Message "Start-BitsTransfer did not succeed. Now attempting with Copy-Item - no progress bar will be shown."
 						try
 						{
 							Copy-Item -Path $from -Destination $remotefilename -ErrorAction Stop
 						}
 						catch
 						{
-							Write-Warning "Access denied. This can happen for a number of reasons including issues with cloned disks."
-							Write-Warning "Alternatively, you may need to run PowerShell as Administrator, especially when running on localhost."
-							break
+							Write-Message -Level Warning -Message "Access denied. This can happen for a number of reasons including issues with cloned disks."
+							Stop-Function -Message  "Alternatively, you may need to run PowerShell as Administrator, especially when running on localhost." -Target $from
+							return
 						}
 					}
 				}
@@ -589,14 +589,14 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				else
 				{
 					# add to failed because ATTACH was unsuccessful
-					Write-Warning "Could not attach $dbname."
+					Write-Message -Level Warning -Message "Could not attach $dbname."
 					return "Could not attach database."
 				}
 			}
 			else
 			{
 				# add to failed because DETACH was unsuccessful
-				Write-Warning "Could not detach $dbname."
+				Write-Message -Level Warning -Message "Could not detach $dbname."
 				return "Could not detach database."
 			}
 		}
@@ -638,7 +638,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			{
 				If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
 				{
-					Write-Warning "When running DetachAttach locally on the console, it's likely you'll need to Run As Administrator. Trying anyway."
+					Write-Message -Level Warning -Message  "When running DetachAttach locally on the console, it's likely you'll need to Run As Administrator. Trying anyway."
 				}
 			}
 		}
@@ -650,23 +650,31 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		{
 			if ($(Test-SqlPath -SqlServer $sourceserver -Path $NetworkShare) -eq $false)
 			{
-				Write-Warning "$Source may not be able to access $NetworkShare. Trying anyway."
+				Write-Message -Level Warning -Message "$Source may not be able to access $NetworkShare. Trying anyway."
 			}
 			
 			if ($(Test-SqlPath -SqlServer $destserver -Path $NetworkShare) -eq $false)
 			{
-				Write-Warning "$Destination may not be able to access $NetworkShare. Trying anyway."
+				Write-Message -Level Warning -Message "$Destination may not be able to access $NetworkShare. Trying anyway."
 			}
 			
 			if ($networkshare.StartsWith('\\'))
 			{
-				$shareserver = ($networkshare -split "\\")[2]
-				$hostentry = ([Net.Dns]::GetHostEntry($shareserver)).HostName -split "\."
+                try 
+                {
+				    $shareserver = ($networkshare -split "\\")[2]
+				    $hostentry = ([Net.Dns]::GetHostEntry($shareserver)).HostName -split "\."
 				
-				if ($shareserver -ne $hostentry[0])
-				{
-					Write-Warning "Using CNAME records for the network share may present an issue if an SPN has not been created. Trying anyway. If it doesn't work, use a different (A record) hostname."
-				}
+				    if ($shareserver -ne $hostentry[0])
+				    {
+					    Write-Message -Level Warning -Message "Using CNAME records for the network share may present an issue if an SPN has not been created. Trying anyway. If it doesn't work, use a different (A record) hostname."
+				    }
+                }
+                catch
+                {
+                    Stop-Function -Message "Error validating unc path: $_"
+                    return
+                }
 			}
 		}
 		
@@ -681,7 +689,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		Write-Output "Checking to ensure the source isn't the same as the destination"
 		if ($source -eq $destination)
 		{
-			throw "Source and Destination Sql Servers instances are the same. Quitting."
+			Stop-Function -Message "Source and Destination Sql Servers instances are the same. Quitting."
+            return
 		}
 		
 		if ($NetworkShare.Length -gt 0)
@@ -689,7 +698,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			Write-Output "Checking to ensure network path is valid"
 			if (!($NetworkShare.StartsWith("\\")))
 			{
-				throw "Network share must be a valid UNC path (\\server\share)."
+				Stop-Function -Message "Network share must be a valid UNC path (\\server\share)."
+                return
 			}
 			
 			try
@@ -701,7 +711,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			}
 			catch
 			{
-				Write-Warning "$networkshare share cannot be accessed. Still trying anyway, in case the SQL Server service accounts have access."
+				Write-Message -Level Warning -Message "$networkshare share cannot be accessed. Still trying anyway, in case the SQL Server service accounts have access."
 			}
 			
 		}
@@ -709,19 +719,19 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		Write-Output "Checking to ensure server is not SQL Server 7 or below"
 		if ($sourceserver.versionMajor -lt 8 -and $destserver.versionMajor -lt 8)
 		{
-			throw "This script can only be run on Sql Server 2000 and above. Quitting."
+			Stop-Function -Message  "This script can only be run on Sql Server 2000 and above. Quitting."
 		}
 		
 		Write-Output "Checking to ensure detach/attach is not attempted on SQL Server 2000"
 		if ($destserver.versionMajor -lt 9 -and $DetachAttach)
 		{
-			throw "Detach/Attach not supported when destination Sql Server is version 2000. Quitting."
+			Stop-Function -Message "Detach/Attach not supported when destination Sql Server is version 2000. Quitting."
 		}
 		
 		Write-Output "Checking to ensure SQL Server 2000 migration isn't directly attempted to SQL Server 2012"
 		if ($sourceserver.versionMajor -lt 9 -and $destserver.versionMajor -gt 10)
 		{
-			throw "Sql Server 2000 databases cannot be migrated to Sql Server versions 2012 and above. Quitting."
+			Stop-Function -Message "Sql Server 2000 databases cannot be migrated to Sql Server versions 2012 and above. Quitting."
 		}
 		
 		Write-Message -Level Verbose -Message  "Warning if migration from 2005 to 2012 and above and attach/detach is used."
@@ -734,7 +744,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		if ($sourceserver.collation -ne $destserver.collation)
 		{
 			Write-Output "Warning on different collation"
-			Write-Warning "Collation on $Source, $($sourceserver.collation) differs from the $Destination, $($destserver.collation)."
+			Write-Message -Level Warning -Message "Collation on $Source, $($sourceserver.collation) differs from the $Destination, $($destserver.collation)."
 		}
 		
 		Write-Output "Ensuring user databases exist (counting databases)"
@@ -742,13 +752,13 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		
 		if ($dbtotal -le 4)
 		{
-			throw "No user databases to migrate. Quitting."
+			Stop-Function -Message  "No user databases to migrate. Quitting."
 		}
 		
 		Write-Output "Ensuring destination server version is equal to or greater than source"
 		if ([version]$sourceserver.ResourceVersionString -gt [version]$destserver.ResourceVersionString)
 		{
-			throw "Source Sql Server version build must be <= destination Sql Server for database migration."
+			Stop-Function -Message  "Source Sql Server version build must be <= destination Sql Server for database migration."
 		}
 		
 		# SMO's filestreamlevel is sometimes null
@@ -760,7 +770,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		Write-Output "Writing warning about filestream being enabled"
 		if ($fswarning)
 		{
-			Write-Warning "FILESTREAM enabled on $source but not $destination. Databases that use FILESTREAM will be skipped."
+			Write-Message -Level Warning -Message "FILESTREAM enabled on $source but not $destination. Databases that use FILESTREAM will be skipped."
 		}
 		
 		if ($DetachAttach -eq $true)
@@ -770,30 +780,32 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 			
 			If ((Test-Path $remotesourcepath) -ne $true -and $DetachAttach)
 			{
-				Write-Warning "Can't access remote Sql directories on $source which is required to perform detach/copy/attach."
-				Write-Warning "You can manually try accessing $remotesourcepath to diagnose any issues."
-				Write-Warning "Halting database migration."
+				Write-Message -Level Warning -Message "Can't access remote Sql directories on $source which is required to perform detach/copy/attach."
+				Write-Message -Level Warning -Message "You can manually try accessing $remotesourcepath to diagnose any issues."
+				Stop-Function -Message "Halting database migration."
 				return
 			}
 			
 			$remotedestpath = Join-AdminUNC $destnetbios (Get-SqlDefaultPaths $destserver data)
 			If ((Test-Path $remotedestpath) -ne $true -and $DetachAttach)
 			{
-				Write-Warning "Can't access remote Sql directories on $destination which is required to perform detach/copy/attach."
-				Write-Warning "You can manually try accessing $remotedestpath to diagnose any issues."
-				Write-Warning "Halting database migration."
+				Write-Message -Level Warning -Message "Can't access remote Sql directories on $destination which is required to perform detach/copy/attach."
+				Write-Message -Level Warning -Message "You can manually try accessing $remotedestpath to diagnose any issues."
+				Stop-Function -Message "Halting database migration."
 				return
 			}
 		}
 		
 		if (($Databases -or $Exclude -or $IncludeSupportDbs) -and (!$DetachAttach -and !$BackupRestore))
 		{
-			throw "You did not select a migration method. Please use -BackupRestore or -DetachAttach"
+			Stop-Function -Message  "You did not select a migration method. Please use -BackupRestore or -DetachAttach"
+            return
 		}
 		
 		if ((!$Databases -and !$AllDatabases -and !$IncludeSupportDbs) -and ($DetachAttach -or $BackupRestore))
 		{
-			throw "You did not select any databases to migrate. Please use -AllDatabases or -Databases or -IncludeSupportDbs"
+			Stop-Function -Message  "You did not select any databases to migrate. Please use -AllDatabases or -Databases or -IncludeSupportDbs"
+            return
 		}
 		
 		
@@ -871,7 +883,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				Write-Message -Level Verbose -Message  "Checking for accessibility"
 				if ($database.IsAccessible -eq $false)
 				{
-					Write-Warning "Skipping $dbname. Database is inaccessible."
+					Write-Message -Level Warning -Message "Skipping $dbname. Database is inaccessible."
 					continue
 				}
 				
@@ -881,7 +893,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 					
 					if ($fsrows.count -gt 0)
 					{
-						Write-Warning "Skipping $dbname (contains FILESTREAM)"
+						Write-Message -Level Warning -Message "Skipping $dbname (contains FILESTREAM)"
 						continue
 					}
 				}
@@ -899,7 +911,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				if ($database.AvailabilityGroupName.Length -gt 0 -and !$force -and $DetachAttach)
 				{
 					$agname = $database.AvailabilityGroupName
-					Write-Warning "Database is part of an Availability Group ($agname). Use -Force to drop from $agname and migrate. Alternatively, you can use the safer backup/restore method."
+					Write-Message -Level Warning -Message  "Database is part of an Availability Group ($agname). Use -Force to drop from $agname and migrate. Alternatively, you can use the safer backup/restore method."
 					continue
 				}
 				
@@ -907,25 +919,25 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 				
 				if ($dbstatus.StartsWith("Normal") -eq $false)
 				{
-					Write-Warning "$dbname is not in a Normal state. Skipping."
+					Write-Message -Level Warning -Message "$dbname is not in a Normal state. Skipping."
 					continue
 				}
 				
 				if ($database.ReplicationOptions -ne "None" -and $DetachAttach -eq $true)
 				{
-					Write-Warning "$dbname is part of replication. Skipping."
+					Write-Message -Level Warning -Message "$dbname is part of replication. Skipping."
 					continue
 				}
 				
 				if ($database.IsMirroringEnabled -and !$force -and $DetachAttach)
 				{
-					Write-Warning "Database is being mirrored. Use -Force to break mirror and migrate. Alternatively, you can use the safer backup/restore method."
+					Write-Message -Level Warning -Message "Database is being mirrored. Use -Force to break mirror and migrate. Alternatively, you can use the safer backup/restore method."
 					continue
 				}
 				
 				if (($destserver.Databases[$dbname] -ne $null) -and !$force -and !$WithReplace)
 				{
-					Write-Warning "Database exists at destination. Use -Force to drop and migrate. Aborting routine for this database."
+					Write-Message -Level Warning -Message "Database exists at destination. Use -Force to drop and migrate. Aborting routine for this database."
 					continue
 				}
 				elseif ($destserver.Databases[$dbname] -ne $null -and $force)
@@ -937,7 +949,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						
 						if ($dropresult -eq $false)
 						{
-							Write-Warning "Database could not be dropped. Aborting routine for this database"
+							Write-Message -Level Warning -Message "Database could not be dropped. Aborting routine for this database"
 							continue
 						}
 					}
@@ -967,7 +979,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						
 						if ($result -eq $false)
 						{
-							Write-Warning "Couldn't set database to read-only. Aborting routine for this database"
+							Write-Message -Level Warning -Message "Couldn't set database to read-only. Aborting routine for this database"
 							continue
 						}
 					}
@@ -987,7 +999,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						if ($backupresult -eq $false)
 						{
 							$serviceaccount = $sourceserver.ServiceAccount
-							Write-Warning "Backup Failed. Does Sql Server account $serviceaccount have access to $NetworkShare? Aborting routine for this database"
+							Write-Message -Level Warning -Message "Backup Failed. Does Sql Server account $serviceaccount have access to $NetworkShare? Aborting routine for this database"
 							continue
 						}
 						
@@ -1003,13 +1015,13 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						{
 							if ($ReuseSourceFolderStructure)
 							{
-								Write-Warning "Failed to restore $dbname to $destination. You specified -ReuseSourceFolderStructure. Does the exact same destination directory structure exist?"
-								Write-Warning "Aborting routine for this database"
+								Write-Message -Level Warning -Message "Failed to restore $dbname to $destination. You specified -ReuseSourceFolderStructure. Does the exact same destination directory structure exist?"
+								Write-Message -Level Warning -Message "Aborting routine for this database"
 								continue
 							}
 							else
 							{
-								Write-Warning "Failed to restore $dbname to $destination. Aborting routine for this database."
+								Write-Message -Level Warning -Message "Failed to restore $dbname to $destination. Aborting routine for this database."
 								continue
 							}
 						}
@@ -1071,7 +1083,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 							}
 							else
 							{
-								Write-Warning "Could not reattach $dbname to $source."
+								Write-Message -Level Warning -Message "Could not reattach $dbname to $source."
 							}
 						}
 						
@@ -1082,7 +1094,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						}
 						else
 						{
-							Write-Warning "Failed to attach $dbname to $destination. Aborting routine for this database."
+							Write-Message -Level Warning -Message "Failed to attach $dbname to $destination. Aborting routine for this database." 
 							continue
 						}
 					}
@@ -1104,8 +1116,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 							}
 							catch
 							{
-								Write-Warning "Failed to update DatabaseOwnershipChaining for $sourcedbownerchaining on $dbname on $destination"
-								Write-Exception $_
+								Write-Message -Level Warning -Message "Failed to update DatabaseOwnershipChaining for $sourcedbownerchaining on $dbname on $destination" -Silent
+								Stop-Function -Message "Exception: $_" -Continue -Target $destination
 							}
 						}
 					}
@@ -1122,8 +1134,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 							}
 							catch
 							{
-								Write-Warning "Failed to update Trustworthy to $sourcedbtrustworthy for $dbname on $destination"
-								Write-Exception $_
+								Write-Message -Level Warning -Message  "Failed to update Trustworthy to $sourcedbtrustworthy for $dbname on $destination"
+								Stop-Function -Message "Exception: $_" -Continue -Target $destination 
 							}
 						}
 					}
@@ -1140,8 +1152,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 							}
 							catch
 							{
-								Write-Warning "Failed to update BrokerEnabled to $sourcedbbrokerenabled for $dbname on $destination"
-								Write-Exception $_
+								Write-Message -Level Warning -Message "Failed to update BrokerEnabled to $sourcedbbrokerenabled for $dbname on $destination"
+								Stop-Function -Message "Exception: $_" -Continue -Target $destination 
 							}
 						}
 					}
@@ -1158,8 +1170,8 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						}
 						else
 						{
-							Write-Warning "Failed to update ReadOnly status on $dbname"
-							Write-Exception $_
+							Write-Message -Level Warning -Message  "Failed to update ReadOnly status on $dbname"
+							Stop-Function -Message "Exception: $_" -Continue -Target $destination 
 						}
 					}
 				}
@@ -1190,17 +1202,25 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 	{
 		If ($Pscmdlet.ShouldProcess("console", "Showing migration time elapsed"))
 		{
-			$totaltime = ($elapsed.Elapsed.toString().Split(".")[0])
+            if ($null -ne $elapsed)
+            {
+            		
+        	    $totaltime = ($elapsed.Elapsed.toString().Split(".")[0])
 			
-			Write-Output "`nDatabase migration finished"
-			Write-Output "Migration started: $started"
-			Write-Output "Migration completed: $(Get-Date)"
-			Write-Output "Total Elapsed time: $totaltime"
+			    Write-Output "`nDatabase migration finished"
+			    Write-Output "Migration started: $started"
+			    Write-Output "Migration completed: $(Get-Date)"
+			    Write-Output "Total Elapsed time: $totaltime"
 			
-			if ($networkshare.length -gt 0 -and $NoBackupCleanup)
-			{
-				Write-Warning "Backups still exist at $networkshare."
-			}
+			    if ($networkshare.length -gt 0 -and $NoBackupCleanup)
+			    {
+				    Write-Message -Level Warning -Message "Backups still exist at $networkshare."
+			    }
+            }
+            else
+            {
+                Write-output "No work was done, as we stopped during setup phase"
+            }
 		}
 		
 		$sourceserver.ConnectionContext.Disconnect()

--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -1164,7 +1164,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
                     If ($Pscmdlet.ShouldProcess($destination, "Setting $dbname offline on $source"))
                     {
                         Stop-DbaProcess -SqlServer $sourceserver -Databases $dbname
-                        $sourceserver.databases[$dbname].SetOffline()
+                        Set-DbaDatabaseState -SqlInstance $sourceserver -Credential $SourceSqlCredential -database $dbname -Offline
                     }
                 }
 				

--- a/functions/Copy-SqlDatabase.ps1
+++ b/functions/Copy-SqlDatabase.ps1
@@ -1155,7 +1155,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						
 						#$restoreresult = Restore-SqlDatabase $destserver $dbname $backupfile $filestructure $numberfiles
 						
-						$restoresulttmp = $backupTmpResult | Restore-DbaDatabase -SqlServer $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery	
+						$restoresulttmp = $backupTmpResult | Restore-DbaDatabase -SqlServer $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery -TrustDbBackupHistory
 						$restoreresult = $RestoreResultTmp.RestoreComplete
 						if ($restoreresult -eq $true)
 						{

--- a/internal/Update-SqlDbOwner.ps1
+++ b/internal/Update-SqlDbOwner.ps1
@@ -18,7 +18,24 @@ Internal function. Updates specified database dbowner.
 	)
 	
 	$sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
-	$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
+    try 
+    {
+        if ($Destination -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject])
+        {
+            $Newconnection  = $true
+            $destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $SqlCredential	
+        }
+        else
+        {
+            $destserver = $Destination
+        }
+    }
+    catch 
+    {
+        Write-Warning "$FunctionName - Cannot connect to $SqlServer" 
+        break
+    }
+	#$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 	
 	$source = $sourceserver.DomainInstanceName
 	$destination = $destserver.DomainInstanceName


### PR DESCRIPTION
Fixes #1175 and #1169 

Changes proposed in this pull request:
 - Moved function over to use the new Backup-DbaDatabase/Restore-DbaDatabase functions rather than the internal ones
 - Fixed up Update-SqlDbOwner so it doesn't leabe a session open and block the rest of the copy
 - Added a SetSourceOffline switch to set the source db offline

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

