### PR TITLE
Restore-DbFromFilteredArray output bug

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -277,6 +277,7 @@ function Restore-DbaDatabase {
         Write-Message -Level Debug -Message "Parameters bound: $($PSBoundParameters.Keys -join ", ")"
 		
         #region Validation
+        $useDestinationDefaultDirectories = $true
         $paramCount = 0
         if (Was-Bound "FileMapping") {
             $paramCount += 1
@@ -340,7 +341,7 @@ function Restore-DbaDatabase {
         $isLocal = [dbavalidate]::IsLocalHost($SqlInstance.ComputerName)
 		
         $backupFiles = @()
-        $useDestinationDefaultDirectories = $true
+        #$useDestinationDefaultDirectories = $true
     }
     process {
         if (Test-FunctionInterrupt) { return }

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -352,10 +352,12 @@ Function Restore-DBFromFilteredArray {
                     if ($ReuseSourceFolderStructure) {
                         $RestoreDirectory = ((Split-Path $RestoreFiles[0].FileList.PhysicalName) | sort-Object -unique) -join ','
                         $RestoredFile = ((Split-Path $RestoreFiles[0].FileList.PhysicalName -Leaf) | sort-Object -unique) -join ','
+                        $RestoredFileFull = $RestoreFiles[0].Filelist.PhysicalName -join ','
                     }
                     else {
                         $RestoreDirectory = ((Split-Path $Restore.RelocateFiles.PhysicalFileName) | sort-Object -unique) -join ','
                         $RestoredFile = (Split-Path $Restore.RelocateFiles.PhysicalFileName -Leaf) -join ','
+                        $RestoredFileFull = $Restore.RelocateFiles.PhysicalFileName -join ','
                     }
                     if ($ScriptOnly -eq $false) {
                         [PSCustomObject]@{
@@ -371,7 +373,7 @@ Function Restore-DBFromFilteredArray {
                             CompressedBackupSizeMB = if ([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSizeMb')) {($RestoreFiles | measure-object -property CompressedBackupSizeMB -Sum).sum}else {$null}
                             BackupFile             = $RestoreFiles.BackupPath -join ','
                             RestoredFile           = $RestoredFile
-                            RestoredFileFull       = $RestoreFiles[0].Filelist.PhysicalName -join ','
+                            RestoredFileFull       = $RestoredFileFull
                             RestoreDirectory       = $RestoreDirectory
                             BackupSize             = if ([bool]($RestoreFiles.PSobject.Properties.name -match 'BackupSize')) {($RestoreFiles | measure-object -property BackupSize -Sum).sum}else {$null}
                             CompressedBackupSize   = if ([bool]($RestoreFiles.PSobject.Properties.name -match 'CompressedBackupSize')) {($RestoreFiles | measure-object -property CompressedBackupSize -Sum).sum}else {$null}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Restore-DbFromFilteredArray now populates the RestoreFileFull property correctly for moved files
 - Hidden property so no one noticed, I only spotted while writing pester tests.
 - No functional changes

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

