### PR TITLE
DbaAgent functions - work without job values

### DIFF
--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -133,7 +133,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [object[]]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]$SqlCredential,
@@ -411,12 +411,15 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
                     Write-Message -Message "Applying the target (local) to job $Job" -Level Verbose
                     $smoJob.ApplyToTargetServer("(local)")
 
+                    # Refresh the object
+                    $smoJob.Refresh()
+
                     # If a schedule needs to be attached
-                    if($Schedule){
+                    if ($Schedule) {
                         Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule -SqlCredential $SqlCredential
                     }
 
-                    if($ScheduleId){
+                    if ($ScheduleId) {
                         Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $ScheduleId -SqlCredential $SqlCredential
                     }
                 }

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -255,7 +255,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Verbose
             try {
-                $server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to $instance. Message: $($_.Exception.Message)" -Target $instance -Continue -InnerErrorRecord $_

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -413,6 +413,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 
                     # Refresh the object
                     $smoJob.Refresh()
+                    $server.JobServer.Refresh()
 
                     # If a schedule needs to be attached
                     if ($Schedule) {

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -413,11 +413,11 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 
                     # If a schedule needs to be attached
                     if($Schedule){
-                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule
+                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule -SqlCredential $SqlCredential
                     }
 
                     if($ScheduleId){
-                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $ScheduleId
+                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $ScheduleId -SqlCredential $SqlCredential
                     }
                 }
                 catch {

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -255,7 +255,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Verbose
             try {
-                $server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to $instance. Message: $($_.Exception.Message)" -Target $instance -Continue -InnerErrorRecord $_

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -18,6 +18,12 @@ To connect as a different Windows user, run PowerShell as that user.
 .PARAMETER Job
 The name of the job. The name must be unique and cannot contain the percent (%) character.
 
+.PARAMETER Schedule
+Schedule to attach to job. This can be more than one schedule.
+
+.PARAMETER ScheduleId
+Schedule ID to attach to job. This can be more than one schedule ID.
+
 .PARAMETER Disabled
 Sets the status of the job to disabled. By default a job is enabled.
 
@@ -127,46 +133,71 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
+        [object[]]$SqlInstance,
+
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]$SqlCredential,
+        
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$Job,
+
+        [Parameter(Mandatory = $false)]
+        [object[]]$Schedule,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$ScheduleId,
+        
         [Parameter(Mandatory = $false)]
         [switch]$Disabled,
+        
         [Parameter(Mandatory = $false)]
         [string]$Description,
+        
         [Parameter(Mandatory = $false)]
         [int]$StartStepId,
+        
         [Parameter(Mandatory = $false)]
         [string]$Category,
+        
         [Parameter(Mandatory = $false)]
         [int]$CategoryId,
+        
         [Parameter(Mandatory = $false)]
         [string]$OwnerLogin,
+        
         [Parameter(Mandatory = $false)]
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$EventLogLevel,
+        
         [Parameter(Mandatory = $false)]
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$EmailLevel,
+        
         [Parameter(Mandatory = $false)]
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$NetsendLevel,
+        
         [Parameter(Mandatory = $false)]
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$PageLevel,
+        
         [Parameter(Mandatory = $false)]
         [string]$EmailOperator,
+        
         [Parameter(Mandatory = $false)]
         [string]$NetsendOperator,
+        
         [Parameter(Mandatory = $false)]
         [string]$PageOperator,
+        
         [Parameter(Mandatory = $false)]
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        
         [object]$DeleteLevel,
+        
         [switch]$Force,
+        
         [switch]$Silent
     )
 	
@@ -224,10 +255,10 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Verbose
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
-				Stop-Function -Message "Could not connect to $instance. Message: $($_.Exception.Message)" -Target $instance -Continue -InnerErrorRecord $_
+                Stop-Function -Message "Could not connect to $instance. Message: $($_.Exception.Message)" -Target $instance -Continue -InnerErrorRecord $_
             }
 			
             # Check if the job already exists
@@ -379,8 +410,15 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
                     # Make sure the target is set for the job
                     Write-Message -Message "Applying the target (local) to job $Job" -Level Verbose
                     $smoJob.ApplyToTargetServer("(local)")
-					
-                    
+
+                    # If a schedule needs to be attached
+                    if($Schedule){
+                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule
+                    }
+
+                    if($ScheduleId){
+                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $ScheduleId
+                    }
                 }
                 catch {
                     Stop-Function -Message "Something went wrong creating the job. `n$($_.Exception.Message)" -Continue -InnerErrorRecord $_
@@ -388,7 +426,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
             }
 
             # Return the job
-            $smoJob
+            return $smoJob
         }
     }
 	

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -411,17 +411,13 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
                     Write-Message -Message "Applying the target (local) to job $Job" -Level Verbose
                     $smoJob.ApplyToTargetServer("(local)")
 
-                    # Refresh the object
-                    $smoJob.Refresh()
-                    $server.JobServer.Refresh()
-
                     # If a schedule needs to be attached
                     if ($Schedule) {
                         Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule -SqlCredential $SqlCredential
                     }
 
                     if ($ScheduleId) {
-                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $ScheduleId -SqlCredential $SqlCredential
+                        Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -ScheduleId $ScheduleId -SqlCredential $SqlCredential
                     }
                 }
                 catch {

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -387,7 +387,7 @@ Creates a schedule that's not connected to a job
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance $instance" -Target $instance -InnerErrorRecord $_ -Continue

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -387,7 +387,7 @@ Creates a schedule that's not connected to a job
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance $instance" -Target $instance -InnerErrorRecord $_ -Continue

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -4,7 +4,7 @@ function Remove-DbaAgentJob {
 Remove-DbaAgentJob removes a job.
 
 .DESCRIPTION
-Remove-DbaAgentJob removes a job in the SQL Server Agent.
+Remove-DbaAgentJob removes a a job in the SQL Server Agent.
 
 .PARAMETER SqlInstance
 SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -62,7 +62,7 @@ Removes the job from multiple servers
 
 .EXAMPLE   
 sql1, sql2, sql3 | Remove-DbaAgentJob -Job Job1 
-Removes the job from multiple servers using pipeline
+Removes the job from multiple servers using pipe line
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
@@ -70,16 +70,21 @@ Removes the job from multiple servers using pipeline
     param(
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
+        [object[]]$SqlInstance,
+
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]$SqlCredential,
+        
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string[]]$Job,
+        [object[]]$Job,
+        
         [Parameter(Mandatory = $false)]
         [switch]$KeepHistory,
+        
         [Parameter(Mandatory = $false)]
         [switch]$KeepUnusedSchedule,
+        
         [Parameter(Mandatory = $false)]
         [switch]$Silent
     )
@@ -91,7 +96,7 @@ Removes the job from multiple servers using pipeline
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $Server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -96,7 +96,7 @@ Removes the job from multiple servers using pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -96,7 +96,7 @@ Removes the job from multiple servers using pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -89,7 +89,7 @@ Remove the schedule on multiple servers using pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance $instance" -Target $instance -InnerRecord $_ -Continue

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -89,7 +89,7 @@ Remove the schedule on multiple servers using pipe line
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance $instance" -Target $instance -InnerRecord $_ -Continue

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -5,7 +5,7 @@ function Remove-DbaAgentSchedule {
 Remove-DbaAgentJobSchedule removes a job schedule.
 
 .DESCRIPTION
-Remove-DbaAgentJobSchedule removes a job schedule in the SQL Server Agent.
+Remove-DbaAgentJobSchedule removes a a job in the SQL Server Agent.
 
 .PARAMETER SqlInstance
 SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -15,10 +15,7 @@ Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integ
 $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
 To connect as a different Windows user, run PowerShell as that user.
 
-.PARAMETER Job
-The name of the job. 
-
-.PARAMETER ScheduleName
+.PARAMETER Schedule
 The name of the job schedule. 
 
 .PARAMETER WhatIf
@@ -46,24 +43,24 @@ License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 https://dbatools.io/Remove-DbaAgentJobSchedule
 
 .EXAMPLE   
-Remove-DbaAgentSchedule -SqlInstance sql1 -Job Job1 -ScheduleName weekly
-Remove the job schedule weekly from the job
+Remove-DbaAgentSchedule -SqlInstance sql1 -Schedule weekly
+Remove the schedule weekly 
 
 .EXAMPLE   
-Remove-DbaAgentSchedule -SqlInstance sql1 -Job Job1 -ScheduleName weekly -Force 
-Remove the job schedule weekly from the job even if the schedule is being used by another job.
+Remove-DbaAgentSchedule -SqlInstance sql1 -Schedule weekly -Force 
+Remove the schedule weekly from the job even if the schedule is being used by another job.
 
 .EXAMPLE   
-Remove-DbaAgentSchedule -SqlInstance sql1 -Job Job1, Job2, Job3 -ScheduleName 'daily' 
-Remove the job schedule for multiple jobs
+Remove-DbaAgentSchedule -SqlInstance sql1 -Schedule daily, weekly
+Remove multiple schedule 
 
 .EXAMPLE   
-Remove-DbaAgentSchedule -SqlInstance sql1, sql2, sql3 -Job Job1, Job2, Job3 -ScheduleName 'daily' 
-Remove the job schedule on multiple servers for multiple jobs
+Remove-DbaAgentSchedule -SqlInstance sql1, sql2, sql3 -Schedule daily, weekly
+Remove the schedule on multiple servers for multiple scheukes
 
 .EXAMPLE   
-sql1, sql2, sql3 | Remove-DbaAgentSchedule -Job Job1, Job2, Job3 -ScheduleName 'daily' 
-Remove the job schedule on multiple servers using pipeline
+sql1, sql2, sql3 | Remove-DbaAgentSchedule -Schedule daily, weekly
+Remove the schedule on multiple servers using pipe line
 
 #>  
 
@@ -72,18 +69,17 @@ Remove the job schedule on multiple servers using pipeline
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
-        [System.Management.Automation.PSCredential]$SqlCredential,
+        [object[]]$SqlInstance,
+
+        [System.Management.Automation.PSCredential]
+        $SqlCredential,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [object[]]$Job,
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [string]$ScheduleName,
-        [Parameter(Mandatory = $false)]
+        [object[]]$Schedule,
+
         [switch]$Silent,
-        [Parameter(Mandatory = $false)]
+
         [switch]$Force
     ) 
 
@@ -93,50 +89,89 @@ Remove the job schedule on multiple servers using pipeline
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $Server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance $instance" -Target $instance -InnerRecord $_ -Continue
             }
 
-            foreach ($j in $Job) {
+            foreach ($s in $Schedule) {
 
-                # Check if the job exists
-                if ($Server.JobServer.Jobs.Name -notcontains $j) {
-                    Write-Message -Message "Job $j doesn't exists on $instance" -Level Warning
-                }
-                else {
-                    # Check if the job step exists
-                    if ($Server.JobServer.Jobs[$j].JobSchedules[$ScheduleName].Name -notcontains $ScheduleName) {
-                        Write-Message -Message "Step $ScheduleName doesn't exists for job $j" -Level Warning
+                if ($Server.JobServer.SharedSchedules.Name -contains $s) {
+                    # Get job count
+                    $jobCount = $Server.JobServer.SharedSchedules[$s].JobCount -ge 1
+
+                    # Check if the schedule is shared among other jobs
+                    if ($jobCount -gt 1 -and -not $Force) {
+                        Stop-Function -Message "The schedule $s is shared connected to one or more jobs. If removal is neccesary use -Force." -Target $instance -Continue
                     }
-                    elseif (-not $Force -and ($Server.JobServer.Jobs[$j].JobSchedules[$ScheduleName].JobCount -gt 1)) {
-                        Stop-Function -Message "The schedule $ScheduleName is shared among other jobs. If removal is neccesary use -Force." -Target $instance -Continue
+                    elseif ($jobCount -gt 1 -and $Force) {
+                        # Get the job ids 
+                        $jobGuids = $Server.JobServer.SharedSchedules[$s].EnumJobReferences()
+
+                        # Loop though each of the jobs
+                        foreach ($guid in $jobGuids) {
+                            # Get the job object
+                            $smoJob = $Server.JobServer.GetJobByID($guid)
+
+                            # Get the job schedule
+                            $jobSchedule = $Server.JobServer.Jobs[$smoJob].JobSchedules[$Schedule][0]
+
+                            # Remove the job schedule
+                            if ($PSCmdlet.ShouldProcess($instance, "Removing the schedule $jobSchedule for job $smoJob on $instance")) {
+                                try {
+                                    Write-Message -Message "Removing the schedule $jobSchedule for job $smoJob" -Level Output
+
+                                    $jobSchedule.Drop()
+                                }
+                                catch {
+                                    Stop-Function -Message  "Something went wrong removing the job schedule. `n$($_.Exception.Message)" -Target $instance -InnerRecord $_ -Continue
+                                }
+                            }
+                        }
                     }
-                    else {
+                    elseif ($jobCount -eq 1) {
+
+                        # Get the job ids 
+                        $job = $Server.JobServer.SharedSchedules[$s].EnumJobReferences()
+
+                        # Get the job object
+                        $smoJob = $Server.JobServer.GetJobByID($job.Guid)
+
                         # Get the job schedule
-                        try {
-                            $JobSchedule = $Server.JobServer.Jobs[$j].JobSchedules[$ScheduleName][0]
-                        }
-                        catch {
-                            Stop-Function -Message "Something went wrong creating the job schedule. `n$($_.Exception.Message)" -Target $instance -InnerRecord $_ -Continue
-                        }
+                        $jobSchedule = $Server.JobServer.Jobs[$smoJob].JobSchedules[$Schedule][0]
 
-                        # Execute 
-                        if ($PSCmdlet.ShouldProcess($instance, "Removing the schedule $ScheduleName for job $j")) {
+                        # Remove the job schedule
+                        if ($PSCmdlet.ShouldProcess($instance, "Removing the schedule $jobSchedule for job $smoJob on $instance")) {
                             try {
-                                Write-Message -Message "Removing the job schedule $ScheduleName for job $j" -Level Output
+                                Write-Message -Message "Removing the schedule $jobSchedule for job $smoJob" -Level Output
 
-                                $JobSchedule.Drop()
+                                $jobSchedule.Drop()
                             }
                             catch {
                                 Stop-Function -Message  "Something went wrong removing the job schedule. `n$($_.Exception.Message)" -Target $instance -InnerRecord $_ -Continue
                             }
                         }
-                    }
-                }
 
-            } # foreach object job
+                    } 
+                    else {
+                        # Remove the job schedule
+                        if ($PSCmdlet.ShouldProcess($instance, "Removing schedule $s on $instance")) {
+                            try {
+                                Write-Message -Message "Removing schedule $s on $instance" -Level Output
+
+                                $Server.JobServer.SharedSchedules[$s].Drop()
+                            }
+                            catch {
+                                Stop-Function -Message  "Something went wrong removing the job schedule. `n$($_.Exception.Message)" -Target $instance -InnerErrorRecord $_ -Continue
+                            }
+                        }
+                    }
+                } # if contains schedule
+                else {
+                    Stop-Function -Message "Schedule $s is not present on instance $instance" -Target $instance -Continue
+                }
+            } #foreach object schedule
         } # foreach object instance
     } # process
 

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -17,6 +17,12 @@ To connect as a different Windows user, run PowerShell as that user.
 .PARAMETER Job
 The name of the job. 
 
+.PARAMETER Schedule
+Schedule to attach to job. This can be more than one schedule.
+
+.PARAMETER ScheduleId
+Schedule ID to attach to job. This can be more than one schedule ID.
+
 .PARAMETER NewName
 The new name for the job. 
 
@@ -126,319 +132,377 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
 
 .EXAMPLE   
 sql1, sql2, sql3 | Set-DbaAgentJob -Job Job1 -Description 'Job One'
-Changes a job with the name "Job1" on multiple servers to have another description using pipeline
+Changes a job with the name "Job1" on multiple servers to have another description using pipe line
 
 #>
-	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
-	param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[Parameter(Mandatory = $false)]
-		[System.Management.Automation.PSCredential]$SqlCredential,
-		[Parameter(Mandatory = $true)]
-		[ValidateNotNullOrEmpty()]
-		[object[]]$Job,
-		[Parameter(Mandatory = $false)]
-		[string]$NewName,
-		[Parameter(Mandatory = $false)]
-		[switch]$Enabled,
-		[Parameter(Mandatory = $false)]
-		[switch]$Disabled,
-		[Parameter(Mandatory = $false)]
-		[string]$Description,
-		[Parameter(Mandatory = $false)]
-		[int]$StartStepId,
-		[Parameter(Mandatory = $false)]
-		[string]$Category,
-		[Parameter(Mandatory = $false)]
-		[string]$OwnerLogin,
-		[Parameter(Mandatory = $false)]
-		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-		[object]$EventLogLevel,
-		[Parameter(Mandatory = $false)]
-		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-		[object]$EmailLevel,
-		[Parameter(Mandatory = $false)]
-		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-		[object]$NetsendLevel,
-		[Parameter(Mandatory = $false)]
-		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-		[object]$PageLevel,
-		[Parameter(Mandatory = $false)]
-		[string]$EmailOperator,
-		[Parameter(Mandatory = $false)]
-		[string]$NetsendOperator,
-		[Parameter(Mandatory = $false)]
-		[string]$PageOperator,
-		[Parameter(Mandatory = $false)]
-		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-		[object]$DeleteLevel,
-		[switch]$Silent
-	)
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+    param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [object[]]$SqlInstance,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$SqlCredential,
+		
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [object[]]$Job,
+
+        [Parameter(Mandatory = $false)]
+        [object[]]$Schedule,
+
+        [Parameter(Mandatory = $false)]
+        [int[]]$ScheduleId,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$NewName,
+		
+        [Parameter(Mandatory = $false)]
+        [switch]$Enabled,
+		
+        [Parameter(Mandatory = $false)]
+        [switch]$Disabled,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$Description,
+		
+        [Parameter(Mandatory = $false)]
+        [int]$StartStepId,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$Category,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$OwnerLogin,
+		
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        [object]$EventLogLevel,
+		
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        [object]$EmailLevel,
+		
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        [object]$NetsendLevel,
+		
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        [object]$PageLevel,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$EmailOperator,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$NetsendOperator,
+		
+        [Parameter(Mandatory = $false)]
+        [string]$PageOperator,
+		
+        [Parameter(Mandatory = $false)]
+        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+        [object]$DeleteLevel,
+		
+        [switch]$Silent
+    )
 	
-	begin {
-		# Check of the event log level is of type string and set the integer value
-		if (($EventLogLevel -notin 0, 1, 2, 3) -and ($EventLogLevel -ne $null)) {
-			$EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-		}
+    begin {
+        # Check of the event log level is of type string and set the integer value
+        if (($EventLogLevel -notin 0, 1, 2, 3) -and ($EventLogLevel -ne $null)) {
+            $EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+        }
 		
-		# Check of the email level is of type string and set the integer value
-		if (($EmailLevel -notin 0, 1, 2, 3) -and ($EmailLevel -ne $null)) {
-			$EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-		}
+        # Check of the email level is of type string and set the integer value
+        if (($EmailLevel -notin 0, 1, 2, 3) -and ($EmailLevel -ne $null)) {
+            $EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+        }
 		
-		# Check of the net send level is of type string and set the integer value
-		if (($NetsendLevel -notin 0, 1, 2, 3) -and ($NetsendLevel -ne $null)) {
-			$NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-		}
+        # Check of the net send level is of type string and set the integer value
+        if (($NetsendLevel -notin 0, 1, 2, 3) -and ($NetsendLevel -ne $null)) {
+            $NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+        }
 		
-		# Check of the page level is of type string and set the integer value
-		if (($PageLevel -notin 0, 1, 2, 3) -and ($PageLevel -ne $null)) {
-			$PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-		}
+        # Check of the page level is of type string and set the integer value
+        if (($PageLevel -notin 0, 1, 2, 3) -and ($PageLevel -ne $null)) {
+            $PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+        }
 		
-		# Check of the delete level is of type string and set the integer value
-		if (($DeleteLevel -notin 0, 1, 2, 3) -and ($DeleteLevel -ne $null)) {
-			$DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-		}
+        # Check of the delete level is of type string and set the integer value
+        if (($DeleteLevel -notin 0, 1, 2, 3) -and ($DeleteLevel -ne $null)) {
+            $DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+        }
 		
-		# Check the e-mail operator name
-		if (($EmailLevel -ge 1) -and (-not $EmailOperator)) {
-			Stop-Function -Message "Please set the e-mail operator when the e-mail level parameter is set." -Target $sqlinstance
-			return
-		}
+        # Check the e-mail operator name
+        if (($EmailLevel -ge 1) -and (-not $EmailOperator)) {
+            Stop-Function -Message "Please set the e-mail operator when the e-mail level parameter is set." -Target $sqlinstance
+            return
+        }
 		
-		# Check the e-mail operator name
-		if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
-			Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $sqlinstance
-			return
-		}
+        # Check the e-mail operator name
+        if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
+            Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $sqlinstance
+            return
+        }
 		
-		# Check the e-mail operator name
-		if (($PageLevel -ge 1) -and (-not $PageOperator)) {
-			Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $sqlinstance
-			return
-		}
-	}
+        # Check the e-mail operator name
+        if (($PageLevel -ge 1) -and (-not $PageOperator)) {
+            Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $sqlinstance
+            return
+        }
+    }
 	
-	process {
+    process {
 		
-		if (Test-FunctionInterrupt) { return }
+        if (Test-FunctionInterrupt) { return }
 		
-		foreach ($instance in $sqlinstance) {
+        foreach ($instance in $sqlinstance) {
 			
-			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
-			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-			}
-			catch {
-				Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue
-			}
+            # Try connecting to the instance
+            Write-Message -Message "Attempting to connect to $instance" -Level Output
+            try {
+                $server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue
+            }
 			
-			foreach ($j in $Job) {
+            foreach ($j in $Job) {
 				
-				# Check if the job exists
-				if ($Server.JobServer.Jobs.Name -notcontains $j) {
-					Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
-				}
-				else {
-					# Get the job
-					try {
-						$smojob = $server.JobServer.Jobs[$j]
-					}
-					catch {
-						Stop-Function -Message "Something went wrong retrieving the job. `n$($_.Exception.Message)" -Target $j -Continue
-					}
+                # Check if the job exists
+                if ($Server.JobServer.Jobs.Name -notcontains $j) {
+                    Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
+                }
+                else {
+                    # Get the job
+                    try {
+                        $smojob = $server.JobServer.Jobs[$j]
+                    }
+                    catch {
+                        Stop-Function -Message "Something went wrong retrieving the job. `n$($_.Exception.Message)" -Target $j -InnerErrorRecord $_ -Continue
+                    }
 					
-					#region job options
-					# Settings the options for the job
-					if ($NewName) {
-						Write-Message -Message "Setting job name to $NewName" -Level Verbose
-						$smojob.Rename($NewName)
-					}
+                    #region job options
+                    # Settings the options for the job
+                    if ($NewName) {
+                        Write-Message -Message "Setting job name to $NewName" -Level Verbose
+                        $smojob.Rename($NewName)
+                    }
 					
-					if ($Enabled) {
-						Write-Message -Message "Setting job to enabled" -Level Verbose
-						$smojob.IsEnabled = $true
-					}
-					
-					if ($Disabled) {
-						Write-Message -Message "Setting job to disabled" -Level Verbose
-						$smojob.IsEnabled = $false
-					}
-					
-					if ($Description) {
-						Write-Message -Message "Setting job description to $Description" -Level Verbose
-						$smojob.Description = $Description
-					}
-					
-					if ($StartStepId) {
-						# Get the job steps
-						$smojobSteps = $smojob.JobSteps
+                    if ($Schedule) {
+                        # Loop through each of the schedules
+                        foreach ($s in $Schedule) {
+                            if ($Server.JobServer.SharedSchedules.Name -contains $s) {
+                                # Get the schedule ID
+                                $sID = $Server.JobServer.SharedSchedules[$s].ID
+							
+                                # Add schedule to job
+                                Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
+                                $smojob.AddSharedSchedule($sID)
+                            }
+                            else {
+								Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
+                            }
 						
-						# Check if there are any job steps
-						if ($smojobSteps.Count -ge 1) {
-							# Check if the start step id value is one of the job steps in the job
-							if ($smojobSteps.ID -contains $StartStepId) {
-								Write-Message -Message "Setting job start step id to $StartStepId" -Level Verbose
-								$smojob.StartStepID = $StartStepId
-							}
-							else {
-								Write-Message -Message "The step id is not present in job $j on instance $instance" -Warning
-							}
-							
-						}
-						else {
-							Stop-Function -Message "There are no job steps present for job $j on instance $instance" -Target $instance -Continue
-						}
+                        }
+                    }
+
+                    if ($ScheduleId) {
+                        # Loop through each of the schedules IDs
+                        foreach ($sID in $ScheduleId) {
+                            # Check if the schedule is 
+                            if ($Server.JobServer.SharedSchedules.ID -contains $sID) {
+                                # Add schedule to job
+                                Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
+                                $smojob.AddSharedSchedule($sID)
+                                
+                            }
+                            else {
+                                Stop-Function -Message "Schedule ID $sID cannot be found on instance $instance" -Target $sID -Continue
+                            }
+                        }
+                    }
+
+                    if ($Enabled) {
+                        Write-Message -Message "Setting job to enabled" -Level Verbose
+                        $smojob.IsEnabled = $true
+                    }
+					
+                    if ($Disabled) {
+                        Write-Message -Message "Setting job to disabled" -Level Verbose
+                        $smojob.IsEnabled = $false
+                    }
+					
+                    if ($Description) {
+                        Write-Message -Message "Setting job description to $Description" -Level Verbose
+                        $smojob.Description = $Description
+                    }
+					
+                    if ($StartStepId) {
+                        # Get the job steps
+                        $smojobSteps = $smojob.JobSteps
 						
-					}
-					
-					if ($Category) {
-						Write-Message -Message "Setting job category to $Category" -Level Verbose
-						$smojob.Category = $Category
-					}
-					
-					if ($OwnerLogin) {
-						# Check if the login name is present on the instance
-						if ($Server.Logins.Name -contains $OwnerLogin) {
-							Write-Message -Message "Setting job owner login name to $OwnerLogin" -Level Verbose
-							$smojob.OwnerLoginName = $OwnerLogin
-						}
-						else {
-							Stop-Function -Message "The given owner log in name $OwnerLogin does not exist on instance $instance" -Target $instance -Continue
-						}
-					}
-					
-					if ($EventLogLevel) {
-						Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
-						$smojob.EventLogLevel = $EventLogLevel
-					}
-					
-					if ($EmailLevel) {
-						# Check if the notifiction needs to be removed
-						if ($EmailLevel -eq 0) {
-							# Remove the operator
-							$smojob.OperatorToEmail = $null
+                        # Check if there are any job steps
+                        if ($smojobSteps.Count -ge 1) {
+                            # Check if the start step id value is one of the job steps in the job
+                            if ($smojobSteps.ID -contains $StartStepId) {
+                                Write-Message -Message "Setting job start step id to $StartStepId" -Level Verbose
+                                $smojob.StartStepID = $StartStepId
+                            }
+                            else {
+                                Write-Message -Message "The step id is not present in job $j on instance $instance" -Warning
+                            }
 							
-							# Remove the notification
-							$smojob.EmailLevel = $EmailLevel
-						}
-						else {
-							# Check if either the operator e-mail parameter is set or the operator is set in the job
-							if ($EmailOperator -or $smojob.OperatorToEmail) {
-								Write-Message -Message "Setting job e-mail level to $EmailLevel" -Level Verbose
-								$smojob.EmailLevel = $EmailLevel
-							}
-							else {
-								Stop-Function -Message "Cannot set e-mail level $EmailLevel without a valid e-mail operator name" -Target $instance -Continue
-							}
-						}
-					}
+                        }
+                        else {
+                            Stop-Function -Message "There are no job steps present for job $j on instance $instance" -Target $instance -Continue
+                        }
+						
+                    }
 					
-					if ($NetsendLevel) {
-						# Check if the notifiction needs to be removed
-						if ($NetsendLevel -eq 0) {
-							# Remove the operator
-							$smojob.OperatorToNetSend = $null
+                    if ($Category) {
+                        Write-Message -Message "Setting job category to $Category" -Level Verbose
+                        $smojob.Category = $Category
+                    }
+					
+                    if ($OwnerLogin) {
+                        # Check if the login name is present on the instance
+                        if ($Server.Logins.Name -contains $OwnerLogin) {
+                            Write-Message -Message "Setting job owner login name to $OwnerLogin" -Level Verbose
+                            $smojob.OwnerLoginName = $OwnerLogin
+                        }
+                        else {
+                            Stop-Function -Message "The given owner log in name $OwnerLogin does not exist on instance $instance" -Target $instance -Continue
+                        }
+                    }
+					
+                    if ($EventLogLevel) {
+                        Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
+                        $smojob.EventLogLevel = $EventLogLevel
+                    }
+					
+                    if ($EmailLevel) {
+                        # Check if the notifiction needs to be removed
+                        if ($EmailLevel -eq 0) {
+                            # Remove the operator
+                            $smojob.OperatorToEmail = $null
 							
-							# Remove the notification
-							$smojob.NetSendLevel = $NetsendLevel
-						}
-						else {
-							# Check if either the operator netsend parameter is set or the operator is set in the job
-							if ($NetsendOperator -or $smojob.OperatorToNetSend) {
-								Write-Message -Message "Setting job netsend level to $NetsendLevel" -Level Verbose
-								$smojob.NetSendLevel = $NetsendLevel
-							}
-							else {
-								Stop-Function -Message "Cannot set netsend level $NetsendLevel without a valid netsend operator name" -Target $instance -Continue
-							}
-						}
-					}
+                            # Remove the notification
+                            $smojob.EmailLevel = $EmailLevel
+                        }
+                        else {
+                            # Check if either the operator e-mail parameter is set or the operator is set in the job
+                            if ($EmailOperator -or $smojob.OperatorToEmail) {
+                                Write-Message -Message "Setting job e-mail level to $EmailLevel" -Level Verbose
+                                $smojob.EmailLevel = $EmailLevel
+                            }
+                            else {
+                                Stop-Function -Message "Cannot set e-mail level $EmailLevel without a valid e-mail operator name" -Target $instance -Continue
+                            }
+                        }
+                    }
 					
-					if ($PageLevel) {
-						# Check if the notifiction needs to be removed
-						if ($PageLevel -eq 0) {
-							# Remove the operator
-							$smojob.OperatorToPage = $null
+                    if ($NetsendLevel) {
+                        # Check if the notifiction needs to be removed
+                        if ($NetsendLevel -eq 0) {
+                            # Remove the operator
+                            $smojob.OperatorToNetSend = $null
 							
-							# Remove the notification
-							$smojob.PageLevel = $PageLevel
-						}
-						else {
-							# Check if either the operator pager parameter is set or the operator is set in the job
-							if ($PageOperator -or $smojob.OperatorToPage) {
-								Write-Message -Message "Setting job pager level to $PageLevel" -Level Verbose
-								$smojob.PageLevel = $PageLevel
-							}
-							else {
-								Stop-Function -Message "Cannot set page level $PageLevel without a valid netsend operator name" -Target $instance -Continue
-							}
-						}
-					}
+                            # Remove the notification
+                            $smojob.NetSendLevel = $NetsendLevel
+                        }
+                        else {
+                            # Check if either the operator netsend parameter is set or the operator is set in the job
+                            if ($NetsendOperator -or $smojob.OperatorToNetSend) {
+                                Write-Message -Message "Setting job netsend level to $NetsendLevel" -Level Verbose
+                                $smojob.NetSendLevel = $NetsendLevel
+                            }
+                            else {
+                                Stop-Function -Message "Cannot set netsend level $NetsendLevel without a valid netsend operator name" -Target $instance -Continue
+                            }
+                        }
+                    }
 					
-					# Check the current setting of the job's email level
-					if ($EmailOperator) {
-						# Check if the operator name is present
-						if ($Server.JobServer.Operators.Name -contains $EmailOperator) {
-							Write-Message -Message "Setting job e-mail operator to $EmailOperator" -Level Verbose
-							$smojob.OperatorToEmail = $EmailOperator
-						}
-						else {
-							Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
-						}
-					}
-					
-					if ($NetsendOperator) {
-						# Check if the operator name is present
-						if ($Server.JobServer.Operators.Name -contains $NetsendOperator) {
-							Write-Message -Message "Setting job netsend operator to $NetsendOperator" -Level Verbose
-							$smojob.OperatorToNetSend = $NetsendOperator
-						}
-						else {
-							Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
-						}
-					}
-					
-					if ($PageOperator) {
-						# Check if the operator name is present
-						if ($Server.JobServer.Operators.Name -contains $PageOperator) {
-							Write-Message -Message "Setting job pager operator to $PageOperator" -Level Verbose
-							$smojob.OperatorToPage = $PageOperator
-						}
-						else {
-							Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $instance -Continue
-						}
-					}
-					
-					if ($DeleteLevel) {
-						Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
-						$smojob.DeleteLevel = $DeleteLevel
-					}
-					#endregion job options
-					
-					# Execute 
-					if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
-						try {
-							Write-Message -Message ("Changing the job") -Level Output
+                    if ($PageLevel) {
+                        # Check if the notifiction needs to be removed
+                        if ($PageLevel -eq 0) {
+                            # Remove the operator
+                            $smojob.OperatorToPage = $null
 							
-							# Change the job
-							$smojob.Alter()
-						}
-						catch {
-							Stop-Function -Message "Something went wrong changing the job. `n$($_.Exception.Message)" -Target $instance -Continue
-						}
-						Get-DbaAgentJob -SqlInstance $server | Where-Object Name -eq $smojob.name
-					}
-				}
-			} # foreach object job
-		} # foreach instance
-	} # Process
+                            # Remove the notification
+                            $smojob.PageLevel = $PageLevel
+                        }
+                        else {
+                            # Check if either the operator pager parameter is set or the operator is set in the job
+                            if ($PageOperator -or $smojob.OperatorToPage) {
+                                Write-Message -Message "Setting job pager level to $PageLevel" -Level Verbose
+                                $smojob.PageLevel = $PageLevel
+                            }
+                            else {
+                                Stop-Function -Message "Cannot set page level $PageLevel without a valid netsend operator name" -Target $instance -Continue
+                            }
+                        }
+                    }
+					
+                    # Check the current setting of the job's email level
+                    if ($EmailOperator) {
+                        # Check if the operator name is present
+                        if ($Server.JobServer.Operators.Name -contains $EmailOperator) {
+                            Write-Message -Message "Setting job e-mail operator to $EmailOperator" -Level Verbose
+                            $smojob.OperatorToEmail = $EmailOperator
+                        }
+                        else {
+                            Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
+                        }
+                    }
+					
+                    if ($NetsendOperator) {
+                        # Check if the operator name is present
+                        if ($Server.JobServer.Operators.Name -contains $NetsendOperator) {
+                            Write-Message -Message "Setting job netsend operator to $NetsendOperator" -Level Verbose
+                            $smojob.OperatorToNetSend = $NetsendOperator
+                        }
+                        else {
+                            Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
+                        }
+                    }
+					
+                    if ($PageOperator) {
+                        # Check if the operator name is present
+                        if ($Server.JobServer.Operators.Name -contains $PageOperator) {
+                            Write-Message -Message "Setting job pager operator to $PageOperator" -Level Verbose
+                            $smojob.OperatorToPage = $PageOperator
+                        }
+                        else {
+                            Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $instance -Continue
+                        }
+                    }
+					
+                    if ($DeleteLevel) {
+                        Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
+                        $smojob.DeleteLevel = $DeleteLevel
+                    }
+                    #endregion job options
+					
+                    # Execute 
+                    if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
+                        try {
+                            Write-Message -Message ("Changing the job") -Level Output
+							
+                            # Change the job
+                            $smojob.Alter()
+                        }
+                        catch {
+                            Stop-Function -Message "Something went wrong changing the job. `n$($_.Exception.Message)" -Target $instance -Continue
+                        }
+                        Get-DbaAgentJob -SqlInstance $server | Where-Object Name -eq $smojob.name
+                    }
+                }
+            } # foreach object job
+        } # foreach instance
+    } # Process
 	
