### PR TITLE
Enhancements/new dba sql connection string/more parameters

### DIFF
--- a/functions/New-DbaSqlConnectionStringBuilder.ps1
+++ b/functions/New-DbaSqlConnectionStringBuilder.ps1
@@ -10,6 +10,24 @@ Creates a System.Data.SqlClient.SqlConnectionStringBuilder from a connection str
 .PARAMETER ConnectionString
 A Connection String
 
+.PARAMETER ApplicationName
+The application name to tell SQL Server the connection is associated with.
+
+.PARAMETER DataSource
+The Sql Server to connect to.
+
+.PARAMETER InitialCatalog
+The initial database on the server to connect to.
+
+.PARAMETER IntegratedSecurity
+Set to true to use windows authentication.
+
+.PARAMETER SqlUser
+Sql User Name to connect with.
+
+.PARAMETER Password
+Password to use to connect withy.
+
 .NOTES
 Author: zippy1981
 Tags: SqlBuild
@@ -37,9 +55,45 @@ Returns a connection string builder that can be used to connect to the local sql
 	[CmdletBinding()]
 	Param (
 		[Parameter(Mandatory = $false, ValueFromPipeline = $true)]
-        [string[]]$ConnectionString = $null
+        [string[]]$ConnectionString = "",
+		[Parameter(Mandatory = $false)]
+		[string]$ApplicationName = "dbatools Powershell Module",
+		[Parameter(Mandatory = $false)]
+		[string]$DataSource = $null,
+		[Parameter(Mandatory = $false)]
+		[string]$InitialCatalog = $null,
+		[Parameter(Mandatory = $false)]
+		[Nullable[bool]]$IntegratedSecurity = $null,
+		[Parameter(Mandatory = $false)]
+		[string]$SqlUser = $null,
+		# No point in securestring here, the memory is never stored securely in memory.
+		[Parameter(Mandatory = $false)]
+		[string]$Password = $null
 	)
     process {
-		New-Object Data.SqlClient.SqlConnectionStringBuilder $ConnectionString
+		foreach ($string in $ConnectionString) {
+			$builder = New-Object Data.SqlClient.SqlConnectionStringBuilder $ConnectionString
+			if ($builder.ApplicationName -eq ".Net SqlClient Data Provider") {
+				$builder['Application Name'] = $ApplicationName
+			}
+			if ($DataSource -ne $null) {
+				$builder['Data Source'] = $DataSource
+			}
+			if ($InitialCatalog -ne $null) {
+				$builder['Initial Catalog'] = $InitialCatalog
+			}
+			if ($IntegratedSecurity -ne $null) {
+				$builder['Integrated Security'] = $IntegratedSecurity
+			}
+			<#
+			if ($SqlUser -ne $null) {
+				$builder['User ID'] = $SqlUser
+			}
+			if ($Password -ne $null) {
+				$builder['Password'] = $Password
+			}
+			#>
+			$builder
+		}
     }
 }

--- a/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
+++ b/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
     Context "Get a ConnectionStringBuilder and assert its values" {
-        $results = New-DbaSqlConnectionStringBuilder "Data Source=localhost,1433;Initial Catalog=AlwaysEncryptedSample;UID=sa;PWD=alwaysB3Encrypt1ng;Application Name=Always Encrypted MvcString;Column Encryption Setting=enabled" 
+        $results = New-DbaSqlConnectionStringBuilder "Data Source=localhost,1433;Initial Catalog=AlwaysEncryptedSample;UID=sa;PWD=alwaysB3Encrypt1ng;Column Encryption Setting=enabled" 
         It "Should be a connection string builder" {
             $results.GetType() | Should Be System.Data.SqlClient.SqlConnectionStringBuilder
         }
@@ -8,7 +8,32 @@ Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
             $results.ColumnEncryptionSetting  | Should Be "Enabled"
         }
         It "Should have a user name of sa" {
+            $results.UID  | Should Be "sa"
+        }
+        It "Should have an Application name of `"dbatools Powershell Module`"" {
+            $results.ApplicationName  | Should Be "dbatools Powershell Module"
+        }
+    }
+    Context "Assert that the default Application name is preserved" {
+        $results = New-DbaSqlConnectionStringBuilder "Data Source=localhost,1433;Initial Catalog=AlwaysEncryptedSample;UID=sa;PWD=alwaysB3Encrypt1ng;Application Name=Always Encrypted MvcString;Column Encryption Setting=enabled" 
+        It "Should have the Application name of `"Always Encrypted MvcString`"" {
+            $results.ApplicationName  | Should Be "Always Encrypted MvcString"
+        }
+    }
+    Context "Build a ConnectionStringBuilder by parameters" {
+        $results = New-DbaSqlConnectionStringBuilder `
+            -DataSource "localhost,1433" `
+            -InitialCatalog "AlwaysEncryptedSample" `
+            -SqlUser "sa" `
+            -Password "alwaysB3Encrypt1ng" 
+        It "Should be a connection string builder" {
+            $results.GetType() | Should Be System.Data.SqlClient.SqlConnectionStringBuilder
+        }
+        It "Should have a user name of sa" {
             $results.UserID  | Should Be "sa"
+        }
+        It "Should have an Application name of `"dbatools Powershell Module`"" {
+            $results.ApplicationName  | Should Be "dbatools Powershell Module"
         }
     }
 }


### PR DESCRIPTION
**WIP**  wanted to make sure I'm going in the right direction before I polish this off

Changes proposed in this pull request:
 - `New-DbaSqlConnection` has paramaters to "build" the connection string
 - There is a default connection string of "dbatools Powershell Module"
 - 

How to test this code: 
- [ ] Create connection strings with all the parameters
- [ ] Pass a connection string, and other parameters make sure the parameters override the connection string
- [ ] Test that the applcation name is applied to connection strings 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [X]  SQL Server 2000

Has been tested on maximum requirements:
- [X]  SQL Server vNext
- [X]  Windows 10
- [X]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

