### PR TITLE
Copy function rename for 1.0 release

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -262,6 +262,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Alert migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Alert migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlAlert
 	}
 }

--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlAlert
+function Copy-DbaAgentAlert
 {
 <#
 .SYNOPSIS 
-Copy-SqlAlert migrates alerts from one SQL Server to another. 
+Copy-DbaAgentAlert migrates alerts from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all alerts are copied. The -Alerts parameter is autopopulated for command-line completion and can be used to copy only specific alerts.
@@ -45,7 +45,7 @@ Prompts you for confirmation before executing any changing operations within the
 Drops and recreates the Alert if it exists
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -59,20 +59,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlAlert
+https://dbatools.io/Copy-DbaAgentAlert
 
 .EXAMPLE   
-Copy-SqlAlert -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentAlert -Source sqlserver2014a -Destination sqlcluster
 
 Copies all alerts from sqlserver2014a to sqlcluster, using Windows credentials. If alerts with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlAlert -Source sqlserver2014a -Destination sqlcluster -Alert PSAlert -SourceSqlCredential $cred -Force
+Copy-DbaAgentAlert -Source sqlserver2014a -Destination sqlcluster -Alert PSAlert -SourceSqlCredential $cred -Force
 
 Copies a single alert, the PSAlert alert from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a alert with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlAlert -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentAlert -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>
@@ -246,7 +246,7 @@ Shows what would happen if the command were executed using force.
 					if ($e -like '*The specified @operator_name (''*'') does not exist*')
 					{
 						Write-Warning "One or more operators for this alert are not configured and will not be added to this alert."
-						Write-Warning "Please run Copy-SqlOperator if you would like to move operators to destination server."
+						Write-Warning "Please run Copy-DbaAgentOperator if you would like to move operators to destination server."
 					}
 					else
 					{

--- a/functions/Copy-DbaAgentCategory.ps1
+++ b/functions/Copy-DbaAgentCategory.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlAgentCategory
+function Copy-DbaAgentCategory
 {
 <#
 .SYNOPSIS 
-Copy-SqlAgentCategory migrates SQL Agent categories from one SQL Server to another. This is similar to sp_add_category.
+Copy-DbaAgentCategory migrates SQL Agent categories from one SQL Server to another. This is similar to sp_add_category.
 
 https://msdn.microsoft.com/en-us/library/ms181597.aspx
 
@@ -61,7 +61,7 @@ Prompts you for confirmation before executing any changing operations within the
 Drops and recreates the XXXXX if it exists
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -75,20 +75,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlAgentCategory
+https://dbatools.io/Copy-DbaAgentCategory
 
 .EXAMPLE   
-Copy-SqlAgentCategory -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentCategory -Source sqlserver2014a -Destination sqlcluster
 
 Copies all operator categories from sqlserver2014a to sqlcluster, using Windows credentials. If operator categories with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlAgentCategory -Source sqlserver2014a -Destination sqlcluster -OperatorCategory PSOperator -SourceSqlCredential $cred -Force
+Copy-DbaAgentCategory -Source sqlserver2014a -Destination sqlcluster -OperatorCategory PSOperator -SourceSqlCredential $cred -Force
 
 Copies a single operator category, the PSOperator operator category from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a operator category with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlAgentCategory -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentCategory -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>
@@ -110,11 +110,11 @@ Shows what would happen if the command were executed using force.
 	BEGIN
 	{
 		
-		Function Copy-SqlJobCategory
+		Function Copy-JobCategory
 		{
 			<#
 			.SYNOPSIS 
-			Copy-SqlJobCategory migrates job categories from one SQL Server to another. 
+			Copy-JobCategory migrates job categories from one SQL Server to another. 
 
 			.DESCRIPTION
 			By default, all job categories are copied. The -JobCategories parameter is autopopulated for command-line completion and can be used to copy only specific job categories.
@@ -185,11 +185,11 @@ Shows what would happen if the command were executed using force.
 			}
 		}
 		
-		Function Copy-SqlOperatorCategory
+		Function Copy-OperatorCategory
 		{
 			<#
 			.SYNOPSIS 
-			Copy-SqlOperatorCategory migrates operator categories from one SQL Server to another. 
+			Copy-OperatorCategory migrates operator categories from one SQL Server to another. 
 
 			.DESCRIPTION
 			By default, all operator categories are copied. The -OperatorCategories parameter is autopopulated for command-line completion and can be used to copy only specific operator categories.
@@ -264,11 +264,11 @@ Shows what would happen if the command were executed using force.
 			}
 		}
 		
-		Function Copy-SqlAlertCategory
+		Function Copy-AlertCategory
 		{
 			<#
 			.SYNOPSIS 
-			Copy-SqlAlertCategory migrates alert categories from one SQL Server to another. 
+			Copy-AlertCategory migrates alert categories from one SQL Server to another. 
 
 			.DESCRIPTION
 			By default, all alert categories are copied. The -AlertCategories parameter is autopopulated for command-line completion and can be used to copy only specific alert categories.
@@ -368,15 +368,15 @@ Shows what would happen if the command were executed using force.
 			switch ($CategoryType)
 			{
 				"Job" {
-					Copy-SqlJobCategory
+					Copy-JobCategory
 				}
 				
 				"Alert" {
-					Copy-SqlAlertCategory
+					Copy-AlertCategory
 				}
 				
 				"Operator" {
-					Copy-SqlOperatorCategory
+					Copy-OperatorCategory
 				}
 			}
 			
@@ -388,25 +388,25 @@ Shows what would happen if the command were executed using force.
 			
 			if ($operatorcategories.count -gt 0)
 			{
-				Copy-SqlOperatorCategory -OperatorCategories $operatorcategories 
+				Copy-OperatorCategory -OperatorCategories $operatorcategories 
 			}
 			
 			if ($alertcategories.count -gt 0)
 			{
-				Copy-SqlAlertCategory -AlertCategories $alertcategories 
+				Copy-AlertCategory -AlertCategories $alertcategories 
 			}
 			
 			if ($jobcategories.count -gt 0)
 			{
-				Copy-SqlJobCategory -JobCategories $jobcategories 
+				Copy-JobCategory -JobCategories $jobcategories 
 			}
 			
 			return
 		}
 		
-		Copy-SqlOperatorCategory 
-		Copy-SqlAlertCategory 
-		Copy-SqlJobCategory 
+		Copy-OperatorCategory 
+		Copy-AlertCategory 
+		Copy-JobCategory 
 	}
 	
 	END

--- a/functions/Copy-DbaAgentCategory.ps1
+++ b/functions/Copy-DbaAgentCategory.ps1
@@ -415,6 +415,7 @@ Shows what would happen if the command were executed using force.
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Agent category migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Agent category migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlAgentCategory
 	}
 }

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -1,7 +1,7 @@
-function Copy-SqlJob {
+function Copy-DbaAgentJob {
     <#
 .SYNOPSIS
-Copy-SqlJob migrates jobs from one SQL Server to another.
+Copy-DbaAgentJob migrates jobs from one SQL Server to another.
 
 .DESCRIPTION
 By default, all jobs are copied. The -Jobs parameter is autopopulated for command-line completion and can be used to copy only specific jobs.
@@ -50,7 +50,7 @@ Drops and recreates the Job if it exists
 Replaces user friendly yellow warnings with bloody red exceptions of doom!
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -64,20 +64,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlJob
+https://dbatools.io/Copy-DbaAgentJob
 
 .EXAMPLE
-Copy-SqlJob -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentJob -Source sqlserver2014a -Destination sqlcluster
 
 Copies all jobs from sqlserver2014a to sqlcluster, using Windows credentials. If jobs with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE
-Copy-SqlJob -Source sqlserver2014a -Destination sqlcluster -Job PSJob -SourceSqlCredential $cred -Force
+Copy-DbaAgentJob -Source sqlserver2014a -Destination sqlcluster -Job PSJob -SourceSqlCredential $cred -Force
 
 Copies a single job, the PSJob job from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a job with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE
-Copy-SqlJob -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentJob -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -219,5 +219,6 @@ Shows what would happen if the command were executed using force.
         $sourceServer.ConnectionContext.Disconnect()
         $destServer.ConnectionContext.Disconnect()
         if ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Job migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlAlert
     }
 }

--- a/functions/Copy-DbaAgentOperator.ps1
+++ b/functions/Copy-DbaAgentOperator.ps1
@@ -160,6 +160,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Operator migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Operator migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlOperator
 	}
 }

--- a/functions/Copy-DbaAgentOperator.ps1
+++ b/functions/Copy-DbaAgentOperator.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlOperator
+function Copy-DbaAgentOperator
 {
 <#
 .SYNOPSIS 
-Copy-SqlOperator migrates operators from one SQL Server to another. 
+Copy-DbaAgentOperator migrates operators from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all operators are copied. The -Operators parameter is autopopulated for command-line completion and can be used to copy only specific operators.
@@ -42,7 +42,7 @@ Prompts you for confirmation before executing any changing operations within the
 Drops and recreates the Operator if it exists
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -56,20 +56,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlOperator
+https://dbatools.io/Copy-DbaAgentOperator
 
 .EXAMPLE   
-Copy-SqlOperator -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentOperator -Source sqlserver2014a -Destination sqlcluster
 
 Copies all operators from sqlserver2014a to sqlcluster, using Windows credentials. If operators with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlOperator -Source sqlserver2014a -Destination sqlcluster -Operator PSOperator -SourceSqlCredential $cred -Force
+Copy-DbaAgentOperator -Source sqlserver2014a -Destination sqlcluster -Operator PSOperator -SourceSqlCredential $cred -Force
 
 Copies a single operator, the PSOperator operator from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an operator with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlOperator -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentOperator -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -175,6 +175,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server proxy account migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server proxy account migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlProxyAccount
 	}
 }

