### PR TITLE
Fixing BackupCleanup

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -892,7 +892,7 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 						Write-Message -Level Verbose -Message "Resuse = $ReuseSourceFolderStructure"
 						$RestoreResultTmp = $backupTmpResult | Restore-DbaDatabase -SqlInstance $destserver -DatabaseName $dbname -ReuseSourceFolderStructure:$ReuseSourceFolderStructure -NoRecovery:$norecovery -TrustDbBackupHistory -WithReplace:$WithReplace
 						$restoreresult = $RestoreResultTmp.RestoreComplete
-						$RestoreResultTmp	
+						
 						if ($restoreresult -eq $true) {
 							Write-Output "Successfully restored $dbname to $destination"
 						}
@@ -907,9 +907,9 @@ It also includes the support databases (ReportServer, ReportServerTempDb, distri
 								continue
 							}
 						}
-                        if ($NoBackupCleanup -eq $false)
+                        if ($NoBackupCleanUp -ne $true)
                         {
-                            foreach ($backupfile in $backupTmpResult.BackupFiles)
+                            foreach ($backupfile in ($RestoreResultTmp.BackupFile -split ','))
                             {
                                 try		
                 				{		


### PR DESCRIPTION
Fixes #1248 

Changes proposed in this pull request:
 - Backups now removed as expected.
 - Someone had forgotten the object property he was using wasn't an object or an array.....
 - Improved the test to do the deletes
 - Removed the unwanted output.

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

