### PR TITLE
Help fixes

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -35,7 +35,7 @@ function Copy-DbaLogin {
 		.PARAMETER Login
 			The login(s) to process - this list is autopopulated from the server. If unspecified, all logins will be processed.
 
-		.PARAMETER Exclude
+		.PARAMETER ExcludeLogin
 			The login(s) to exclude - this list is autopopulated from the server
 
 		.PARAMETER SyncOnly

--- a/functions/Set-DbaQueryStoreConfig.ps1
+++ b/functions/Set-DbaQueryStoreConfig.ps1
@@ -13,7 +13,7 @@ The SQL Server that you're connecting to.
 .PARAMETER SqlCredential
 SqlCredential object used to connect to the SQL Server as a different user.
 
-.PARAMETER Databases
+.PARAMETER Database
 Set Query Store configuration for specific databases.
 
 .PARAMETER Exclude

--- a/tests/InModule.Help.Exceptions.ps1
+++ b/tests/InModule.Help.Exceptions.ps1
@@ -5,3 +5,8 @@ $global:FunctionHelpTestExceptions = @(
 $global:HelpTestEnumeratedArrays = @(
 	"SqlCollective.Dbatools.Connection.ManagementConnectionType[]"
 )
+
+$global:HelpTestSkipParameterType = @{
+	"Get-DbaCmObject" = @("DoNotUse")
+	"Test-DbaCmConnection" = @("Type")
+}

--- a/tests/InModule.Help.Exceptions.ps1
+++ b/tests/InModule.Help.Exceptions.ps1
@@ -1,3 +1,7 @@
 $global:FunctionHelpTestExceptions = @(
     "TabExpansion2"
 )
+
+$global:HelpTestEnumeratedArrays = @(
+	"SqlCollective.Dbatools.Connection.ManagementConnectionType[]"
+)

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -85,7 +85,7 @@ foreach ($command in $commands) {
                         $names = $parameter.ParameterType::GetNames($parameter.ParameterType)
                         $parameterHelp.parameterValueGroup.parameterValue | Should be $names
                     }
-					elseif (($null -ne $parameter.ParameterType) -and ($parameter.ParameterType.BaseType.FullName -eq "System.Array") -and ($parameter.ParameterType.DeclaredMembers[0].ReturnType.IsEnum)) {
+					elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
 						# Enumerations often have issues with the typename not being reliably available
                         $names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
                         $parameterHelp.parameterValueGroup.parameterValue | Should be $names

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -85,6 +85,11 @@ foreach ($command in $commands) {
                         $names = $parameter.ParameterType::GetNames($parameter.ParameterType)
                         $parameterHelp.parameterValueGroup.parameterValue | Should be $names
                     }
+					elseif (($null -ne $parameter.ParameterType) -and ($parameter.ParameterType.BaseType.FullName -eq "System.Array") -and ($parameter.ParameterType.DeclaredMembers[0].ReturnType.IsEnum)) {
+						# Enumerations often have issues with the typename not being reliably available
+                        $names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
+                        $parameterHelp.parameterValueGroup.parameterValue | Should be $names
+					}
                     else {
                         # To avoid calling Trim method on a null object.
                         $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -75,12 +75,14 @@ foreach ($command in $commands) {
                     $codeMandatory = $parameter.IsMandatory.toString()
                     $parameterHelp.Required | Should Be $codeMandatory
                 }
+				
+				if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
                 
                 # Parameter type in Help should match code
                 It "help for $commandName has correct parameter type for $parameterName" {
                     $codeType = $parameter.ParameterType.Name
                     
-                    if ($parameter.ParameterType.IsEnum) {
+					if ($parameter.ParameterType.IsEnum) {
                         # Enumerations often have issues with the typename not being reliably available
                         $names = $parameter.ParameterType::GetNames($parameter.ParameterType)
                         $parameterHelp.parameterValueGroup.parameterValue | Should be $names

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -93,7 +93,7 @@ foreach ($command in $commands) {
                     else {
                         # To avoid calling Trim method on a null object.
                         $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
-                        $helpType | Should be $codeType
+                        $helpType | Should be $codeType 
                     }
                 }
             }

--- a/tests/manual.pester.ps1
+++ b/tests/manual.pester.ps1
@@ -13,6 +13,10 @@ Param (
     [string[]]
     $Path,
 	
+	[ValidateSet('None', 'Default', 'Passed', 'Failed', 'Pending', 'Skipped', 'Inconclusive', 'Describe', 'Context', 'Summary', 'Header', 'All', 'Fails')]
+	[string]
+	$Show = "All",
+	
 	[switch]
 	$TestIntegration,
     
@@ -38,12 +42,12 @@ if ($Path)
     foreach ($item in $Path)
     {
 		if ($testInt) { Invoke-Pester $item }
-        else { Invoke-Pester $item -ExcludeTag "Integrationtests" }
+        else { Invoke-Pester $item -ExcludeTag "Integrationtests" -Show $Show }
     }
 }
 
 else
 {
     if ($testInt) { Invoke-Pester }
-	else { Invoke-Pester -ExcludeTag "Integrationtests" }
+	else { Invoke-Pester -ExcludeTag "Integrationtests" -Show $Show }
 }


### PR DESCRIPTION
Resolves some bad help fixes:
 - Two instances of renamed parameter where the help was missed
 - Type validation when an array of an enumerated type was required