### PR TITLE
WorkstationId, MARS and password

### DIFF
--- a/functions/New-DbaSqlConnectionStringBuilder.ps1
+++ b/functions/New-DbaSqlConnectionStringBuilder.ps1
@@ -25,14 +25,23 @@ Set to true to use windows authentication.
 Sql User Name to connect with.
 
 .PARAMETER Password
-Password to use to connect withy.
+Password to use to connect with.
+
+.PARAMETER MultipleActiveResultSets
+Enable Multiple Active Result Sets.
+
+.PARAMETER ColumnEncryptionSetting
+Enable Always Encrypted.
+
+.PARAMETER WorkstationID
+Set the Workstation Id that is associated with the connection.
 
 .NOTES
 Author: zippy1981
 Tags: SqlBuild
 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+Copyright (C) 2017 Chrissy LeMaire
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
@@ -103,14 +112,10 @@ Returns a connection string builder that can be used to connect to the local sql
 				$builder['Workstation ID'] = $WorkstationId
 			}
 			if ($MultipleActiveResultSets -eq $true) {
-				Write-Host "Here"
 				$builder['MultipleActiveResultSets'] = $true
-				Write-Host $builder
 			}
 			if ($ColumnEncryptionSetting -eq [Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled) {
-				Write-Host "Here"
 				$builder['Column Encryption Setting'] = [Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled
-				Write-Host $builder
 			}
 			$builder
 		}

--- a/functions/New-DbaSqlConnectionStringBuilder.ps1
+++ b/functions/New-DbaSqlConnectionStringBuilder.ps1
@@ -71,6 +71,10 @@ Returns a connection string builder that can be used to connect to the local sql
 		[Alias('MARS')]
 		[Parameter(Mandatory = $false)]
 		[switch]$MultipleActiveResultSets,
+		[Alias('AlwaysEncrypted')]
+		[Parameter(Mandatory = $false)]
+		[Data.SqlClient.SqlConnectionColumnEncryptionSetting]$ColumnEncryptionSetting = 
+			[Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled,
 		[Parameter(Mandatory = $false)]
 		[string]$WorkstationId = $env:COMPUTERNAME
 	)
@@ -101,6 +105,11 @@ Returns a connection string builder that can be used to connect to the local sql
 			if ($MultipleActiveResultSets -eq $true) {
 				Write-Host "Here"
 				$builder['MultipleActiveResultSets'] = $true
+				Write-Host $builder
+			}
+			if ($ColumnEncryptionSetting -eq [Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled) {
+				Write-Host "Here"
+				$builder['Column Encryption Setting'] = [Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled
 				Write-Host $builder
 			}
 			$builder

--- a/functions/New-DbaSqlConnectionStringBuilder.ps1
+++ b/functions/New-DbaSqlConnectionStringBuilder.ps1
@@ -67,7 +67,12 @@ Returns a connection string builder that can be used to connect to the local sql
 		[string]$UserName = $null,
 		# No point in securestring here, the memory is never stored securely in memory.
 		[Parameter(Mandatory = $false)]
-		[string]$Password = $null
+		[string]$Password =  $null,
+		[Alias('MARS')]
+		[Parameter(Mandatory = $false)]
+		[switch]$MultipleActiveResultSets,
+		[Parameter(Mandatory = $false)]
+		[string]$WorkstationId = $env:COMPUTERNAME
 	)
     process {
 		foreach ($cs in $ConnectionString) {
@@ -87,11 +92,17 @@ Returns a connection string builder that can be used to connect to the local sql
 			if (![string]::IsNullOrWhiteSpace($UserName)) {
 				$builder["User ID"] = $UserName
 			}
-			<#
-			if ($Password -ne $null) {
+			if (![string]::IsNullOrWhiteSpace($Password)) {
 				$builder['Password'] = $Password
 			}
-			#>
+			if (![string]::IsNullOrWhiteSpace($WorkstationId)) {
+				$builder['Workstation ID'] = $WorkstationId
+			}
+			if ($MultipleActiveResultSets -eq $true) {
+				Write-Host "Here"
+				$builder['MultipleActiveResultSets'] = $true
+				Write-Host $builder
+			}
 			$builder
 		}
     }

--- a/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
+++ b/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
@@ -5,7 +5,7 @@ Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
             $results.GetType() | Should Be System.Data.SqlClient.SqlConnectionStringBuilder
         }
         It "Should enable Always Encrypted" {
-            $results.ColumnEncryptionSetting  | Should Be "Enabled"
+            $results.ColumnEncryptionSetting | Should Be Enabled
         }
         It "Should have a user name of sa" {
             $results.UserID  | Should Be "sa"
@@ -62,6 +62,12 @@ Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
         $results = New-DbaSqlConnectionStringBuilder -MARS
         It "Should have a MultipeActiveResultSets value of true" {
             $results.MultipleActiveResultSets | Should Be $true
+        }
+    }
+    Context "Set AlwaysEncrypted" {
+        $results = New-DbaSqlConnectionStringBuilder -AlwaysEncrypted "Enabled" 
+        It "Should have a `"Column Encryption Setting`" value of `"Enabled`"" {
+            $results.ColumnEncryptionSetting | Should Be 'Enabled'
         }
     }
 }

