### PR TITLE
Copy-DbaDatabase fix for cleanup

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -276,15 +276,19 @@ sql credential dbatoolscred registered on the sql2016 instance
 				Write-Message -Level Verbose -Message "Creating differential backup"
 				$type = "Database"
 				$backup.Incremental = $true
+                $outputType = 'Differential'
 			}
 			
 			if ($Type -eq "Log") {
 				Write-Message -Level Verbose -Message "Creating log backup"
 				$Suffix = "trn"
+                $OutputType = 'Log'
 			}
 			
-			if ($type -eq 'Full') {
+			if ($type -in 'Full', 'Database') {
+                Write-verbose "Setting type"
 				$type = "Database"
+                $OutputType='Full'
 			}
 			
 			$backup.CopyOnly = $copyonly
@@ -449,6 +453,7 @@ sql credential dbatoolscred registered on the sql2016 instance
 							FullName = ($FinalBackupPath | Sort-Object -Unique)
 							FileList = $FileList
 							SoftwareVersionMajor = $server.VersionMajor
+                            Type = $outputType
 						} | Restore-DbaDatabase -SqlServer $server -SqlCredential $SqlCredential -DatabaseName DbaVerifyOnly -VerifyOnly
 						if ($verifiedResult[0] -eq "Verify successful") {
 							$failures += $verifiedResult[0]
@@ -484,6 +489,7 @@ sql credential dbatoolscred registered on the sql2016 instance
 				FileList = $FileList
 				SoftwareVersionMajor = $server.VersionMajor
 				Verified = $Verified
+                Type = $outputType
 			} | Select-DefaultView -ExcludeProperty $OutputExclude
 			$BackupFileName = $null
 		}


### PR DESCRIPTION
Fixes #1248  

Changes proposed in this pull request:
 - No cleans up after itself
 - Not sure whats happened, but backup type wasn't coming through, now there.
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

