### PR TITLE
DbaInstanceParameter split issue fix

### DIFF
--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -1,10 +1,12 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
 function Set-DbaStartupParameter {
 <#
 .SYNOPSIS
 Sets the Startup Parameters for a SQL Server instance
 
 .DESCRIPTION
-Modifies the startup parameters for a specified SQL Server SqlInstance
+Modifies the startup parameters for a specified SQL Server Instance
 
 For full details of what each parameter does, please refer to this MSDN article - https://msdn.microsoft.com/en-us/library/ms190737(v=sql.105).aspx
 
@@ -12,7 +14,7 @@ For full details of what each parameter does, please refer to this MSDN article 
 The SQL Server instance to be modified
 
 .PARAMETER Credential
-Windows credential with permission to log on to the server running the SQL instance
+Windows Credential with permission to log on to the server running the SQL instance
 
 .PARAMETER MasterData
 Path to the data file for the Master database
@@ -138,223 +140,277 @@ We then change the startup parameters ahead of some work
 After the work has been completed, we can push the original startup parameters back to server1\instance1 and resume normal operation
 
 #>
-	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
-	param ([parameter(Mandatory = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter]$SqlInstance,
-		[PSCredential]$Credential,
-		[string]$MasterData,
-		[string]$MasterLog,
-		[string]$ErrorLog,
-		[string[]]$TraceFlags,
-		[switch]$CommandPromptStart,
-		[switch]$MinimalStart,
-		[int]$MemoryToReserve,
-		[switch]$SingleUser,
-		[string]$SingleUserDetails,
-		[switch]$NoLoggingToWinEvents,
-		[switch]$StartAsNamedInstance,
-		[switch]$DisableMonitoring,
-		[switch]$IncreasedExtents,
-		[switch]$TraceFlagsOverride,
-		[object]$StartUpConfig,
-		[switch]$Silent
-		
-	)
-	process {
-		
-		#Get Current parameters:
-		$currentstartup = Get-DbaStartupParameter -SqlInstance $sqlinstance -Credential $Credential
-		$originalparamstring = $currentstartup.ParameterString
-		
-		Write-Message -Level Output -Message "Original startup parameter string: $originalparamstring"
-		
-		if ('startUpconfig' -in $PsBoundParameters.keys) {
-			Write-Message -Level VeryVerbose -Message "StartupObject passed in"
-			$newstartup = $StartUpConfig
-			$TraceFlagsOverride = $true
-		}
-		else {
-			Write-Message -Level VeryVerbose -Message "Parameters passed in"
-			$newstartup = $currentstartup.PSObject.copy()
-			foreach ($param in ($PsBoundParameters.keys | Where-Object { $_ -in ($newstartup.PSObject.Properties.name) })) {
-				if ($PsBoundParameters.item($param) -ne $newstartup.$param) {
-					$newstartup.$param = $PsBoundParameters.item($param)
-				}
-			}
-		}
-		
-		if (!($currentstartup.SingleUser)) {
-			
-			if ($newstartup.Masterdata.length -gt 0) {
-				if (Test-DbaSqlPath -SqlInstance $sqlinstance -SqlCredential $Credential -Path (Split-Path $newstartup.MasterData -Parent)) {
-					$ParameterString += "-d$($newstartup.MasterData);"
-				}
-				else {
-					Stop-Function -Message "Specified folder for Master Data file is not reachable by instance $sqlinstance"
-				}
-			}
-			else {
-				Stop-Function -Message "MasterData value must be provided"
-			}
-			
-			if ($newstartup.ErrorLog.length -gt 0) {
-				if (Test-DbaSqlPath -SqlInstance $sqlinstance -SqlCredential $Credential -Path (Split-Path $newstartup.ErrorLog -Parent)) {
-					$ParameterString += "-e$($newstartup.ErrorLog);"
-				}
-				else {
-					Stop-Function -Message "Specified folder for ErrorLog  file is not reachable by $sqlinstance"
-				}
-			}
-			else {
-				Stop-Function -Message "ErrorLog value must be provided"
-			}
-			
-			if ($newstartup.MasterLog.Length -gt 0) {
-				if (Test-DbaSqlPath -SqlInstance $sqlinstance -SqlCredential $Credential -Path (Split-Path $newstartup.MasterLog -Parent)) {
-					$ParameterString += "-l$($newstartup.MasterLog);"
-				}
-				else {
-					Stop-Function -Message "Specified folder for Master Log  file is not reachable by $sqlinstance"
-				}
-			}
-			else {
-				Stop-Function -Message "MasterLog value must be provided."
-			}
-		}
-		else {
-			
-			Write-Message -Level Verbose -Message "Sql instance is presently configured for single user, skipping path validation"
-			if ($newstartup.MasterData.Length -gt 0) {
-				$ParameterString += "-d$($newstartup.MasterData);"
-			}
-			else {
-				Stop-Function -Message "Must have a value for MasterData"
-			}
-			if ($newstartup.ErrorLog.Length -gt 0) {
-				$ParameterString += "-e$($newstartup.ErrorLog);"
-			}
-			else {
-				Stop-Function -Message "Must have a value for Errorlog"
-			}
-			if ($newstartup.MasterLog.Length -gt 0) {
-				$ParameterString += "-l$($newstartup.MasterLog);"
-			}
-			else {
-				Stop-Function -Message "Must have a value for MsterLog"
-			}
-		}
-		
-		if ($newstartup.CommandPromptStart) {
-			$ParameterString += "-c;"
-		}
-		if ($newstartup.MinimalStart) {
-			$ParameterString += "-f;"
-		}
-		if ($newstartup.MemoryToReserve -notin ($null, 0)) {
-			$ParameterString += "-g$($newstartup.MemoryToReserve)"
-		}
-		if ($newstartup.SingleUser) {
-			if ($SingleUserDetails.length -gt 0) {
-				if ($SingleUserDetails -match ' ') {
-					$SingleUserDetails = """$SingleUserDetails"""
-				}
-				$ParameterString += "-m$SingleUserDetails;"
-			}
-			else {
-				$ParameterString += "-m;"
-			}
-		}
-		if ($newstartup.NoLoggingToWinEvents) {
-			$ParameterString += "-n;"
-		}
-		If ($newstartup.StartAsNamedInstance) {
-			$ParameterString += "-s;"
-		}
-		if ($newstartup.DisableMonitoring) {
-			$ParameterString += "-x;"
-		}
-		if ($newstartup.IncreasedExtents) {
-			$ParameterString += "-E;"
-		}
-		if ($newstartup.TraceFlags -eq 'None') {
-			$newstartup.TraceFlags = ''
-		}
-		if ($TraceFlagsOverride -and 'TraceFlags' -in $PsBoundParameters.keys) {
-			if ($null -ne $TraceFlags -and '' -ne $TraceFlags) {
-				$newstartup.TraceFlags = $TraceFlags -join ','
-				$ParameterString += (($TraceFlags.split(',') | ForEach-Object { "-T$_" }) -join ';') + ";"
-			}
-		}
-		else {
-			if ('TraceFlags' -in $PsBoundParameters.keys) {
-				if ($null -eq $TraceFlags) { $TraceFlags = '' }
-				$oldflags = @($currentstartup.TraceFlags) -split ',' | Where-Object { $_ -ne 'None' }
-				$newflags = $TraceFlags
-				$newflags = $oldflags + $newflags
-				$newstartup.TraceFlags = ($oldFlags + $newflags | Sort-Object -Unique) -join ','
-			}
-			elseif ($TraceFlagsOverride) {
-				$newstartup.TraceFlags = ''
-			}
-			else {
-				$newstartup.TraceFlags = if ($currentstartup.TraceFlags -eq 'None') { }
-				else { $currentstartup.TraceFlags -join ',' }
-			}
-			If ($newstartup.TraceFlags.Length -ne 0) {
-				$ParameterString += (($newstartup.TraceFlags.split(',') | ForEach-Object { "-T$_" }) -join ';') + ";"
-			}
-		}
-		
-		$instance, $instancename = ($sqlinstance.Split('\'))
-		Write-Message -Level Verbose -Message "Attempting to connect to $instancename on $instance"
-		
-		if ($instancename.Length -eq 0) { $instancename = "MSSQLSERVER" }
-		
-		$displayname = "SQL Server ($instancename)"
-		
-		if ($originalparamstring -eq "$ParameterString" -or "$originalparamstring;" -eq "$ParameterString") {
-			Stop-Function -Message "New parameter string would be the same as the old parameter string. Nothing to do." -Target $ParameterString
-			return
-		}
-		
-		$Scriptblock = {
-			$instance = $args[0]
-			$displayname = $args[1]
-			$ParameterString = $args[2]
-			
-			$wmisvc = $wmi.Services | Where-Object { $_.DisplayName -eq $displayname }
-			$wmisvc.StartupParameters = $ParameterString
-			$wmisvc.Alter()
-			$wmisvc.Refresh()
-			if ($wmisvc.StartupParameters -eq $ParameterString) {
-				$true
-			}
-			else {
-				$false
-			}
-		}
-		
-		if ($pscmdlet.ShouldProcess("Setting Sql Server start parameters on $sqlinstance to $ParameterString")) {
-			try {
-				if ($credential) {
-					$response = Invoke-ManagedComputerCommand -Server $instance -Credential $credential -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString
-					$output = Get-DbaStartupParameter -SqlInstance $sqlinstance -Credential $Credential
-					Add-Member -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
-				}
-				else {
-					$response = Invoke-ManagedComputerCommand -Server $instance -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString
-					$output = Get-DbaStartupParameter -SqlInstance $sqlinstance
-					Add-Member -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
-				}
-				
-				$output
-				
-				Write-Message -Level Output -Message "Startup parameters changed on $sqlinstance. You must restart SQL Server for changes to take effect."
-				}
-			catch {
-				Stop-Function -Message "Startup parameters failed to change on $sqlinstance. Failure reported: $_" -Target $_
-			}
-		}
-	}
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    param ([parameter(Mandatory = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter]
+        $SqlInstance,
+        
+        [PSCredential]
+        $Credential,
+        
+        [string]
+        $MasterData,
+        
+        [string]
+        $MasterLog,
+        
+        [string]
+        $ErrorLog,
+        
+        [string[]]
+        $TraceFlags,
+        
+        [switch]
+        $CommandPromptStart,
+        
+        [switch]
+        $MinimalStart,
+        
+        [int]
+        $MemoryToReserve,
+        
+        [switch]
+        $SingleUser,
+        
+        [string]
+        $SingleUserDetails,
+        
+        [switch]
+        $NoLoggingToWinEvents,
+        
+        [switch]
+        $StartAsNamedInstance,
+        
+        [switch]
+        $DisableMonitoring,
+        
+        [switch]
+        $IncreasedExtents,
+        
+        [switch]
+        $TraceFlagsOverride,
+        
+        [object]
+        $StartUpConfig,
+        
+        [switch]
+        $Silent
+        
+    )
+    process {
+        try {
+            Write-Message -Level VeryVerbose -Message "Connecting to $SqlInstance" -Target $SqlInstance
+            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $Credential
+        }
+        catch {
+            Stop-Function -Message "Failed to process Instance $SqlInstance" -ErrorRecord $_ -Target $SqlInstance
+            return
+        }
+        
+        #Get Current parameters:
+        $currentstartup = Get-DbaStartupParameter -SqlInstance $server -Credential $Credential
+        $originalparamstring = $currentstartup.ParameterString
+        
+        Write-Message -Level Output -Message "Original startup parameter string: $originalparamstring"
+        
+        if ('startUpconfig' -in $PsBoundParameters.keys) {
+            Write-Message -Level VeryVerbose -Message "StartupObject passed in"
+            $newstartup = $StartUpConfig
+            $TraceFlagsOverride = $true
+        }
+        else {
+            Write-Message -Level VeryVerbose -Message "Parameters passed in"
+            $newstartup = $currentstartup.PSObject.copy()
+            foreach ($param in ($PsBoundParameters.keys | Where-Object { $_ -in ($newstartup.PSObject.Properties.name) })) {
+                if ($PsBoundParameters.item($param) -ne $newstartup.$param) {
+                    $newstartup.$param = $PsBoundParameters.item($param)
+                }
+            }
+        }
+        
+        if (!($currentstartup.SingleUser)) {
+            
+            if ($newstartup.Masterdata.length -gt 0) {
+                if (Test-DbaSqlPath -SqlInstance $server -SqlCredential $Credential -Path (Split-Path $newstartup.MasterData -Parent)) {
+                    $ParameterString += "-d$($newstartup.MasterData);"
+                }
+                else {
+                    Stop-Function -Message "Specified folder for Master Data file is not reachable by instance $SqlInstance"
+                    return
+                }
+            }
+            else {
+                Stop-Function -Message "MasterData value must be provided"
+                return
+            }
+            
+            if ($newstartup.ErrorLog.length -gt 0) {
+                if (Test-DbaSqlPath -SqlInstance $server -SqlCredential $Credential -Path (Split-Path $newstartup.ErrorLog -Parent)) {
+                    $ParameterString += "-e$($newstartup.ErrorLog);"
+                }
+                else {
+                    Stop-Function -Message "Specified folder for ErrorLog  file is not reachable by $SqlInstance"
+                    return
+                }
+            }
+            else {
+                Stop-Function -Message "ErrorLog value must be provided"
+                return
+            }
+            
+            if ($newstartup.MasterLog.Length -gt 0) {
+                if (Test-DbaSqlPath -SqlInstance $server -SqlCredential $Credential -Path (Split-Path $newstartup.MasterLog -Parent)) {
+                    $ParameterString += "-l$($newstartup.MasterLog);"
+                }
+                else {
+                    Stop-Function -Message "Specified folder for Master Log  file is not reachable by $SqlInstance"
+                    return
+                }
+            }
+            else {
+                Stop-Function -Message "MasterLog value must be provided."
+                return
+            }
+        }
+        else {
+            
+            Write-Message -Level Verbose -Message "Sql instance is presently configured for single user, skipping path validation"
+            if ($newstartup.MasterData.Length -gt 0) {
+                $ParameterString += "-d$($newstartup.MasterData);"
+            }
+            else {
+                Stop-Function -Message "Must have a value for MasterData"
+                return
+            }
+            if ($newstartup.ErrorLog.Length -gt 0) {
+                $ParameterString += "-e$($newstartup.ErrorLog);"
+            }
+            else {
+                Stop-Function -Message "Must have a value for Errorlog"
+                return
+            }
+            if ($newstartup.MasterLog.Length -gt 0) {
+                $ParameterString += "-l$($newstartup.MasterLog);"
+            }
+            else {
+                Stop-Function -Message "Must have a value for MsterLog"
+                return
+            }
+        }
+        
+        if ($newstartup.CommandPromptStart) {
+            $ParameterString += "-c;"
+        }
+        if ($newstartup.MinimalStart) {
+            $ParameterString += "-f;"
+        }
+        if ($newstartup.MemoryToReserve -notin ($null, 0)) {
+            $ParameterString += "-g$($newstartup.MemoryToReserve)"
+        }
+        if ($newstartup.SingleUser) {
+            if ($SingleUserDetails.length -gt 0) {
+                if ($SingleUserDetails -match ' ') {
+                    $SingleUserDetails = """$SingleUserDetails"""
+                }
+                $ParameterString += "-m$SingleUserDetails;"
+            }
+            else {
+                $ParameterString += "-m;"
+            }
+        }
+        if ($newstartup.NoLoggingToWinEvents) {
+            $ParameterString += "-n;"
+        }
+        If ($newstartup.StartAsNamedInstance) {
+            $ParameterString += "-s;"
+        }
+        if ($newstartup.DisableMonitoring) {
+            $ParameterString += "-x;"
+        }
+        if ($newstartup.IncreasedExtents) {
+            $ParameterString += "-E;"
+        }
+        if ($newstartup.TraceFlags -eq 'None') {
+            $newstartup.TraceFlags = ''
+        }
+        if ($TraceFlagsOverride -and 'TraceFlags' -in $PsBoundParameters.keys) {
+            if ($null -ne $TraceFlags -and '' -ne $TraceFlags) {
+                $newstartup.TraceFlags = $TraceFlags -join ','
+                $ParameterString += (($TraceFlags.split(',') | ForEach-Object { "-T$_" }) -join ';') + ";"
+            }
+        }
+        else {
+            if ('TraceFlags' -in $PsBoundParameters.keys) {
+                if ($null -eq $TraceFlags) { $TraceFlags = '' }
+                $oldflags = @($currentstartup.TraceFlags) -split ',' | Where-Object { $_ -ne 'None' }
+                $newflags = $TraceFlags
+                $newflags = $oldflags + $newflags
+                $newstartup.TraceFlags = ($oldFlags + $newflags | Sort-Object -Unique) -join ','
+            }
+            elseif ($TraceFlagsOverride) {
+                $newstartup.TraceFlags = ''
+            }
+            else {
+                $newstartup.TraceFlags = if ($currentstartup.TraceFlags -eq 'None') { }
+                else { $currentstartup.TraceFlags -join ',' }
+            }
+            If ($newstartup.TraceFlags.Length -ne 0) {
+                $ParameterString += (($newstartup.TraceFlags.split(',') | ForEach-Object { "-T$_" }) -join ';') + ";"
+            }
+        }
+        
+        $instance = $SqlInstance.ComputerName
+        $instancename = $SqlInstance.InstanceName
+        Write-Message -Level Verbose -Message "Attempting to connect to $instancename on $instance"
+        
+        if ($instancename.Length -eq 0) { $instancename = "MSSQLSERVER" }
+        
+        $displayname = "SQL Server ($instancename)"
+        
+        if ($originalparamstring -eq "$ParameterString" -or "$originalparamstring;" -eq "$ParameterString") {
+            Stop-Function -Message "New parameter string would be the same as the old parameter string. Nothing to do." -Target $ParameterString
+            return
+        }
+        
+        $Scriptblock = {
+            $instance = $args[0]
+            $displayname = $args[1]
+            $ParameterString = $args[2]
+            
+            $wmisvc = $wmi.Services | Where-Object { $_.DisplayName -eq $displayname }
+            $wmisvc.StartupParameters = $ParameterString
+            $wmisvc.Alter()
+            $wmisvc.Refresh()
+            if ($wmisvc.StartupParameters -eq $ParameterString) {
+                $true
+            }
+            else {
+                $false
+            }
+        }
+        
+        if ($pscmdlet.ShouldProcess("Setting Sql Server start parameters on $SqlInstance to $ParameterString")) {
+            try {
+                if ($Credential) {
+                    $response = Invoke-ManagedComputerCommand -Server $instance -Credential $Credential -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -Silent
+                    $output = Get-DbaStartupParameter -SqlInstance $server -Credential $Credential -Silent
+                    Add-Member -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
+                }
+                else {
+                    $response = Invoke-ManagedComputerCommand -Server $instance -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -Silent
+                    $output = Get-DbaStartupParameter -SqlInstance $server -Silent
+                    Add-Member -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
+                }
+                
+                $output
+                
+                Write-Message -Level Output -Message "Startup parameters changed on $SqlInstance. You must restart SQL Server for changes to take effect."
+            }
+            catch {
+                Stop-Function -Message "Startup parameters failed to change on $SqlInstance. " -Target $SqlInstance -ErrorRecord $_
+                return
+            }
+        }
+    }
 }

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -1,180 +1,193 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
 Function Set-DbaTcpPort {
 <#
-.SYNOPSIS
-Changes the TCP port used by the specified SQL Server.
-	
-.DESCRIPTION
-This function changes the TCP port used by the specified SQL Server. 
-		
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
-
-.PARAMETER Credential
-Credential object used to connect to the SQL Server as a different user
-
-.PARAMETER IPAddress
-Wich IPAddress should the portchange , if omitted allip (0.0.0.0) will be changed with the new portnumber. 
-
-.PARAMETER Port
-TCPPort that SQLService should listen on.
-
-.NOTES 
-Author: Hansson7707@gmail.com
-	
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
-
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
-
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
-
-.PARAMETER Silent 
-Use this switch to disable any kind of verbose messages
-
-.LINK
-https://dbatools.io/Set-DbaTcpPort
-
-.EXAMPLE
-Set-DbaTcpPort -SqlInstance SqlInstance2014a -Port 1433
-
-Sets the port number 1433 for allips on the default instance on SqlInstance2014a
-
-.EXAMPLE
-Set-DbaTcpPort -SqlInstance winserver\sqlexpress -IpAddress 192.168.1.22 -Port 1433
-
-Sets the port number 1433 for IP 192.168.1.22 on the sqlexpress instance on winserver	
-
-.EXAMPLE
-Set-DbaTcpPort -SqlInstance 'SQLDB2014A' ,'SQLDB2016B' -port 1337
-
-Sets the port number 1337 for ALLIP's on SqlInstance SQLDB2014A and SQLDB2016B
+    .SYNOPSIS
+        Changes the TCP port used by the specified SQL Server.
+    
+    .DESCRIPTION
+        This function changes the TCP port used by the specified SQL Server.
+    
+    .PARAMETER SqlInstance
+        The SQL Server that you're connecting to.
+    
+    .PARAMETER Credential
+        Credential object used to connect to the SQL Server as a different user
+    
+    .PARAMETER Port
+        TCPPort that SQLService should listen on.
+    
+    .PARAMETER IPAddress
+        Wich IPAddress should the portchange , if omitted allip (0.0.0.0) will be changed with the new portnumber.
+    
+    .PARAMETER Silent
+        Replaces user friendly yellow warnings with bloody red exceptions of doom!
+        Use this if you want the function to throw terminating errors you want to catch.
+    
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+    
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+    
+    .EXAMPLE
+        Set-DbaTcpPort -SqlInstance SqlInstance2014a -Port 1433
+        
+        Sets the port number 1433 for allips on the default instance on SqlInstance2014a
+    
+    .EXAMPLE
+        Set-DbaTcpPort -SqlInstance winserver\sqlexpress -IpAddress 192.168.1.22 -Port 1433
+        
+        Sets the port number 1433 for IP 192.168.1.22 on the sqlexpress instance on winserver
+    
+    .EXAMPLE
+        Set-DbaTcpPort -SqlInstance 'SQLDB2014A' ,'SQLDB2016B' -port 1337
+        
+        Sets the port number 1337 for ALLIP's on SqlInstance SQLDB2014A and SQLDB2016B
+    
+    .NOTES
+        Author: Hansson7707@gmail.com
+        
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+    
+    .LINK
+        https://dbatools.io/Set-DbaTcpPort
 #>
-	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
-	Param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[Alias("SqlCredential")]
-		[PsCredential]$Credential,
-		[parameter(Mandatory = $true)]
-		[ValidateRange(1, 65535)]
-		[int]$Port,
-		[ipaddress[]]$IpAddress,
-		[switch]$Silent
-	)
-	
-	begin {
-		
-		if ($ipaddress.Length -eq 0) {
-			$ipaddress = '0.0.0.0'
-		}
-		else {
-			if ($SqlInstance.count -gt 1) {
-				Stop-Function -Message "-IpAddress switch cannot be used with a collection of serveraddresses" -Target $SqlInstance
-			}
-		}
-	}
-	
-	process {
-		if (Test-FunctionInterrupt) { return }
-		
-		foreach ($instance in $SqlInstance) {
-			
-			try {
-				Write-Message -Level Verbose -Message "Connecting to $instance"
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-			}
-			catch {
-				Stop-Function -Message "Failed to connect to: $instance" -Target $instance -ErrorRecord $_ -Continue
-			}
-			
-			$wmiinstancename = $server.instanceName
-			if ($wmiinstancename.length -eq 0) {
-				$wmiinstancename = 'MSSqlInstance'
-			}
-			if ($server.IsClustered) {
-				Write-Message -Level Verbose -Message "Instance is clustered fetching nodes..."
-				$clusterquery = "select nodename from sys.dm_os_cluster_nodes where not nodename = '$($server.ComputerNamePhysicalNetBIOS)'"
-				$clusterresult = $server.ConnectionContext.ExecuteWithResults("$clusterquery")
-				foreach ($row in $clusterresult.tables[0].rows) { $ClusterNodes += $row.Item(0) + " " }
-				Write-Warning "$instance is a clustered instance, portchanges will be reflected on other nodes ( $clusternodes) after a failover..."
-			}
-			$scriptblock = {
-				$instance = $args[0]
-				$wmiinstancename = $args[1]
-				$port = $args[2]
-				$ipaddress = $args[3]
-				$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $instance
-				$wmiinstance = $wmi.ServerInstances | Where-Object { $_.Name -eq $wmiinstancename }
-				$tcp = $wmiinstance.ServerProtocols | Where-Object { $_.DisplayName -eq 'TCP/IP' }
-				$ipaddress = $tcp.IPAddresses | where-object { $_.IPAddress -eq $ipaddress }
-				$tcpport = $ipaddress.IPAddressProperties | Where-Object { $_.Name -eq 'TcpPort' }
-				
-				try {
-					$tcpport.value = $port
-					$tcp.Alter()
-				}
-				catch {
-					# Can't do a stop function because this is a remote session
-					return $_
-				}
-			}
-			
-			try {
-				$computerName = $instance.split("\")[0]
-				$resolved = Resolve-DbaNetworkName -ComputerName $computerName
-				
-				Write-Message -Level Verbose -Message "Writing TCPPort $port for $instance to $($resolved.FQDN)..."
-				$setport = Invoke-ManagedComputerCommand -Server $resolved.FQDN -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $ipaddress
-				if ($setport.length -eq 0) {
-					if ($ipaddress -eq '0.0.0.0') {
-						Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
-					}
-					else {
-						Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
-					}
-				}
-				else {
-					if ($ipaddress -eq '0.0.0.0') {
-						Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
-						Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
-					}
-					else {
-						Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
-						Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
-					}
-				}
-			}
-			catch {
-				try {
-					Write-Message -Level Verbose -Message "Failed to write TCPPort $port for $instance to $($resolved.FQDN) trying computername $($server.ComputerNamePhysicalNetBIOS)...."
-					$setport = Invoke-ManagedComputerCommand -Server $server.ComputerNamePhysicalNetBIOS -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $ipaddress
-					if ($setport.length -eq 0) {
-						if ($ipaddress -eq '0.0.0.0') {
-							Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
-						}
-						else {
-							Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
-						}
-					}
-					else {
-						if ($ipaddress -eq '0.0.0.0') {
-							Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
-							Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
-						}
-						else {
-							Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
-							Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
-						}
-					}
-				}
-				catch {
-					Stop-Function -Message "Could not write new TCPPort for $instance" -Continue -Target $instance -ErrorRecord $_
-				}
-			}
-		}
-	}
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    Param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]
+        $SqlInstance,
+        
+        [Alias("SqlCredential")]
+        [PsCredential]
+        $Credential,
+        
+        [parameter(Mandatory = $true)]
+        [ValidateRange(1, 65535)]
+        [int]
+        $Port,
+        
+        [ipaddress[]]
+        $IpAddress,
+        
+        [switch]
+        $Silent
+    )
+    
+    begin {
+        
+        if ($ipaddress.Length -eq 0) {
+            $ipaddress = '0.0.0.0'
+        }
+        else {
+            if ($SqlInstance.count -gt 1) {
+                Stop-Function -Message "-IpAddress switch cannot be used with a collection of serveraddresses" -Target $SqlInstance
+                return
+            }
+        }
+    }
+    
+    process {
+        if (Test-FunctionInterrupt) { return }
+        
+        foreach ($instance in $SqlInstance) {
+            
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failed to connect to: $instance" -Target $instance -ErrorRecord $_ -Continue
+            }
+            
+            $wmiinstancename = $server.instanceName
+            if ($wmiinstancename.length -eq 0) {
+                $wmiinstancename = 'MSSqlInstance'
+            }
+            if ($server.IsClustered) {
+                Write-Message -Level Verbose -Message "Instance is clustered fetching nodes..."
+                $clusterquery = "select nodename from sys.dm_os_cluster_nodes where not nodename = '$($server.ComputerNamePhysicalNetBIOS)'"
+                $clusterresult = $server.ConnectionContext.ExecuteWithResults("$clusterquery")
+                foreach ($row in $clusterresult.tables[0].rows) { $ClusterNodes += $row.Item(0) + " " }
+                Write-Warning "$instance is a clustered instance, portchanges will be reflected on other nodes ( $clusternodes) after a failover..."
+            }
+            $scriptblock = {
+                $instance = $args[0]
+                $wmiinstancename = $args[1]
+                $port = $args[2]
+                $ipaddress = $args[3]
+                $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $instance
+                $wmiinstance = $wmi.ServerInstances | Where-Object { $_.Name -eq $wmiinstancename }
+                $tcp = $wmiinstance.ServerProtocols | Where-Object { $_.DisplayName -eq 'TCP/IP' }
+                $ipaddress = $tcp.IPAddresses | where-object { $_.IPAddress -eq $ipaddress }
+                $tcpport = $ipaddress.IPAddressProperties | Where-Object { $_.Name -eq 'TcpPort' }
+                
+                try {
+                    $tcpport.value = $port
+                    $tcp.Alter()
+                }
+                catch {
+                    # Can't do a stop function because this is a remote session
+                    return $_
+                }
+            }
+            
+            try {
+                $computerName = $instance.ComputerName
+                $resolved = Resolve-DbaNetworkName -ComputerName $computerName
+                
+                Write-Message -Level Verbose -Message "Writing TCPPort $port for $instance to $($resolved.FQDN)..."
+                $setport = Invoke-ManagedComputerCommand -Server $resolved.FQDN -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $ipaddress
+                if ($setport.length -eq 0) {
+                    if ($ipaddress -eq '0.0.0.0') {
+                        Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
+                    }
+                    else {
+                        Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
+                    }
+                }
+                else {
+                    if ($ipaddress -eq '0.0.0.0') {
+                        Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
+                        Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
+                    }
+                    else {
+                        Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
+                        Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
+                    }
+                }
+            }
+            catch {
+                try {
+                    Write-Message -Level Verbose -Message "Failed to write TCPPort $port for $instance to $($resolved.FQDN) trying computername $($server.ComputerNamePhysicalNetBIOS)...."
+                    $setport = Invoke-ManagedComputerCommand -Server $server.ComputerNamePhysicalNetBIOS -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $ipaddress
+                    if ($setport.length -eq 0) {
+                        if ($ipaddress -eq '0.0.0.0') {
+                            Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
+                        }
+                        else {
+                            Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
+                        }
+                    }
+                    else {
+                        if ($ipaddress -eq '0.0.0.0') {
+                            Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: ALLIP's PORT: $port"
+                            Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
+                        }
+                        else {
+                            Write-Message -Level Verbose -Message "SqlInstance: $instance IPADDRESS: $ipaddress PORT: $port"
+                            Write-Message -Level Verbose -Message " FAILED!" -ForegroundColor Red
+                        }
+                    }
+                }
+                catch {
+                    Stop-Function -Message "Could not write new TCPPort for $instance" -Continue -Target $instance -ErrorRecord $_
+                }
+            }
+        }
+    }
 }

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -1,270 +1,242 @@
-Function Test-DbaConnection
-{
-<# 
-.SYNOPSIS 
-Exported function. Tests a the connection to a single instance and shows the output.
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 
-.DESCRIPTION
-Tests a the connection to a single instance and shows the output.
-
-.PARAMETER SqlInstance
-The SQL Server Instance to test connection against
-
-.PARAMETER SqlCredential 
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
-  
-$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.  
- 
-Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. To connect as a different Windows user, run PowerShell as that user. 
-
-
-.EXAMPLE
-Test-DbaConnection sql01
-
-Sample output:
-
-Local PowerShell Enviornment
-
-Windows    : 10.0.10240.0
-PowerShell : 5.0.10240.16384
-CLR        : 4.0.30319.42000
-SMO        : 13.0.0.0
-DomainUser : True
-RunAsAdmin : False
-
-SQL Server Connection Information
-
-ServerName         : sql01
-BaseName           : sql01
-InstanceName       : (Default)
-AuthType           : Windows Authentication (Trusted)
-ConnectingAsUser   : ad\dba
-ConnectSuccess     : True
-SqlServerVersion   : 12.0.2370
-AddlConnectInfo    : N/A
-RemoteServer       : True
-IPAddress          : 10.0.1.4
-NetBIOSname        : SQLSERVER2014A
-RemotingAccessible : True
-Pingable           : True
-DefaultSQLPortOpen : True
-RemotingPortOpen   : True
-
-
-.NOTES
-Tags: CIM
-Original Author: Chrissy LeMaire
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-#>	
-	[CmdletBinding()]
-	param (
-		[Parameter(Mandatory = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter]$SqlInstance,
-		[System.Management.Automation.PSCredential]$SqlCredential
-	)
-	
-	
-	# Get local enviornment
-	Write-Output "Getting local enivornment information"
-	$localinfo = @{ } | Select-Object Windows, PowerShell, CLR, SMO, DomainUser, RunAsAdmin
-	$localinfo.Windows = [environment]::OSVersion.Version.ToString()
-	$localinfo.PowerShell = $PSVersionTable.PSversion.ToString()
-	$localinfo.CLR = $PSVersionTable.CLRVersion.ToString()
-	$smo = (([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]
-	$localinfo.SMO = $smo.TrimStart("Version=")
-	$localinfo.DomainUser = $env:computername -ne $env:USERDOMAIN
-	$localinfo.RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
-	
-	# SQL Server
-	if ($SqlInstance.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) { $SqlInstance = $SqlInstance.Name.ToString() }
-	
-	$serverinfo = @{ } | Select-Object ServerName, BaseName, InstanceName, AuthType, ConnectingAsUser, ConnectSuccess, SqlServerVersion, AddlConnectInfo, RemoteServer, IPAddress, NetBIOSname, RemotingAccessible, Pingable, DefaultSQLPortOpen, RemotingPortOpen
-	
-	$serverinfo.ServerName = $SqlInstance
-	
-	[regex]$portdetection = ":\d{1,5}$"
-	if ($SqlInstance.LastIndexOf(":") -ne -1)
-	{
-		$portnumber = $SqlInstance.substring($SqlInstance.LastIndexOf(":"))
-		if ($portnumber -match $portdetection)
-		{
-			$replacedportseparator = $portnumber -replace ":", ","
-			$SqlInstance = $SqlInstance -replace $portnumber, $replacedportseparator
-		}
-	}
-	
-	Write-Output "Determining SQL Server base address"
-	$baseaddress = $SqlInstance.Split(",")[0]
-	$baseaddress = $baseaddress.Split("\")[0]
-	try { $instance = $SqlInstance.Split("\")[1] }
-	catch { $instance = "(Default)" }
-	if ([string]::IsNullOrEmpty($instance)) { $instance = "(Default)" }
-	
-	if ($baseaddress -eq "." -or $baseaddress -eq $env:COMPUTERNAME)
-	{
-		$ipaddr = "."
-		$hostname = $env:COMPUTERNAME
-		$baseaddress = $env:COMPUTERNAME
-	}
-	
-	$serverinfo.BaseName = $baseaddress
-	$remote = $baseaddress -ne $env:COMPUTERNAME
-	$serverinfo.InstanceName = $instance
-	$serverinfo.RemoteServer = $remote
-	
-	Write-Output "Resolving IP address"
-	try
-	{
-		$hostentry = [System.Net.Dns]::GetHostEntry($baseaddress)
-		$ipaddr = ($hostentry.AddressList | Where-Object { $_ -notlike '169.*' } | Select-Object -First 1).IPAddressToString
-	}
-	catch { $ipaddr = "Unable to resolve" }
-	
-	$serverinfo.IPAddress = $ipaddr
-	
-	Write-Output "Resolving NetBIOS name"
-	try
-	{
-		$sessionoptions = New-CimSessionOption -Protocol DCOM
-		$CIMsession = New-CimSession -ComputerName $ipaddr -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $SqlCredential
-		$hostname = (Get-CimInstance -CimSession $CIMsession -ClassName Win32_NetworkAdapterConfiguration -Filter "IPEnabled=TRUE").PSComputerName
-
-		if ([string]::IsNullOrEmpty($hostname)) { $hostname = (nbtstat -A $ipaddr | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim() }
-	}
-	catch { $hostname = "Unknown" }
-	
-	$serverinfo.NetBIOSname = $hostname
-	
-	
-	if ($remote -eq $true)
-	{
-		# Test for WinRM #Test-WinRM neh
-		Write-Output "Checking remote acccess"
-		winrm id -r:$hostname 2>$null | Out-Null
-		if ($LastExitCode -eq 0) { $remoting = $true }
-		else { $remoting = $false }
-		
-		$serverinfo.RemotingAccessible = $remoting
-		
-		Write-Output "Testing raw socket connection to PowerShell remoting port"
-		$tcp = New-Object System.Net.Sockets.TcpClient
-		try
-		{
-			$tcp.Connect($baseaddress, 135)
-			$tcp.Close()
-			$tcp.Dispose()
-			$remotingport = $true
-		}
-		catch { $remotingport = $false }
-		
-		$serverinfo.RemotingPortOpen = $remotingport
-	}
-	
-	# Test Connection first using Test-Connection which requires ICMP access then failback to tcp if pings are blocked
-	Write-Output "Testing ping to $baseaddress"
-	$testconnect = Test-Connection -ComputerName $baseaddress -Count 1 -Quiet
-	
-	$serverinfo.Pingable = $testconnect
-	
-	# SQL Server connection
-	
-	if ($instance -eq "(Default)")
-	{
-		Write-Output "Testing raw socket connection to default SQL port"
-		$tcp = New-Object System.Net.Sockets.TcpClient
-		try
-		{
-			$tcp.Connect($baseaddress, 1433)
-			$tcp.Close()
-			$tcp.Dispose()
-			$sqlport = $true
-		}
-		catch { $sqlport = $false }
-		$serverinfo.DefaultSQLPortOpen = $sqlport
-	}
-	else { $serverinfo.DefaultSQLPortOpen = "N/A" }
-	
-	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlInstance
-	
-	try
-	{
-		if ($SqlCredential -ne $null)
-		{
-			$username = ($SqlCredential.username).TrimStart("\")
-
-			if ($username -like "*\*")
-			{
-				$username = $username.Split("\")[1]
-				$authtype = "Windows Authentication with Credential"
-				$server.ConnectionContext.LoginSecure = $true
-				$server.ConnectionContext.ConnectAsUser = $true
-				$server.ConnectionContext.ConnectAsUserName = $username
-				$server.ConnectionContext.ConnectAsUserPassword = ($SqlCredential).GetNetworkCredential().Password
-			}
-			else
-			{
-				$authtype = "SQL Authentication"
-				$server.ConnectionContext.LoginSecure = $false
-				$server.ConnectionContext.set_Login($username)
-				$server.ConnectionContext.set_SecurePassword($SqlCredential.Password)
-			}
-		}
-		else
-		{
-			$authtype = "Windows Authentication (Trusted)"
-			$username = "$env:USERDOMAIN\$env:username"
-		}
-	}
-	catch
-	{
-		Write-Exception $_
-		$authtype = "Windows Authentication (Trusted)"
-		$username = "$env:USERDOMAIN\$env:username"
-	}
-	
-	$serverinfo.ConnectingAsUser = $username
-	$serverinfo.AuthType = $authtype
-	
-	
-	Write-Output "Attempting to connect to $SqlInstance as $username "
-	try
-	{
-		$server.ConnectionContext.ConnectTimeout = 10
-		$server.ConnectionContext.Connect()
-		$connectSuccess = $true
-		$version = $server.Version.ToString()
-		$addlinfo = "N/A"
-		$server.ConnectionContext.Disconnect()
-	}
-	catch
-	{
-		$connectSuccess = $false
-		$version = "N/A"
-		$addlinfo = $_.Exception
-	}
-	
-	$serverinfo.ConnectSuccess = $connectSuccess
-	$serverinfo.SqlServerVersion = $version
-	$serverinfo.AddlConnectInfo = $addlinfo
-	
-	Write-Output "`nLocal PowerShell Enviornment"
-	$localinfo | Select-Object Windows, PowerShell, CLR, SMO, DomainUser, RunAsAdmin
-	
-	Write-Output "SQL Server Connection Information`n"
-	$serverinfo | Select-Object ServerName, BaseName, InstanceName, AuthType, ConnectingAsUser, ConnectSuccess, SqlServerVersion, AddlConnectInfo, RemoteServer, IPAddress, NetBIOSname, RemotingAccessible, Pingable, DefaultSQLPortOpen, RemotingPortOpen
-	
-	Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Test-SqlConnection
+Function Test-DbaConnection {
+<#
+    .SYNOPSIS
+        Exported function. Tests a the connection to a single instance and shows the output.
+    
+    .DESCRIPTION
+        Tests a the connection to a single instance and shows the output.
+    
+    .PARAMETER SqlInstance
+        The SQL Server Instance to test connection against
+    
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+        
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+        
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. To connect as a different Windows user, run PowerShell as that user.
+    
+    .PARAMETER Silent
+        Replaces user friendly yellow warnings with bloody red exceptions of doom!
+        Use this if you want the function to throw terminating errors you want to catch.
+    
+    .EXAMPLE
+        Test-DbaConnection sql01
+        
+        Sample output:
+        
+        Local PowerShell Enviornment
+        
+        Windows    : 10.0.10240.0
+        PowerShell : 5.0.10240.16384
+        CLR        : 4.0.30319.42000
+        SMO        : 13.0.0.0
+        DomainUser : True
+        RunAsAdmin : False
+        
+        SQL Server Connection Information
+        
+        ServerName         : sql01
+        BaseName           : sql01
+        InstanceName       : (Default)
+        AuthType           : Windows Authentication (Trusted)
+        ConnectingAsUser   : ad\dba
+        ConnectSuccess     : True
+        SqlServerVersion   : 12.0.2370
+        AddlConnectInfo    : N/A
+        RemoteServer       : True
+        IPAddress          : 10.0.1.4
+        NetBIOSname        : SQLSERVER2014A
+        RemotingAccessible : True
+        Pingable           : True
+        DefaultSQLPortOpen : True
+        RemotingPortOpen   : True
+    
+    .NOTES
+        Tags: CIM
+        Original Author: Chrissy LeMaire
+        dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+        Copyright (C) 2016 Chrissy LeMaire
+        This program is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+        This program is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+        You should have received a copy of the GNU General Public License
+        along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#>    
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter]
+        $SqlInstance,
+        
+        [System.Management.Automation.PSCredential]
+        $SqlCredential,
+        
+        [switch]
+        $Silent
+    )
+    
+    Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Test-SqlConnection
+    
+    
+    # Get local enviornment
+    Write-Message -Level Verbose -Message "Getting local enivornment information"
+    $localinfo = [pscustomobject]@{
+        Windows = [environment]::OSVersion.Version.ToString()
+        PowerShell = $PSVersionTable.PSversion.ToString()
+        CLR = $PSVersionTable.CLRVersion.ToString()
+        SMO = ((([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]).TrimStart("Version=")
+        DomainUser = $env:computername -ne $env:USERDOMAIN
+        RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
+    }
+    
+    $serverinfo = @{ } | Select-Object ServerName, BaseName, InstanceName, AuthType, ConnectingAsUser, ConnectSuccess, SqlServerVersion, AddlConnectInfo, RemoteServer, IPAddress, NetBIOSname, RemotingAccessible, Pingable, DefaultSQLPortOpen, RemotingPortOpen
+    
+    $serverinfo.ServerName = $SqlInstance.FullSmoName
+    
+    $baseaddress = $SqlInstance.ComputerName
+    $instance = $SqlInstance.InstanceName
+    if ([string]::IsNullOrEmpty($instance)) { $instance = "(Default)" }
+    
+    if ($baseaddress -eq "." -or $baseaddress -eq $env:COMPUTERNAME) {
+        $ipaddr = "."
+        $hostname = $env:COMPUTERNAME
+        $baseaddress = $env:COMPUTERNAME
+    }
+    
+    $serverinfo.BaseName = $baseaddress
+    $remote = [dbavalidate]::IsLocalHost($env:COMPUTERNAME)
+    $serverinfo.InstanceName = $instance
+    $serverinfo.RemoteServer = $remote
+    
+    Write-Message -Level Verbose -Message "Resolving IP address"
+    try {
+        $hostentry = [System.Net.Dns]::GetHostEntry($baseaddress)
+        $ipaddr = ($hostentry.AddressList | Where-Object { $_ -notlike '169.*' } | Select-Object -First 1).IPAddressToString
+    }
+    catch { $ipaddr = "Unable to resolve" }
+    
+    $serverinfo.IPAddress = $ipaddr
+    
+    Write-Message -Level Verbose -Message "Resolving NetBIOS name"
+    try {
+        $hostname = (Get-DbaCmObject -ClassName Win32_NetworkAdapterConfiguration -ComputerName $ipaddr -Silent | Where-Object IPEnabled).PSComputerName
+                
+        if ([string]::IsNullOrEmpty($hostname)) { $hostname = (nbtstat -A $ipaddr | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim() }
+    }
+    catch { $hostname = "Unknown" }
+    
+    $serverinfo.NetBIOSname = $hostname
+    
+    
+    if ($remote -eq $true) {
+        # Test for WinRM #Test-WinRM neh
+        Write-Message -Level Verbose -Message "Checking remote acccess"
+        winrm id -r:$hostname 2>$null | Out-Null
+        if ($LastExitCode -eq 0) { $remoting = $true }
+        else { $remoting = $false }
+        
+        $serverinfo.RemotingAccessible = $remoting
+        
+        Write-Message -Level Verbose -Message "Testing raw socket connection to PowerShell remoting port"
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        try {
+            $tcp.Connect($baseaddress, 135)
+            $tcp.Close()
+            $tcp.Dispose()
+            $remotingport = $true
+        }
+        catch { $remotingport = $false }
+        
+        $serverinfo.RemotingPortOpen = $remotingport
+    }
+    
+    # Test Connection first using Test-Connection which requires ICMP access then failback to tcp if pings are blocked
+    Write-Message -Level Verbose -Message "Testing ping to $baseaddress"
+    $serverinfo.Pingable = Test-Connection -ComputerName $baseaddress -Count 1 -Quiet
+    
+    # SQL Server connection
+    if ($instance -eq "(Default)") {
+        Write-Message -Level Verbose -Message "Testing raw socket connection to default SQL port"
+        $tcp = New-Object System.Net.Sockets.TcpClient
+        try {
+            $tcp.Connect($baseaddress, 1433)
+            $tcp.Close()
+            $tcp.Dispose()
+            $sqlport = $true
+        }
+        catch { $sqlport = $false }
+        $serverinfo.DefaultSQLPortOpen = $sqlport
+    }
+    else { $serverinfo.DefaultSQLPortOpen = "N/A" }
+    
+    $server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlInstance.FullSmoName
+    
+    try {
+        if ($null -ne $SqlCredential) {
+            $username = ($SqlCredential.username).TrimStart("\")
+            
+            if ($username -like "*\*") {
+                $username = $username.Split("\")[1]
+                $authtype = "Windows Authentication with Credential"
+                $server.ConnectionContext.LoginSecure = $true
+                $server.ConnectionContext.ConnectAsUser = $true
+                $server.ConnectionContext.ConnectAsUserName = $username
+                $server.ConnectionContext.ConnectAsUserPassword = ($SqlCredential).GetNetworkCredential().Password
+            }
+            else {
+                $authtype = "SQL Authentication"
+                $server.ConnectionContext.LoginSecure = $false
+                $server.ConnectionContext.set_Login($username)
+                $server.ConnectionContext.set_SecurePassword($SqlCredential.Password)
+            }
+        }
+        else {
+            $authtype = "Windows Authentication (Trusted)"
+            $username = "$env:USERDOMAIN\$env:username"
+        }
+    }
+    catch {
+        Write-Message -Level Warning -Message $_ -ErrorRecord $_
+        
+        $authtype = "Windows Authentication (Trusted)"
+        $username = "$env:USERDOMAIN\$env:username"
+    }
+    
+    $serverinfo.ConnectingAsUser = $username
+    $serverinfo.AuthType = $authtype
+    
+    
+    Write-Message -Level Verbose -Message "Attempting to connect to $SqlInstance as $username "
+    try {
+        $server.ConnectionContext.ConnectTimeout = 10
+        $server.ConnectionContext.Connect()
+        $connectSuccess = $true
+        $version = $server.Version.ToString()
+        $addlinfo = "N/A"
+        $server.ConnectionContext.Disconnect()
+    }
+    catch {
+        $connectSuccess = $false
+        $version = "N/A"
+        $addlinfo = $_.Exception
+    }
+    
+    $serverinfo.ConnectSuccess = $connectSuccess
+    $serverinfo.SqlServerVersion = $version
+    $serverinfo.AddlConnectInfo = $addlinfo
+    
+    Write-Message -Level Verbose -Message "Local PowerShell Environment" -Target $localinfo
+    $localinfo | Select-Object Windows, PowerShell, CLR, SMO, DomainUser, RunAsAdmin
+    
+    Write-Message -Level Verbose -Message "SQL Server Connection Information" -Target $serverinfo
+    $serverinfo | Select-Object ServerName, BaseName, InstanceName, AuthType, ConnectingAsUser, ConnectSuccess, SqlServerVersion, AddlConnectInfo, RemoteServer, IPAddress, NetBIOSname, RemotingAccessible, Pingable, DefaultSQLPortOpen, RemotingPortOpen
 }


### PR DESCRIPTION
Fixes the last three known instances of failed execution due to calling `.Split()` on a `DbaInstanceParameter` type object.