### PR TITLE
Test-DbaSpn, local account fixes

### DIFF
--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -66,9 +66,13 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 			ForEach ($account in $AccountName)
 			{
 				Write-Message -Message "Looking for account $account..." -Level Verbose
+				$searchfor = 'User'
+				if($account.EndsWith('$')) {
+					$searchfor = 'Computer'
+				}
 				try
 				{
-					$Result = Get-DbaADObject -ADObject $account -Type User -Credential $Credential -Silent
+					$Result = Get-DbaADObject -ADObject $account -Type $searchfor -Credential $Credential -Silent
 				}
 				catch
 				{
@@ -81,11 +85,11 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 						$results = $Result.GetUnderlyingObject()
 						$spns = $results.Properties.servicePrincipalName
 					} catch {
-						Write-Message -Message "The SQL Service account ($serviceAccount) has been found, but you don't have enough permission to inspect its SPNs" -Level Warning
+						Write-Message -Message "The SQL Service account ($Account) has been found, but you don't have enough permission to inspect its SPNs" -Level Warning
 						continue
 					}
 				} else {
-					Write-Message -Message "The SQL Service account ($serviceAccount) has not been found" -Level Warning
+					Write-Message -Message "The SQL Service account ($Account) has not been found" -Level Warning
 					continue
 				}
 				
@@ -107,8 +111,8 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
 						}
 					}
 					[pscustomobject] @{
-						Input = $account
-						AccountName = $account
+						Input = $Account
+						AccountName = $Account
 						ServiceClass = "MSSQLSvc" # $serviceclass
 						Port = $port
 						SPN = $spn

--- a/functions/Remove-DbaSpn.ps1
+++ b/functions/Remove-DbaSpn.ps1
@@ -84,8 +84,12 @@ Removes all set SPNs for sql2005 and the relative delegations
 	
 	process {
 		Write-Message -Message "Looking for account $ServiceAccount..." -Level Verbose
+		$searchfor = 'User'
+		if($ServiceAccount.EndsWith('$')) {
+			$searchfor = 'Computer'
+		}
 		try {
-			$Result = Get-DbaADObject -ADObject $ServiceAccount -Type User -Credential $Credential -Silent
+			$Result = Get-DbaADObject -ADObject $ServiceAccount -Type $searchfor -Credential $Credential -Silent
 		}
 		catch {
 			Stop-Function -Message "AD lookup failure. This may be because the domain cannot be resolved for the SQL Server service account ($ServiceAccount). $($_.Exception.Message)" -Silent $Silent -InnerErrorRecord $_ -Target $ServiceAccount

--- a/functions/Set-DbaSpn.ps1
+++ b/functions/Set-DbaSpn.ps1
@@ -92,12 +92,15 @@ Displays what would happen trying to set all missing SPNs for sql2016
 	
 	process
 	{
-		
 		#did we find the server account?
 		Write-Message -Message "Looking for account $ServiceAccount..." -Level Verbose
+		$searchfor = 'User'
+		if($ServiceAccount.EndsWith('$')) {
+			$searchfor = 'Computer'
+		}
 		try
 		{
-			$Result = Get-DbaADObject -ADObject $ServiceAccount -Type User -Credential $Credential -Silent
+			$Result = Get-DbaADObject -ADObject $ServiceAccount -Type $searchfor -Credential $Credential -Silent
 		}
 		catch
 		{


### PR DESCRIPTION
Fixes #1366 (or, it *should*)

Changes: 
- when the serviceaccount is detected as LocalSystem or is of type "NT SERVICE\xxx" replaces the object where to register the SPN with the computer object.

Clusters should be fine, 'cause - theoretically - they should not run on a local account. 

Remains to be seen how the cmdlet handles instances with a MSAs, but I don't have any available at hand to verify.