--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlProxyAccount
+function Copy-DbaAgentProxyAccount
 {
 <#
 .SYNOPSIS 
-Copy-SqlProxyAccount migrates proxy accounts from one SQL Server to another. 
+Copy-DbaAgentProxyAccount migrates proxy accounts from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all proxy accounts are copied. The -ProxyAccounts parameter is autopopulated for command-line completion and can be used to copy only specific proxy accounts.
@@ -41,7 +41,7 @@ Prompts you for confirmation before executing any changing operations within the
 Drops and recreates the Proxy Account if it exists
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlProxyAccount
+https://dbatools.io/Copy-DbaAgentProxyAccount
 
 .EXAMPLE   
-Copy-SqlProxyAccount -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentProxyAccount -Source sqlserver2014a -Destination sqlcluster
 
 Copies all proxy accounts from sqlserver2014a to sqlcluster, using Windows credentials. If proxy accounts with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlProxyAccount -Source sqlserver2014a -Destination sqlcluster -ProxyAccount PSProxy -SourceSqlCredential $cred -Force
+Copy-DbaAgentProxyAccount -Source sqlserver2014a -Destination sqlcluster -ProxyAccount PSProxy -SourceSqlCredential $cred -Force
 
 Copies a single proxy account, the PSProxy proxy account from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a proxy account with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlProxyAccount -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentProxyAccount -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaAgentSharedSchedule.ps1
+++ b/functions/Copy-DbaAgentSharedSchedule.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlSharedSchedule
+function Copy-DbaAgentSharedSchedule
 {
 <#
 .SYNOPSIS 
-Copy-SqlSharedSchedule migrates shared job schedules from one SQL Server to another. 
+Copy-DbaAgentSharedSchedule migrates shared job schedules from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all shared job schedules are copied. The -SharedSchedules parameter is autopopulated for command-line completion and can be used to copy only specific shared job schedules.
@@ -41,7 +41,7 @@ Prompts you for confirmation before executing any changing operations within the
 Drops and recreates the schedule if it exists
 
 .NOTES
-Tags: Migration
+Tags: Migration, Agent
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlSharedSchedule
+https://dbatools.io/Copy-DbaAgentSharedSchedule
 
 .EXAMPLE   
-Copy-SqlSharedSchedule -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaAgentSharedSchedule -Source sqlserver2014a -Destination sqlcluster
 
 Copies all shared job schedules from sqlserver2014a to sqlcluster, using Windows credentials. If shared job schedules with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlSharedSchedule -Source sqlserver2014a -Destination sqlcluster -SharedSchedule Weekly -SourceSqlCredential $cred -Force
+Copy-DbaAgentSharedSchedule -Source sqlserver2014a -Destination sqlcluster -SharedSchedule Weekly -SourceSqlCredential $cred -Force
 
 Copies a single shared job schedule, the Weekly shared job schedule from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a shared job schedule with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlSharedSchedule -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaAgentSharedSchedule -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaAgentSharedSchedule.ps1
+++ b/functions/Copy-DbaAgentSharedSchedule.ps1
@@ -165,6 +165,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Job schedule migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Job schedule migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlSharedSchedule
 	}
 }

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -216,6 +216,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "backup device migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "backup device migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlBackupDevice
 	}
 }

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlBackupDevice
+function Copy-DbaBackupDevice
 {
 <#
 .SYNOPSIS
@@ -57,21 +57,21 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlBackupDevice
+https://dbatools.io/Copy-DbaBackupDevice
 
 .EXAMPLE   
-Copy-SqlBackupDevice -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server backup devices from sqlserver2014a to sqlcluster, using Windows credentials. If backup devices with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlBackupDevice -Source sqlserver2014a -Destination sqlcluster -BackupDevices backup01 -SourceSqlCredential $cred -Force
+Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster -BackupDevices backup01 -SourceSqlCredential $cred -Force
 
 Copies a single backup device, backup01, from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a
 and Windows credentials for sqlcluster. If a backup device with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlBackupDevice -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaCentralManagementServer.ps1
+++ b/functions/Copy-DbaCentralManagementServer.ps1
@@ -1,11 +1,11 @@
-Function Copy-SqlCentralManagementServer
+function Copy-DbaCentralManagementServer
 {
 <# 
 .SYNOPSIS 
 Migrates SQL Server Central Management groups and server instances from one SQL Server to another.
 
 .DESCRIPTION 
-Copy-SqlCentralManagementServer copies all groups, subgroups, and server instances from one SQL Server to another. 
+Copy-DbaCentralManagementServer copies all groups, subgroups, and server instances from one SQL Server to another. 
 
 .PARAMETER Source
 The SQL Server Central Management Server you are migrating from.
@@ -15,7 +15,7 @@ The SQL Server Central Management Server you are migrating to.
 
 .PARAMETER CMSGroups
 This is an auto-populated array that contains your Central Management Server top-level groups on $Source. You can specify one, many or none.
-If -CMSGroups is not specified, the Copy-SqlCentralManagementServer script will migrate all groups in your Central Management Server. Note this variable is only populated by top level groups.
+If -CMSGroups is not specified, the Copy-DbaCentralManagementServer script will migrate all groups in your Central Management Server. Note this variable is only populated by top level groups.
 
 .PARAMETER SwitchServerName
 Central Management Server does not allow you to add a shared registered server with the same name as the Configuration Server. If you wish to change all migrating instance names of $Destination to $Source, use this switch.
@@ -60,20 +60,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlCentralManagementServer
+https://dbatools.io/Copy-DbaCentralManagementServer
 
 .EXAMPLE   
-Copy-SqlCentralManagementServer -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaCentralManagementServer -Source sqlserver2014a -Destination sqlcluster
 
 In the above example, all groups, subgroups, and server instances are copied from sqlserver's Central Management Server to sqlcluster's Central Management Server.
 
 .EXAMPLE   
-Copy-SqlCentralManagementServer -Source sqlserver2014a -Destination sqlcluster -CMSGroups Group1,Group3
+Copy-DbaCentralManagementServer -Source sqlserver2014a -Destination sqlcluster -CMSGroups Group1,Group3
 
 In the above example, top level Group1 and Group3, along with its subgroups and server instances are copied from sqlserver to sqlcluster.
 
 .EXAMPLE   
-Copy-SqlCentralManagementServer -Source sqlserver2014a -Destination sqlcluster -CMSGroups Group1,Group3 -SwitchServerName -SourceSqlCredential $SourceSqlCredential -DestinationSqlCredential $DestinationSqlCredential
+Copy-DbaCentralManagementServer -Source sqlserver2014a -Destination sqlcluster -CMSGroups Group1,Group3 -SwitchServerName -SourceSqlCredential $SourceSqlCredential -DestinationSqlCredential $DestinationSqlCredential
 
 In the above example, top level Group1 and Group3, along with its subgroups and server instances are copied from sqlserver to sqlcluster. When adding sql instances to sqlcluster, if the server name of the migrating instance is "sqlcluster", it will be switched to "sqlserver". If SwitchServerName is not specified, "sqlcluster" will be skipped.
 

--- a/functions/Copy-DbaCentralManagementServer.ps1
+++ b/functions/Copy-DbaCentralManagementServer.ps1
@@ -293,9 +293,9 @@ In the above example, top level Group1 and Group3, along with its subgroups and 
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) 
-		{ 
-			Write-Output "Central Management Server migration finished" 
-		}
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { 
+            Write-Output "Central Management Server migration finished" 
+        }
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlCentralManagementServer
 	}
 }

--- a/functions/Copy-DbaCredential.ps1
+++ b/functions/Copy-DbaCredential.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlCredential
+function Copy-DbaCredential
 {
 <# 
 .SYNOPSIS 
-Copy-SqlCredential migrates SQL Server Credentials from one SQL Server to another, while maintaining Credential passwords.
+Copy-DbaCredential migrates SQL Server Credentials from one SQL Server to another, while maintaining Credential passwords.
 
 .DESCRIPTION 
 By using password decryption techniques provided by Antti Rantasaari (NetSPI, 2014), this script migrates SQL Server Credentials from one server to another, while maintaining username and password.
@@ -64,16 +64,16 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlCredential
+https://dbatools.io/Copy-DbaCredential
 
 .EXAMPLE   
-Copy-SqlCredential -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaCredential -Source sqlserver2014a -Destination sqlcluster
 
 Description
 Copies all SQL Server Credentials on sqlserver2014a to sqlcluster. If credentials exist on destination, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlCredential -Source sqlserver2014a -Destination sqlcluster -Credentials "PowerShell Proxy Account" -Force
+Copy-DbaCredential -Source sqlserver2014a -Destination sqlcluster -Credentials "PowerShell Proxy Account" -Force
 
 Description
 Copies over one SQL Server Credential (PowerShell Proxy Account) from sqlserver to sqlcluster. If the credential already exists on the destination, it will be dropped and recreated.

--- a/functions/Copy-DbaCredential.ps1
+++ b/functions/Copy-DbaCredential.ps1
@@ -393,6 +393,7 @@ Copies over one SQL Server Credential (PowerShell Proxy Account) from sqlserver 
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Credential migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Credential migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlCredential
 	}
 }

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -165,6 +165,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Custom error migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Custom error migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlCustomError
 	}
 } 

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlCustomError
+function Copy-DbaCustomError
 {
 <#
 .SYNOPSIS 
-Copy-SqlCustomError migrates custom errors (user defined messages) from one SQL Server to another. 
+Copy-DbaCustomError migrates custom errors (user defined messages) from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all  custom errors are copied. The -CustomErrors parameter is autopopulated for command-line completion and can be used to copy only specific custom errors.
@@ -57,20 +57,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlCustomError
+https://dbatools.io/Copy-DbaCustomError
 
 .EXAMPLE   
-Copy-SqlCustomError -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server custom errors from sqlserver2014a to sqlcluster, using Windows credentials. If custom errors with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlCustomError -Source sqlserver2014a -Destination sqlcluster -Trigger 60000 -SourceSqlCredential $cred -Force
+Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster -Trigger 60000 -SourceSqlCredential $cred -Force
 
 Copies a single custom error, the custom error with ID number 6000 from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a custom error with the same name exists on sqlcluster, it will be updated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlCustomError -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlDatabase
+function Copy-DbaDatabase
 {
 <#
 .SYNOPSIS 
@@ -91,7 +91,7 @@ Takes dbobject from pipeline
 Number of files to split the backup. Default is 3.
 
 .PARAMETER NoCopyOnly
-By default, Copy-SqlDatabase backups are backed up with COPY_ONLY, which avoids breaking the LSN backup chain. This parameter will set CopyOnly to $false.
+By default, Copy-DbaDatabase backups are backed up with COPY_ONLY, which avoids breaking the LSN backup chain. This parameter will set CopyOnly to $false.
 
 .PARAMETER SetSourceOffline
 Sets the Source db to offline after copy
@@ -119,21 +119,21 @@ You should have received a copy of the GNU General Public License along with thi
 
 
 .LINK
-https://dbatools.io/Copy-SqlDatabase
+https://dbatools.io/Copy-DbaDatabase
 
 .EXAMPLE
-Copy-SqlDatabase -Source sqlserver2014a -Destination sqlserver2014b -Database TestDB -BackupRestore -NetworkShare \\fileshare\sql\migration
+Copy-DbaDatabase -Source sqlserver2014a -Destination sqlserver2014b -Database TestDB -BackupRestore -NetworkShare \\fileshare\sql\migration
 
 Migrates a single user database TestDB using Backup and restore from instance sqlserver2014a to sqlserver2014b. Backup files are stored in \\fileshare\sql\migration.
 
 .EXAMPLE   
-Copy-SqlDatabase -Source sqlserver2014a -Destination sqlcluster -DetachAttach -Reattach
+Copy-DbaDatabase -Source sqlserver2014a -Destination sqlcluster -DetachAttach -Reattach
 
 Databases will be migrated from sqlserver2014a to sqlcluster using the detach/copy files/attach method.The following will be perfomed: kick all users out of the database, detach all data/log files, move files across the network over an admin share (\\SqlSERVER\M$\MSSql...), attach file on destination server, reattach at source. If the database files (*.mdf, *.ndf, *.ldf) on *destination* exist and aren't in use, they will be overwritten.
 
 
 .EXAMPLE   
-Copy-SqlDatabase -Source sqlserver2014a -Destination sqlcluster -Exclude Northwind, pubs -IncludeSupportDbs -Force -BackupRestore -NetworkShare \\fileshare\sql\migration
+Copy-DbaDatabase -Source sqlserver2014a -Destination sqlcluster -Exclude Northwind, pubs -IncludeSupportDbs -Force -BackupRestore -NetworkShare \\fileshare\sql\migration
 
 Migrates all user databases except for Northwind and pubs by using backup/restore (copy-only). Backup files are stored in \\fileshare\sql\migration. If the database exists on the destination, it will be dropped prior to attach.
 

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1224,6 +1224,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		}
 		
 		$sourceserver.ConnectionContext.Disconnect()
-		$destserver.ConnectionContext.Disconnect()
+        $destserver.ConnectionContext.Disconnect()
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlDatabase
 	}
 }

--- a/functions/Copy-DbaDatabaseAssembly.ps1
+++ b/functions/Copy-DbaDatabaseAssembly.ps1
@@ -208,6 +208,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Assembly migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Assembly migration finished" }
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlDatabaseAssembly
 	}
 }

