### PR TITLE
Resolve-DbaNetworkName Adjusted ComputerName to be 1.0 compliant

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -1,94 +1,84 @@
-Function Resolve-DbaNetworkName
-{
-  <#
-      .SYNOPSIS
-      Returns information about the network connection of the target computer including NetBIOS name, IP Address, domain name and fully qualified domain name (FQDN).
+function Resolve-DbaNetworkName {
+	<#
+	  .SYNOPSIS
+		Returns information about the network connection of the target computer including NetBIOS name, IP Address, domain name and fully qualified domain name (FQDN).
 
-      .DESCRIPTION
-      Retrieves the IPAddress, ComputerName from one computer.
-      The object can be used to take action against its name or IPAddress.
+	  .DESCRIPTION
+		Retrieves the IPAddress, ComputerName from one computer.
+		The object can be used to take action against its name or IPAddress.
 
-      First ICMP is used to test the connection, and get the connected IPAddress.
+		First ICMP is used to test the connection, and get the connected IPAddress.
 
-      If your local Powershell version is not higher than 2, WMI is tried to get the computername.
-      If not, CIM is used, first via WinRM, and if not successful, via DCOM.
+		Multiple protocols (e.g. WMI, CIM, etc) are attempted before giving up.
 
-      .PARAMETER ComputerName
-      The Server that you're connecting to.
-      This can be the name of a computer, a SMO object, an IP address or a SQL Instance.
+	  .PARAMETER ComputerName
+		The Server that you're connecting to.
+		This can be the name of a computer, a SMO object, an IP address or a SQL Instance.
 
-      .PARAMETER Credential
-      Credential object used to connect to the SQL Server as a different user
+	  .PARAMETER Credential
+		Credential object used to connect to the SQL Server as a different user
 
-      .PARAMETER Turbo
-      Resolves without accessing the serer itself. Faster but may be less accurate.
+	  .PARAMETER Turbo
+		Resolves without accessing the serer itself. Faster but may be less accurate.
 
-      .PARAMETER Silent
-      Use this switch to disable any kind of verbose messages.
+	  .PARAMETER Silent
+		Use this switch to disable any kind of verbose messages.
 
-      .NOTES
-      Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+	  .NOTES
+	  	Tags: Network, Resolve
+		Original Author: Klaas Vandenberghe ( @PowerDBAKlaas )
 
-      dbatools PowerShell module (https://dbatools.io)
-      Copyright (C) 2016 Chrissy LeMaire
-      This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+		Website: https://dbatools.io
+		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-      .LINK
-      https://dbatools.io/Resolve-DbaNetworkName
+	  .LINK
+		https://dbatools.io/Resolve-DbaNetworkName
 
-      .EXAMPLE
-      Resolve-DbaNetworkName -ComputerName ServerA
+	  .EXAMPLE
+		Resolve-DbaNetworkName -ComputerName ServerA
 
-      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for ServerA
-	
-      .EXAMPLE
-      Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress
+		Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for ServerA
 
-      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress
-	
-      .EXAMPLE
-      Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress, sql2014
+	  .EXAMPLE
+		Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress
 
-      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress and sql2014
+		Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress
 
-      Get-SqlRegisteredServerName -SqlInstance sql2014 | Resolve-DbaNetworkName
-	
-      Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-SqlRegisteredServerName
+	  .EXAMPLE
+		Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress, sql2014
+
+		Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress and sql2014
+
+		Get-SqlRegisteredServerName -SqlInstance sql2014 | Resolve-DbaNetworkName
+
+		Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-SqlRegisteredServerName
   #>
 	[CmdletBinding()]
 	param (
 		[parameter(ValueFromPipeline)]
 		[Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlInstance')]
 		[string[]]$ComputerName = $env:COMPUTERNAME,
-    	[PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential,
+		[PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential,
 		[Alias('FastParrot')]
 		[switch]$Turbo,
 		[switch]$Silent
 	)
-	BEGIN
-	{
-		$functionName = (Get-PSCallstack)[0].Command
-	}
-	PROCESS
-	{
-		foreach ($Computer in $ComputerName)
-		{
+
+	process {
+		foreach ($Computer in $ComputerName) {
 			$conn = $ipaddress = $CIMsession = $null
-			
-			if ($Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server])
-			{
+
+			if ($Computer.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 				$Computer = $Computer.NetName
 			}
-			
+
 			$OGComputer = $Computer
-			
-			if ($Computer -eq 'localhost' -or $Computer -eq '.')
-			{
+
+			if ($Computer -eq 'localhost' -or $Computer -eq '.') {
 				$Computer = $env:COMPUTERNAME
 			}
-			
+
 			if ($Computer.GetType() -eq [Sqlcollective.Dbatools.Parameter.DbaInstanceParameter]) {
 				$Computer = $Computer.ComputerName
 			}
@@ -97,175 +87,127 @@ Function Resolve-DbaNetworkName
 				$Computer = ($Computer -Split ('\:'))[0]
 				$Computer = ($Computer.Split('\,'))[0]
 			}
-			
-			if ($Turbo)
-			{
-				try
-				{
-					Write-Message -Level Verbose -Message "$functionName - Resolving $Computer using .NET.Dns GetHostEntry"
+
+			if ($Turbo) {
+				try {
+					Write-Message -Level Verbose -Message "Resolving $Computer using .NET.Dns GetHostEntry"
 					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-					Write-Message -Level Verbose -Message "$functionName - Resolving $ipaddress using .NET.Dns GetHostByAddress"
+					Write-Message -Level Verbose -Message "Resolving $ipaddress using .NET.Dns GetHostByAddress"
 					$fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
 				}
-				catch
-				{
-					try
-					{
-						Write-Message -Level Verbose -Message "$functionName - Resolving $Computer and IP using .NET.Dns GetHostEntry"
+				catch {
+					try {
+						Write-Message -Level Verbose -Message "Resolving $Computer and IP using .NET.Dns GetHostEntry"
 						$resolved = [System.Net.Dns]::GetHostEntry($Computer)
 						$ipaddress = $resolved.AddressList[0].IPAddressToString
 						$fqdn = $resolved.HostName
 					}
-					catch
-					{
-						Write-Message -Level Warning -Message "$functionName - DNS name not found"
+					catch {
+						Write-Message -Level Warning -Message "DNS name not found"
 						continue
 					}
 				}
-				
-				if ($fqdn -notmatch "\.")
-				{
+
+				if ($fqdn -notmatch "\.") {
 					$dnsdomain = $env:USERDNSDOMAIN.ToLower()
 					$fqdn = "$fqdn.$dnsdomain"
 				}
-				
+
 				$hostname = $fqdn.Split(".")[0]
-				
+
 				[PSCustomObject]@{
-					InputName = $OGComputer
+					InputName    = $OGComputer
 					ComputerName = $hostname.ToUpper()
-					IPAddress = $ipaddress
-					DNSHostname = $hostname
-					Domain = $fqdn.Replace("$hostname.", "")
+					IPAddress    = $ipaddress
+					DNSHostname  = $hostname
+					Domain       = $fqdn.Replace("$hostname.", "")
 					DNSHostEntry = $fqdn
-					FQDN = $fqdn
+					FQDN         = $fqdn
 				}
 				return
 			}
-			
-			Write-Message -Level Verbose -Message "$functionName - Connecting to $Computer"
-			
-			try
-			{
+
+			Write-Message -Level Verbose -Message "Connecting to $Computer"
+
+			try {
 				$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
 			}
-			catch
-			{
-				try
-				{
+			catch {
+				try {
 					$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
 					$Computer = "$Computer.$env:USERDNSDOMAIN"
 				}
-				catch
-				{
+				catch {
 					$Computer = $OGComputer
 					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
 				}
 			}
-			
-			if ($ipaddress)
-			{
-				Write-Message -Level Verbose -Message "$functionName - IP Address from $Computer is $ipaddress"
+
+			if ($ipaddress) {
+				Write-Message -Level Verbose -Message "IP Address from $Computer is $ipaddress"
 			}
-			else
-			{
-				Write-Message -Level Verbose -Message "$functionName - No IP Address returned from $Computer"
-				Write-Message -Level Verbose -Message "$functionName - Using .NET.Dns to resolve IP Address"
+			else {
+				Write-Message -Level Verbose -Message "No IP Address returned from $Computer"
+				Write-Message -Level Verbose -Message "Using .NET.Dns to resolve IP Address"
 				return (Resolve-DbaNetworkName -ComputerName $Computer -Turbo)
 			}
-			
-			if ($host.Version.Major -gt 2)
-			{
-				Write-Message -Level Verbose -Message "$functionName - Your PowerShell Version is $($host.Version.Major)"
-				try
-				{
-					Write-Message -Level Verbose -Message "$functionName - Getting computer information from $Computer via CIM (WSMan)"
-					if ($Credential)
-					{
-						$CIMsession = New-CimSession -ComputerName $Computer -ErrorAction Stop -Credential $Credential
-						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession -ErrorAction Stop
+
+			if ($host.Version.Major -gt 2) {
+				Write-Message -Level Verbose -Message "Your PowerShell Version is $($host.Version.Major)"
+				try {
+					Write-Message -Level Verbose -Message "Getting computer information from $Computer"
+					if (Was-Bound "Credential") {
+						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Credential $Credential
 					}
-					else
-					{
-						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -ComputerName $Computer -ErrorAction Stop
+					else {
+						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer
 					}
 				}
-				catch
-				{
-					Write-Message -Level Verbose -Message "$functionName - No WSMan connection to $Computer"
+				catch {
+					Write-Message -Level Verbose -Message "Unable to get computer information from $Computer"
 				}
-				if (!$conn)
-				{
-					try
-					{
-						Write-Message -Level Verbose -Message "$functionName - Getting computer information from $Computer via CIM (DCOM)"
-						$sessionoption = New-CimSessionOption -Protocol DCOM
-						if ($Credential)
-						{
-							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Stop -Credential $Credential
-							
-						}
-						else
-						{
-							$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Stop
-						}
-						
-						$conn = Get-CimInstance -Query "Select * FROM Win32_computersystem" -CimSession $CIMsession -ErrorAction Stop
-					}
-					catch
-					{
-						Write-Message -Level Warning -Message "$functionName - No DCOM connection for CIM to $Computer"
-					}
-				}
-				
-				if (!$conn)
-				{
-					Write-Message -Level Verbose -Message "$functionName - No CIM from $Computer. Getting HostName via .NET.Dns"
-					try
-					{
+
+				if (!$conn) {
+					Write-Message -Level Verbose -Message "No WMI/CIM from $Computer. Getting HostName via .NET.Dns"
+					try {
 						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
 						$hostname = $fqdn.Split(".")[0]
-						
+
 						$conn = [PSCustomObject]@{
-							Name = $Computer
+							Name        = $Computer
 							DNSHostname = $hostname
-							Domain = $fqdn.Replace("$hostname.", "")
+							Domain      = $fqdn.Replace("$hostname.", "")
 						}
 					}
-					catch
-					{
-						Write-Message -Level Warning -Message "$functionName - No .NET.Dns information from $Computer"
+					catch {
+						Write-Message -Level Warning -Message "No .NET.Dns information from $Computer"
 						continue
 					}
 				}
 			}
-			
-			
-			try
-			{
-				Write-Message -Level Verbose -Message "$functionName - Resolving $($conn.DNSHostname) using .NET.Dns GetHostEntry"
+
+			try {
+				Write-Message -Level Verbose -Message "Resolving $($conn.DNSHostname) using .NET.Dns GetHostEntry"
 				$hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
 			}
-			catch
-			{
-				Write-Message -Level Warning -Message "$functionName - .NET.Dns GetHostEntry failed for $($conn.DNSHostname)"
+			catch {
+				Write-Message -Level Warning -Message ".NET.Dns GetHostEntry failed for $($conn.DNSHostname)"
 			}
-			
+
 			$fqdn = "$($conn.DNSHostname).$($conn.Domain)"
-			if ($fqdn -eq ".")
-			{
-				Write-Message -Level Verbose -Message "$functionName - No full FQDN found. Setting to null"
+			if ($fqdn -eq ".") {
+				Write-Message -Level Verbose -Message "No full FQDN found. Setting to null"
 				$fqdn = $null
 			}
-			
+
 			[PSCustomObject]@{
-				InputName = $OGComputer
+				InputName    = $OGComputer
 				ComputerName = $conn.Name
-				IPAddress = $ipaddress
-				DNSHostName = $conn.DNSHostname
-				Domain = $conn.Domain
+				IPAddress    = $ipaddress
+				DNSHostName  = $conn.DNSHostname
+				Domain       = $conn.Domain
 				DNSHostEntry = $hostentry
-				FQDN = $fqdn
+				FQDN         = $fqdn
 			}
 		}
 	}

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -119,14 +119,16 @@ function Resolve-DbaNetworkName {
 				$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
 			}
 			catch {
-				try {
-					$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
-					$Computer = "$Computer.$env:USERDNSDOMAIN"
-				}
-				catch {
-					$Computer = $OGComputer
-					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-				}
+								try {
+										if ($env:USERDNSDOMAIN) {
+												$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+												$Computer = "$Computer.$env:USERDNSDOMAIN"
+										}
+								}
+								catch {
+										$Computer = $OGComputer
+										$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+								}
 			}
 
 			if ($ipaddress) {

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -57,8 +57,8 @@ Function Resolve-DbaNetworkName
 	[CmdletBinding()]
 	param (
 		[parameter(ValueFromPipeline)]
-		[Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlServer')]
-		[DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
+		[Alias('cn', 'host', 'ServerInstance', 'Server', 'SqlInstance')]
+		[string[]]$ComputerName = $env:COMPUTERNAME,
     	[PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential,
 		[Alias('FastParrot')]
 		[switch]$Turbo

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -90,7 +90,7 @@ function Resolve-DbaNetworkName {
 						$fqdn = $resolved.HostName
 					}
 					catch {
-						Stop-Function -Message "DNS name not found" -Continue
+						Stop-Function -Message "DNS name not found" -Continue -InnerErrorRecord $_
 					}
 				}
 
@@ -145,10 +145,10 @@ function Resolve-DbaNetworkName {
 				try {
 					Write-Message -Level Verbose -Message "Getting computer information from $Computer"
 					if (Was-Bound "Credential") {
-						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Credential $Credential
+						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Credential $Credential -Silent
 					}
 					else {
-						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer
+						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Silent
 					}
 				}
 				catch {


### PR DESCRIPTION
- Adjusted ComputerName to be a string instead of the DbaInstanceParameter type. If you pass in a computer that does not exist it will throw an error that it cannot convert the value and then can't parse the instance name. Then output the expected warning messages.

- Adjusted the alias to match the example, SqlServer to SqlInstance.

- Removed all the CIM variations and put in `Get-DbaCmObject`...think I did it right but should be checked closely.

- Added messaging system

- Removed `$FunctionName` since messaging system handles that in output.
