### PR TITLE
Added ExecutionMode

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -2308,6 +2308,31 @@ namespace Sqlcollective.Dbatools
         }
     }
 
+    namespace General
+    {
+        /// <summary>
+        /// What kind of mode do you want to run a command in?
+        /// This allows the user to choose how a dbatools function handles a bump in the execution where terminating directly may not be actually mandated.
+        /// </summary>
+        public enum ExecutionMode
+        {
+            /// <summary>
+            /// When encountering issues, terminate, or skip the currently processed input, rather than continue.
+            /// </summary>
+            Strict,
+
+            /// <summary>
+            /// Continue as able with a best-effort attempt. Simple verbose output should do the rest.
+            /// </summary>
+            Lazy,
+
+            /// <summary>
+            /// Continue, but provide output that can be used to identify the operations that had issues.
+            /// </summary>
+            Report
+        }
+    }
+
     namespace Parameter
     {
         using Connection;

--- a/bin/typealiases.ps1
+++ b/bin/typealiases.ps1
@@ -17,3 +17,5 @@ try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators
 catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbavalidate", "Sqlcollective.Dbatools.Utility.Validation") }
 catch { }
+try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("DbaMode", "Sqlcollective.Dbatools.General.ExecutionMode") }
+catch { }


### PR DESCRIPTION
Added a new enumeration and its type accelerator-alias `[DbaMode]`
To be used when allowing the user to choose how to handle non-terminating issues.


Three modes have been implemented:
 - Strict: Terminate on non-critical error
 - Lazy: Continue on non-critical error
 - Report: Continue, but add a report object to the results. Should not be the default mode.

Ideally, `Report` should emit similar objects. That is, the output should be able to handle all items just the same with all objects having the same properties.
This may not always be possible though.