### PR TITLE
Fix schema validation with underlying objects 

### DIFF
--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -1,5 +1,4 @@
-Function Remove-DbaOrphanUser
-{
+Function Remove-DbaOrphanUser {
 <#
 .SYNOPSIS
 Drop orphan users with no existing login to map
@@ -81,303 +80,263 @@ Remove-DbaOrphanUser -SqlServer sqlserver2014a -Users OrphanUser -Force
 Will remove from all databases the user OrphanUser EVEN if exists their matching login. First will change any schema that it owns to 'dbo'.
 
 #>
-	[CmdletBinding(SupportsShouldProcess = $true)]
-	Param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("ServerInstance", "SqlInstance")]
-		[object[]]$SqlServer,
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    Param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlInstance")]
+        [object[]]$SqlServer,
         [object]$SqlCredential,
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [object[]]$Users,
-        [switch]$Force
-	)
+        [switch]$Force,
+        [switch]$Silent
+    )
 
     DynamicParam { if ($SqlServer) { return Get-ParamSqlDatabases -SqlServer $SqlServer[0] -SqlCredential $SqlCredential } }
 
-	BEGIN
-	{
-	}
+    BEGIN {
+    }
 
-	PROCESS
-	{
+    PROCESS {
 
-        foreach ($Instance in $SqlServer)
-		{
-            Write-Verbose "Attempting to connect to $Instance"
-			try
-			{
-				$server = Connect-SqlServer -SqlServer $Instance -SqlCredential $SqlCredential
-			}
-			catch
-			{
-				Write-Warning "Can't connect to $Instance or access denied. Skipping."
-				continue
-			}
+        foreach ($Instance in $SqlServer) {
+            Write-Message -Level Verbose -Message "Attempting to connect to $Instance"
+            try {
+                $server = Connect-SqlServer -SqlServer $Instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Write-Message -Level Warning -Message "Can't connect to $Instance or access denied. Skipping."
+                continue
+            }
 
             # Convert from RuntimeDefinedParameter object to regular array
-		    $databases = $psboundparameters.Databases
+            $databases = $psboundparameters.Databases
 
-            if ($databases.Count -eq 0)
-            {
+            if ($databases.Count -eq 0) {
                 $databases = $server.Databases | Where-Object {$_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true}
             }
-            else
-            {
-                if ($pipedatabase.Length -gt 0)
-		        {
-			        $Source = $pipedatabase[0].parent.name
-			        $databases = $pipedatabase.name
-		        }
-                else
-                {
+            else {
+                if ($pipedatabase.Length -gt 0) {
+                    $Source = $pipedatabase[0].parent.name
+                    $databases = $pipedatabase.name
+                }
+                else {
                     $databases = $server.Databases | Where-Object {$_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true -and ($databases -contains $_.Name)}
                 }
             }
 
 
             $CallStack = Get-PSCallStack | Select-Object -Property *
-            if ($CallStack.Count -eq 1)
-            {
+            if ($CallStack.Count -eq 1) {
                 $StackSource = $CallStack[0].Command
             }
-            else
-            {
+            else {
                 #-2 because index base is 0 and we want the one before the last (the last is the actual command)
                 $StackSource = $CallStack[($CallStack.Count - 2)].Command
             }
 
-            if ($databases.Count -gt 0)
-            {
+            if ($databases.Count -gt 0) {
                 $start = [System.Diagnostics.Stopwatch]::StartNew()
 
-                foreach ($db in $databases)
-                {
-                    try
-                    {
+                foreach ($db in $databases) {
+                    try {
                         #if SQL 2012 or higher only validate databases with ContainmentType = NONE
-                        if ($server.versionMajor -gt 10)
-		                {
-                            if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None)
-                            {
-                                Write-Warning "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
+                        if ($server.versionMajor -gt 10) {
+                            if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None) {
+                                Write-Message -Level Warnig -Message "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
                                 Continue
                             }
                         }
 
-                        if ($StackSource -eq "Repair-DbaOrphanUser")
-                        {
-                            Write-Verbose "Call origin: Repair-DbaOrphanUser"
+                        if ($StackSource -eq "Repair-DbaOrphanUser") {
+                            Write-Message -Level Verbose -Message "Call origin: Repair-DbaOrphanUser"
                             #Will use collection from parameter ($Users)
                         }
-                        else
-                        {
-                            Write-Verbose "Validating users on database '$($db.Name)'"
+                        else {
+                            Write-Message -Level Verbose -Message "Validating users on database '$($db.Name)'"
 
-                            if ($Users.Count -eq 0)
-                            {
+                            if ($Users.Count -eq 0) {
                                 #the third validation will remove from list sql users without login. The rule here is Sid with length higher than 16
                                 $Users = $db.Users | Where-Object {$_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false)}
                             }
-                            else
-                            {
-                                if ($pipedatabase.Length -gt 0)
-		                        {
-			                        $Source = $pipedatabase[0].parent.name
-			                        $Users = $pipedatabase.name
-		                        }
-                                else
-                                {
+                            else {
+                                if ($pipedatabase.Length -gt 0) {
+                                    $Source = $pipedatabase[0].parent.name
+                                    $Users = $pipedatabase.name
+                                }
+                                else {
                                     #the fourth validation will remove from list sql users without login. The rule here is Sid with length higher than 16
                                     $Users = $db.Users | Where-Object {$_.Login -eq "" -and ($_.ID -gt 4) -and ($Users -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false)}
                                 }
                             }
                         }
 
-                        if ($Users.Count -gt 0)
-                        {
-                            Write-Verbose "Orphan users found"
-                            foreach ($User in $Users)
-                            {
+                        if ($Users.Count -gt 0) {
+                            Write-Message -Level Verbose -Message "Orphan users found"
+                            foreach ($User in $Users) {
                                 $SkipUser = $false
 
                                 $ExistLogin = $null
 
-                                if ($StackSource -ne "Repair-DbaOrphanUser")
-                                {
+                                if ($StackSource -ne "Repair-DbaOrphanUser") {
                                     #Need to validate Existing Login because the call does not came from Repair-DbaOrphanUser
-                                    $ExistLogin = $server.logins | Where-Object {$_.Isdisabled -eq $False -and
-                                                                                       $_.IsSystemObject -eq $False -and
-                                                                                       $_.IsLocked -eq $False -and
-                                                                                       $_.Name -eq $User.Name }
+                                    $ExistLogin = $server.logins | Where-Object {$_.Isdisabled -eq $False -and 
+                                        $_.IsSystemObject -eq $False -and 
+                                        $_.IsLocked -eq $False -and 
+                                        $_.Name -eq $User.Name }
                                 }
 
                                 #Schemas only appears on SQL Server 2005 (v9.0)
-                                if ($server.versionMajor -gt 8)
-                                {
+                                if ($server.versionMajor -gt 8) {
                                 
                                     #Validate if user owns any schema
                                     $Schemas = @()
 
-                                    $Schemas = $db.Schemas | Where-Object {$_.Owner -eq $User.Name}
+                                    $Schemas = $db.Schemas | Where-Object Owner -eq $User.Name
 
-                                    if(@($Schemas).Count -gt 0)
-                                    {
-                                        Write-Verbose "User '$($User.Name)' owns one or more schemas."
+                                    if (@($Schemas).Count -gt 0) {
+                                        Write-Message -Level Verbose -Message "User '$($User.Name)' owns one or more schemas."
 
                                         $AlterSchemaOwner = ""
                                         $DropSchema = ""
 
-                                        foreach ($sch in $Schemas)
-                                        {
-                                            $NumberObjects = ($db.EnumObjects() | Where-Object {$_.Schema -eq $sch.Name} | Measure-Object).Count
+                                        foreach ($sch in $Schemas) {
+                                            <#
+                                                On sql server 2008 or lower the EnumObjects method does not accept empty parameter.
+                                                0x1FFFFFFF is the way we can say we want everything known by those versions
 
-                                            if ($NumberObjects -gt 0)
-                                            {
-                                                if ($Force)
-                                                {
-                                                    Write-Verbose "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
+                                                When it is an higer version we can use empty to get all
+                                            #>
+                                            if ($server.versionMajor -lt 11) {
+                                                $NumberObjects = ($db.EnumObjects(0x1FFFFFFF) | Where-Object {$_.Schema -eq $sch.Name} | Measure-Object).Count
+                                            }
+                                            else {
+                                                $NumberObjects = ($db.EnumObjects() | Where-Object {$_.Schema -eq $sch.Name} | Measure-Object).Count   
+                                            }
 
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used."))
-				                                    {
+                                            if ($NumberObjects -gt 0) {
+                                                if ($Force) {
+                                                    Write-Message -Level Verbose -Message "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
+
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used.")) {
                                                         $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
                                                         [pscustomobject]@{
-                                                                            Instance = $server.Name
-                                                                            Database = $db.Name
-                                                                            SchemaName = $sch.Name
-                                                                            Action = "ALTER OWNER"
-                                                                            SchemaOwnerBefore = $sch.Owner
-                                                                            SchemaOwnerAfter = "dbo"
-                                                                        }
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "ALTER OWNER"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "dbo"
+                                                        }
                                                     }
                                                 }
-                                                else
-                                                {
-                                                    Write-Warning "Schema '$($sch.Name)' owned by user $($User.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$USer'"
+                                                else {
+                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' owned by user $($User.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$USer'"
                                                     $SkipUser = $true
                                                     break
                                                 }
                                             }
-                                            else
-                                            {
-                                                if ($sch.Name -eq $User.Name)
-                                                {
-                                                    Write-Verbose "The schema '$($sch.Name)' have the same name as user '$($User.Name)'. Schema will be dropped."
+                                            else {
+                                                if ($sch.Name -eq $User.Name) {
+                                                    Write-Message -Level Verbose -Message "The schema '$($sch.Name)' have the same name as user '$($User.Name)'. Schema will be dropped."
 
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'."))
-                                                    {
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'.")) {
                                                         $DropSchema += "DROP SCHEMA [$($sch.Name)]"
 
                                                         [pscustomobject]@{
-                                                                            Instance = $server.Name
-                                                                            Database = $db.Name
-                                                                            SchemaName = $sch.Name
-                                                                            Action = "DROP"
-                                                                            SchemaOwnerBefore = $sch.Owner
-                                                                            SchemaOwnerAfter = "N/A"
-                                                                        }
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "DROP"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "N/A"
+                                                        }
                                                     }
                                                 }
-                                                else
-                                                {
-                                                    Write-Warning "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
+                                                else {
+                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
 
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'."))
-                                                    {
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'.")) {
                                                         $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
                                                         [pscustomobject]@{
-                                                                            Instance = $server.Name
-                                                                            Database = $db.Name
-                                                                            SchemaName = $sch.Name
-                                                                            Action = "ALTER OWNER"
-                                                                            SchemaOwnerBefore = $sch.Owner
-                                                                            SchemaOwnerAfter = "dbo"
-                                                                        }
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "ALTER OWNER"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "dbo"
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
 
                                     }
-                                    else
-                                    {
-                                        Write-Verbose "User '$($User.Name)' does not own any schema. Will be dropped."
+                                    else {
+                                        Write-Message -Level Verbose -Message "User '$($User.Name)' does not own any schema. Will be dropped."
                                     }
 
                                     $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $User
 
-                                    Write-Debug $query
+                                    Write-Message -Level Debug -Message $query
                                 }
-                                else
-                                {
+                                else {
                                     $query = "EXEC master.dbo.sp_droplogin @loginame = N'$User'"
                                 }
 
-                                if ($ExistLogin)
-                                {
-                                    if (!$SkipUser)
-                                    {
-                                        if ($Force)
-                                        {
-                                            if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user '$($User.Name)' using -Force"))
-				                            {
+                                if ($ExistLogin) {
+                                    if (-not $SkipUser) {
+                                        if ($Force) {
+                                            if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user '$($User.Name)' using -Force")) {
                                                 $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-												Write-Output "User '$($User.Name)' was dropped from $($db.Name). -Force parameter was used!"
+                                                Write-Message -Level Verbose -Message "User '$($User.Name)' was dropped from $($db.Name). -Force parameter was used!"
                                             }
                                         }
-                                        else
-                                        {
-                                            Write-Warning "Orphan user $($User.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
+                                        else {
+                                            Write-Message -Level Warning -Message "Orphan user $($User.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
                                             Continue
                                         }
                                     }
                                 }
-                                else
-                                {
-                                    if (!$SkipUser)
-                                    {
-                                        if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user '$($User.Name)'"))
-				                        {
+                                else {
+                                    if (-not $SkipUser) {
+                                        if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user '$($User.Name)'")) {
                                             $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-											Write-Output "User '$($User.Name)' was dropped from $($db.Name)."
+                                            Write-Message -Level Verbose -Message "User '$($User.Name)' was dropped from $($db.Name)."
                                         }
                                     }
                                 }
                             }
                         }
-                        else
-                        {
-                            Write-Verbose "No orphan users found on database '$($db.Name)'."
+                        else {
+                            Write-Message -Level Verbose -Message "No orphan users found on database '$($db.Name)'."
                         }
                         #reset collection
                         $Users = $null
                     }
-                    catch
-                    {
-                        Write-Error $_
+                    catch {
+                        Write-Message -Level Error -Message $_
                     }
                 }
             }
-            else
-            {
-                Write-Verbose "There are no databases to analyse."
+            else {
+                Write-Message -Level Verbose -Message "There are no databases to analyse."
             }
         }
-	}
+    }
 
-	END
-	{
-		$server.ConnectionContext.Disconnect()
+    END {
+        $server.ConnectionContext.Disconnect()
 
         $totaltime = ($start.Elapsed)
 
         #If the call don't come from Repair-DbaOrphanUser function, show elapsed time
-		if ($StackSource -ne "Repair-DbaOrphanUser")
-        {
-           Write-Verbose "Total Elapsed time: $totaltime"
+        if ($StackSource -ne "Repair-DbaOrphanUser") {
+            Write-Message -Level Verbose -Message "Total Elapsed time: $totaltime"
         }
 		
-		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Remove-SqlOrphanUser
-	}
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Remove-SqlOrphanUser
+    }
 }


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - The validation for underlying objects on a schema that has user as owner was failing on SQL Server 2008 or lower on EnumObjects() method
 - Added new message system
 - formatted the code {

How to test this code: 
- [ ] Create a login
- [ ] Create a user for the login
- [ ] Create schema and set owner the user
- [ ] Create an object (table for example) on the schema
- [ ] Drop login so user can become orphan

Tests for tester:
- [ ] Test on sql2008 R2 / sql2008 / sql2005 - before was failing
Before this correction when running on sql 2008 or lower version:
![image](https://cloud.githubusercontent.com/assets/19521315/26131893/9294b53e-3a94-11e7-8044-9929f2910f67.png)

After should return a message like:
![image](https://cloud.githubusercontent.com/assets/19521315/26131906/a4e60ac6-3a94-11e7-9ad2-2f565de8839c.png)

- [ ] Test on sql 2012 + always worked. It must continue working