### PR TITLE
Fix for LSN filtering issue

### DIFF
--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -171,6 +171,7 @@ function Get-FilteredRestoreFile {
             $TlogStartlsn = 0
             if (!($continue)) {
                 $Fullbackup = $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq 'Database' -and $_.BackupStartDate -lt $RestoreTime} | Sort-Object -Property BackupStartDate -descending | Select-Object -First 1
+                $TlogStartlsn = $Fullbackup.FirstLSN
                 if ($Fullbackup -eq $null) {
                     Stop-Function -Message "No Full backup found to anchor the restore" -Continue -Target $database
                     break


### PR DESCRIPTION
Fixes  a small error introduced into the filtering in the last features release

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

