### PR TITLE
Snapshot Management, first round

### DIFF
--- a/functions/Get-DbaDatabaseSnapshot.ps1
+++ b/functions/Get-DbaDatabaseSnapshot.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#FlowControl#
 Function Get-DbaDatabaseSnapshot
 {
 <#
@@ -19,15 +20,17 @@ Return information for only specific base dbs
 .PARAMETER Snapshots
 Return information for only specific snapshots
 
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages
+
 .NOTES
 Tags: Snapshot
 Author: niphlod
 
-dbatools PowerShell module (https://dbatools.io)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
 
 .LINK
  https://dbatools.io/Get-DbaDatabaseSnapshot
@@ -52,8 +55,9 @@ Returns information for database snapshots HR_snapshot and Accounting_snapshot
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[string[]]$SqlInstance,
-		[PsCredential]$Credential
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PsCredential]$Credential,
+		[switch]$Silent
 	)
 	
 	DynamicParam
@@ -64,59 +68,47 @@ Returns information for database snapshots HR_snapshot and Accounting_snapshot
 		}
 	}
 	
-	BEGIN
+	begin
 	{
 		# Convert from RuntimeDefinedParameter object to regular array
 		$databases = $psboundparameters.Databases
 		$snapshots = $psboundparameters.Snapshots
 	}
 