-	end {
-		Write-Message -Message "Finished changing job(s)." -Level Output
-	}
+    end {
+        Write-Message -Message "Finished changing job(s)." -Level Output
+    }
 }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -261,7 +261,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -139,7 +139,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [object[]]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance,
 
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]$SqlCredential,
@@ -277,6 +277,9 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     # Get the job
                     try {
                         $smojob = $server.JobServer.Jobs[$j]
+						
+                        # Refresh the object
+                        $smoJob.Refresh()
                     }
                     catch {
                         Stop-Function -Message "Something went wrong retrieving the job. `n$($_.Exception.Message)" -Target $j -InnerErrorRecord $_ -Continue
@@ -301,7 +304,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                                 $smojob.AddSharedSchedule($sID)
                             }
                             else {
-								Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
+                                Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
                             }
 						
                         }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -261,7 +261,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
             # Try connecting to the instance
             Write-Message -Message "Attempting to connect to $instance" -Level Output
             try {
-                $server = Connect-SqlServer -SqlServer $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlServer $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Could not connect to Sql Server instance" -Target $instance -Continue


### PR DESCRIPTION
New-DbaAgentJob was cleaned in the parameter section. Two parameters are
added (schedule and scheduleid) to make it possible to attach a shared schedule when the new job gets created. The return of the object was also improved.

New-DbaAgentSchedule got a cleanup in the parameter section. It not longer needs a job to create a schedule. The job parameters can still be used to assign the schedule to a job.

Remove-DbaAgentJob cleanup in the parameter section and the job parameter was set to be an object type instead of a string.

Remove-DbaAgentSchedule had the help improved and a cleanup in the
parameter section. It not longer relies on the job and has had a full rewrite to support that.

Set-DbaAgentJob had a cleanup in the parameter section.  Two parameters
are added (schedule and scheduleid) to make it possible to attach a shared schedule to a job.