--- a/functions/Copy-DbaDatabaseAssembly.ps1
+++ b/functions/Copy-DbaDatabaseAssembly.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlDatabaseAssembly
+function Copy-DbaDatabaseAssembly
 {
 <#
 .SYNOPSIS 
-Copy-SqlDatabaseAssembly migrates assemblies from one SQL Server to another. 
+Copy-DbaDatabaseAssembly migrates assemblies from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all assemblies are copied. The -Assemblies parameter is autopopulated for command-line completion and can be used to copy only specific assemblies.
@@ -60,19 +60,19 @@ You should have received a copy of the GNU General Public License along with thi
 http://dbatools.io/Get-SqlDatabaseAssembly
 
 .EXAMPLE   
-Copy-SqlDatabaseAssembly -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaDatabaseAssembly -Source sqlserver2014a -Destination sqlcluster
 
 Copies all assemblies from sqlserver2014a to sqlcluster, using Windows credentials. If assemblies with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlDatabaseAssembly -Source sqlserver2014a -Destination sqlcluster -Assemblies dbname.assemblyname, dbname3.anotherassembly -SourceSqlCredential $cred -Force
+Copy-DbaDatabaseAssembly -Source sqlserver2014a -Destination sqlcluster -Assemblies dbname.assemblyname, dbname3.anotherassembly -SourceSqlCredential $cred -Force
 
 Copies two assemblies, the dbname.assemblyname and dbname3.anotherassembly, from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a assembly with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 	
 In this example, anotherassembly will be copied to the dbname3 database on the server "sqlcluster".
 	
 .EXAMPLE   
-Copy-SqlThing -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaThing -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaDatabaseMail.ps1
+++ b/functions/Copy-DbaDatabaseMail.ps1
@@ -91,347 +91,350 @@ Copy-DbaDatabaseMail -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 #>
-	[cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
-	param (
-		[parameter(Mandatory = $true)]
-		[object]$Source,
-		[parameter(Mandatory = $true)]
-		[object]$Destination,
-		[Parameter(ParameterSetName = 'SpecifcTypes')]
-		[ValidateSet('ConfigurationValues', 'Profiles', 'Accounts', 'mailServers')]
-		[string[]]$Type,
-		[System.Management.Automation.PSCredential]$SourceSqlCredential,
-		[System.Management.Automation.PSCredential]$DestinationSqlCredential,
-		[switch]$Force,
-		[switch]$Silent
-	)
+    [cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
+    param (
+        [parameter(Mandatory = $true)]
+        [object]$Source,
+        [parameter(Mandatory = $true)]
+        [object]$Destination,
+        [Parameter(ParameterSetName = 'SpecifcTypes')]
+        [ValidateSet('ConfigurationValues', 'Profiles', 'Accounts', 'mailServers')]
+        [string[]]$Type,
+        [System.Management.Automation.PSCredential]$SourceSqlCredential,
+        [System.Management.Automation.PSCredential]$DestinationSqlCredential,
+        [switch]$Force,
+        [switch]$Silent
+    )
 	
-	DynamicParam {
-		if ($source) {
-			return (Get-ParamSqlDatabaseMail -SqlServer $Source -SqlCredential $SourceSqlCredential)
-		}
-	}
+    DynamicParam {
+        if ($source) {
+            return (Get-ParamSqlDatabaseMail -SqlServer $Source -SqlCredential $SourceSqlCredential)
+        }
+    }
 	
-	begin {
+    begin {
 		
-		function Copy-DbaDatabaseMailConfig {
-			[cmdletbinding(SupportsShouldProcess = $true)]
-			param ()
+        function Copy-DbaDatabaseMailConfig {
+            [cmdletbinding(SupportsShouldProcess = $true)]
+            param ()
 			
-			Write-Message -Message "Migrating mail server configuration values" -Level Verbose
-			$copyMailConfigStatus = [pscustomobject]@{
-				SourceServer = $sourceServer
-				DestinationServer = $destServer
-				Name = "Mail Configuration"
-				Type = "Configuration"
-				Status = $null
-				DateTime = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
-			}
-			if ($pscmdlet.ShouldProcess($destination, "Migrating all mail server configuration values")) {
-				try {
-					$sql = $mail.ConfigurationValues.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
-					Write-Message -Message $sql -Level Debug
-					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
-					$mail.ConfigurationValues.Refresh()
-					$copyMailConfigStatus.Status = "Successful"
-				}
-				catch {
-					$copyMailConfigStatus.Status = "Failed"
-					$copyMailConfigStatus
-					Stop-Function -Message "Unable to migrate mail configuration" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Silent $Silent
-				}
-			}
-			$copyMailConfigStatus
-		}
+            Write-Message -Message "Migrating mail server configuration values" -Level Verbose
+            $copyMailConfigStatus = [pscustomobject]@{
+                SourceServer      = $sourceServer
+                DestinationServer = $destServer
+                Name              = "Mail Configuration"
+                Type              = "Configuration"
+                Status            = $null
+                DateTime          = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
+            }
+            if ($pscmdlet.ShouldProcess($destination, "Migrating all mail server configuration values")) {
+                try {
+                    $sql = $mail.ConfigurationValues.Script() | Out-String
+                    $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                    Write-Message -Message $sql -Level Debug
+                    $destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+                    $mail.ConfigurationValues.Refresh()
+                    $copyMailConfigStatus.Status = "Successful"
+                }
+                catch {
+                    $copyMailConfigStatus.Status = "Failed"
+                    $copyMailConfigStatus
+                    Stop-Function -Message "Unable to migrate mail configuration" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Silent $Silent
+                }
+            }
+            $copyMailConfigStatus
+        }
 		
-		function Copy-DbaDatabaseAccount {
-			$sourceAccounts = $sourceServer.Mail.Accounts
-			$destAccounts = $destServer.Mail.Accounts
+        function Copy-DbaDatabaseAccount {
+            $sourceAccounts = $sourceServer.Mail.Accounts
+            $destAccounts = $destServer.Mail.Accounts
 			
-			Write-Message -Message "Migrating accounts" -Level Verbose
-			foreach ($account in $sourceAccounts) {
-				$accountName = $account.name
-				$copyMailAccountStatus = [pscustomobject]@{
-					SourceServer = $sourceServer
-					DestinationServer = $destServer
-					Name = $accountName
-					Type = "Mail Account"
-					Status = $null
-					DateTime = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
-				}
+            Write-Message -Message "Migrating accounts" -Level Verbose
+            foreach ($account in $sourceAccounts) {
+                $accountName = $account.name
+                $copyMailAccountStatus = [pscustomobject]@{
+                    SourceServer      = $sourceServer
+                    DestinationServer = $destServer
+                    Name              = $accountName
+                    Type              = "Mail Account"
+                    Status            = $null
+                    DateTime          = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
+                }
 				
-				if ($accounts.count -gt 0 -and $accounts -notcontains $accountName) {
-					Stop-Function -Message "No matching accounts found" -Continue -Silent $Silent
-				}
+                if ($accounts.count -gt 0 -and $accounts -notcontains $accountName) {
+                    Stop-Function -Message "No matching accounts found" -Continue -Silent $Silent
+                }
 				
-				if ($destAccounts.name -contains $accountName) {
-					if ($force -eq $false) {
-						$copyMailAccountStatus.Status = "Skipped"
-						$copyMailAccountStatus
-						Stop-Function -Message "Account $accountName exists at destination. Use -Force to drop and migrate." -Continue -Silent $Silent
-					}
+                if ($destAccounts.name -contains $accountName) {
+                    if ($force -eq $false) {
+                        $copyMailAccountStatus.Status = "Skipped"
+                        $copyMailAccountStatus
+                        Stop-Function -Message "Account $accountName exists at destination. Use -Force to drop and migrate." -Continue -Silent $Silent
+                    }
 					
-					If ($pscmdlet.ShouldProcess($destination, "Dropping account $accountName and recreating")) {
-						try {
-							Write-Message -Message "Dropping account $accountName" -Level Verbose
-							$destServer.Mail.Accounts[$accountName].Drop()
-							$destServer.Mail.Accounts.Refresh()
-						}
-						catch {
-							$copyMailAccountStatus.Status = "Failed"
-							$copyMailAccountStatus
-							Stop-Function -Message "Issue dropping account" -Target $accountName -InnerErrorRecord $_ -Continue -Silent $Silent
-						}
-					}
-				}
+                    If ($pscmdlet.ShouldProcess($destination, "Dropping account $accountName and recreating")) {
+                        try {
+                            Write-Message -Message "Dropping account $accountName" -Level Verbose
+                            $destServer.Mail.Accounts[$accountName].Drop()
+                            $destServer.Mail.Accounts.Refresh()
+                        }
+                        catch {
+                            $copyMailAccountStatus.Status = "Failed"
+                            $copyMailAccountStatus
+                            Stop-Function -Message "Issue dropping account" -Target $accountName -InnerErrorRecord $_ -Continue -Silent $Silent
+                        }
+                    }
+                }
 				
-				if ($pscmdlet.ShouldProcess($destination, "Migrating account $accountName")) {
-					try {
-						Write-Message -Message "Copying mail account $accountName" -Level Verbose
-						$sql = $account.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
-						Write-Message -Message $sql -Level Debug
-						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
-						$copyMailAccountStatus.Status = "Successful"
-					}
-					catch {
-						$copyMailAccountStatus.Status = "Failed"
-						$copyMailAccountStatus
-						Stop-Function -Message "Issue copying mail account" -Target $accountName -InnerErrorRecord $_ -Silent $Silent
-					}
-				}
-				$copyMailAccountStatus
-			}
-		}
+                if ($pscmdlet.ShouldProcess($destination, "Migrating account $accountName")) {
+                    try {
+                        Write-Message -Message "Copying mail account $accountName" -Level Verbose
+                        $sql = $account.Script() | Out-String
+                        $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                        Write-Message -Message $sql -Level Debug
+                        $destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+                        $copyMailAccountStatus.Status = "Successful"
+                    }
+                    catch {
+                        $copyMailAccountStatus.Status = "Failed"
+                        $copyMailAccountStatus
+                        Stop-Function -Message "Issue copying mail account" -Target $accountName -InnerErrorRecord $_ -Silent $Silent
+                    }
+                }
+                $copyMailAccountStatus
+            }
+        }
 		
-		function Copy-DbaDatabaseMailProfile {
+        function Copy-DbaDatabaseMailProfile {
 			
-			$sourceProfiles = $sourceServer.Mail.Profiles
-			$destProfiles = $destServer.Mail.Profiles
+            $sourceProfiles = $sourceServer.Mail.Profiles
+            $destProfiles = $destServer.Mail.Profiles
 			
-			Write-Message -Message "Migrating mail profiles" -Level Verbose
-			foreach ($profile in $sourceProfiles) {
+            Write-Message -Message "Migrating mail profiles" -Level Verbose
+            foreach ($profile in $sourceProfiles) {
 				
-				$profileName = $profile.name
-				$copyMailProfileStatus = [pscustomobject]@{
-					SourceServer = $sourceServer
-					DestinationServer = $destServer
-					Name = $profileName
-					Type = "Mail Profile"
-					Status = $null
-					DateTime = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
-				}
+                $profileName = $profile.name
+                $copyMailProfileStatus = [pscustomobject]@{
+                    SourceServer      = $sourceServer
+                    DestinationServer = $destServer
+                    Name              = $profileName
+                    Type              = "Mail Profile"
+                    Status            = $null
+                    DateTime          = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
+                }
 				
-				if ($profiles.count -gt 0 -and $profiles -notcontains $profileName) {
-					Stop-Function -Message "No matching profiles found" -Continue -Silent $Silent
-				}
+                if ($profiles.count -gt 0 -and $profiles -notcontains $profileName) {
+                    Stop-Function -Message "No matching profiles found" -Continue -Silent $Silent
+                }
 				
-				if ($destProfiles.name -contains $profileName) {
-					if ($force -eq $false) {
-						$copyMailProfileStatus.Status = "Skipped"
-						$copyMailProfileStatus
-						Stop-Function -Message "Profile $profileName exists at destination. Use -Force to drop and migrate." -Continue -Silent $Silent
-					}
+                if ($destProfiles.name -contains $profileName) {
+                    if ($force -eq $false) {
+                        $copyMailProfileStatus.Status = "Skipped"
+                        $copyMailProfileStatus
+                        Stop-Function -Message "Profile $profileName exists at destination. Use -Force to drop and migrate." -Continue -Silent $Silent
+                    }
 					
-					If ($pscmdlet.ShouldProcess($destination, "Dropping profile $profileName and recreating")) {
-						try {
-							Write-Message -Message "Dropping profile $profileName" -Level Verbose
-							$destServer.Mail.Profiles[$profileName].Drop()
+                    If ($pscmdlet.ShouldProcess($destination, "Dropping profile $profileName and recreating")) {
+                        try {
+                            Write-Message -Message "Dropping profile $profileName" -Level Verbose
+                            $destServer.Mail.Profiles[$profileName].Drop()
 							$destServer.Mail.Profiles.Refresh()
-						}
-						catch {
-							$copyMailProfileStatus.Status = "Failed"
-							$copyMailProfileStatus
-							Stop-Function -Message "Issue dropping profile" -Target $profileName -InnerErrorRecord $_ -Continue -Silent $Silent
-						}
-					}
-				}
+                        }
+                        catch {
+                            $copyMailProfileStatus.Status = "Failed"
+                            $copyMailProfileStatus
+                            Stop-Function -Message "Issue dropping profile" -Target $profileName -InnerErrorRecord $_ -Continue -Silent $Silent
+                        }
+                    }
+                }
 				
-				if ($pscmdlet.ShouldProcess($destination, "Migrating mail profile $profileName")) {
-					try {
-						Write-Message -Message "Copying mail profile $profileName" -Level Verbose
-						$sql = $profile.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
-						Write-Message -Message $sql -Level Debug
-						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
-						$destServer.Mail.Profiles.Refresh()
-						$copyMailProfileStatus.Status = "Successful"
-					}
-					catch {
-						$copyMailProfileStatus.Status = "Failed"
-						$copyMailProfileStatus
-						Stop-Function -Message "Issue copying mail profile" -Target $profileName -InnerErrorRecord $_ -Silent $Silent
-					}
-				}
-				$copyMailProfileStatus
-			}
-		}
+                if ($pscmdlet.ShouldProcess($destination, "Migrating mail profile $profileName")) {
+                    try {
+                        Write-Message -Message "Copying mail profile $profileName" -Level Verbose
+                        $sql = $profile.Script() | Out-String
+                        $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                        Write-Message -Message $sql -Level Debug
+                        $destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+                        $destServer.Mail.Profiles.Refresh()
+                        $copyMailProfileStatus.Status = "Successful"
+                    }
+                    catch {
+                        $copyMailProfileStatus.Status = "Failed"
+                        $copyMailProfileStatus
+                        Stop-Function -Message "Issue copying mail profile" -Target $profileName -InnerErrorRecord $_ -Silent $Silent
+                    }
+                }
+                $copyMailProfileStatus
+            }
+        }
 		
-		function Copy-DbaDatabasemailServer {
-			$sourceMailServers = $sourceServer.Mail.Accounts.mailServers
-			$destMailServers = $destServer.Mail.Accounts.mailServers
+        function Copy-DbaDatabasemailServer {
+            $sourceMailServers = $sourceServer.Mail.Accounts.mailServers
+            $destMailServers = $destServer.Mail.Accounts.mailServers
 			
-			Write-Message -Message "Migrating mail servers" -Level Verbose
-			foreach ($mailServer in $sourceMailServers) {
-				$mailServerName = $mailServer.name
-				$copyMailServerStatus = [pscustomobject]@{
-					SourceServer = $sourceServer
-					DestinationServer = $destServer
-					Name = $mailServerName
-					Type = "Mail Server"
-					Status = $null
-					DateTime = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
-				}
-				if ($mailServers.count -gt 0 -and $mailServers -notcontains $mailServerName) {
-					Stop-Function -Message "No data found" -Continue -Silent $Silent
-				}
+            Write-Message -Message "Migrating mail servers" -Level Verbose
+            foreach ($mailServer in $sourceMailServers) {
+                $mailServerName = $mailServer.name
+                $copyMailServerStatus = [pscustomobject]@{
+                    SourceServer      = $sourceServer
+                    DestinationServer = $destServer
+                    Name              = $mailServerName
+					Type                             = "Mail Server"
+                    Status            = $null
+                    DateTime          = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
+                }
+                if ($mailServers.count -gt 0 -and $mailServers -notcontains $mailServerName) {
+                    Stop-Function -Message "No data found" -Continue -Silent $Silent
+                }
 				
-				if ($destMailServers.name -contains $mailServerName) {
-					if ($force -eq $false) {
-						$copyMailServerStatus.Status = "Skipped"
-						$copyMailServerStatus
-						Stop-Function -Message "Mail server $mailServerName exists at destination. Use -Force to drop and migrate." -Target $mailServerName -Silent $Silent -Continue
-					}
+                if ($destMailServers.name -contains $mailServerName) {
+                    if ($force -eq $false) {
+                        $copyMailServerStatus.Status = "Skipped"
+                        $copyMailServerStatus
+                        Stop-Function -Message "Mail server $mailServerName exists at destination. Use -Force to drop and migrate." -Target $mailServerName -Silent $Silent -Continue
+                    }
 					
-					If ($pscmdlet.ShouldProcess($destination, "Dropping mail server $mailServerName and recreating")) {
-						try {
-							Write-Message -Message "Dropping mail server $mailServerName" -Level Verbose
-							$destServer.Mail.Accounts.mailServers[$mailServerName].Drop()
-						}
-						catch {
+                    If ($pscmdlet.ShouldProcess($destination, "Dropping mail server $mailServerName and recreating")) {
+                        try {
+                            Write-Message -Message "Dropping mail server $mailServerName" -Level Verbose
+                            $destServer.Mail.Accounts.mailServers[$mailServerName].Drop()
+                        }
+                        catch {
 							$copyMailServerStatus.Status = "Failed"
-							$copyMailServerStatus
-							Stop-Function -Message "Issue dropping mail server" -Target $mailServerName -InnerErrorRecord $_ -Continue -Silent $Silent
-						}
-					}
-				}
+                            $copyMailServerStatus
+                            Stop-Function -Message "Issue dropping mail server" -Target $mailServerName -InnerErrorRecord $_ -Continue -Silent $Silent
+                        }
+                    }
+                }
 				
-				if ($pscmdlet.ShouldProcess($destination, "Migrating account mail server $mailServerName")) {
-					try {
-						Write-Message -Message "Copying mail server $mailServerName" -Level Verbose
-						$sql = $mailServer.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
-						Write-Message -Message $sql -Level Debug
-						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
-						$copyMailServerStatus.Status = "Successful"
-					}
-					catch {
-						$copyMailServerStatus.Status = "Failed"
-						$copyMailServerStatus
-						Stop-Function -Message "Issue copying mail server" -Target $mailServerName -InnerErrorRecord $_ -Silent $Silent
-					}
-				}
-			}
-		}
+                if ($pscmdlet.ShouldProcess($destination, "Migrating account mail server $mailServerName")) {
+                    try {
+                        Write-Message -Message "Copying mail server $mailServerName" -Level Verbose
+                        $sql = $mailServer.Script() | Out-String
+                        $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                        Write-Message -Message $sql -Level Debug
+                        $destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+                        $copyMailServerStatus.Status = "Successful"
+                    }
+                    catch {
+                        $copyMailServerStatus.Status = "Failed"
+                        $copyMailServerStatus
+                        Stop-Function -Message "Issue copying mail server" -Target $mailServerName -InnerErrorRecord $_ -Silent $Silent
+                    }
+                }
+            }
+        }
 		
-		$sourceServer = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
-		$destServer = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
+        $sourceServer = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
+        $destServer = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 		
-		$source = $sourceServer.DomainInstanceName
-		$destination = $destServer.DomainInstanceName
+        $source = $sourceServer.DomainInstanceName
+        $destination = $destServer.DomainInstanceName
 		
 		
-		if ($sourceServer.versionMajor -lt 9 -or $destServer.versionMajor -lt 9) {
-			Stop-Function -Message "Database Mail is only supported in SQL Server 2005 and above. Quitting." -Silent $Silent
-		}
+        if ($sourceServer.versionMajor -lt 9 -or $destServer.versionMajor -lt 9) {
+            Stop-Function -Message "Database Mail is only supported in SQL Server 2005 and above. Quitting." -Silent $Silent
+        }
 		
-		$mail = $sourceServer.mail
-	}
-	process {
+        $mail = $sourceServer.mail
+    }
+    process {
 		
-		if ($type.count -gt 0) {
+        if ($type.count -gt 0) {
 			
-			switch ($type) {
-				"ConfigurationValues" {
-					Copy-DbaDatabaseMailConfig
-					$destServer.Mail.ConfigurationValues.Refresh()
-				}
+            switch ($type) {
+                "ConfigurationValues" {
+                    Copy-DbaDatabaseMailConfig
+                    $destServer.Mail.ConfigurationValues.Refresh()
+                }
 				
-				"Profiles" {
-					Copy-DbaDatabaseMailProfile
-					$destServer.Mail.Profiles.Refresh()
-				}
+                "Profiles" {
+                    Copy-DbaDatabaseMailProfile
+                    $destServer.Mail.Profiles.Refresh()
+                }
 				
-				"Accounts" {
-					Copy-DbaDatabaseAccount
-					$destServer.Mail.Accounts.Refresh()
-				}
+                "Accounts" {
+                    Copy-DbaDatabaseAccount
+                    $destServer.Mail.Accounts.Refresh()
+                }
 				
-				"mailServers" {
-					Copy-DbaDatabasemailServer
-				}
-			}
+                "mailServers" {
+                    Copy-DbaDatabasemailServer
+                }
+            }
 			
-			return
-		}
+            return
+        }
 		
 		
-		$profiles = $psboundparameters.Profiles
-		$accounts = $psboundparameters.Accounts
-		$mailServers = $psboundparameters.mailServers
+        $profiles = $psboundparameters.Profiles
+        $accounts = $psboundparameters.Accounts
+        $mailServers = $psboundparameters.mailServers
 		
-		if (($profiles.count + $accounts.count + $mailServers.count) -gt 0) {
+        if (($profiles.count + $accounts.count + $mailServers.count) -gt 0) {
 			
-			if ($profiles.count -gt 0) {
-				Copy-DbaDatabaseMailProfile -Profiles $profiles
-				$destServer.Mail.Profiles.Refresh()
-			}
+            if ($profiles.count -gt 0) {
+                Copy-DbaDatabaseMailProfile -Profiles $profiles
+                $destServer.Mail.Profiles.Refresh()
+            }
 			
-			if ($accounts.count -gt 0) {
-				Copy-DbaDatabaseAccount -Accounts $accounts
-				$destServer.Mail.Accounts.Refresh()
-			}
+            if ($accounts.count -gt 0) {
+                Copy-DbaDatabaseAccount -Accounts $accounts
+                $destServer.Mail.Accounts.Refresh()
+            }
 			
-			if ($mailServers.count -gt 0) {
-				Copy-DbaDatabasemailServer -mailServers $mailServers
-			}
+            if ($mailServers.count -gt 0) {
+                Copy-DbaDatabasemailServer -mailServers $mailServers
+            }
 			
-			return
-		}
+            return
+        }
 		
-		Copy-DbaDatabaseMailConfig
-		$destServer.Mail.ConfigurationValues.Refresh()
-		Copy-DbaDatabaseAccount
-		$destServer.Mail.Accounts.Refresh()
-		Copy-DbaDatabaseMailProfile
-		$destServer.Mail.Profiles.Refresh()
-		Copy-DbaDatabasemailServer
-		$copyMailConfigStatus
-		$copyMailAccountStatus
-		$copyMailProfileStatus
-		$copyMailServerStatus
-		$enableDBMailStatus
+        Copy-DbaDatabaseMailConfig
+        $destServer.Mail.ConfigurationValues.Refresh()
+        Copy-DbaDatabaseAccount
+        $destServer.Mail.Accounts.Refresh()
+        Copy-DbaDatabaseMailProfile
+        $destServer.Mail.Profiles.Refresh()
+        Copy-DbaDatabasemailServer
+        $copyMailConfigStatus
+        $copyMailAccountStatus
+        $copyMailProfileStatus
+        $copyMailServerStatus
+        $enableDBMailStatus
 		
         <# ToDo: Use Get/Set-DbaSpConfigure once the dynamic parameters are replaced. #>
 		
-		$sourceDbMailEnabled = ($sourceServer.Configuration.DatabaseMailEnabled).ConfigValue
-		Write-Message -Message "$sourceServer DBMail configuration value: $sourceDbMailEnabled" -Level Verbose
+        $sourceDbMailEnabled = ($sourceServer.Configuration.DatabaseMailEnabled).ConfigValue
+        Write-Message -Message "$sourceServer DBMail configuration value: $sourceDbMailEnabled" -Level Verbose
 		
-		$destDbMailEnabled = ($destServer.Configuration.DatabaseMailEnabled).ConfigValue
-		Write-Message -Message "$destServer DBMail configuration value: $destDbMailEnabled" -Level Verbose
-		$enableDBMailStatus = [pscustomobject]@{
-			SourceServer = $sourceServer.name
-			DestinationServer = $destServer.name
-			Name = "Enabled DBMail on Destination"
-			Type = "Configuration"
-			Status = if ($destDbMailEnabled -eq 1) { "Enabled" } else { $null }
-			DateTime = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
-		}
+        $destDbMailEnabled = ($destServer.Configuration.DatabaseMailEnabled).ConfigValue
+        Write-Message -Message "$destServer DBMail configuration value: $destDbMailEnabled" -Level Verbose
+        $enableDBMailStatus = [pscustomobject]@{
+            SourceServer      = $sourceServer.name
+            DestinationServer = $destServer.name
+            Name              = "Enabled DBMail on Destination"
+            Type              = "Configuration"
+            Status            = if ($destDbMailEnabled -eq 1) { "Enabled" } else { $null }
+            DateTime          = [sqlcollective.dbatools.Utility.DbaDateTime](Get-Date)
+        }
 		
-		if (($sourceDbMailEnabled -eq 1) -and ($destDbMailEnabled -eq 0)) {
-			if ($pscmdlet.ShouldProcess($destination, "Enabling Database Mail")) {
-				try {
-					Write-Message -Message "Enabling Database Mail on $destServer" -Level Verbose
-					$destServer.Configuration.DatabaseMailEnabled.ConfigValue = 1
-					$destServer.Alter()
-					$enableDBMailStatus.Status = "Successful"
-				}
-				catch {
-					Stop-Function -Message "Cannot enable Database Mail" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Silent $Silent
-					$enableDBMailStatus.Status = "Failed"
-				}
-			}
-		}
+        if (($sourceDbMailEnabled -eq 1) -and ($destDbMailEnabled -eq 0)) {
+            if ($pscmdlet.ShouldProcess($destination, "Enabling Database Mail")) {
+                try {
+                    Write-Message -Message "Enabling Database Mail on $destServer" -Level Verbose
+                    $destServer.Configuration.DatabaseMailEnabled.ConfigValue = 1
+                    $destServer.Alter()
+                    $enableDBMailStatus.Status = "Successful"
+                }
+                catch {
+                    Stop-Function -Message "Cannot enable Database Mail" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Silent $Silent
+                    $enableDBMailStatus.Status = "Failed"
+                }
+            }
+        }
+    }
+	end {
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlDatabaseMail
 	}
 }

--- a/functions/Copy-DbaDatabaseMail.ps1
+++ b/functions/Copy-DbaDatabaseMail.ps1
@@ -1,4 +1,4 @@
-function Copy-SqlDatabaseMail {
+function Copy-DbaDatabaseMail {
     <#
 .SYNOPSIS
 Migrates Mail Profiles, Accounts, Mail Servers and Mail Server Configs from one SQL Server to another.
@@ -74,20 +74,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlDatabaseMail
+https://dbatools.io/Copy-DbaDatabaseMail
 
 .EXAMPLE
-Copy-SqlDatabaseMail -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaDatabaseMail -Source sqlserver2014a -Destination sqlcluster
 
 Copies all database mail objects from sqlserver2014a to sqlcluster, using Windows credentials. If database mail objects with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE
-Copy-SqlDatabaseMail -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaDatabaseMail -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all database mail objects from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE
-Copy-SqlDatabaseMail -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaDatabaseMail -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 #>
@@ -114,7 +114,7 @@ Shows what would happen if the command were executed.
 	
 	begin {
 		
-		function Copy-SqlDatabaseMailConfig {
+		function Copy-DbaDatabaseMailConfig {
 			[cmdletbinding(SupportsShouldProcess = $true)]
 			param ()
 			
@@ -145,7 +145,7 @@ Shows what would happen if the command were executed.
 			$copyMailConfigStatus
 		}
 		
-		function Copy-SqlDatabaseAccount {
+		function Copy-DbaDatabaseAccount {
 			$sourceAccounts = $sourceServer.Mail.Accounts
 			$destAccounts = $destServer.Mail.Accounts
 			
@@ -205,7 +205,7 @@ Shows what would happen if the command were executed.
 			}
 		}
 		
-		function Copy-SqlDatabaseMailProfile {
+		function Copy-DbaDatabaseMailProfile {
 			
 			$sourceProfiles = $sourceServer.Mail.Profiles
 			$destProfiles = $destServer.Mail.Profiles
@@ -268,7 +268,7 @@ Shows what would happen if the command were executed.
 			}
 		}
 		
-		function Copy-SqlDatabasemailServer {
+		function Copy-DbaDatabasemailServer {
 			$sourceMailServers = $sourceServer.Mail.Accounts.mailServers
 			$destMailServers = $destServer.Mail.Accounts.mailServers
 			
@@ -344,22 +344,22 @@ Shows what would happen if the command were executed.
 			
 			switch ($type) {
 				"ConfigurationValues" {
-					Copy-SqlDatabaseMailConfig
+					Copy-DbaDatabaseMailConfig
 					$destServer.Mail.ConfigurationValues.Refresh()
 				}
 				
 				"Profiles" {
-					Copy-SqlDatabaseMailProfile
+					Copy-DbaDatabaseMailProfile
 					$destServer.Mail.Profiles.Refresh()
 				}
 				
 				"Accounts" {
-					Copy-SqlDatabaseAccount
+					Copy-DbaDatabaseAccount
 					$destServer.Mail.Accounts.Refresh()
 				}
 				
 				"mailServers" {
-					Copy-SqlDatabasemailServer
+					Copy-DbaDatabasemailServer
 				}
 			}
 			
@@ -374,29 +374,29 @@ Shows what would happen if the command were executed.
 		if (($profiles.count + $accounts.count + $mailServers.count) -gt 0) {
 			
 			if ($profiles.count -gt 0) {
-				Copy-SqlDatabaseMailProfile -Profiles $profiles
+				Copy-DbaDatabaseMailProfile -Profiles $profiles
 				$destServer.Mail.Profiles.Refresh()
 			}
 			
 			if ($accounts.count -gt 0) {
-				Copy-SqlDatabaseAccount -Accounts $accounts
+				Copy-DbaDatabaseAccount -Accounts $accounts
 				$destServer.Mail.Accounts.Refresh()
 			}
 			
 			if ($mailServers.count -gt 0) {
-				Copy-SqlDatabasemailServer -mailServers $mailServers
+				Copy-DbaDatabasemailServer -mailServers $mailServers
 			}
 			
 			return
 		}
 		
-		Copy-SqlDatabaseMailConfig
+		Copy-DbaDatabaseMailConfig
 		$destServer.Mail.ConfigurationValues.Refresh()
-		Copy-SqlDatabaseAccount
+		Copy-DbaDatabaseAccount
 		$destServer.Mail.Accounts.Refresh()
-		Copy-SqlDatabaseMailProfile
+		Copy-DbaDatabaseMailProfile
 		$destServer.Mail.Profiles.Refresh()
-		Copy-SqlDatabasemailServer
+		Copy-DbaDatabasemailServer
 		$copyMailConfigStatus
 		$copyMailAccountStatus
 		$copyMailProfileStatus

--- a/functions/Copy-DbaEndpoint.ps1
+++ b/functions/Copy-DbaEndpoint.ps1
@@ -155,6 +155,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server endpoint migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server endpoint migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlEndpoint
 	}
 }

--- a/functions/Copy-DbaEndpoint.ps1
+++ b/functions/Copy-DbaEndpoint.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlEndpoint
+function Copy-DbaEndpoint
 {
 <#
 .SYNOPSIS 
-Copy-SqlEndpoint migrates server endpoints from one SQL Server to another. 
+Copy-DbaEndpoint migrates server endpoints from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all endpoints are copied. The -Endpoints parameter is autopopulated for command-line completion and can be used to copy only specific endpoints.
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlEndpoint
+https://dbatools.io/Copy-DbaEndpoint
 
 .EXAMPLE   
-Copy-SqlEndpoint -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaEndpoint -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server endpoints from sqlserver2014a to sqlcluster, using Windows credentials. If endpoints with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlEndpoint -Source sqlserver2014a -Destination sqlcluster -Endpoint tg_noDbDrop -SourceSqlCredential $cred -Force
+Copy-DbaEndpoint -Source sqlserver2014a -Destination sqlcluster -Endpoint tg_noDbDrop -SourceSqlCredential $cred -Force
 
 Copies a single endpoint, the tg_noDbDrop endpoint from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an endpoint with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlEndpoint -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaEndpoint -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -187,7 +187,8 @@ Copies two Extended Events, CheckQueries and MonitorUserDefinedException, from s
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Extended Event migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Extended Event migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlExtendedEvent
 	}
 }
 

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlExtendedEvent
+function Copy-DbaExtendedEvent
 {
 <#
 .SYNOPSIS
@@ -57,25 +57,25 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlExtendedEvent
+https://dbatools.io/Copy-DbaExtendedEvent
 
 .EXAMPLE   
-Copy-SqlExtendedEvent -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaExtendedEvent -Source sqlserver2014a -Destination sqlcluster
 
 Copies all extended event sessions from sqlserver2014a to sqlcluster, using Windows credentials. 
 
 .EXAMPLE   
-Copy-SqlExtendedEvent -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaExtendedEvent -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all extended event sessions from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlExtendedEvent -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaExtendedEvent -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 	
 .EXAMPLE   
-Copy-SqlExtendedEvent -Source sqlserver2014a -Destination sqlcluster -Sessions CheckQueries, MonitorUserDefinedException 
+Copy-DbaExtendedEvent -Source sqlserver2014a -Destination sqlcluster -Sessions CheckQueries, MonitorUserDefinedException 
 
 Copies two Extended Events, CheckQueries and MonitorUserDefinedException, from sqlserver2014a to sqlcluster.
 #>

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -411,6 +411,7 @@ Copies over two SQL Server Linked Servers (SQL2K and SQL2K2) from sqlserver to s
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Linked Server migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Linked Server migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlLinkedServer
 	}
 }

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlLinkedServer
+function Copy-DbaLinkedServer
 {
 <# 
 .SYNOPSIS 
-Copy-SqlLinkedServer migrates Linked Servers from one SQL Server to another. Linked Server logins and passwords are migrated as well.
+Copy-DbaLinkedServer migrates Linked Servers from one SQL Server to another. Linked Server logins and passwords are migrated as well.
 
 .DESCRIPTION 
 By using password decryption techniques provided by Antti Rantasaari (NetSPI, 2014), this script migrates SQL Server Linked Servers from one server to another, while maintaining username and password.
@@ -64,16 +64,16 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlLinkedServer 
+https://dbatools.io/Copy-DbaLinkedServer 
 
 .EXAMPLE   
-Copy-SqlLinkedServer -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaLinkedServer -Source sqlserver2014a -Destination sqlcluster
 
 Description
 Copies all SQL Server Linked Servers on sqlserver2014a to sqlcluster. If Linked Server exists on destination, it will be skipped.
 
 .EXAMPLE   
-Copy-SqlLinkedServer -Source sqlserver2014a -Destination sqlcluster -LinkedServers SQL2K5,SQL2k -Force
+Copy-DbaLinkedServer -Source sqlserver2014a -Destination sqlcluster -LinkedServers SQL2K5,SQL2k -Force
 
 Description
 Copies over two SQL Server Linked Servers (SQL2K and SQL2K2) from sqlserver to sqlcluster. If the credential already exists on the destination, it will be dropped.
@@ -251,7 +251,7 @@ Copies over two SQL Server Linked Servers (SQL2K and SQL2K2) from sqlserver to s
 			return $decryptedlogins
 		}
 		
-		Function Copy-SqlLinkedServers
+		Function Copy-DbaLinkedServers
 		{
 			param (
 				[string[]]$LinkedServers,
@@ -403,7 +403,7 @@ Copies over two SQL Server Linked Servers (SQL2K and SQL2K2) from sqlserver to s
 		catch { throw "Can't connect to registry on $source. Quitting." }
 		
 		# Magic happens here
-		Copy-SqlLinkedServers $linkedservers -force:$force
+		Copy-DbaLinkedServers $linkedservers -force:$force
 		
 	}
 	

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -439,16 +439,17 @@ Limitations: Does not support Application Roles yet
 	
 	END {
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
-			Write-Output "Login migration completed: $(Get-Date)"
-			$totaltime = ($elapsed.Elapsed.toString().Split(".")[0])
-			$sourceserver.ConnectionContext.Disconnect()
+        If ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
+            Write-Output "Login migration completed: $(Get-Date)"
+            $totaltime = ($elapsed.Elapsed.toString().Split(".")[0])
+            $sourceserver.ConnectionContext.Disconnect()
 			
-			if ($Destination.length -gt 0) {
-				$destserver.ConnectionContext.Disconnect()
-			}
+            if ($Destination.length -gt 0) {
+                $destserver.ConnectionContext.Disconnect()
+            }
 			
-			Write-Output "Total elapsed time: $totaltime"
-		}
+            Write-Output "Total elapsed time: $totaltime"
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlLogin
 	}
 }

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlLogin
+function Copy-DbaLogin
 {
 <#
 .SYNOPSIS
@@ -82,32 +82,32 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlLogin
+https://dbatools.io/Copy-DbaLogin
 
 .EXAMPLE
-Copy-SqlLogin -Source sqlserver2014a -Destination sqlcluster -Force
+Copy-DbaLogin -Source sqlserver2014a -Destination sqlcluster -Force
 
 Copies all logins from source server to destination server. If a SQL login on source exists on the destination, the destination login will be dropped and recreated.
 
 .EXAMPLE
-Copy-SqlLogin -Source sqlserver2014a -Destination sqlcluster -Exclude realcajun -SourceSqlCredential $scred -DestinationSqlCredential $dcred
+Copy-DbaLogin -Source sqlserver2014a -Destination sqlcluster -Exclude realcajun -SourceSqlCredential $scred -DestinationSqlCredential $dcred
 
 Authenticates to SQL Servers using SQL Authentication.
 
 Copies all logins except for realcajun. If a login already exists on the destination, the login will not be migrated.
 
 .EXAMPLE
-Copy-SqlLogin -Source sqlserver2014a -Destination sqlcluster -Logins realcajun, netnerds -force
+Copy-DbaLogin -Source sqlserver2014a -Destination sqlcluster -Logins realcajun, netnerds -force
 
 Copies ONLY logins netnerds and realcajun. If login realcajun or netnerds exists on the destination, they will be dropped and recreated.
 
 .EXAMPLE
-Copy-SqlLogin -Source sqlserver2014a -Destination sqlcluster -SyncOnly
+Copy-DbaLogin -Source sqlserver2014a -Destination sqlcluster -SyncOnly
 
 Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins or users. If a matching login does not exist on the destination, the login will be skipped.
 
 .EXAMPLE 
-Copy-SqlLogin -LoginRenameHashtable @{ "OldUser" ="newlogin" } -Source $Sql01 -Destination Localhost -SourceSqlCredential $sqlcred 
+Copy-DbaLogin -LoginRenameHashtable @{ "OldUser" ="newlogin" } -Source $Sql01 -Destination Localhost -SourceSqlCredential $sqlcred 
 
 Copys down OldUser and then renames it to newlogin.
 

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlResourceGovernor
+function Copy-DbaResourceGovernor
 {
 <#
 .SYNOPSIS
@@ -57,20 +57,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlResourceGovernor
+https://dbatools.io/Copy-DbaResourceGovernor
 
 .EXAMPLE   
-Copy-SqlResourceGovernor -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaResourceGovernor -Source sqlserver2014a -Destination sqlcluster
 
 Copies all extended event policies from sqlserver2014a to sqlcluster, using Windows credentials. 
 
 .EXAMPLE   
-Copy-SqlResourceGovernor -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaResourceGovernor -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all extended event policies from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlResourceGovernor -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaResourceGovernor -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 #>

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -229,10 +229,10 @@ Shows what would happen if the command were executed.
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message"))
-		{
-			Write-Output "Resource Governor migration finished"
-		}
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) {
+            Write-Output "Resource Governor migration finished"
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlResourceGovernor
 	}
 	
 }

--- a/functions/Copy-DbaServerRole.ps1
+++ b/functions/Copy-DbaServerRole.ps1
@@ -265,6 +265,7 @@ BEGIN {
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server role migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server role migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlServerRole
 	}
 }

--- a/functions/Copy-DbaServerRole.ps1
+++ b/functions/Copy-DbaServerRole.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlServerRole
+function Copy-DbaServerRole
 {
 <#
 .SYNOPSIS 
-Copy-SqlServerRole migrates server roles from one SQL Server to another. 
+Copy-DbaServerRole migrates server roles from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all roles are copied. The -Roles parameter is autopopulated for command-line completion and can be used to copy only specific roles.
@@ -56,20 +56,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlServerRole 
+https://dbatools.io/Copy-DbaServerRole 
 
 .EXAMPLE   
-Copy-SqlServerRole -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaServerRole -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server roles from sqlserver2014a to sqlcluster, using Windows credentials. If roles with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlServerRole -Source sqlserver2014a -Destination sqlcluster -Role tg_noDbDrop -SourceSqlCredential $cred -Force
+Copy-DbaServerRole -Source sqlserver2014a -Destination sqlcluster -Role tg_noDbDrop -SourceSqlCredential $cred -Force
 
 Copies a single role, the tg_noDbDrop role from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a role with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlServerRole -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaServerRole -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlServerTrigger
+function Copy-DbaServerTrigger
 {
 <#
 .SYNOPSIS 
-Copy-SqlServerTrigger migrates server triggers from one SQL Server to another. 
+Copy-DbaServerTrigger migrates server triggers from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all triggers are copied. The -Triggers parameter is autopopulated for command-line completion and can be used to copy only specific triggers.
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlServerTrigger
+https://dbatools.io/Copy-DbaServerTrigger
 
 .EXAMPLE   
-Copy-SqlServerTrigger -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server triggers from sqlserver2014a to sqlcluster, using Windows credentials. If triggers with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlServerTrigger -Source sqlserver2014a -Destination sqlcluster -Trigger tg_noDbDrop -SourceSqlCredential $cred -Force
+Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -Trigger tg_noDbDrop -SourceSqlCredential $cred -Force
 
 Copies a single trigger, the tg_noDbDrop trigger from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a trigger with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlServerTrigger -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -159,6 +159,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server trigger migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server trigger migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlServerTrigger
 	}
 }

--- a/functions/Copy-DbaSpConfigure.ps1
+++ b/functions/Copy-DbaSpConfigure.ps1
@@ -148,10 +148,10 @@ Shows what would happen if the command were executed.
 	    $sourceserver.ConnectionContext.Disconnect()
 	    $destserver.ConnectionContext.Disconnect()
 	
-	    If ($Pscmdlet.ShouldProcess("console", "Showing finished message"))
-	    {
-		    Write-Output "Server configuration update finished"
-		}
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) {
+            Write-Output "Server configuration update finished"
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlSpConfigure
 	}
 	
 }

--- a/functions/Copy-DbaSpConfigure.ps1
+++ b/functions/Copy-DbaSpConfigure.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlSpConfigure
+function Copy-DbaSpConfigure
 {
 <#
 .SYNOPSIS 
-Copy-SqlSpConfigure migrates configuration values from one SQL Server to another. 
+Copy-DbaSpConfigure migrates configuration values from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all configuration values are copied. The -Configs parameter is autopopulated for command-line completion and can be used to copy only specific configs.
@@ -36,7 +36,7 @@ Shows what would happen if the command were to run. No actions are actually perf
 Prompts you for confirmation before executing any changing operations within the command. 
 
 .NOTES
-Tags: Migration
+Tags: Migration, Configure
 Author: Chrissy LeMaire (@cl), netnerds.net
 Requires: sysadmin access on SQL Servers
 
@@ -50,20 +50,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlSpConfigure 
+https://dbatools.io/Copy-DbaSpConfigure 
 
 .EXAMPLE   
-Copy-SqlSpConfigure -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSpConfigure -Source sqlserver2014a -Destination sqlcluster
 
 Copies all sp_configure settings from sqlserver2014a to sqlcluster
 
 .EXAMPLE   
-Copy-SqlSpConfigure -Source sqlserver2014a -Destination sqlcluster -Configs DefaultBackupCompression, IsSqlClrEnabled -SourceSqlCredential $cred -Force
+Copy-DbaSpConfigure -Source sqlserver2014a -Destination sqlcluster -Configs DefaultBackupCompression, IsSqlClrEnabled -SourceSqlCredential $cred -Force
 
 Updates the values for two configs, the  IsSqlClrEnabled and DefaultBackupCompression, from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlSpConfigure -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaSpConfigure -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 #>

--- a/functions/Copy-DbaSqlAudit.ps1
+++ b/functions/Copy-DbaSqlAudit.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlAudit
+function Copy-DbaSqlAudit
 {
 <#
 .SYNOPSIS 
-Copy-SqlAudit migrates server audits from one SQL Server to another. 
+Copy-DbaSqlAudit migrates server audits from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all audits are copied. The -Audits parameter is autopopulated for command-line completion and can be used to copy only specific audits.
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlAudit
+https://dbatools.io/Copy-DbaSqlAudit
 
 .EXAMPLE   
-Copy-SqlAudit -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSqlAudit -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server audits from sqlserver2014a to sqlcluster, using Windows credentials. If audits with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlAudit -Source sqlserver2014a -Destination sqlcluster -Audit tg_noDbDrop -SourceSqlCredential $cred -Force
+Copy-DbaSqlAudit -Source sqlserver2014a -Destination sqlcluster -Audit tg_noDbDrop -SourceSqlCredential $cred -Force
 
 Copies a single audit, the tg_noDbDrop audit from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an audit with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlAudit -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaSqlAudit -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaSqlAudit.ps1
+++ b/functions/Copy-DbaSqlAudit.ps1
@@ -210,6 +210,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server audit migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server audit migration finished" }
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlAudit
 	}
 }

--- a/functions/Copy-DbaSqlAuditSpecification.ps1
+++ b/functions/Copy-DbaSqlAuditSpecification.ps1
@@ -169,6 +169,7 @@ Shows what would happen if the command were executed using force.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server audit migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Server audit migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlAuditSpecification
 	}
 }

