### PR TITLE
Fix for Get-DbaDatabaseHistory not returning properly in raw mode

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -177,8 +177,12 @@ Function Get-DbaBackupHistory {
                     else {
                         $TLogStartLSN = $fulldb.FirstLsn
                     }
-                    $Allbackups += $Logdb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$raw | Where-object {$_.Type -eq 'Log' -and $_.LastLsn -gt $TLogstartLSN }
-                    $Allbackups | Sort-Object FirstLSN
+					if ($raw)
+					{$Filter = 'first_Lsn'}
+					else
+					{$Filter = 'FirstLsn'}
+                    $Allbackups += $Logdb = Get-DbaBackupHistory -SqlServer $server -Databases $db -raw:$raw | Where-object {$_.Type -eq 'Log' -and $_.$filter -gt $TLogstartLSN }
+                    $Allbackups | Sort-Object $Filter
                 }
 				continue
 			}


### PR DESCRIPTION
Fixes #1178 

Changes proposed in this pull request:
 - Sets the filters for -Last to use a dynamic property name as the output is different for raw/nonraw
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

