### PR TITLE
Moved TEPP cache building to runspace

### DIFF
--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -127,23 +127,24 @@
         {
             $server.ConnectionContext.Connect()
         }
-        
-        # Update cache for instance names
-        if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower())
-        {
-            [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $ConvertedSqlInstance.FullSmoName.ToLower()
-        }
-        
-        # Update cache for tepp names
-		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Databases.Name
-		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Logins.Name
-		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Jobs.Name
-        [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Operators.Name
-
-        $snapshots = $server.Databases | Where-Object IsDatabaseSnapShot
-        [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $snapshots.Name
 		
-        return $server
+		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext, ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
+		
+		# Update cache for instance names
+		if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower()) {
+			[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $ConvertedSqlInstance.FullSmoName.ToLower()
+		}
+		
+		# Update lots of registered stuff
+		if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
+			$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
+			foreach ($scriptBlock in ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast)) {
+				$ExecutionContext.InvokeCommand.InvokeScript($false, $scriptBlock, $null, $null)
+			}
+		}
+		
+		return $server
     }
     #endregion Input Object was a server object
     
@@ -249,22 +250,25 @@
             $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'ActiveConnections', 'AvailabilityDatabaseSynchronizationState', 'AvailabilityGroupName', 'BrokerEnabled', 'Collation', 'CompatibilityLevel', 'ContainmentType', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsMirroringEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Trustworthy', 'Version')
             $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'AsymmetricKey', 'Certificate', 'CreateDate', 'Credential', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'MustChangePassword', 'Name', 'PasswordExpirationEnabled', 'PasswordHashAlgorithm', 'PasswordPolicyEnforced', 'Sid', 'WindowsLoginAccessType')
         }
-    }
-    
-    # Update cache for instance names
+	}
+	
+	# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext, ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
+	
+	# Update cache for instance names
     if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower())
     {
         [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $ConvertedSqlInstance.FullSmoName.ToLower()
     }
-    
-    # Update cache for tepp names
-	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Databases.Name
-	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.Logins.Name
-	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Jobs.Name
-    [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $server.JobServer.Operators.Name
-
-    $snapshots = $server.Databases | Where-Object IsDatabaseSnapShot
-    [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$ConvertedSqlInstance.FullSmoName.ToLower()] = $snapshots.Name
-    return $server
+	
+	# Update lots of registered stuff
+	if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
+		$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
+		foreach ($scriptBlock in ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast)) {
+			$ExecutionContext.InvokeCommand.InvokeScript($false, $scriptBlock, $null, $null)
+		}
+	}
+	
+	return $server
     #endregion Input Object was anything else
 }

--- a/internal/Register-DbaTeppInstanceCacheBuilder.ps1
+++ b/internal/Register-DbaTeppInstanceCacheBuilder.ps1
@@ -1,0 +1,52 @@
+﻿function Register-DbaTeppInstanceCacheBuilder {
+	<#
+		.SYNOPSIS
+			Registers a scriptblock used to build the TEPP cache from an instance connection.
+		
+		.DESCRIPTION
+			Registers a scriptblock used to build the TEPP cache from an instance connection.
+			Used only on import of the module.
+		
+		.PARAMETER ScriptBlock
+			The ScriptBlock used to build the cache.
+	
+			The ScriptBlock may assume the following two variables to exist:
+			- $FullSmoName (A string containing the full SMO name as presented by the DbaInstanceParameter class-interpreted input)
+			- $server (An SMO connection object)
+		
+		.PARAMETER Slow
+			This switch implies a gathering process that takes too much time to be performed synchronously.
+			Basically, when retrieving the information takes more than 25ms on an average server (on top of establishing the original connection), this switch should be set.
+		
+		.EXAMPLE
+			Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+	
+			Registers the scriptblock stored in the aptly named variable $ScriptBlock as a fest cache building scriptblock.
+			Note: The scriptblock must execute swiftly! (less than 25ms)
+	
+		.EXAMPLE
+			Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock -Slow
+	
+			Registers the scriptblock stored in the aptly named variable $ScriptBlock as a slow cache building scriptblock.
+			This is suitable for cache building scriptblocks that take a while to execute.
+		
+		.NOTES
+			Additional information about the function.
+	#>
+	[CmdletBinding()]
+	Param (
+		[Parameter(Mandatory = $true)]
+		[System.Management.Automation.ScriptBlock]
+		$ScriptBlock,
+		
+		[switch]
+		$Slow
+	)
+	
+	if ($Slow -and ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsSlow -notcontains $ScriptBlock)) {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsSlow.Add($ScriptBlock)
+	}
+	elseif ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast -notcontains $ScriptBlock) {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast.Add($ScriptBlock)
+	}
+}