--- a/functions/Copy-DbaSqlAuditSpecification.ps1
+++ b/functions/Copy-DbaSqlAuditSpecification.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlAuditSpecification
+function Copy-DbaSqlAuditSpecification
 {
 <#
 .SYNOPSIS 
-Copy-SqlAuditSpecification migrates server audit specifications from one SQL Server to another. 
+Copy-DbaSqlAuditSpecification migrates server audit specifications from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all audits are copied. The -ServerAuditSpecifications parameter is autopopulated for command-line completion and can be used to copy only specific audits.
@@ -55,20 +55,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlAuditSpecification
+https://dbatools.io/Copy-DbaSqlAuditSpecification
 
 .EXAMPLE   
-Copy-SqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster
 
 Copies all server audits from sqlserver2014a to sqlcluster, using Windows credentials. If audits with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster -ServerAuditSpecifications tg_noDbDrop -SourceSqlCredential $cred -Force
+Copy-DbaSqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster -ServerAuditSpecifications tg_noDbDrop -SourceSqlCredential $cred -Force
 
 Copies a single audit, the tg_noDbDrop audit from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an audit with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaSqlAuditSpecification -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 #>

--- a/functions/Copy-DbaSqlDataCollector.ps1
+++ b/functions/Copy-DbaSqlDataCollector.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlDataCollector
+Function Copy-DbaSqlDataCollector
 {
 <#
 .SYNOPSIS
@@ -60,25 +60,25 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlDataCollector
+https://dbatools.io/Copy-DbaSqlDataCollector
 
 .EXAMPLE   
-Copy-SqlDataCollector -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSqlDataCollector -Source sqlserver2014a -Destination sqlcluster
 
 Copies all Data Collector Objects and Configurations from sqlserver2014a to sqlcluster, using Windows credentials. 
 
 .EXAMPLE   
-Copy-SqlDataCollector -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaSqlDataCollector -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all Data Collector Objects and Configurations from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlDataCollector -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaSqlDataCollector -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 	
 .EXAMPLE   
-Copy-SqlDataCollector -Source sqlserver2014a -Destination sqlcluster -CollectionSets 'Server Activity', 'Table Usage Analysis' 
+Copy-DbaSqlDataCollector -Source sqlserver2014a -Destination sqlcluster -CollectionSets 'Server Activity', 'Table Usage Analysis' 
 
 Copies two Collection Sets, Server Activity and Table Usage Analysis, from sqlserver2014a to sqlcluster.
 #>

--- a/functions/Copy-DbaSqlDataCollector.ps1
+++ b/functions/Copy-DbaSqlDataCollector.ps1
@@ -224,7 +224,8 @@ Copies two Collection Sets, Server Activity and Table Usage Analysis, from sqlse
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Data Collector migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Data Collector migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlDataCollector
 	}
 }
 

