### PR TITLE
Continue fix

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -325,7 +325,8 @@ function Restore-DbaDatabase {
             }
         }
         if ($Continue) {
-            $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential 
+            $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $WithReplace = $true 
             #$ContinuePoints
         }
 		

--- a/internal/Get-RestoreContinuableDatabase.ps1
+++ b/internal/Get-RestoreContinuableDatabase.ps1
@@ -20,7 +20,7 @@ Takes a SQL instance and checks for databases with a redo_start_lsn value, and r
 
 		try 
 		{
-			$Server = Connect-SqlServer -SqlServer $SqlInstance -SqlCredential $SqlCredential	
+            $Server = Connect-SqlInstance -Sqlinstance $SqlInstance -SqlCredential $SqlCredential	
 		}
 		catch {
 


### PR DESCRIPTION
Fixes #1320 

Changes proposed in this pull request:
 - Changes the reference for the internal connection function. This doesn't appear to pull the alias and throws a less than helpful error message about exactly what is failing
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

