### PR TITLE
Fixed tepp for Snapshot parameter

### DIFF
--- a/functions/Get-DbaDatabaseSnapshot.ps1
+++ b/functions/Get-DbaDatabaseSnapshot.ps1
@@ -97,7 +97,7 @@ Returns information for database snapshots HR_snapshot and Accounting_snapshot
                 $dbs = $dbs | Where-Object IsDatabaseSnapshot -eq $true | Sort-Object DatabaseSnapshotBaseName, Name
             }
             if ($ExcludeSnapshot) {
-                $dbs = $dbs | Where-Object { $ExcludeSnapshot -notcontains $_.DatabaseSnapshotBaseName }
+                $dbs = $dbs | Where-Object { $ExcludeSnapshot -notcontains $_.Name }
             }
 
             foreach ($db in $dbs) {

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -139,7 +139,9 @@
 		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Logins.Name
 		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Jobs.Name
         [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Operators.Name
-        [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = ($server.Databases | Where-Object IsDatabaseSnapShot).Name
+
+        $snapshots = $server.Databases | Where-Object IsDatabaseSnapShot
+        [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $snapshots.Name
 		
         return $server
     }
@@ -260,7 +262,9 @@
 	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Logins.Name
 	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Jobs.Name
     [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Operators.Name
-    [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = ($server.Databases | Where-Object IsDatabaseSnapShot).Name
+
+    $snapshots = $server.Databases | Where-Object IsDatabaseSnapShot
+    [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $snapshots.Name
     return $server
     #endregion Input Object was anything else
 }

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -29,10 +29,10 @@ foreach ($function in $functions) {
     if ($function.Parameters.Keys -contains "ExcludeOperator") {
         Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeOperator -Name Operator
     }
-    if ($functino.Parameters.Keys -contains "Snapshot") {
+    if ($function.Parameters.Keys -contains "Snapshot") {
         Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Snapshot -Name Snapshot
     }
-	if ($functino.Parameters.Keys -contains "ExcludeSnapshot") {
+	if ($function.Parameters.Keys -contains "ExcludeSnapshot") {
         Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSnapshot -Name Snapshot
 	}
 }


### PR DESCRIPTION
Odd enough in order to pass in a property where you need to filter, had to set as a variable and then pass in that variable to TEPP for it to pick up. Not sure why that is.

Changes proposed in this pull request:
 - Adjusted files to accommodate snapshot parameter for tepp 
 - Fixed filter I missed seeing with Get-DbaDatabaseSnapshot as well.