--- a/internal/configurations/tabexpansion.handler.ps1
+++ b/internal/configurations/tabexpansion.handler.ps1
@@ -1,0 +1,135 @@
+﻿#region TabExpansion.Disable
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success = $True
+		Message = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled = $Value
+	
+	# Disable Async TEPP runspace if not needed
+	if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled -or [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled) {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Stop()
+	}
+	else {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Start()
+	}
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'TabExpansion.Disable' -ScriptBlock $ScriptBlock
+#endregion TabExpansion.Disable
+
+#region TabExpansion.Disable.Asynchronous
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success = $True
+		Message = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled = $Value
+	
+	# Disable Async TEPP runspace if not needed
+	if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled -or [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled) {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Stop()
+	}
+	else {
+		[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Start()
+	}
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'TabExpansion.Disable.Asynchronous' -ScriptBlock $ScriptBlock
+#endregion TabExpansion.Disable.Asynchronous
+
+#region TabExpansion.Disable.Synchronous
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success = $True
+		Message = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'TabExpansion.Disable.Synchronous' -ScriptBlock $ScriptBlock
+#endregion TabExpansion.Disable.Synchronous
+
+#region TabExpansion.UpdateInterval
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success = $True
+		Message = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.TimeSpan") {
+		$Result.Message = "Not a TimeSpan: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateInterval = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'TabExpansion.UpdateInterval' -ScriptBlock $ScriptBlock
+#endregion TabExpansion.UpdateInterval
+
+#region TabExpansion.UpdateTimeout
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success = $True
+		Message = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.TimeSpan") {
+		$Result.Message = "Not a TimeSpan: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateTimeout = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'TabExpansion.UpdateTimeout' -ScriptBlock $ScriptBlock
+#endregion TabExpansion.UpdateInterval

--- a/internal/configurations/tabexpansion.ps1
+++ b/internal/configurations/tabexpansion.ps1
@@ -1,0 +1,8 @@
+﻿# Sets the default interval and timeout for TEPP updates
+Set-DbaConfig -Name 'TabExpansion.UpdateInterval' -Value (New-TimeSpan -Minutes 3) -Default -DisableHandler -Description 'The frequency in which TEPP tries to update each cache for autocompletion'
+Set-DbaConfig -Name 'TabExpansion.UpdateTimeout' -Value (New-TimeSpan -Minutes 30) -Default -DisableHandler -Description 'After this timespan has passed without connections to a server, the TEPP updater will no longer update the cache.'
+
+# Disable the management cache entire
+Set-DbaConfig -Name 'TabExpansion.Disable' -Value $false -Default -DisableHandler -Description 'Globally disables all TEPP functionality by dbatools'
+Set-DbaConfig -Name 'TabExpansion.Disable.Asynchronous' -Value $false -Default -DisableHandler -Description 'Globally disables asynchronous TEPP updates in the background'
+Set-DbaConfig -Name 'TabExpansion.Disable.Synchronous' -Value $true -Default -DisableHandler -Description 'Globally disables synchronous TEPP updates, performed whenever connecting o the server. If this is not disabled, it will only perform updates that are fast to perform, in order to minimize performance impact. This may lead to some TEPP functionality loss if asynchronous updates are disabled.'

--- a/internal/dynamicparams/database.ps1
+++ b/internal/dynamicparams/database.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"] = @{ }
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"] = @{ }
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
     param (
         $commandName,
@@ -66,3 +71,11 @@ $ScriptBlock = {
 }
 
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Database
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["database"][$FullSmoName] = $server.Databases.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/job.ps1
+++ b/internal/dynamicparams/job.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"] = @{ }
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"] = @{ }
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
 	param (
 		$commandName,
@@ -55,3 +60,11 @@ $ScriptBlock = {
 }
 
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Job
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["job"][$FullSmoName] = $server.JobServer.Jobs.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/login.ps1
+++ b/internal/dynamicparams/login.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"] = @{ }
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"] = @{ }
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
 	param (
 		$commandName,
@@ -55,3 +60,11 @@ $ScriptBlock = {
 }
 
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Login
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["login"][$FullSmoName] = $server.Logins.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/operator.ps1
+++ b/internal/dynamicparams/operator.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"] = @{ }
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"] = @{ }
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
     param (
         $commandName,
@@ -65,3 +70,11 @@ $ScriptBlock = {
 }
 
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Operator
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["operator"][$FullSmoName] = $server.JobServer.Operators.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/snapshot.ps1
+++ b/internal/dynamicparams/snapshot.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"] = @{ }
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"] = @{ }
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
     param (
         $commandName,
@@ -65,3 +70,12 @@ $ScriptBlock = {
 }
 
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name snapshot
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+	if ($PSVersionTable.PSVersion.Major -ge 4) { [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$FullSmoName] = $server.Databases.Where({ $_.IsDatabaseSnapShot }).Name }
+	else { [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["snapshot"][$FullSmoName] = ($server.Databases | Where-Object IsDatabaseSnapShot).Name }
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/sqlinstance.ps1
+++ b/internal/dynamicparams/sqlinstance.ps1
@@ -1,5 +1,10 @@
-﻿[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] = @()
+﻿#region Initialize Cache
+if (-not [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"]) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] = @()
+}
+#endregion Initialize Cache
 
+#region Tepp Data return
 $ScriptBlock = {
     param (
         $commandName,
@@ -23,3 +28,4 @@ $ScriptBlock = {
     [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Scripts["sqlinstance"].LastDuration = (Get-Date) - $start
 }
 Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name "sqlinstance"
+#endregion Tepp Data return

--- a/internal/scripts/updateTeppAsync.ps1
+++ b/internal/scripts/updateTeppAsync.ps1
@@ -1,0 +1,76 @@
+﻿$scriptBlock = {
+	#region Utility Functions
+	function Get-PriorityServer {
+		$res = [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT (New-Object System.DateTime(1, 1, 1, 1, 1, 1))
+		$res | Export-Csv "C:\temp\debug-priority.csv"
+		$res
+	}
+	
+	function Get-ActionableServer {
+		$res = [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT ((Get-Date) - ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateInterval)) | Where-Object -Property LastUpdate -GT ((Get-Date) - ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateTimeout))
+		$res | Export-Csv "C:\temp\debug-regular.csv"
+		$res
+	}
+	
+	function Update-TeppCache {
+		[CmdletBinding()]
+		Param (
+			[Parameter(ValueFromPipeline = $true)]
+			$ServerAccess
+		)
+		
+		begin {
+			
+		}
+		Process {
+			if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUdaterStopper) { break }
+			
+			foreach ($instance in $ServerAccess) {
+				if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUdaterStopper) { break }
+				$server = New-Object Microsoft.SqlServer.Management.Smo.Server($instance.ConnectionObject)
+				try {
+					$server.ConnectionContext.Connect()
+				}
+				catch {
+					Write-Message -Level Warning -Message "Failed to connect in order to update the Tepp Cache" -ErrorRecord $_ -Silent $true
+					continue
+				}
+				
+				$FullSmoName = ([Sqlcollective.Dbatools.Parameter.DbaInstanceParameter]$server).FullSmoName.ToLower()
+				
+				foreach ($scriptBlock in ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast)) {
+					# Workaround to avoid stupid issue with scriptblock from different runspace
+					[ScriptBlock]::Create($scriptBlock).Invoke()
+				}
+				
+				foreach ($scriptBlock in ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsSlow)) {
+					# Workaround to avoid stupid issue with scriptblock from different runspace
+					[ScriptBlock]::Create($scriptBlock).Invoke()
+				}
+				
+				$instance.LastUpdate = Get-Date
+			}
+		}
+		end {
+			
+		}
+	}
+	#endregion Utility Functions
+	
+	#region Main Execution
+	while ($true) {
+		if ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppUdaterStopper) { break }
+		
+		Get-PriorityServer | Update-TeppCache
+		
+		Get-ActionableServer | Update-TeppCache
+		
+		Start-Sleep -Seconds 5
+	}
+	#endregion Main Execution
+}
+
+[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::SetScript($scriptBlock)
+if (-not ([Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled -or [Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled)) {
+	[Sqlcollective.Dbatools.TabExpansion.TabExpansionHost]::Start()
+}


### PR DESCRIPTION
Overhauled the TEPP system to run _by default_ in the background and not as part of the direct connection process.
This prevents delays in execution, especially on bad connections, due to requesting information not pertinent to the command the user was meaning to run.
However, it is possible to opt into the previous model of TEPP updates (for example in case number of connections is an issue)

It also adds some configuration options to TEPP, in order to provide better flexibility:
`'TabExpansion.UpdateInterval'` - How frequent the TEPP cache is updated (default: 3 minutes)
`'TabExpansion.UpdateTimeout'` - How long after the last connection the cache is being updated (default: 30 minutes)
`'TabExpansion.Disable'` - Disables Tab Expansion (not fully implemented yet)
`'TabExpansion.Disable.Asynchronous'` - Disables background updates of the TEPP cache
`'TabExpansion.Disable.Synchronous'` - Disables foreground updates of the TEPP cache (enabled by default)