### PR TITLE
Fix bug in RegEx replace for source and destination

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -115,7 +115,7 @@ function Copy-DbaAgentAlert {
 				try {
 					Write-Message -Message "Creating Alert Defaults" -Level Output
 					$sql = $sourceServer.JobServer.AlertSystem.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$Destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$Destination'"
 
 					Write-Message -Message $sql -Level Debug
 					$null = $destServer.ConnectionContext.ExecuteNonQuery($sql)
@@ -180,7 +180,7 @@ function Copy-DbaAgentAlert {
 					#>
                     Write-Message -Message "Copying Alert $alertName" -Level Output
                     $sql = $alert.Script() | Out-String
-                    $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$Destination'")
+                    $sql = $sql -replace [Regex]::Escape("'$source'"), "'$Destination'"
                     $sql = $sql -replace "@job_id=N'........-....-....-....-............", "@job_id=N'00000000-0000-0000-0000-000000000000"
 
                     Write-Message -Message $sql -Level Debug

--- a/functions/Copy-DbaAgentCategory.ps1
+++ b/functions/Copy-DbaAgentCategory.ps1
@@ -167,7 +167,7 @@ Shows what would happen if the command were executed using force.
 						{
 							Write-Output "Copying Job category $categoryname"
 							$sql = $jobcategory.Script() | Out-String
-							$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+							$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 							Write-Verbose $sql
 							$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 						}
@@ -229,7 +229,7 @@ Shows what would happen if the command were executed using force.
 									$destserver.jobserver.operatorcategories[$categoryname].Drop()
 									Write-Output "Copying Operator category $categoryname"
 									$sql = $operatorcategory.Script() | Out-String
-									$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+									$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 									Write-Verbose $sql
 									$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 								}
@@ -245,7 +245,7 @@ Shows what would happen if the command were executed using force.
 							{
 								Write-Output "Copying Operator category $categoryname"
 								$sql = $operatorcategory.Script() | Out-String
-								$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+								$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 								Write-Verbose $sql
 								$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 							}
@@ -313,7 +313,7 @@ Shows what would happen if the command were executed using force.
 									$destserver.jobserver.alertcategories[$categoryname].Drop()
 									Write-Output "Copying Alert category $categoryname"
 									$sql = $alertcategory.Script() | Out-String
-									$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+									$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 									Write-Verbose $sql
 									$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 								}
@@ -329,7 +329,7 @@ Shows what would happen if the command were executed using force.
 							{
 								Write-Output "Copying Alert category $categoryname"
 								$sql = $alertcategory.Script() | Out-String
-								$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+								$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 								Write-Verbose $sql
 								$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 							}

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -185,7 +185,7 @@ Shows what would happen if the command were executed using force.
                 try {
                     Write-Message -Message "Copying Job $jobName" -Level Output -Silent $Silent
                     $sql = $job.Script() | Out-String
-                    $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                    $sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
                     Write-Message -Message $sql -Level Debug -Silent $Silent
                     $destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
                 }

--- a/functions/Copy-DbaAgentOperator.ps1
+++ b/functions/Copy-DbaAgentOperator.ps1
@@ -135,7 +135,7 @@ function Copy-DbaAgentOperator {
 				try {
 					Write-Message -Mesage "Copying Operator $operatorName" -Level Output
 					$sql = $sOperator.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Message -Message $sql -Level Debug
 					$null = $destServer.ConnectionContext.ExecuteNonQuery($sql)
 				}

--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -136,7 +136,7 @@ Shows what would happen if the command were executed using force.
                 try {
                     Write-Output "Copying server proxy account $proxyname"
                     $sql = $proxyaccount.Script() | Out-String
-                    $sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+                    $sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
                     Write-Verbose $sql
                     $destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
                 }

--- a/functions/Copy-DbaAgentSharedSchedule.ps1
+++ b/functions/Copy-DbaAgentSharedSchedule.ps1
@@ -146,7 +146,7 @@ Shows what would happen if the command were executed using force.
 				{
 					Write-Output "Copying schedule $schedulename"
 					$sql = $schedule.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 				}

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -138,7 +138,7 @@ Shows what would happen if the command were executed using force.
 				try
 				{
 					$sql = $backupdevice.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 				}
 				catch { 
 					Write-Exception $_
@@ -174,7 +174,7 @@ Shows what would happen if the command were executed using force.
 					{
 						Write-Output "Updating $devicename to use $backupdirectory"
 						$sql = $sql -replace $path, $backupdirectory
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					}
 					catch { 
 						Write-Exception $_

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -145,7 +145,7 @@ Shows what would happen if the command were executed using force.
 				{
 					Write-Output "Copying custom error $customerrorid $language"
 					$sql = $customerror.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 				}

--- a/functions/Copy-DbaDatabaseMail.ps1
+++ b/functions/Copy-DbaDatabaseMail.ps1
@@ -122,7 +122,7 @@ function Copy-DbaDatabaseMail {
 			if ($pscmdlet.ShouldProcess($destination, "Migrating all mail server configuration values")) {
 				try {
 					$sql = $mail.ConfigurationValues.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Message -Message $sql -Level Debug
 					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 					$mail.ConfigurationValues.Refresh()
@@ -183,7 +183,7 @@ function Copy-DbaDatabaseMail {
 					try {
 						Write-Message -Message "Copying mail account $accountName" -Level Verbose
 						$sql = $account.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 						Write-Message -Message $sql -Level Debug
 						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 						$copyMailAccountStatus.Status = "Successful"
@@ -246,7 +246,7 @@ function Copy-DbaDatabaseMail {
 					try {
 						Write-Message -Message "Copying mail profile $profileName" -Level Verbose
 						$sql = $profile.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 						Write-Message -Message $sql -Level Debug
 						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 						$destServer.Mail.Profiles.Refresh()
@@ -306,7 +306,7 @@ function Copy-DbaDatabaseMail {
 					try {
 						Write-Message -Message "Copying mail server $mailServerName" -Level Verbose
 						$sql = $mailServer.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 						Write-Message -Message $sql -Level Debug
 						$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 						$copyMailServerStatus.Status = "Successful"

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -157,7 +157,7 @@ Copies two Extended Events, CheckQueries and MonitorUserDefinedException, from s
 				try
 				{
 					$sql = $session.ScriptCreate().GetScript() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Migrating session $sessionName"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -320,7 +320,7 @@ Copies over two SQL Server Linked Servers (SQL2K and SQL2K2) from sqlserver to s
 					try
 					{
 						$sql = $linkedserver.Script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 						Write-Verbose $sql
 						
 						[void]$destserver.ConnectionContext.ExecuteNonQuery($sql)

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -105,7 +105,7 @@ Shows what would happen if the command were executed.
 			else {
 				try {
 					$sql = $sourceserver.resourceGovernor.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Updating Resource Governor settings"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)
@@ -158,7 +158,7 @@ Shows what would happen if the command were executed.
 			if ($Pscmdlet.ShouldProcess($destination, "Migrating pool $poolName")) {
 				try {
 					$sql = $pool.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Copying pool $poolName"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)
@@ -167,7 +167,7 @@ Shows what would happen if the command were executed.
 					foreach ($workloadgroup in $workloadgroups) {
 						$workgroupname = $workloadgroup.name
 						$sql = $workloadgroup.script() | Out-String
-						$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 						Write-Verbose $sql
 						Write-Output "Copying $workgroupname"
 						$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)

--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -110,7 +110,7 @@ Shows what would happen if the command were executed using force.
 			}
 			
 			$sql = $audit.Script() | Out-String
-			$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+			$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 			
 			if ($destaudits.name -contains $auditname)
 			{

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -137,7 +137,7 @@ Shows what would happen if the command were executed using force.
 				{
 					Write-Output "Copying server trigger $triggername"
 					$sql = $trigger.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					$sql = $sql -replace "CREATE TRIGGER", "`nGO`nCREATE TRIGGER"
 					$sql = $sql -replace "ENABLE TRIGGER", "`nGO`nENABLE TRIGGER"
 					

--- a/functions/Copy-DbaSqlDataCollector.ps1
+++ b/functions/Copy-DbaSqlDataCollector.ps1
@@ -194,7 +194,7 @@ Copies two Collection Sets, Server Activity and Table Usage Analysis, from sqlse
 				try
 				{
 					$sql = $set.ScriptCreate().GetScript() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Migrating collection set $collectionName"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)

--- a/functions/Copy-DbaSqlPolicyManagement.ps1
+++ b/functions/Copy-DbaSqlPolicyManagement.ps1
@@ -175,7 +175,7 @@ Copies only one policy, 'xp_cmdshell must be disabled' from sqlserver2014a to sq
 				try
 				{
 					$sql = $condition.ScriptCreate().GetScript() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Copying condition $conditionName"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)
@@ -232,7 +232,7 @@ Copies only one policy, 'xp_cmdshell must be disabled' from sqlserver2014a to sq
 					$deststore.conditions.Refresh()
 					$deststore.policies.Refresh()
 					$sql = $policy.ScriptCreateWithDependencies().GetScript() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Verbose $sql
 					Write-Output "Copying policy $policyName"
 					$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)

--- a/functions/Copy-DbaSqlServerAgent.ps1
+++ b/functions/Copy-DbaSqlServerAgent.ps1
@@ -136,7 +136,7 @@ Shows what would happen if the command were executed.
 			{
 				Write-Output "Copying SQL Agent Properties"
 				$sql = $sourceagent.Script() | Out-String
-				$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+				$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 				$sql = $sql -replace [Regex]::Escape("@errorlog_file="), [Regex]::Escape("--@errorlog_file=")
 				Write-Verbose $sql
 				$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null

--- a/functions/Sync-DbaLoginPermissions.ps1
+++ b/functions/Sync-DbaLoginPermissions.ps1
@@ -353,7 +353,7 @@ https://dbatools.io/Sync-SqlLoginPermissions
 					if ($destdb.users[$dbusername] -eq $null) {
 						If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname")) {
 							$sql = $sourceserver.databases[$dbname].users[$dbusername].script() | Out-String
-							$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+							$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 							try {
 								$destdb.ExecuteNonQuery($sql)
 								Write-Output "Added user $dbusername (login: $dblogin) to $dbname"

--- a/internal/Update-SqlPermissions.ps1
+++ b/internal/Update-SqlPermissions.ps1
@@ -290,7 +290,7 @@ Function Update-SqlPermissions
 				If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname"))
 				{
 					$sql = $sourceserver.databases[$dbname].users[$dbusername].script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), [Regex]::Escape("'$destination'")
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					try
 					{
 						$destdb.ExecuteNonQuery($sql)


### PR DESCRIPTION
Changes proposed in this pull request:
 - Change ` [Regex]::Escape("'$destination'")` to ` "'$destination'"` in all commands.

How to test this code: 
- [ ] None really unless you have an instance with special characters in the name (e.g. SomeServer\Instance.Name