### PR TITLE
Change $host to $PSVersionTable

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -140,8 +140,8 @@ function Resolve-DbaNetworkName {
 				return (Resolve-DbaNetworkName -ComputerName $Computer -Turbo)
 			}
 
-			if ($host.Version.Major -gt 2) {
-				Write-Message -Level Verbose -Message "Your PowerShell Version is $($host.Version.Major)"
+			if ($PSVersionTable.PSVersion.Major -gt 2) {
+                Write-Message -Level Verbose -Message "Your PowerShell Version is $($PSVersionTable.PSVersion.Major)"
 				try {
 					Write-Message -Level Verbose -Message "Getting computer information from $Computer"
 					if (Was-Bound "Credential") {

--- a/optional/Compress-Archive.ps1
+++ b/optional/Compress-Archive.ps1
@@ -1,5 +1,4 @@
-﻿if ($Host.Version.Major -lt 5)
-{
+﻿if ($PSVersionTable.PSVersion.Major -lt 5) {
     
 <#
 Copied from the Microsoft Module: Microsoft.PowerShell.Archive

--- a/optional/Expand-Archive.ps1
+++ b/optional/Expand-Archive.ps1
@@ -1,4 +1,4 @@
-﻿if ($Host.Version.Major -lt 5)
+﻿if ($PSVersionTable.PSVersion.Major -lt 5)
 {
     
     


### PR DESCRIPTION
Fixes issue when dbatools is being run in customer terminals for ISE/editors like Visual Studio Code. ($host returns information about the Integrated Terminal for the PS Extension, which is 1.3.1 as of today.)

Changes proposed in this pull request:
 - Changed `$host.Version.Major` to $PSVersionTable.PSVersion.Major`