### PR TITLE
Get-DbaDatabaseFile: Fixed Size, UsedSpace and MaxSize calculation

### DIFF
--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -158,12 +158,12 @@ Function Get-DbaDatabaseFile {
 				$results = Invoke-DbaSqlcmd -ServerInstance $server -Query $sql -Database $db.name
 				
 				foreach ($result in $results) {
-					$size = [dbasize]($result.Size * 1024 * 1024)
-					$usedspace = [dbasize]($result.UsedSpace * 1024 * 1024)
+					$size = [dbasize]($result.Size * 8096)
+					$usedspace = [dbasize]($result.UsedSpace * 8096)
 					$maxsize = $result.MaxSize
 					
 					if ($maxsize -gt -1) {
-						$maxsize = [dbasize]($result.MaxSize * 1024 * 1024)
+						$maxsize = [dbasize]($result.MaxSize * 8096)
 					}
 					
 					if ($result.VolumeFreeSpace) {

--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -158,12 +158,12 @@ Function Get-DbaDatabaseFile {
 				$results = Invoke-DbaSqlcmd -ServerInstance $server -Query $sql -Database $db.name
 				
 				foreach ($result in $results) {
-					$size = [dbasize]($result.Size * 8096)
-					$usedspace = [dbasize]($result.UsedSpace * 8096)
+					$size = [dbasize]($result.Size * 8192)
+					$usedspace = [dbasize]($result.UsedSpace * 8192)
 					$maxsize = $result.MaxSize
 					
 					if ($maxsize -gt -1) {
-						$maxsize = [dbasize]($result.MaxSize * 8096)
+						$maxsize = [dbasize]($result.MaxSize * 8192)
 					}
 					
 					if ($result.VolumeFreeSpace) {


### PR DESCRIPTION
Those fields represent size in pages, page had 8K bytes

Changes proposed in this pull request:
 - Fixed calculation for three fields, they represent 8K pages not bytes