--- a/functions/Copy-DbaSqlPolicyManagement.ps1
+++ b/functions/Copy-DbaSqlPolicyManagement.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlPolicyManagement
+function Copy-DbaSqlPolicyManagement
 {
 <#
 .SYNOPSIS
@@ -57,25 +57,25 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlPolicyManagement 
+https://dbatools.io/Copy-DbaSqlPolicyManagement 
 
 .EXAMPLE   
-Copy-SqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster
 
 Copies all policies and conditions from sqlserver2014a to sqlcluster, using Windows credentials. 
 
 .EXAMPLE   
-Copy-SqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaSqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all policies and conditions from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaSqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 	
 .EXAMPLE   
-Copy-SqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -Policy 'xp_cmdshell must be disabled'
+Copy-DbaSqlPolicyManagement -Source sqlserver2014a -Destination sqlcluster -Policy 'xp_cmdshell must be disabled'
 
 Copies only one policy, 'xp_cmdshell must be disabled' from sqlserver2014a to sqlcluster. No conditions are migrated.
 	

--- a/functions/Copy-DbaSqlPolicyManagement.ps1
+++ b/functions/Copy-DbaSqlPolicyManagement.ps1
@@ -257,6 +257,7 @@ Copies only one policy, 'xp_cmdshell must be disabled' from sqlserver2014a to sq
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Policy Management migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Policy Management migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlPolicyManagement
 	}
 }