--- a/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
+++ b/tests/New-DbaSqlConnectionStringBuilder.Tests.ps1
@@ -13,6 +13,12 @@ Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
         It "Should have an Application name of `"dbatools Powershell Module`"" {
             $results.ApplicationName  | Should Be "dbatools Powershell Module"
         }
+        It "Should have an Workstation ID of `"${env:COMPUTERNAME}`"" {
+            $results.WorkstationID  | Should Be $env:COMPUTERNAME
+        }
+        It "Should have a null MultipeActiveRcordSets" {
+            $results.MultipeActiveRcordSets  | Should Be $null
+        }
     }
     Context "Assert that the default Application name is preserved" {
         $results = New-DbaSqlConnectionStringBuilder "Data Source=localhost,1433;Initial Catalog=AlwaysEncryptedSample;UID=sa;PWD=alwaysB3Encrypt1ng;Application Name=Always Encrypted MvcString;Column Encryption Setting=enabled" 
@@ -25,15 +31,37 @@ Describe "New-DbaSqlConnectionStringBuilder Unit Tests" -Tag 'Unittests' {
             -DataSource "localhost,1433" `
             -InitialCatalog "AlwaysEncryptedSample" `
             -UserName "sa" `
-            -Password "alwaysB3Encrypt1ng" 
+            -Password "alwaysB3Encrypt1ng"
         It "Should be a connection string builder" {
             $results.GetType() | Should Be System.Data.SqlClient.SqlConnectionStringBuilder
         }
         It "Should have a user name of sa" {
-            $results.UserID  | Should Be "sa"
+            $results.UserID | Should Be "sa"
+        }
+        It "Should have a password of alwaysB3Encrypt1ng" {
+            $results.Password | Should Be "alwaysB3Encrypt1ng"
+        }
+        It "Should have a WorkstationID of {$env:COMPUTERNAME}" {
+            $results.WorkstationID | Should Be $env:COMPUTERNAME
         }
         It "Should have an Application name of `"dbatools Powershell Module`"" {
             $results.ApplicationName  | Should Be "dbatools Powershell Module"
+        }
+        It "Should have an Workstation ID of `"${env:COMPUTERNAME}`"" {
+            $results.WorkstationID  | Should Be ${env:COMPUTERNAME}
+        }
+    }
+    Context "Explicitly set MARS to false" {
+        $results = New-DbaSqlConnectionStringBuilder `
+            -MultipleActiveResultSets:$false
+        It "Should not enable Multipe Active Record Sets" {
+            $results.MultipleActiveResultSets | Should Be $false
+        }
+    }
+    Context "Set MARS via alias" {
+        $results = New-DbaSqlConnectionStringBuilder -MARS
+        It "Should have a MultipeActiveResultSets value of true" {
+            $results.MultipleActiveResultSets | Should Be $true
         }
     }
 }


### PR DESCRIPTION
This is the final list of parameters I think should be in there unless someone asks for more. I'm wondering at this point if this cmdlet still makes sense with New-DbaSqlConnectionString though. This will work without SMO, which is good.

Moving on to other things either way, probably password encryption.

Changes proposed in this pull request:
 - `-Password` works now
 - ``New paramaters
  - `-WorkstationID`
  - `-MultipleActiveResultSets` `-MARS`
  - `ColumnEncryptedSetting`, `-Mars`

How to test this code: 
- [ ] Set those settings


Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