-	PROCESS
+	process
 	{
 		foreach ($instance in $SqlInstance)
 		{
-			Write-Verbose "Connecting to $instance"
-			try
-			{
-				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $Credential
-				
-			}
-			catch
-			{
-				Write-Warning "Can't connect to $instance"
-				Continue
+			Write-Message -Level Verbose -Message "Connecting to $instance"
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+			} catch {
+				Stop-Function -Message "Failed to connect to: $instance" -InnerErrorRecord $_ -Target $instance -Continue -Silent $Silent
 			}
 			
 			$dbs = $server.Databases 
 
-			if ($databases.count -gt 0)
-			{
+			if ($databases.count -gt 0) {
 				$dbs = $dbs | Where-Object { $databases -contains $_.DatabaseSnapshotBaseName }
 			}
-
-			if ($snapshots.count -gt 0)
-			{
+			if ($snapshots.count -gt 0) {
 				$dbs = $dbs | Where-Object { $snapshots -contains $_.Name }
 			}
-			
-			if ($snapshots.count -eq 0 -and $databases.count -eq 0)
-			{
+			if ($snapshots.count -eq 0 -and $databases.count -eq 0) {
 				$dbs = $dbs | Where-Object IsDatabaseSnapshot -eq $true | Sort-Object DatabaseSnapshotBaseName, Name
 			}
-			
-			
 			foreach ($db in $dbs)
 			{
 				$object = [PSCustomObject]@{
-					Server = $server.name
+					SqlInstance = $server.DomainInstanceName
 					Database = $db.name
 					SnapshotOf = $db.DatabaseSnapshotBaseName
-					SizeMB = [Math]::Round($db.Size,2)
-					DatabaseCreated = $db.createDate
+					SizeMB = [Math]::Round($db.Size,2) ##FIXME, should use the stats for sparse files
+					DatabaseCreated = [dbadatetime]$db.createDate
 					SnapshotDb = $db
 				}
 				
-				Select-DefaultView -InputObject $object -Property Server, Database, SnapshotOf, SizeMB, DatabaseCreated
+				Select-DefaultView -InputObject $object -Property SqlInstance, Database, SnapshotOf, SizeMB, DatabaseCreated
 			}
 		}
 	}

--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#FlowControl#
 Function New-DbaDatabaseSnapshot
 {
 <#
@@ -15,7 +16,7 @@ Credential object used to connect to the SQL Server as a different user
 
 .PARAMETER AllDatabases
 Creates snapshot for all eligible databases
-	
+
 .PARAMETER Databases
 Creates snapshot for only specific databases
 
@@ -26,12 +27,6 @@ You can also pass a standard placeholder, in which case it'll be interpolated (e
 .PARAMETER Path
 Snapshot files will be created here (by default the filestructure will be created in the same folder as the base db)
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run. No actions are actually performed.
-
-.PARAMETER Confirm
-Prompts you for confirmation before executing any changing operations within the command.
-
 .PARAMETER Force
 Databases with Filestream FG can be snapshotted, but the Filestream FG is marked offline
 in the snapshot. To create a "partial" snapshot, you need to pass -Force explicitely
@@ -39,15 +34,16 @@ in the snapshot. To create a "partial" snapshot, you need to pass -Force explici
 NB: You can't then restore the Database from the newly-created snapshot.
 For details, check https://msdn.microsoft.com/en-us/library/bb895334.aspx
 
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages
+
 .NOTES
 Tags: DisasterRecovery, Snapshot, Restore
 Author: niphlod
 
-dbatools PowerShell module (https://dbatools.io)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
 .LINK
  https://dbatools.io/New-DbaDatabaseSnapshot
@@ -78,12 +74,13 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[string[]]$SqlInstance,
+		[DbaInstanceParameter[]]$SqlInstance,
 		[PsCredential]$Credential,
 		[switch]$AllDatabases,
 		[string]$Name,
 		[string]$Path,
-		[switch]$Force
+		[switch]$Force,
+		[switch]$Silent
 	)
 
 	DynamicParam
@@ -94,7 +91,7 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 		}
 	}
 
-	BEGIN
+	begin
 	{
 		# Convert from RuntimeDefinedParameter object to regular array
 		$databases = $psboundparameters.Databases
@@ -102,22 +99,16 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 		$NoSupportForSnap = @('model', 'master', 'tempdb')
 		# Evaluate the default suffix here for naming consistency
 		$DefaultSuffix = (Get-Date -Format "yyyyMMdd_HHmmss")
-		if ($Name.Length -gt 0)
-		{
+		if ($Name.Length -gt 0) {
 			#Validate if Name can be interpolated
-			try
-			{
+			try {
 				$null = $Name -f 'some_string'
+			} catch {
+				Stop-Function -Message "Name parameter must be a template only containing one parameter {0}" -ErrorRecord $_
 			}
-			catch
-			{
-				throw "Name parameter must be a template only containing one parameter {0}"
-			}
-
 		}
 
-		function Resolve-SnapshotError($server)
-		{
+		function Resolve-SnapshotError($server) {
 			$errhelp = ''
 			$CurrentEdition = $server.Edition.toLower()
 			$CurrentVersion = $server.Version.Major * 1000000 + $server.Version.Minor * 10000 + $server.Version.Build
@@ -141,130 +132,99 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 			{
 				$message += "This module can't tell you why the snapshot creation failed. Feel free to report back to dbatools what happened"
 			}
-			Write-Warning $message
+			Write-Message -Level Warning -Message $message
 		}
 
 	}
 
 
-	PROCESS
+	process
 	{
-		if ($databases.Length -eq 0 -and $AllDatabases -eq $false -and !$smodatabase)
-		{
+		if ($databases.Length -eq 0 -and $AllDatabases -eq $false -and !$smodatabase) {
 			throw "You must specify a -AllDatabases or -Database to continue"
 		}
 		
-		foreach ($instance in $SqlInstance)
-		{
-			Write-Verbose "Connecting to $instance"
-			try
-			{
-				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $Credential
-			}
-			catch
-			{
-				Write-Warning "Can't connect to $instance"
-				Continue
+		foreach ($instance in $SqlInstance) {
+			Write-Message -Level Verbose -Message "Connecting to $instance"
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+			} catch {
+				Stop-Function -Message "Failed to connect to: $instance" -InnerErrorRecord $_ -Target $instance -Continue -Silent $Silent
 			}
 			#Checks for path existence
-			if ($Path.Length -gt 0)
-			{
-				if (!(Test-DbaSqlPath -SqlServer $instance -Path $Path))
-				{
-					Write-Warning "'$instance' cannot access the directory '$Path'"
-					Continue
+			if ($Path.Length -gt 0) {
+				if (!(Test-DbaSqlPath -SqlServer $instance -Path $Path)) {
+					Stop-Function -Message "$instance cannot access the directory $Path" -InnerErrorRecord $_ -Target $instance -Continue -Silent $Silent
 				}
 			}
 			
-			if ($AllDatabases)
-			{
+			if ($AllDatabases) {
 				$dbs = $server.Databases
 			}
-			
-			if ($databases.count -gt 0)
-			{
+			if ($databases.count -gt 0) {
 				$dbs = $server.Databases | Where-Object { $databases -contains $_.Name }
 			}
 
 			$sourcedbs = @()
 
 			## double check for gotchas
-			foreach ($db in $dbs)
-			{
-				if ($db.IsDatabaseSnapshot)
-				{
-					Write-Warning "'$($db.name)' is a snapshot, skipping"
-				}
-				elseif ($db.name -in $NoSupportForSnap)
-				{
-					Write-Warning "'$($db.name)' snapshots are prohibited"
-				}
-				else
-				{
+			foreach ($db in $dbs) {
+				if ($db.IsDatabaseSnapshot) {
+					Write-Message -Level Warning -Message "$($db.name) is a snapshot, skipping"
+				} elseif ($db.name -in $NoSupportForSnap) {
+					Write-Message -Level Warning -Message "$($db.name) snapshots are prohibited"
+				} else {
 					$sourcedbs += $db
 				}
 			}
 
-			foreach ($db in $sourcedbs)
-			{
-				if ($Name.Length -gt 0)
-				{
+			foreach ($db in $sourcedbs) {
+				if ($Name.Length -gt 0) {
 					$SnapName = $Name -f $db.Name
-					if ($SnapName -eq $Name)
-					{
+					if ($SnapName -eq $Name) {
 						#no interpolation, just append
 						$SnapName = '{0}{1}' -f $db.Name, $Name
 					}
-				}
-				else
-				{
+				} else {
 					$SnapName = "{0}_{1}" -f $db.Name, $DefaultSuffix
 				}
-				if ($SnapName -in $server.Databases.Name)
-				{
-					Write-Warning "A database named '$Snapname' already exists, skipping"
-					Continue
+				if ($SnapName -in $server.Databases.Name) {
+					Write-Message -Level Warning -Message "A database named $Snapname already exists, skipping"
+					continue
 				}
 				$all_FSD = $db.FileGroups | Where-Object FileGroupType -eq 'FileStreamDataFileGroup'
 				$all_MMO = $db.FileGroups | Where-Object FileGroupType -eq 'MemoryOptimizedDataFileGroup'
 				$has_FSD = $all_FSD.Count -gt 0
 				$has_MMO = $all_MMO.Count -gt 0
-				if ($has_MMO)
-				{
-					Write-Warning "MEMORY_OPTIMIZED_DATA detected, snapshots are not possible"
-					Continue
+				if ($has_MMO) {
+					Write-Message -Level Warning -Message "MEMORY_OPTIMIZED_DATA detected, snapshots are not possible"
+					continue
 				}
 				if ($has_FSD -and $Force -eq $false)
 				{
-					Write-Warning "Filestream detected, skipping. You need to specify -Force. See Get-Help for details"
-					Continue
+					Write-Message -Level Warning -Message "Filestream detected, skipping. You need to specify -Force. See Get-Help for details"
+					continue
 				}
 				$snaptype = "db snapshot"
-				if ($has_FSD)
-				{
+				if ($has_FSD) {
 					$snaptype = "partial db snapshot"
 				}
-				If ($Pscmdlet.ShouldProcess($instance, "Create $snaptype '$SnapName' of '$($db.Name)'"))
-				{
+				If ($Pscmdlet.ShouldProcess($instance, "Create $snaptype $SnapName of $($db.Name)")) {
 					$CustomFileStructure = @{ }
 					$counter = 0
-					foreach ($fg in $db.FileGroups)
-					{
+					foreach ($fg in $db.FileGroups) {
 						$CustomFileStructure[$fg.Name] = @()
-						if ($fg.FileGroupType -eq 'FileStreamDataFileGroup')
-						{
+						if ($fg.FileGroupType -eq 'FileStreamDataFileGroup') {
 							Continue
 						}
-						foreach ($file in $fg.Files)
-						{
+						foreach ($file in $fg.Files) {
 							$counter += 1
 							# fixed extension is hardcoded as "ss", which seems a "de-facto" standard
 							$fname = [IO.Path]::ChangeExtension($file.Filename, "ss")
 							$fname = [IO.Path]::Combine((Split-Path $fname -Parent), ("{0}_{1}" -f $DefaultSuffix, (Split-Path $fname -Leaf)))
 
 							# change path if specified
-							if ($Path.Length -gt 0)
-							{
+							if ($Path.Length -gt 0) {
 								$basename = Split-Path $fname -Leaf
 								# we need to avoid cases where basename is the same for multiple FG
 								$basename = '{0:0000}_{1}' -f $counter, $basename
@@ -275,12 +235,10 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 					}
 					$SnapDB = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Database -ArgumentList $server, $Snapname
 					$SnapDB.DatabaseSnapshotBaseName = $db.Name
-					foreach ($fg in $CustomFileStructure.Keys)
-					{
+					foreach ($fg in $CustomFileStructure.Keys) {
 						$SnapFG = New-Object -TypeName Microsoft.SqlServer.Management.Smo.FileGroup $SnapDB, $fg
 						$SnapDB.FileGroups.Add($SnapFG)
-						foreach ($file in $CustomFileStructure[$fg])
-						{
+						foreach ($file in $CustomFileStructure[$fg]) {
 							$SnapFile = New-Object -TypeName Microsoft.SqlServer.Management.Smo.DataFile $SnapFG, $file['name'], $file['filename']
 							$SnapDB.FileGroups[$fg].Files.Add($SnapFile)
 						}
@@ -291,95 +249,70 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 					# info we can get both from testers and from users
 
 					$sql = $SnapDB.Script()
-					try
-					{
+					try {
 						$SnapDB.Create()
 
 						[PSCustomObject]@{
 							Server = $server.name
 							Database = $SnapDB.Name
 							SnapshotOf = $SnapDB.DatabaseSnapshotBaseName
-							SizeMB = [Math]::Round($SnapDB.Size, 2)
+							SizeMB = [Math]::Round($SnapDB.Size, 2)  ##FIXME, should use the stats for sparse files
 							DatabaseCreated = $SnapDB.createDate
 							PrimaryFilePath = $SnapDB.PrimaryFilePath
 							Status = 'Created'
 							Notes = $null
 							SnapshotDb = $SnapDB
 						} | Select-DefaultView -Property Server, Database, SnapshotOf, SizeMB, DatabaseCreated, PrimaryFilePath, Status
-					}
-					catch
-					{
+					} catch {
 						$Status = 'Created'
 						# here we manage issues we DO know about, hoping that the first command
 						# is always the one creating the snapshot, and give an helpful hint
-						try
-						{
+						try {
 							$server.Databases.Refresh()
-							if ($SnapName -notin $server.Databases.Name)
-							{
+							if ($SnapName -notin $server.Databases.Name) {
 								# previous creation failed completely, snapshot is not there already
 								$null = $server.ConnectionContext.ExecuteNonQuery($sql[0])
 								$server.Databases.Refresh()
 								$SnapDB = $server.Databases[$Snapname]
-							}
-							else
-							{
+							} else {
 								$SnapDB = $server.Databases[$Snapname]
 							}
 							$Notes = @()
-							if ($db.ReadOnly -eq $true)
-							{
+							if ($db.ReadOnly -eq $true) {
 								$Notes += 'SMO is probably trying to set a property on a read-only snapshot, run with -Debug to find out and report back'
 							}
-							if ($has_FSD)
-							{
+							if ($has_FSD) {
 								$Status = 'Partial'
 								$Notes += 'Filestream groups are not viable for snapshot'
 							}
 							$Notes = $Notes -Join ';'
 
 							$hints = @("Executing these commands led to a partial failure")
-							foreach ($stmt in $sql)
-							{
+							foreach ($stmt in $sql) {
 								$hints += $stmt
 							}
-							Write-Debug ($hints -Join "`n")
+							Write-Message -Level Debug -Message ($hints -Join "`n")
 
 							[PSCustomObject]@{
-								Server = $server.name
+								SqlInstance = $server.DomainInstanceName
 								Database = $SnapDB.Name
 								SnapshotOf = $SnapDB.DatabaseSnapshotBaseName
-								SizeMB = [Math]::Round($SnapDB.Size, 2)
-								DatabaseCreated = $SnapDB.createDate
+								SizeMB = [Math]::Round($SnapDB.Size, 2)  ##FIXME, should use the stats for sparse files
+								DatabaseCreated = [dbadatetime]$SnapDB.createDate
 								PrimaryFilePath = $SnapDB.PrimaryFilePath
 								Status = $Status
 								Notes = $Notes
 								SnapshotDb = $SnapDB
-							} | Select-DefaultView -Property Server, Database, SnapshotOf, SizeMB, DatabaseCreated, PrimaryFilePath, Status, Notes
-						}
-						catch
-						{
+							} | Select-DefaultView -Property SqlInstance, Database, SnapshotOf, SizeMB, DatabaseCreated, PrimaryFilePath, Status, Notes
+						} catch {
 							# we end up here when even the first issued command didn't create
 							# a valid snapshot
-							$ex = $_
-							Write-Warning 'SMO failed to create the snapshot, run with -Debug to find out and report back'
+							Write-Message -Level Warning -Message 'SMO failed to create the snapshot, run with -Debug to find out and report back' -ErrorRecord $_
 							$hints = @("Executing these commands led to a failure")
-							foreach ($stmt in $sql)
-							{
+							foreach ($stmt in $sql) {
 								$hints += $stmt
 							}
-							Write-Exception $ex
-							$inner = $_.Exception.Message
-							if ($null -ne $ex.Exception.InnerException)
-							{
-								$inner = $ex.Exception.InnerException
-							}
-							if ($null -ne $inner.InnerException)
-							{
-								$inner = $inner.InnerException
-							}
-							Write-Warning "Original exception: $inner"
-							Write-Debug ($hints -Join "`n")
+							Write-Message -Level Debug -Message ($hints -Join "`n")
 							Resolve-SnapshotError $server
 						}
 					}


### PR DESCRIPTION
- implemented new messaging and flow control
- changed "server" to SqlInstance in output props
- adopted dbadatetime
- adopted dtainstanceparameter
- whatever I remembered from styleguide (surely I missed out something)

Things to check:
- [ ] TEPP
- [ ] Pipeline conventions from get-dbadatabasesnapshot (had to revert to a simple pscustomobject)
- [ ] Size property isn't really useful, SMO returns the size of the original database even for the snapshot. Get-DbaDatabaseFile could help there but I found out it needs further refinements ( #1246 ).

PS: I failed to repro #618 since it seems that remove-sqldatabase drops
the connections correctly. Also with the new messaging system I *think*
we don't wanna put exceptions in the 'Notes' Column anymore

