### PR TITLE
Adding lsn info to restorehistory

### DIFF
--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -143,7 +143,11 @@ Returns database restore information for every database on every server listed i
 				     ISNULL(STUFF((SELECT ', ' + rf.destination_phys_name 
 									FROM msdb.dbo.restorefile rf
 								   WHERE rsh.restore_history_id = rf.restore_history_id
-								 FOR XML PATH('')), 1, 2, ''), '') AS [To]  
+								 FOR XML PATH('')), 1, 2, ''), '') AS [To],
+					bs.first_lsn,
+					bs.last_lsn,
+					bs.checkpoint_lsn,
+					bs.database_backup_lsn
 				  "
 				}
 				
@@ -183,7 +187,7 @@ Returns database restore information for every database on every server listed i
 				$sql = "$select $from $where"
 				Write-Debug $sql
 				
-				$server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows
+				$server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-DefaultView -Exclude first_lsn,last_lsn,checkpoint_lsn,database_backup_lsn
 				
 			}
 			catch


### PR DESCRIPTION
Putting this in as it'll make doing the continuing restore work easier as it's a shortcut to find out the last lsn in the recovering/standy db

Changes proposed in this pull request:
 - LSN information added to the output for Get-DbaRestoreHistory
 - Extra fields hidden by select-Defaultview
 - No other changes, fields were in already referenced tables.

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

