### PR TITLE
Get-dbadatabase status improvements

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -99,6 +99,7 @@ Returns databases on multiple instances piped into the function
         [parameter(ParameterSetName = "Encrypted")]
         [switch]$Encrypted,
         [parameter(ParameterSetName = "Status")]
+        [ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
         [string[]]$Status,
         [parameter(ParameterSetName = "Access")]
         [ValidateSet('ReadOnly', 'ReadWrite')]

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -99,8 +99,7 @@ Returns databases on multiple instances piped into the function
         [parameter(ParameterSetName = "Encrypted")]
         [switch]$Encrypted,
         [parameter(ParameterSetName = "Status")]
-        [ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
-        [string]$Status,
+        [string[]]$Status,
         [parameter(ParameterSetName = "Access")]
         [ValidateSet('ReadOnly', 'ReadWrite')]
         [string]$Access,
@@ -122,6 +121,18 @@ Returns databases on multiple instances piped into the function
 
         if ($NoUserDb -and $NoSystemDb) {
             Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue -Silent $Silent
+        }
+
+        if($status.count -gt 0)
+        {
+            foreach ($state in $status)
+            {
+                if ($state -notin ('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect'))
+                {
+                    Stop-Function -Message "$state is not a valid status ('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')" -Continue -Silent $Silent
+                }
+                       
+            }
         }
     }
 
@@ -149,7 +160,12 @@ Returns databases on multiple instances piped into the function
             }
 
             if ($status) {
-                $inputobject = $server.Databases | Where-Object Status -eq $status
+                $StatusInput = @()
+                foreach ($state in $status)
+                {
+                   $StatusInput += $server.Databases | Where-Object {($_.Status -split ', ') -contains $state}
+                }
+                $inputobject = $StatusInput | Select-object -unique  
             }
 
             if ($Owner) {


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Status parameter now works with comma combined statuses (express is bad for this ie; "normal, AutoClosed")
 - Allows multiple statuses to be filtered for. Wanted this for the continue restore functionality to get dbs in states that will allow more log restores (recovering, standby)
 - No other changes

How to test this code: 
- [ ] Get-DbaDatabase -SqlInstance localhost\sqlexpress2016 -Status standby,recovery
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [x] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers

