### PR TITLE
Added new Get-DbaAgentSchedule command

### DIFF
--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -47,12 +47,12 @@ FUNCTION Get-DbaAgentSchedule
 	
 	process {
 		foreach ($instance in $SqlInstance) {
-			Write-Verbose "Attempting to connect to $instance"
+			Write-Message -Level Verbose -Message "Attempting to connect to $instance"
 			try {
 				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
 			}
 			catch {
-				Write-Warning "Can't connect to $instance or access denied. Skipping."
+				Write-Message -Level Warning -Message "Can't connect to $instance or access denied. Skipping."
 				continue
 			}
 

--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -1,0 +1,78 @@
+FUNCTION Get-DbaAgentSchedule
+{
+<#
+	.SYNOPSIS
+	Returns all SQL Agent Shared Schedules on a SQL Server Agent.
+
+	.DESCRIPTION
+	This function returns SQL Agent Shared Schedules.
+
+	.PARAMETER SqlInstance
+	SqlInstance name or SMO object representing the SQL Server to connect to.
+	This can be a collection and receive pipeline input.
+
+	.PARAMETER SqlCredential
+	PSCredential object to connect as. If not specified, currend Windows login will be used.
+
+	.PARAMETER Silent
+	Use this switch to disable any kind of verbose messages
+
+	.NOTES
+	Author: Chris McKeown (@devopsfu), http://www.devopsfu.com
+	Tags: Agent, Schedule
+	Website: https://dbatools.io
+	Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+	.LINK
+	https://dbatools.io/Get-DbaAgentSchedule
+
+	.EXAMPLE
+	Get-DbaAgentSchedule -SqlInstance localhost
+	Returns all SQL Agent Shared Schedules on the local default SQL Server instance
+
+	.EXAMPLE
+	Get-DbaAgentSchedule -SqlInstance localhost, sql2016
+	Returns all SQL Agent Shared Schedules for the local and sql2016 SQL Server instances
+
+#>
+	[CmdletBinding()]
+	Param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "Instance", "SqlServer")]
+		[object[]]$SqlInstance,
+		[System.Management.Automation.PSCredential]$SqlCredential,
+		[switch]$Silent
+	)
+	
+	process {
+		foreach ($instance in $SqlInstance) {
+			Write-Verbose "Attempting to connect to $instance"
+			try {
+				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Write-Warning "Can't connect to $instance or access denied. Skipping."
+				continue
+			}
+
+			Write-Message -Level Verbose -Message "Getting Edition from $server"
+			Write-Message -Level Verbose -Message "$server is a $($server.Edition)"
+			
+			if ($server.Edition -like 'Express*') {
+				Stop-Function -Message "There is no SQL Agent on $server, it's a $($server.Edition)" -Continue
+			}
+			
+			$defaults = "ComputerName", "InstanceName", "SqlInstance", "Parent", "ActiveEndDate", "ActiveEndTimeOfDay", "ActiveStartDate", "ActiveStartTimeOfDay", "DateCreated", "FrequencyInterval", "FrequencyRecurrenceFactor", "FrequencyRelativeIntervals", "FrequencySubDayInterval", "FrequencySubDayTypes", "FrequencyTypes", "IsEnabled", "JobCount", "ScheduleUid"
+
+			foreach ($schedule in $server.JobServer.SharedSchedules)
+			{
+				Add-Member -InputObject $schedule -MemberType NoteProperty ComputerName -value $schedule.Parent.Parent.NetName
+				Add-Member -InputObject $schedule -MemberType NoteProperty InstanceName -value $schedule.Parent.Parent.ServiceName
+				Add-Member -InputObject $schedule -MemberType NoteProperty SqlInstance  -value $schedule.Parent.Parent.DomainInstanceName
+
+				Select-DefaultView -InputObject $schedule -Property $defaults
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Addition of new `Get-DbaAgentSchedule` command

How to test this code: 
- [ ] See the command documentation for usage

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [x]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

