### PR TITLE
Output added for Copy-DbaBackupDevice

### DIFF
--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -190,9 +190,6 @@ function Copy-DbaBackupDevice {
 		}
 	}
 	end	{
-		$sourceServer.ConnectionContext.Disconnect()
-		$destServer.ConnectionContext.Disconnect()
-		if ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "backup device migration finished" }
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlBackupDevice
 	}
 }

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -175,7 +175,6 @@ function Copy-DbaBackupDevice {
 					try {
 						Write-Message -Level Verbose -Message "Updating $deviceName to use $backupDirectory"
 						$sql = $sql -replace $path, $backupDirectory
-						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					}
 					catch {
 						$copyBackupDeviceStatus.Status = "Failed"
@@ -189,7 +188,7 @@ function Copy-DbaBackupDevice {
 			if ($Pscmdlet.ShouldProcess($destination, "Adding backup device $deviceName")) {
 				Write-Message -Level Verbose -Message "Adding backup device $deviceName on $destination"
 				try {
-					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+					$destServer.Query($sql)
 					$destServer.BackupDevices.Refresh()
 				}
 				catch {

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -1,5 +1,5 @@
 function Copy-DbaBackupDevice {
-    <#
+	<#
 		.SYNOPSIS
 			Copies backup devices one by one. Copies both SQL code and the backup file itself.
 
@@ -14,9 +14,9 @@ function Copy-DbaBackupDevice {
 		.PARAMETER SourceSqlCredential
 			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
 
-			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 			To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER Destination
@@ -25,21 +25,21 @@ function Copy-DbaBackupDevice {
 		.PARAMETER DestinationSqlCredential
 			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
 
-			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 			To connect as a different Windows user, run PowerShell as that user.
 
-		.PARAMETER WhatIf 
-			Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER WhatIf
+			Shows what would happen if the command were to run. No actions are actually performed.
 
-		.PARAMETER Confirm 
-			Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Confirm
+			Prompts you for confirmation before executing any changing operations within the command.
 
 		.PARAMETER Force
 			Drops and recreates the backup device if it exists
 
-		.PARAMETER Silent 
+		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
@@ -54,147 +54,145 @@ function Copy-DbaBackupDevice {
 		.LINK
 			https://dbatools.io/Copy-DbaBackupDevice
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster
 
 			Copies all server backup devices from sqlserver2014a to sqlcluster, using Windows credentials. If backup devices with the same name exist on sqlcluster, they will be skipped.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster -BackupDevice backup01 -SourceSqlCredential $cred -Force
 
 			Copies a single backup device, backup01, from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a
 			and Windows credentials for sqlcluster. If a backup device with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaBackupDevice -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 			Shows what would happen if the command were executed using force.
 	#>
-    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
-    param (
-        [parameter(Mandatory = $true)]
-        [DbaInstanceParameter]$Source,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
+	[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
+	param (
+		[parameter(Mandatory = $true)]
+		[DbaInstanceParameter]$Source,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
 		$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
-        [DbaInstanceParameter]$Destination,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
+		[parameter(Mandatory = $true)]
+		[DbaInstanceParameter]$Destination,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
 		$DestinationSqlCredential,
-        [switch]$Force,
-    	[switch]$Silent
-    )
+		[switch]$Force,
+		[switch]$Silent
+	)
 
-	
-    begin {
+	begin {
 
-        $sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
-        $destserver = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
-		
-        $source = $sourceserver.DomainInstanceName
-        $destination = $destserver.DomainInstanceName
-		
-        $serverbackupdevices = $sourceserver.BackupDevices
-        $destbackupdevices = $destserver.BackupDevices
-		
-        Write-Output "Resolving NetBios name"
-        $destnetbios = Resolve-NetBiosName $destserver
-        $sourcenetbios = Resolve-NetBiosName $sourceserver
-		
-    }
-    process	{
-	
-        foreach ($backupdevice in $serverbackupdevices) {
-            $devicename = $backupdevice.name
-			
-            if ($BackupDevices.length -gt 0 -and $BackupDevices -notcontains $devicename) { continue }
-			
-            if ($destbackupdevices.name -contains $devicename) {
-                if ($force -eq $false) {
-                    Write-Warning "backup device $devicename exists at destination. Use -Force to drop and migrate."
-                    continue
-                }
-                else {
-                    If ($Pscmdlet.ShouldProcess($destination, "Dropping backup device $devicename")) {
-                        try {
-                            Write-Verbose "Dropping backup device $devicename"
-                            $destserver.BackupDevices[$devicename].Drop()
-                        }
-                        catch { Write-Exception $_; continue }
-                    }
-                }
-            }
-			
-            If ($Pscmdlet.ShouldProcess($destination, "Generating SQL code for $devicename")) {
-                Write-Output "Scripting out SQL for $devicename"
-                try {
-                    $sql = $backupdevice.Script() | Out-String
-                    $sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
-                }
-                catch { 
-                    Write-Exception $_
-                    continue 
-                }
-            }
-			
-            If ($Pscmdlet.ShouldProcess("console", "Stating that the actual file copy is about to occur")) {
-                Write-Output "Preparing to copy actual backup file"
-            }
-			
-            $path = Split-Path $sourceserver.BackupDevices[$devicename].PhysicalLocation
-            $filename = Split-Path -Leaf $sourceserver.BackupDevices[$devicename].PhysicalLocation
-			
-            $destpath = Join-AdminUnc $destnetbios $path
-            $sourcepath = Join-AdminUnc $sourcenetbios $sourceserver.BackupDevices[$devicename].PhysicalLocation
-			
-            Write-Output "Checking if directory $destpath exists"
-			
-            if ($(Test-DbaSqlPath -SqlInstance $Destination -Path $path) -eq $false) {
-                $backupdirectory = $destserver.BackupDirectory
-                $destpath = Join-AdminUnc $destnetbios $backupdirectory
-				
-                # if ($force -eq $false) { Write-Warning "Destination directory does not exist. Use -Force to use the default backup directory at $backupdirectory "; continue }
-                If ($Pscmdlet.ShouldProcess($destination, "Updating create code to use new path")) {
-                    Write-Warning "$path doesn't exist on $destination"
-                    Write-Warning "Using default backup directory $backupdirectory"
-					
-                    try {
-                        Write-Output "Updating $devicename to use $backupdirectory"
-                        $sql = $sql -replace $path, $backupdirectory
-                        $sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
-                    }
-                    catch { 
-                        Write-Exception $_
-                        continue 
-                    }
-                }
-            }
-			
-            If ($Pscmdlet.ShouldProcess($destination, "Adding backup device $devicename")) {
-                Write-Output "Adding backup device $devicename on $destination"
-                try {
-                    $destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
-                    $destserver.BackupDevices.Refresh()
-                }
-                catch { 
-                    Write-Exception $_
-                    continue 
-                }
-            }
-			
-            If ($Pscmdlet.ShouldProcess($destination, "Copying $sourcepath to $destpath using BITSTransfer")) {
-                try {
-                    Start-BitsTransfer -Source $sourcepath -Destination $destpath
-                    Write-Output "Backup device $devicename successfully copied"
-                }
-                catch { Write-Exception $_ }
-            }
-        }
-    }
-	
-    end	{
-        $sourceserver.ConnectionContext.Disconnect()
-        $destserver.ConnectionContext.Disconnect()
-        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "backup device migration finished" }
-        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlBackupDevice
-    }
+		$sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
+		$destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
+
+		$source = $sourceServer.DomainInstanceName
+		$destination = $destServer.DomainInstanceName
+
+		$serverBackupDevices = $sourceServer.BackupDevices
+		$destBackupDevices = $destServer.BackupDevices
+
+		Write-Output "Resolving NetBios name"
+		$sourceNetBios = Resolve-NetBiosName $sourceServer
+		$destNetBios = Resolve-NetBiosName $destServer
+	}
+	process	{
+		foreach ($backupDevice in $serverBackupDevices) {
+			$deviceName = $backupDevice.Name
+
+			if ($backupDevices.Length -gt 0 -and $backupDevices -notcontains $deviceName) { continue }
+
+			if ($destBackupDevices.Name -contains $deviceName) {
+				if ($force -eq $false) {
+					Write-Warning "backup device $deviceName exists at destination. Use -Force to drop and migrate."
+					continue
+				}
+				else {
+					if ($Pscmdlet.ShouldProcess($destination, "Dropping backup device $deviceName")) {
+						try {
+							Write-Verbose "Dropping backup device $deviceName"
+							$destServer.BackupDevices[$deviceName].Drop()
+						}
+						catch { 
+							Write-Exception $_; 
+							continue
+						}
+					}
+				}
+			}
+
+			if ($Pscmdlet.ShouldProcess($destination, "Generating SQL code for $deviceName")) {
+				Write-Output "Scripting out SQL for $deviceName"
+				try {
+					$sql = $backupDevice.Script() | Out-String
+					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
+				}
+				catch {
+					Write-Exception $_
+					continue
+				}
+			}
+
+			if ($Pscmdlet.ShouldProcess("console", "Stating that the actual file copy is about to occur")) {
+				Write-Output "Preparing to copy actual backup file"
+			}
+
+			$path = Split-Path $sourceServer.BackupDevices[$deviceName].PhysicalLocation
+			$filename = Split-Path -Leaf $sourceServer.BackupDevices[$deviceName].PhysicalLocation
+
+			$destPath = Join-AdminUnc $destNetBios $path
+			$sourcepath = Join-AdminUnc $sourceNetBios $sourceServer.BackupDevices[$deviceName].PhysicalLocation
+
+			Write-Output "Checking if directory $destPath exists"
+
+			if ($(Test-DbaSqlPath -SqlInstance $Destination -Path $path) -eq $false) {
+				$backupDirectory = $destServer.BackupDirectory
+				$destPath = Join-AdminUnc $destNetBios $backupDirectory
+
+				if ($Pscmdlet.ShouldProcess($destination, "Updating create code to use new path")) {
+					Write-Warning "$path doesn't exist on $destination"
+					Write-Warning "Using default backup directory $backupDirectory"
+
+					try {
+						Write-Output "Updating $deviceName to use $backupDirectory"
+						$sql = $sql -replace $path, $backupDirectory
+						$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
+					}
+					catch {
+						Write-Exception $_
+						continue
+					}
+				}
+			}
+
+			if ($Pscmdlet.ShouldProcess($destination, "Adding backup device $deviceName")) {
+				Write-Output "Adding backup device $deviceName on $destination"
+				try {
+					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+					$destServer.BackupDevices.Refresh()
+				}
+				catch {
+					Write-Exception $_
+					continue
+				}
+			}
+
+			if ($Pscmdlet.ShouldProcess($destination, "Copying $sourcepath to $destPath using BITSTransfer")) {
+				try {
+					Start-BitsTransfer -Source $sourcepath -Destination $destPath
+					Write-Output "Backup device $deviceName successfully copied"
+				}
+				catch { Write-Exception $_ }
+			}
+		}
+	}
+	end	{
+		$sourceServer.ConnectionContext.Disconnect()
+		$destServer.ConnectionContext.Disconnect()
+		if ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "backup device migration finished" }
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlBackupDevice
+	}
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - formatted help
 - Add message system
 - update camelCase
 - Add output object
 - All output changed to verbose
 - removed End block code for closing connection and output text.
 - removed regex replace for source and destination as it is not needed.
 - tried to reorder logic as if copy of the bakcup device file fails then the backup device should not be created on the destination. Adjusted bit transfer command to fail properly with stop-function.