### PR TITLE
add instance information, settings and useroptions

### DIFF
--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -55,12 +55,29 @@ Returns SQL Instance properties on sql2 and sql4
 			catch {
 				Stop-Function -Message "Failed to connect to: $instance" -ErrorRecord $_ -Target $instance -Continue -Silent $Silent
 			}
-			$props = $server.properties
+			$props = $server.information.properties
+      foreach ($prop in $props) {
+        Add-Member -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+        Add-Member -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
+        Add-Member -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'Information'
+				Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value, PropertyType
+      }
+      $props = $server.useroptions.properties
 			foreach ($prop in $props) {
 				Add-Member -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
 				Add-Member -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
 				Add-Member -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
-				Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'UserOption'
+				Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value, PropertyType
+			}
+      $props = $server.settings.properties
+			foreach ($prop in $props) {
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
+				Add-Member -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'Setting'
+				Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value, PropertyType
 			}
 		}
 	}


### PR DESCRIPTION
Changes proposed in this pull request:
 - combines useroptions, settings and information properties in one function
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

