### PR TITLE
Copy-DbaDatabase - Adding server version compatibility check

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -570,6 +570,13 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 		$sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
 		
+		$destVersionLower = $destserver.VersionMajor -lt $sourceserver.VersionMajor
+		$destVersionMinorLow = ($destserver.VersionMajor -eq 10 -and $sourceserver.VersionMajor -eq 10) -and ($destserver.VersionMinor -lt $sourceserver.VersionMinor)
+		if ($destVersionLower -or $destVersionMinorLow) {
+			Stop-Function -Message "Error: copy database cannot be made from newer $($sourceserver.VersionString) to older $($destserver.VersionString) SQL Server version"
+			return
+		}
+
 		if ($DetachAttach) {
 			if ($sourceserver.netname -eq $env:COMPUTERNAME -or $destserver.netname -eq $env:COMPUTERNAME) {
 				If (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -549,8 +549,6 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 	}
 	
 	process {
-		$copyonly = !$NoCopyOnly
-		
 		if (($AllDatabases -or $IncludeSupportDbs -or $Database) -and !$DetachAttach -and !$BackupRestore) {
 			throw "You must specify -DetachAttach or -BackupRestore when migrating databases."
 		}
@@ -887,7 +885,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						
 						#$backupresult = Backup-SqlDatabase $sourceserver $dbname $backupfile $numberfiles
 						
-						$backupTmpResult = Backup-DbaDatabase -SqlInstance $sourceserver -Database $dbname -backupDirectory (Split-Path -Path $backupFile -parent) -FileCount $numberfiles
+						$backupTmpResult = Backup-DbaDatabase -SqlInstance $sourceserver -Database $dbname -backupDirectory (Split-Path -Path $backupFile -parent) -FileCount $numberfiles -NoCopyOnly:$NoCopyOnly
 						$backupresult = $BackupTmpResult.BackupComplete
 						if ($backupresult -eq $false) {
 							$serviceaccount = $sourceserver.ServiceAccount


### PR DESCRIPTION
Adding version check for Source and Destination servers

Fixes #1302

Changes proposed in this pull request:
 - Checking source and destination servers version, if not fit, stopping action.
 - Pass -NoCopyOnly switch state from Copy-DbaDatabase to Backup-DbaDatabase

Has been tested on:
- [x]  Powershell 5.1
- [x]  Windows 10
- [x]  SQL Server 2008 & SQL Server 200R2
