### PR TITLE
Fix problem with CHECKDB after restore not working

### DIFF
--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -151,7 +151,7 @@ If there is a DBCC Error it will continue to perform rest of the actions and wil
 		[object]$Destination = $sqlinstance,
 		[object]$DestinationCredential,
 		[parameter(Mandatory = $false)]
-        [Alias("NoCheck")]
+        	[Alias("NoCheck")]
 		[switch]$NoDBCCCheck,
 		[parameter(Mandatory = $true)]
 		[string]$BackupFolder,
@@ -651,20 +651,19 @@ If there is a DBCC Error it will continue to perform rest of the actions and wil
 				}
 			}
 
-            $refreshRetries = 1
-
-            while (($destserver.databases[$dbname] -eq $null) -and $refreshRetries -lt 5)
-            {
-                Write-Verbose "Database $dbname not found! Refreshing collection"
-                
-                #refresh database list, otherwise the next step (DBCC) can fail
-                $destserver.Databases.Refresh()
-                
-                Start-Sleep -Seconds 1
-                
-                $backupRetries+=1
-            }
-           
+            		$refreshRetries = 1
+		
+            		while (($destserver.databases[$dbname] -eq $null) -and $refreshRetries -lt 5)
+            		{
+            		    Write-Verbose "Database $dbname not found! Refreshing collection"
+            		    
+            		    #refresh database list, otherwise the next step (DBCC) can fail
+            		    $destserver.Databases.Refresh()
+            		    
+            		    Start-Sleep -Seconds 1
+            		    
+            		    $refreshRetries += 1
+            		}
 
 			## Run a Dbcc No choice here
 			if ($Pscmdlet.ShouldProcess($dbname, "Running Dbcc CHECKDB on $dbname on $destination")) {
@@ -687,10 +686,10 @@ If there is a DBCC Error it will continue to perform rest of the actions and wil
 			Write-Message -Level Verbose -Message "Rationalisation Finished for $dbname"
 		}
 
-        [PSCustomObject]@{
+        	[PSCustomObject]@{
 				SqlInstance = $source
-                DatabaseName = $dbname
-                JobName = $jobname
+                		DatabaseName = $dbname
+                		JobName = $jobname
 				TestingInstance = $destination
 				BackupFolder = $backupFolder
 			} 


### PR DESCRIPTION
- Added refresh when not finding database after the restore from the job.
Before: 
![image](https://cloud.githubusercontent.com/assets/19521315/26656591/a5ace956-4657-11e7-87f8-9dd092b42a16.png)

After:
![image](https://cloud.githubusercontent.com/assets/19521315/26656685/054089f4-4658-11e7-9789-f293607238e4.png)

- Added $Silent parameter to support messaging system (Write-Message)
- Change all Write-Warning | Write-Verbose | Write-Output to Write-Message system
- Added PSCustomObject as output
- Change NoDBCCCheck and added Alias to old NoCheck
