### PR TITLE
replace server with computername, instancename, sqlinstance

### DIFF
--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -118,7 +118,9 @@ Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, L
 				else { $Status = 'OK' }
 
 				$result = [PSCustomObject]@{
-					Server             = $server.name
+					ComputerName       = $server.NetName
+					InstanceName       = $server.ServiceName
+					SqlInstance        = $server.DomainInstanceName
 					Database           = $db.name
 					RecoveryModel      = $db.recoverymodel
 					LastFullBackup     = if ($db.LastBackupdate -eq 0) { $null } else { $db.LastBackupdate.tostring() }
@@ -129,10 +131,10 @@ Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, L
 					SinceLog           = $SinceLog
 					DatabaseCreated    = $db.createDate
 					DaysSinceDbCreated = $daysSinceDbCreated
-					Status             = $statu
+					Status             = $status
 				}
 				if ($Simple) {
-					$result | Select-Object Server, Database, LastFullBackup, LastDiffBackup, LastLogBackup
+					$result | Select-Object ComputerName, InstanceName, Database, LastFullBackup, LastDiffBackup, LastLogBackup
 				}
 				else {
 					$result

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -40,12 +40,17 @@ Get-DbaLastBackup -SqlInstance ServerA\sql987
 Returns a custom object displaying Server, Database, RecoveryModel, LastFullBackup, LastDiffBackup, LastLogBackup, SinceFull, SinceDiff, SinceLog, Status, DatabaseCreated, DaysSinceDbCreated
 
 .EXAMPLE
-Get-DbaLastBackup -SqlInstance ServerA\sql987 -Simple
+Get-DbaLastBackup -SqlInstance ServerA\sql987
 
 Returns a custom object with Server name, Database name, and the date the last time backups were performed
 
 .EXAMPLE
-Get-DbaLastBackup -SqlInstance ServerA\sql987 | Out-Gridview
+Get-DbaLastBackup -SqlInstance ServerA\sql987 | Select *
+
+Returns a custom object with Server name, Database name, and the date the last time backups were performed, and also recoverymodel and calculations on how long ago backups were taken and what the status is.
+
+.EXAMPLE
+Get-DbaLastBackup -SqlInstance ServerA\sql987 | Select * | Out-Gridview
 
 Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, LastDiffBackup, LastLogBackup, SinceFull, SinceDiff, SinceLog, Status, DatabaseCreated, DaysSinceDbCreated
 
@@ -60,8 +65,7 @@ Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, L
 		$SqlCredential,
 		[Alias("Databases")]
 		[object[]]$Database,
-		[object[]]$ExcludeDatabase,
-		[switch]$Simple
+		[object[]]$ExcludeDatabase
 	)
 
 	process {
@@ -132,13 +136,8 @@ Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, L
 					DatabaseCreated    = $db.createDate
 					DaysSinceDbCreated = $daysSinceDbCreated
 					Status             = $status
-				}
-				if ($Simple) {
-					$result | Select-Object ComputerName, InstanceName, Database, LastFullBackup, LastDiffBackup, LastLogBackup
-				}
-				else {
-					$result
-				}
+				    }
+				Select-DefaultView -InputObject $result -Property ComputerName, InstanceName, SqlInstance, Database, LastFullBackup, LastDiffBackup, LastLogBackup
 			}
 		}
 	}

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -20,9 +20,6 @@ The database(s) to process - this list is autopopulated from the server. If unsp
 .PARAMETER ExcludeDatabase
 The database(s) to exclude - this list is autopopulated from the server
 
-.PARAMETER Simple
-Shows concise information including Server name, Database name, and the date the last time backups were performed
-
 .NOTES
 Tags: DisasterRecovery, Backup
 Author: Klaas Vandenberghe ( @PowerDBAKlaas )


### PR DESCRIPTION

Changes proposed in this pull request:
 - this function still had [server], now it's [ComputerName], [InstanceName], [SqlInstance] like the others
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