--- a/functions/Copy-DbaSqlReplication.ps1
+++ b/functions/Copy-DbaSqlReplication.ps1
@@ -1,4 +1,10 @@
-<#
+function Copy-DbaSqlReplication {
+    [cmdletbinding()]
+    param(
+		[switch]$Silent
+    )
+    Stop-Function -Message "Command is still under construction"
+    <#
 #$transfer.Options.ContinueScriptingOnError
 # replace names
 # Load SMO, create server object, test connection, disconnect
@@ -86,3 +92,4 @@ foreach ($repdb in $repdbs) {
 	}
 }
 #>
+}

--- a/functions/Copy-DbaSqlServerAgent.ps1
+++ b/functions/Copy-DbaSqlServerAgent.ps1
@@ -152,6 +152,7 @@ Shows what would happen if the command were executed.
 	{
 		$sourceserver.ConnectionContext.Disconnect()
 		$destserver.ConnectionContext.Disconnect()
-		If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Job server migration finished" }
+        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Job server migration finished" }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlServerAgent
 	}
 }

--- a/functions/Copy-DbaSqlServerAgent.ps1
+++ b/functions/Copy-DbaSqlServerAgent.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlServerAgent
+Function Copy-DbaSqlServerAgent
 {
 <#
 .SYNOPSIS
@@ -66,20 +66,20 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlServerAgent
+https://dbatools.io/Copy-DbaSqlServerAgent
 
 .EXAMPLE   
-Copy-SqlServerAgent -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSqlServerAgent -Source sqlserver2014a -Destination sqlcluster
 
 Copies all job server objects from sqlserver2014a to sqlcluster, using Windows credentials. If job objects with the same name exist on sqlcluster, they will be skipped.
 
 .EXAMPLE   
-Copy-SqlServerAgent -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
+Copy-DbaSqlServerrAgent -Source sqlserver2014a -Destination sqlcluster -SourceSqlCredential $cred
 
 Copies all job objects from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster.
 
 .EXAMPLE   
-Copy-SqlServerTrigger -Source sqlserver2014a -Destination sqlcluster -WhatIf
+Copy-DbaSqlServerAgent -Source sqlserver2014a -Destination sqlcluster -WhatIf
 
 Shows what would happen if the command were executed.
 #>
@@ -115,18 +115,18 @@ Shows what would happen if the command were executed.
 	{
 		
 		# All of these support whatif inside of them
-		Copy-SqlAgentCategory -Source $sourceserver -Destination $destserver -Force:$force
-		Copy-SqlOperator -Source $sourceserver -Destination $destserver -Force:$force
-		Copy-SqlAlert -Source $sourceserver -Destination $destserver -Force:$force -IncludeDefaults
-		Copy-SqlProxyAccount -Source $sourceserver -Destination $destserver -Force:$force
-		Copy-SqlSharedSchedule -Source $sourceserver -Destination $destserver -Force:$force
-		Copy-SqlJob -Source $sourceserver -Destination $destserver -Force:$force -DisableOnDestination:$DisableJobsOnDestination -DisableOnSource:$DisableJobsOnSource
+		Copy-DbaAgentCategory -Source $sourceserver -Destination $destserver -Force:$force
+		Copy-DbaAgentOperator -Source $sourceserver -Destination $destserver -Force:$force
+		Copy-DbaAgentAlert -Source $sourceserver -Destination $destserver -Force:$force -IncludeDefaults
+		Copy-DbaAgentProxyAccount -Source $sourceserver -Destination $destserver -Force:$force
+		Copy-DbaAgentSharedSchedule -Source $sourceserver -Destination $destserver -Force:$force
+		Copy-DbaAgentJob -Source $sourceserver -Destination $destserver -Force:$force -DisableOnDestination:$DisableJobsOnDestination -DisableOnSource:$DisableJobsOnSource
 		
 		# To do
 		<# 
-			Copy-SqlMasterServer -Source $sourceserver -Destination $destserver -Force:$force
-			Copy-SqlTargetServer -Source $sourceserver -Destination $destserver -Force:$force
-			Copy-SqlTargetServerGroup -Source $sourceserver -Destination $destserver -Force:$force
+			Copy-DbaAgentMasterServer -Source $sourceserver -Destination $destserver -Force:$force
+			Copy-DbaAgentTargetServer -Source $sourceserver -Destination $destserver -Force:$force
+			Copy-DbaAgentTargetServerGroup -Source $sourceserver -Destination $destserver -Force:$force
 		#>
 		
 		# Here are the properties, which must be migrated seperately 

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -660,9 +660,9 @@ Deploy entire SSIS catalog to an instance without a destination catalog.  Passin
 	{
 		$sourceConnection.ConnectionContext.Disconnect()
 		$destinationConnection.ConnectionContext.Disconnect()
-		if ($Pscmdlet.ShouldProcess("console", "Showing finished message"))
-		{
-			Write-Output "Integration services migration finished."
-		}
+        if ($Pscmdlet.ShouldProcess("console", "Showing finished message")) {
+            Write-Output "Integration services migration finished."
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-SqlSsisCatalog
 	}
 }

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -1,8 +1,8 @@
-Function Copy-SqlSsisCatalog
+function Copy-DbaSsisCatalog
 {
 <#
 .SYNOPSIS 
-Copy-SqlSsisCatalog migrates Folders, SSIS projects, and environments from one SQL Server to another. 
+Copy-DbaSsisCatalog migrates Folders, SSIS projects, and environments from one SQL Server to another. 
 
 .DESCRIPTION
 By default, all folders, projects, and environments are copied. 
@@ -54,7 +54,7 @@ $dcred = Get-Credential, this pass this $dcred to the param.
 Windows Authentication will be used if DestinationSqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.	
 
 .NOTES
-Tags: Migration
+Tags: Migration, SSIS
 Original Author: Phil Schwartz (philschwartz.me, @pschwartzzz)
 	
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
@@ -64,27 +64,27 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Copy-SqlSsisCatalog
+https://dbatools.io/Copy-DbaSsisCatalog
 	
 .EXAMPLE   
-Copy-SqlSsisCatalog -Source sqlserver2014a -Destination sqlcluster
+Copy-DbaSsisCatalog -Source sqlserver2014a -Destination sqlcluster
 
 Copies all folders, environments and all ssis Projects from sqlserver2014a to sqlcluster, using Windows credentials. If folders with the same name exist on the destination they will be skipped, but projects will be redeployed.
 
 .EXAMPLE   
-Copy-SqlSsisCatalog -Source sqlserver2014a -Destination sqlcluster -Project Archive_Tables -SourceSqlCredential $cred -Force
+Copy-DbaSsisCatalog -Source sqlserver2014a -Destination sqlcluster -Project Archive_Tables -SourceSqlCredential $cred -Force
 
 Copies a single Project, the Archive_Tables Project from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a
 and Windows credentials for sqlcluster. If a Project with the same name exists on sqlcluster, it will be deleted and recreated because -Force was used.
 
 .EXAMPLE   
-Copy-SqlSsisCatalog -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+Copy-DbaSsisCatalog -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 Shows what would happen if the command were executed using force.
 
 .EXAMPLE
 $SecurePW = Read-Host "Enter password" -AsSecureString
-Copy-SqlSsisCatalog -Source sqlserver2014a -Destination sqlcluster -CreateCatalogPassword $SecurePW
+Copy-DbaSsisCatalog -Source sqlserver2014a -Destination sqlcluster -CreateCatalogPassword $SecurePW
 
 Deploy entire SSIS catalog to an instance without a destination catalog.  Passing -CreateCatalogPassword will bypass any user prompts for creating the destination catalog.
 

--- a/functions/Copy-DbaSysDbUserObject.ps1
+++ b/functions/Copy-DbaSysDbUserObject.ps1
@@ -1,4 +1,4 @@
-Function Copy-SqlSysDbUserObjects
+function Copy-DbaSysDbUserObject
 {
 <#
 .SYNOPSIS
@@ -36,7 +36,7 @@ Shows what would happen if the command were to run. No actions are actually perf
 Prompts you for confirmation before executing any changing operations within the command. 
 
 .EXAMPLE
-Copy-SqlSysDbUserObjects $sourceserver $destserver
+Copy-DbaSysDbUserObject $sourceserver $destserve
 	
 Copies user objects from source to destination 
 
@@ -52,7 +52,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 .LINK
-https://dbatools.io/Get-DetachedDbInfo
+https://dbatools.io/Copy-DbaSysDbUserObject
 
 #>
 	[CmdletBinding(SupportsShouldProcess = $true)]

--- a/functions/Start-DbaMigration.ps1
+++ b/functions/Start-DbaMigration.ps1
@@ -634,13 +634,13 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 		if ($sourceserver.ConnectionContext.IsOpen -eq $true) { $sourceserver.ConnectionContext.Disconnect() }
 		if ($destserver.ConnectionContext.IsOpen -eq $true) { $destserver.ConnectionContext.Disconnect() }
 		
-		If ($Pscmdlet.ShouldProcess("console", "Showing SQL Server migration finished message"))
-		{
-			Write-Output "`n`nSQL Server migration complete"
-			Write-Output "Migration started: $started"
-			Write-Output "Migration completed: $(Get-Date)"
-			Write-Output "Total Elapsed time: $totaltime"
-			Stop-Transcript
-		}
+        If ($Pscmdlet.ShouldProcess("console", "Showing SQL Server migration finished message")) {
+            Write-Output "`n`nSQL Server migration complete"
+            Write-Output "Migration started: $started"
+            Write-Output "Migration completed: $(Get-Date)"
+            Write-Output "Total Elapsed time: $totaltime"
+            Stop-Transcript
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Start-SqlMigration
 	}
 }

--- a/functions/Start-SqlMigration.ps1
+++ b/functions/Start-SqlMigration.ps1
@@ -1,4 +1,4 @@
-Function Start-SqlMigration
+function Start-DbaMigration
 {
 <# 
 .SYNOPSIS 
@@ -12,7 +12,7 @@ Automatically outputs a transcript to disk.
 
 .DESCRIPTION 
 
-Start-SqlMigration consolidates most of the migration tools in dbatools into one command.  This is useful when you're looking to migrate entire instances. It less flexible than using the underlying functions. Think of it as an easy button. It migrates:
+Start-DbaMigration consolidates most of the migration tools in dbatools into one command.  This is useful when you're looking to migrate entire instances. It less flexible than using the underlying functions. Think of it as an easy button. It migrates:
 
 All user databases. Use -NoDatabases to skip.
 All logins. Use -NoLogins to skip.
@@ -192,27 +192,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 			
 
 .LINK 
-https://dbatools.io/Start-SqlMigration
+https://dbatools.io/Start-DbaMigration
 
 .EXAMPLE   
-Start-SqlMigration -Source sqlserver\instance -Destination sqlcluster -DetachAttach 
+Start-DbaMigration -Source sqlserver\instance -Destination sqlcluster -DetachAttach 
 
 Description
 
 All databases, logins, job objects and sp_configure options will be migrated from sqlserver\instance to sqlcluster. Databases will be migrated using the detach/copy files/attach method. Dbowner will be updated. User passwords, SIDs, database roles and server roles will be migrated along with the login.
 
 .EXAMPLE  
-Start-SqlMigration -Verbose -Source sqlcluster -Destination sql2016 -SourceSqlCredential $scred -ReuseSourceFolderStructure -DestinationSqlCredential $cred -Force -NetworkShare \\fileserver\share\sqlbackups\Migration -BackupRestore
+Start-DbaMigration -Verbose -Source sqlcluster -Destination sql2016 -SourceSqlCredential $scred -ReuseSourceFolderStructure -DestinationSqlCredential $cred -Force -NetworkShare \\fileserver\share\sqlbackups\Migration -BackupRestore
 
 Migrate databases uses backup/restore. Also migrate logins, database mail, credentials, SQL Agent, Central Management Server, SQL global configuration.
 
 .EXAMPLE
-Start-SqlMigration -Verbose -Source sqlcluster -Destination sql2016 -NoDatabases -NoLogins
+Start-DbaMigration -Verbose -Source sqlcluster -Destination sql2016 -NoDatabases -NoLogins
 
 Migrates everything but logins and databases.
 
 .EXAMPLE
-Start-SqlMigration -Verbose -Source sqlcluster -Destination sql2016 -DetachAttach -Reattach -SetSourceReadonly
+Start-DbaMigration -Verbose -Source sqlcluster -Destination sql2016 -DetachAttach -Reattach -SetSourceReadonly
 
 Migrate databases using detach/copy/attach. Reattach at source and set source databases read-only. Also migrates everything else. 
 
@@ -322,7 +322,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			Write-Output "`n`nMigrating SQL Server Configuration"
 			try
 			{
-				Copy-SqlSpConfigure -Source $sourceserver -Destination $destserver
+				Copy-DbaSpConfigure -Source $sourceserver -Destination $destserver
 			}
 			catch { Write-Error "Configuration migration reported the following error $($_.Exception.Message) " }
 		}
@@ -333,7 +333,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			Write-Output "`n`nMigrating custom errors (user defined messages)"
 			try
 			{
-				Copy-SqlCustomError -Source $sourceserver -Destination $destserver -Force:$Force
+				Copy-DbaCustomError -Source $sourceserver -Destination $destserver -Force:$Force
 			}
 			catch { Write-Error "Couldn't copy custom errors." }
 		}
@@ -349,7 +349,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating SQL credentials"
 				try
 				{
-					Copy-SqlCredential -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaCredential -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Credential migration reported the following error $($_.Exception.Message) " }
 			}
@@ -366,7 +366,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating database mail"
 				try
 				{
-					Copy-SqlDatabaseMail -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaDatabaseMail -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Database mail migration reported the following error $($_.Exception.Message)" }
 			}
@@ -379,7 +379,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			{
 				If ($Pscmdlet.ShouldProcess($destination, "Copying user objects."))
 				{
-					Copy-SqlSysDbUserObjects -Source $sourceserver -Destination $destserver
+					Copy-DbaSysDbUserObjects -Source $sourceserver -Destination $destserver
 				}
 				
 			}
@@ -397,7 +397,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Central Management Server"
 				try
 				{
-					Copy-SqlCentralManagementServer -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaCentralManagementServer -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch
 				{
@@ -411,7 +411,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			Write-Output "`n`nMigrating Backup Devices"
 			try
 			{
-				Copy-SqlBackupDevice -Source $sourceserver -Destination $destserver -Force:$Force
+				Copy-DbaBackupDevice -Source $sourceserver -Destination $destserver -Force:$Force
 			}
 			catch { Write-Error "Backup device migration reported the following error $($_.Exception.Message)" }
 		}
@@ -421,7 +421,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			Write-Output "`n`nMigrating linked servers"
 			try
 			{
-				Copy-SqlLinkedServer -Source $sourceserver -Destination $destserver -Force:$Force
+				Copy-DbaLinkedServer -Source $sourceserver -Destination $destserver -Force:$Force
 			}
 			catch { Write-Error "Linked server migration reported the following error $($_.Exception.Message) " }
 		}
@@ -437,7 +437,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating System Triggers"
 				try
 				{
-					Copy-SqlServerTrigger -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaServerTrigger -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "System Triggers migration reported the following error $($_.Exception.Message)" }
 			}
@@ -456,11 +456,11 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			{
 				if ($BackupRestore)
 				{
-					Copy-SqlDatabase -Source $sourceserver -Destination $destserver -All -SetSourceReadOnly:$SetSourceReadOnly -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -BackupRestore -NetworkShare $NetworkShare -Force:$Force -NoRecovery:$NoRecovery -WithReplace:$WithReplace
+					Copy-DbaDatabase -Source $sourceserver -Destination $destserver -All -SetSourceReadOnly:$SetSourceReadOnly -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -BackupRestore -NetworkShare $NetworkShare -Force:$Force -NoRecovery:$NoRecovery -WithReplace:$WithReplace
 				}
 				else
 				{
-					Copy-SqlDatabase -Source $sourceserver -Destination $destserver -All -SetSourceReadOnly:$SetSourceReadOnly -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -DetachAttach:$DetachAttach -Reattach:$Reattach -Force:$Force
+					Copy-DbaDatabase -Source $sourceserver -Destination $destserver -All -SetSourceReadOnly:$SetSourceReadOnly -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -DetachAttach:$DetachAttach -Reattach:$Reattach -Force:$Force
 				}
 			}
 			catch { Write-Error "Database migration reported the following error $($_.Exception.Message)" }
@@ -474,11 +474,11 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			{
 				if ($NoSaRename -eq $false)
 				{
-					Copy-SqlLogin -Source $sourceserver -Destination $destserver -Force:$Force -SyncSaName
+					Copy-DbaLogin -Source $sourceserver -Destination $destserver -Force:$Force -SyncSaName
 				}
 				else
 				{
-					Copy-SqlLogin -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaLogin -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 			}
 			catch { Write-Error "Login migration reported the following error $($_.Exception.Message) " }
@@ -505,7 +505,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Data Collector collection sets"
 				try
 				{
-					Copy-SqlDataCollector -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaSqlDataCollector -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Job Server migration reported the following error $($_.Exception.Message) " }
 			}
@@ -523,7 +523,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Audits"
 				try
 				{
-					Copy-SqlAudit -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaSqlAudit -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Backup device migration reported the following error $($_.Exception.Message)" }
 			}
@@ -540,7 +540,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Server Audit Specifications"
 				try
 				{
-					Copy-SqlAuditSpecification -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaSqlAuditSpecification -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Server Audit Specification migration reported the following error $($_.Exception.Message)" }
 			}
@@ -557,7 +557,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Endpoints"
 				try
 				{
-					Copy-SqlEndpoint -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaEndpoint -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Backup device migration reported the following error $($_.Exception.Message)" }
 			}
@@ -575,7 +575,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Policy Management "
 				try
 				{
-					Copy-SqlPolicyManagement -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaSqlPolicyManagement -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Policy Management migration reported the following error $($_.Exception.Message)" }
 			}
@@ -592,7 +592,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Resource Governor"
 				try
 				{
-					Copy-SqlResourceGovernor -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaResourceGovernor -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Resource Governor migration reported the following error $($_.Exception.Message)" }
 			}
@@ -609,7 +609,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 				Write-Output "`n`nMigrating Extended Events"
 				try
 				{
-					Copy-SqlExtendedEvent -Source $sourceserver -Destination $destserver -Force:$Force
+					Copy-DbaExtendedEvent -Source $sourceserver -Destination $destserver -Force:$Force
 				}
 				catch { Write-Error "Extended Event migration reported the following error $($_.Exception.Message)" }
 			}
@@ -620,7 +620,7 @@ Migrate databases using detach/copy/attach. Reattach at source and set source da
 			Write-Output "`n`nMigrating job server"
 			try
 			{
-				Copy-SqlServerAgent -Source $sourceserver -Destination $destserver -DisableJobsOnDestination:$DisableJobsOnDestination -DisableJobsOnSource:$DisableJobsOnSource -Force:$Force
+				Copy-DbaSqlServerAgent -Source $sourceserver -Destination $destserver -DisableJobsOnDestination:$DisableJobsOnDestination -DisableJobsOnSource:$DisableJobsOnSource -Force:$Force
 			}
 			catch { Write-Error "Job Server migration reported the following error $($_.Exception.Message) " }
 		}


