### PR TITLE
Copy-DbaDatabase force/withreplace issue fix

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -892,6 +892,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						Write-Message -Level Verbose -Message "Resuse = $ReuseSourceFolderStructure"
 						$RestoreResultTmp = $backupTmpResult | Restore-DbaDatabase -SqlServer $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery -TrustDbBackupHistory -WithReplace:$WithReplace
 						$restoreresult = $RestoreResultTmp.RestoreComplete
+						$RestoreResultTmp	
 						if ($restoreresult -eq $true) {
 							Write-Output "Successfully restored $dbname to $destination"
 						}

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -842,6 +842,11 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						}
 					}
 				}
+
+				if ($force)
+				{
+					$WithReplace = $true
+				}
 				
 				If ($Pscmdlet.ShouldProcess("console", "Showing start time")) {
 					Write-Output "Started: $dbstart"
@@ -885,7 +890,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						
 						#$restoreresult = Restore-SqlDatabase $destserver $dbname $backupfile $filestructure $numberfiles
 						Write-Message -Level Verbose -Message "Resuse = $ReuseSourceFolderStructure"
-						$RestoreResultTmp = $backupTmpResult | Restore-DbaDatabase -SqlServer $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery -TrustDbBackupHistory
+						$RestoreResultTmp = $backupTmpResult | Restore-DbaDatabase -SqlServer $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery -TrustDbBackupHistory -WithReplace:$WithReplace
 						$restoreresult = $RestoreResultTmp.RestoreComplete
 						if ($restoreresult -eq $true) {
 							Write-Output "Successfully restored $dbname to $destination"

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -100,7 +100,7 @@ Function Restore-DBFromFilteredArray
 						Write-Verbose "$FunctionName - Set $DbName single_user to kill processes"
 						Stop-DbaProcess -SqlServer $Server -Databases $Dbname -WarningAction Silentlycontinue
 						Invoke-DbaSqlcmd -ServerInstance:$SqlServer -Credential:$SqlCredential -query "Alter database $DbName set offline with rollback immediate; alter database $DbName set restricted_user; Alter database $DbName set online with rollback immediate" -database master
-
+						$server.ConnectionContext.Connect()
 					}
 					catch
 					{


### PR DESCRIPTION
Fixes #1270 #1271  

Changes proposed in this pull request:
 - Withreplace parameter now pushed into restore
 - Force parameter sets/implies withReplace
 - underlying issue where the restore smo connection was being closed also fixed (this is the bit that took the time)

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

