### PR TITLE
Making DbaInstanceParameter & TimeSpan great again!

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -4936,6 +4936,18 @@ namespace Sqlcollective.Dbatools
         /// </summary>
         public class DbaTimeSpanPretty : DbaTimeSpan
         {
+            #region Methods
+            /// <summary>
+            /// Creates a new, pretty timespan object from milliseconds
+            /// </summary>
+            /// <param name="Milliseconds">The milliseconds to convert from.</param>
+            /// <returns>A pretty timespan object</returns>
+            public static DbaTimeSpanPretty FromMilliseconds(double Milliseconds)
+            {
+                return new DbaTimeSpanPretty((long)(Milliseconds * 10000));
+            }
+            #endregion Methods
+
             #region Constructors
             /// <summary>
             /// 

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -5025,11 +5025,11 @@ namespace Sqlcollective.Dbatools
 
                 if (_timespan.TotalSeconds < 1)
                 {
-                    temp = Math.Round(_timespan.TotalMilliseconds, Digits).ToString() + "ms";
+                    temp = Math.Round(_timespan.TotalMilliseconds, Digits).ToString() + " ms";
                 }
                 else if (_timespan.TotalSeconds <= 60)
                 {
-                    temp = Math.Round(_timespan.TotalSeconds, Digits).ToString() + "s";
+                    temp = Math.Round(_timespan.TotalSeconds, Digits).ToString() + " s";
                 }
                 else
                 {

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -4948,6 +4948,10 @@ namespace Sqlcollective.Dbatools
             }
             #endregion Methods
 
+            #region Fields
+            public int Digits = 2;
+            #endregion Fields
+
             #region Constructors
             /// <summary>
             /// 
@@ -5021,13 +5025,11 @@ namespace Sqlcollective.Dbatools
 
                 if (_timespan.TotalSeconds < 1)
                 {
-                    temp = Math.Round(_timespan.TotalMilliseconds, 2).ToString() + "ms";
+                    temp = Math.Round(_timespan.TotalMilliseconds, Digits).ToString() + "ms";
                 }
                 else if (_timespan.TotalSeconds <= 60)
                 {
-                    temp = _timespan.Seconds + "s";
-                    if (_timespan.Milliseconds > 0)
-                        temp = temp + ", " + _timespan.Milliseconds + "ms";
+                    temp = Math.Round(_timespan.TotalSeconds, Digits).ToString() + "s";
                 }
                 else
                 {

--- a/bin/typealiases.ps1
+++ b/bin/typealiases.ps1
@@ -13,6 +13,8 @@ try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators
 catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbatimespan", "sqlcollective.dbatools.Utility.DbaTimeSpan") }
 catch { }
+try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("prettytimespan", "sqlcollective.dbatools.Utility.DbaTimeSpanPretty") }
+catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbasize", "sqlcollective.dbatools.Utility.Size") }
 catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("dbavalidate", "Sqlcollective.Dbatools.Utility.Validation") }

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -163,7 +163,7 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 			{
 				try
 				{
-					$server = Connect-SqlInstance -SqlInstance $servername -SqlCredential $Credential
+					$server = Connect-SqlInstance -SqlInstance "TCP:$servername" -SqlCredential $Credential
 				}
 				catch
 				{

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -114,10 +114,10 @@ Function Test-DbaNetworkLatency {
 					InstanceName = $server.ServiceName
 					SqlInstance = $server.DomainInstanceName
 					Count = $count
-					TotalMs = $totaltime
-					AvgMs = $avg
-					ExecuteOnlyTotalMs = $totalwarm
-					ExecuteOnlyAvgMs = $avgwarm
+					Total = [prettytimespan]::FromMilliseconds($totaltime)
+					Avg = [prettytimespan]::FromMilliseconds($avg)
+					ExecuteOnlyTotal = [prettytimespan]::FromMilliseconds($totalwarm)
+					ExecuteOnlyAvg = [prettytimespan]::FromMilliseconds($avgwarm)
 				}
 			}
 			catch {


### PR DESCRIPTION
Major upgrade to the DbaInstanceParameter Parameterclass:
 - Will now show "MSSQLSERVER" as instance name when connecting to a default instance. _This is not specified when connecting to the server!_ This allows uniform use of the `InstanceName` property, for example when targeting services.
 - Will now show port 1433 when connecting to a default instance.
 - Will now accept protocol specifications as part of the name (e.g.: `"TCP:<servername>\<instancename>"` or `"NP:<servername>\<instancename>"`). Only TCP & NP supported so far.
 - Will now understand IPAddress objects as input, connecting to the default instance
 - Will now understand Ping Result objects as input, connecting to the default instance
 - Will now understand DNS Resolution objects as input, connecting to the default instance
 - Will now understand ADComputer objects as input, connecting to the default instance
 - New Property: `IsLocalHost`
 - New Property: `NetworkProtocol`, showing the protocol used
 - Connecting to "." will automatically specify the network protocol "NP" (which it'd use implicitly anyway, but allows the function to see the fact without doing parsing)

Validation:
 - `[dbavalidate]::IsLocalHost("<Computername>")` will now evaluate `"."` as localhost

Timespan:
 - New type available: `[prettytimespan]` allowing our BDFL to enjoy pretty timespans on any scale.

Incremented library version to `0.0.1.11` to reflect these changes.