### PR DESCRIPTION
### Changes proposed in this pull request:
 - Changed ALL `Copy-Sql*` functions to `Copy-Dba*`, including file name change.
 - Updated help examples
 - Updated `Start-SqlMigration` to `Start-DbaMigration`
 - Updated calls to the Copy functions in `Start-DbaMigration` to the new `Copy-Db*` function names.
 - Added tags for some of the functions as only tag in most was just "Migration". (e.g. Agent added to those that copied SQL Agent objects).
 - For `Copy-DbaAgentCategory`, I did also rename the internal functions to just drop the `Sql` prefix from the name...since they are internal functions.
 - For `Copy-DbaSqlReplication`, I went ahead and just added a function wrapper so it would have a name. I also added just a `Stop-Function` call to note that it was still under works. Better to have something there so folks don't wonder why it is unfinished. (Maybe we can get it done for 1.0 release as well.)

### Take special note of for reviewers:
- The functions that dealt with Agent where renamed where the name matched as such. (e.g. `Copy-SqlJob` was changed to `Copy-DbaAgentJob` | `Copy-SqlOperator` changed to `Copy-DbaAgentOperator`). _If you feel some of these should be named differently mark them in the review via a comment for discussion._
- I did change one function call to be singular while it was plural, believe we had decided in our standards to stick with PS practices. So `Copy-SqlSysUserObjects` was renamed to `Copy-DbaSysDbUserObject`. @potatoqualitee if I need to revert this just let me know.

No major code change was performed, short of 

How to test this code: 
- [ ] Do full call to `Start-DbaMigration` be the quickest and ensure you have all the objects to copy.

