### PR TITLE
Adding -Last to Get-DbaRestoreHistory

### DIFF
--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -27,6 +27,7 @@ Datetime object used to narrow the results to a date
 .PARAMETER Force
 Returns a ton of information about the backup history with no max rows
 
+
 .NOTES
 Tags: DisasterRecovery, Backup, Restore
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
@@ -75,7 +76,8 @@ Returns database restore information for every database on every server listed i
 		[Alias("SqlCredential")]
 		[PsCredential]$Credential,
 		[datetime]$Since,
-		[switch]$Force
+		[switch]$Force,
+		[switch]$last
 	)
 	
 	DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $Credential } }
@@ -154,7 +156,7 @@ Returns database restore information for every database on every server listed i
 				$from = " FROM msdb.dbo.restorehistory rsh
 					INNER JOIN msdb.dbo.backupset bs ON rsh.backup_set_id = bs.backup_set_id"
 				
-				if ($exclude.length -gt 0 -or $databases.length -gt 0 -or $Since.length -gt 0)
+				if ($exclude.length -gt 0 -or $databases.length -gt 0 -or $Since.length -gt 0 -or $last)
 				{
 					$where = " WHERE "
 				}
@@ -178,17 +180,38 @@ Returns database restore information for every database on every server listed i
 					$wherearray += "rsh.restore_date >= '$since'"
 				}
 				
+
+				if ($last)
+				{
+					$wherearray += "rsh.backup_set_id in
+						(select max(backup_set_id) from msdb.dbo.restorehistory
+						group by destination_database_name
+						)"
+				}
+
 				if ($where.length -gt 0)
 				{
 					$wherearray = $wherearray -join " and "
 					$where = "$where $wherearray"
 				}
-				
+
 				$sql = "$select $from $where"
+
+
 				Write-Debug $sql
 				
-				$server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-DefaultView -Exclude first_lsn,last_lsn,checkpoint_lsn,database_backup_lsn
-				
+				$results = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows 
+
+				if ($last)
+				{
+					$ga = $results | group-Object database
+					$tmpres = @()	
+					$ga | foreach-Object {
+						$tmpres += $_.Group | SORT-OBJECT RESTORE_DATE -Descending | SELECT * -first 1 
+					}
+					$results = $tmpres
+				}
+				$results | Select-DefaultView -Exclude first_lsn,last_lsn,checkpoint_lsn,database_backup_lsn,RowError,RowState,Table,ItemArray,HasErrors
 			}
 			catch
 			{

--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -27,6 +27,8 @@ Datetime object used to narrow the results to a date
 .PARAMETER Force
 Returns a ton of information about the backup history with no max rows
 
+.PARAMETER Last
+Returns the last restore action performed on each specified database
 
 .NOTES
 Tags: DisasterRecovery, Backup, Restore

--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -79,7 +79,7 @@ Returns database restore information for every database on every server listed i
 		[PsCredential]$Credential,
 		[datetime]$Since,
 		[switch]$Force,
-		[switch]$last
+		[switch]$Last
 	)
 	
 	DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $Credential } }


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Get-DbaRestoreHistory now has a -last switch, which will return the last restore performed on a database
 - Cleanest in house way to get the LastLsn for a db to continue restoring it.
 - 

How to test this code: 
- [ ] Get-DbaRestoreHistory -SqlServer localhost\sqlexpress2016 -Databases standtest -last
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

