### PR TITLE
Warnings in Tests Fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,13 @@
 skip_commits:  
   message: /updated readme.*/
 install:
-  - cinst pester
 build: false
 test_script:
 # Test with native PS version
   - ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force
   - ps: Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force
   - ps: Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force
+  - ps: INstall-Module -Name Pester -Repository PSGallery -Force
   - ps: . .\Tests\appveyor.pester.ps1
 # Test with PS version 3  
   - ps: powershell.exe -version 3.0 -executionpolicy bypass -noprofile -file .\Tests\appveyor.pester.ps1

--- a/tests/Get-DirectoryRestoreFile.Tests.ps1
+++ b/tests/Get-DirectoryRestoreFile.Tests.ps1
@@ -14,13 +14,30 @@ if($env:APPVEYOR_REPO_BRANCH -and $env:APPVEYOR_REPO_BRANCH -notlike "master")
 
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace('.Tests.', '.')
 Import-Module $PSScriptRoot\..\internal\$sut -Force
-
 Describe "Get-DirectoryRestoreFile Unit Tests" -Tag 'Unittests'{
     Context "Test Path handling" {
+         Mock Test-Path {$false}
+         Mock Write-Warning {
+            throw}
         It "Should throw on an invalid Path"{
-            Mock Test-Path {$false}
-            {Get-DirectoryRestoreFile -Path c:\temp\} | Should Throw
+           { Get-DirectoryRestoreFile -Path c:\temp\} | Should Throw
         }
+        It 'Calls Test-Path Mock Once' {
+        $assertMockParams = @{
+            'CommandName' = 'Test-Path'
+            'Times' = 1
+            'Exactly' = $true
+        }
+        Assert-MockCalled @assertMockParams 
+    }
+            It 'Calls Write-Warning Mock Once' {
+        $assertMockParams = @{
+            'CommandName' = 'Write-Warning'
+            'Times' = 1
+            'Exactly' = $true
+        }
+        Assert-MockCalled @assertMockParams 
+    }
     }
     Context "Returning Files from one folder" {
         New-item "TestDrive:\backups\" -ItemType directory

--- a/tests/Get-XpDirTreeRestoreFile.Tests.ps1
+++ b/tests/Get-XpDirTreeRestoreFile.Tests.ps1
@@ -24,15 +24,34 @@ Describe "Get-XpDirTree Unit Tests" -Tag 'Unittests'{
     mock Test-SqlPath {$true}
 
     Context "Test Connection and User Rights" {
+        Mock Test-SQLPath {$false}
+        Mock Write-Warning {Throw}  ## Need to mock the warnign to stop the error in tests
+
         It "Should throw on an invalid SQL Connection" {
-            #mock Test-SQLConnection {(1..12) | %{[System.Collections.ArrayList]$t += @{ConnectSuccess = $false}}}
-            Mock Connect-SQLServer {throw}
-            {Get-XpDirTreeRestoreFile -path c:\dummy -sqlserver bad\bad} | Should Throw 
+            Mock Connect-SQLServer {Throw} ## Mock the Connect call to hit the catch inside the function
+            #mock Test-SQLConnection {(1..12) | %{[System.Collections.ArrayList]$t += @{ConnectSuccess = $false}}}         
+            {Get-XpDirTreeRestoreFile -path c:\dummy -sqlserver bad\bad} | Should Throw
         }
-        It "Should throw if SQL Server can't see the path" {
-            Mock Test-SQLPath {$false}
-            {Get-XpDirTreeRestoreFile -path c:\dummy -sqlserver bad\bad} | Should Throw 
+        It "Should throw if SQL Server can't see the path" {   
+            $srv = New-Object Microsoft.SQLServer.Management.Smo.Server dummy    ## Mock the server object else throws on Connect and doesnt test path
+            {Get-XpDirTreeRestoreFile -path c:\dummy -sqlserver $srv} | Should Throw 
         }
+        It 'Calls Connect-SQLServer Mock Once' {
+        $assertMockParams = @{
+            'CommandName' = 'Connect-SQLServer'
+            'Times' = 1
+            'Exactly' = $true
+        }
+        Assert-MockCalled @assertMockParams ## Ensure Mocks are called 
+    }
+    It 'Calls Test-SqlPath Mock Once' {
+        $assertMockParams = @{
+            'CommandName' = 'Test-SqlPath'
+            'Times' = 1
+            'Exactly' = $true
+        }
+        Assert-MockCalled @assertMockParams ## Ensure Mocks are called 
+    }
     }
     Context "Non recursive filestructure" {
         $array = (@{subdirectory='full.bak';depth=1;file=1},

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -20,7 +20,7 @@ param([switch]$Finalize)
 		
         Import-Module Pester
 		Set-Variable ProgressPreference -Value SilentlyContinue
-        Invoke-Pester -Quiet -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
+        Invoke-Pester -Show Failed -Path "$ProjectRoot\Tests" -OutputFormat NUnitXml -OutputFile "$ProjectRoot\$TestFile" -PassThru |
         Export-Clixml -Path "$ProjectRoot\PesterResults$PSVersion.xml"
     }
 


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:

Resolves warnings in tests for internal backup restore tests. Has been validated by Stuart Moore

How to test this code: 

Invoke-Pester at root of module path

Has been tested on minimum requirements:
- [ yup]  Powershell 3
- [ NA]  Windows 7
- [NA ]  SQL Server 2000

Has been tested on maximum requirements:
- [NA ]  SQL Server vNext
- [ NA]  Windows 10
- [ NA]  Azure Database


