### PR TITLE
Correct check to know if DB is accessible for Find-DbaUserObject

### DIFF
--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -265,7 +265,7 @@ Shows all user owned (non-sa, non-dbo) objects and verbose output
 
 			
 			## Loop internal database
-			foreach ($db in $server.Databases | Where-Object { $_.Status -eq "Normal" })
+			foreach ($db in $server.Databases | Where-Object { $_.IsAccessible -eq $true })
 			{
 				Write-Verbose "Gather user owned object in database: $db"
 				##schemas

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -265,7 +265,7 @@ Shows all user owned (non-sa, non-dbo) objects and verbose output
 
 			
 			## Loop internal database
-			foreach ($db in $server.Databases | Where-Object { $_.IsAccessible -eq $true })
+			foreach ($db in $server.Databases | Where-Object IsAccessible)
 			{
 				Write-Verbose "Gather user owned object in database: $db"
 				##schemas


### PR DESCRIPTION
Changes proposed in this pull request:
 - Changed filter of databases to iterate over to do `where {$_.IsAccessible -eq $true}` instead of checking the Status value.

The status value will show normal even if the database is a secondary replica in an AG or mirror. Which in those cases it is not accessible. IsAccessible property is more accurate to know if you can read into the database or not.

How to test this code: 
- [ ] Try to run command on databases that are online/offline/secondary AG database

I have verified this change against multiple AGs in client environment to verify if leaving contractor's account owned anything. It worked as expected...which his account did not. I knew my account did and it returned the expected objects as well.