### PR TITLE
Fixing TEPP error on PSv3/v4

### DIFF
--- a/internal/dynamicparams/tag.ps1
+++ b/internal/dynamicparams/tag.ps1
@@ -94,5 +94,4 @@
     }
 }
 
-if ($TEPP) { TabExpansionPlusPlus\Register-ArgumentCompleter -CommandName "Find-DbaCommand" -ParameterName "Tag" -ScriptBlock $ScriptBlock }
-else { Register-ArgumentCompleter -CommandName "Find-DbaCommand" -ParameterName "Tag" -ScriptBlock $ScriptBlock }
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name "tag"

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -1,4 +1,6 @@
 ﻿$functions = Get-ChildItem function:\*-Dba*
+
+#region Automatic TEPP by parameter name
 foreach ($function in $functions) {
     if ($function.Parameters.Keys -contains "SqlInstance") {
         Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter SqlInstance -Name SqlInstance
@@ -28,3 +30,8 @@ foreach ($function in $functions) {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeOperator -Name Operator
 	}
 }
+#endregion Automatic TEPP by parameter name
+
+#region Explicit TEPP
+Register-DbaTeppArgumentCompleter -Command "Find-DbaCommand" -Parameter Tag -Name tag
+#endregion Explicit TEPP


### PR DESCRIPTION
Moved the tag-TEPP completion to the central scriptfile, so it no longer tries to register stuff before importing the optional TEPP stuff.

Tested on W7 PS3, error went away.