### PR TITLE
Correct casing

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -270,7 +270,7 @@ function Get-DbaBackupHistory {
 								  backupset.database_name AS [Database],
 								  backupset.user_name AS Username,
 								  backupset.backup_start_date AS Start,
-								  backupset.server_name as [server],
+								  backupset.server_name as [Server],
 								  backupset.backup_finish_date AS [End],
 								  DATEDIFF(SECOND, backupset.backup_start_date, backupset.backup_finish_date) AS Duration,
 								  mediafamily.physical_device_name AS Path,
@@ -287,7 +287,7 @@ function Get-DbaBackupHistory {
 								  END AS Type,
 								  backupset.media_set_id AS MediaSetId,
 								  mediafamily.media_family_id as mediafamilyid,
-								  backupset.backup_set_id as backupsetid,
+								  backupset.backup_set_id as BackupSetID,
 								  CASE mediafamily.device_type
 									WHEN 2 THEN 'Disk'
 									WHEN 102 THEN 'Permanent Disk  Device'


### PR DESCRIPTION
Corrected casing in subquery that was causing errors on case sensitive instances.

Fixes # 1435

Changes proposed in this pull request:
 - Correct query to use the same casing as the subquery.


How to test this code: 
- [ ] Run against case sensitive instance


Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

