### PR TITLE
Smo Server Extension v2

### DIFF
--- a/internal/type-extensions.ps1
+++ b/internal/type-extensions.ps1
@@ -1,9 +1,13 @@
-# Implement query accelerator
+# Implement query accelerator for the server object
 Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName Query -MemberType ScriptMethod -Value {
     Param (
-        $Database,
-        $Query
+		$Query,
+		
+        $Database = "master",
+        
+		$AllTables = $false
     )
     
-    ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0]
+	if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
+    else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
 }

--- a/internal/type-extensions.ps1
+++ b/internal/type-extensions.ps1
@@ -1,13 +1,13 @@
 # Implement query accelerator for the server object
 Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName Query -MemberType ScriptMethod -Value {
     Param (
-		$Query,
+        $Query,
 		
         $Database = "master",
         
-		$AllTables = $false
+        $AllTables = $false
     )
     
-	if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
+    if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
     else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
 }


### PR DESCRIPTION
New features:
 - Defaults to master
 - New optional parameter: All tables. Returns all tables instead of only the first one.

Breaking change:
 - Reordered the input order

Examples of usage:
Run query against master:
`$server.Query($query)`
Run query against other db:
`$server.Query($query, "db1")`
Run query against other db and return all tables:
`$server.Query($query, "db1", $true)`

Note:
There is no sane way to support default database and explicit `$AllTables`. Parameters in method calls are positional and the order is respected. I could work around this, but it'd be a hack causing trouble down the road. 