### PR TITLE
Fixing BackupHistory

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1235,7 +1235,7 @@ namespace Sqlcollective.Dbatools
             /// <summary>
             /// Where is the backup stored
             /// </summary>
-            public string Path;
+            public string[] Path;
 
             /// <summary>
             /// What is the total size of the backup
@@ -1250,7 +1250,7 @@ namespace Sqlcollective.Dbatools
             /// <summary>
             /// The ID for the Backup job
             /// </summary>
-            public string BackupSetupId;
+            public string BackupSetId;
 
             /// <summary>
             /// What kind of backup-device was the backup stored to
@@ -1265,12 +1265,12 @@ namespace Sqlcollective.Dbatools
             /// <summary>
             /// The full name of the backup
             /// </summary>
-            public string FullName;
+            public string[] FullName;
 
             /// <summary>
             /// The files that are part of this backup
             /// </summary>
-            public string[] FileList;
+            public Object FileList;
 
             /// <summary>
             /// The position of the backup

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -405,7 +405,7 @@ Function Get-DbaBackupHistory {
 					$historyObject.Path = $group.Group.Path
 					$historyObject.TotalSize = ($group.group.TotalSize | Measure-Object -Sum).sum
 					$historyObject.Type = $group.Group[0].Type
-					$historyObject.BackupSetupId = $group.Group[0].BackupSetId
+					$historyObject.BackupSetId = $group.Group[0].BackupSetId
 					$historyObject.DeviceType = $group.Group[0].DeviceType
 					$historyObject.Software = $group.Group[0].Software
 					$historyObject.FullName = $group.Group.Path


### PR DESCRIPTION
Fixes #1196 and #1143

I think I've modified the type definition right, and stuff looks 'righter' at my end. Fred need to confirm though!

And while I'm going this, whats the management view on the different return names? Easy enough to standardise, just which is the preferred one:
Raw:
Name
----
BackupSetID
checkpoint_lsn
Database
database_backup_lsn
DeviceType
Duration
End
first_lsn
FullName
last_lsn
MediaSetId
Path
position
Server
Software
software_major_version
Start
TotalSize
Type
Username

object:
Name
----
BackupSetId
CheckpointLsn
ComputerName
Database
DatabaseBackupLsn
DeviceType
Duration
End
FileList
FirstLsn
FullName
InstanceName
LastLsn
Path
Position
Software
SoftwareVersionMajor
SqlInstance
Start
TotalSize
Type
UserName