### PR TITLE
Write-HostColor - Bringing color to your console

### DIFF
--- a/internal/Write-HostColor.ps1
+++ b/internal/Write-HostColor.ps1
@@ -1,0 +1,90 @@
+﻿function Write-HostColor {
+<#
+	.SYNOPSIS
+		Function that recognizes html-style tags to insert color into printed text.
+	
+	.DESCRIPTION
+		Function that recognizes html-style tags to insert color into printed text.
+	
+		Color tags should be designed to look like this:
+		<c="<console color>">Text</c>
+		For example this would be a valid string:
+		"This message should <c="red">partially be painted in red</c>!"
+	
+		This allows specifying color within strings and avoids having to piece together colored text in multiple calls to Write-Host.
+		Only colors that are part of the ConsoleColor enumeration can be used. Bad colors will be ignored in favor of the default color.
+	
+	.PARAMETER String
+		The message to write to host.
+		
+	.PARAMETER DefaultColor
+		Default: (Get-DbaConfigValue -Name "message.infocolor")
+		The color to write stuff to host in when no (or bad) color-code was specified.
+	
+	.EXAMPLE
+		Write-HostColor -String 'This is going to be <c="red">bloody red</c> text! And this is <c="green">green stuff</c> for extra color'
+	
+		Will print the specified line in multiple colors
+	
+	.EXAMPLE
+		$string1 = 'This is going to be <c="red">bloody red</c> text! And this is <c="green">green stuff</c> for extra color'
+		$string2 = '<c="red">bloody red</c> text! And this is <c="green">green stuff</c> for extra color'
+		$string3 = 'This is going to be <c="red">bloody red</c> text! And this is <c="green">green stuff</c>'
+		$string1, $string2, $string3 | Write-HostColor -DefaultColor "Magenta"
+	
+		Will print all three lines, respecting the color-codes, but use the color "Magenta" as default color.
+	
+	.EXAMPLE
+		$stringLong = @"
+		Dear <c="red">Sirs</c><c="green"> and</c> <c="blue">Madams</c>,
+
+		it has come to our attention that you are not sufficiently <c="darkblue">awesome!</c>
+		Kindly improve your <c="yellow">AP</c> (<c="magenta">awesome-ness points</c>) by at least 50% to maintain you membership in Awesome Inc!
+
+		You have <c="green">27 3/4</c> days time to meet this deadline. <c="darkyellow">After this we will unfortunately be forced to rend you assunder and sacrifice your remains to the devil</c>.
+
+		Best regards,
+		<c="red">Luzifer</c>
+		"@
+		Write-HostColor -String $stringLong
+	
+		Will print a long multiline text in its entirety while still respecting the colorcodes
+#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+	[CmdletBinding()]
+	Param (
+		[Parameter(ValueFromPipeline = $true)]
+		[string[]]
+		$String,
+		
+		[ConsoleColor]
+		$DefaultColor = (Get-DbaConfigValue -Name "message.infocolor")
+	)
+	process {
+		foreach ($line in $String) {
+			foreach ($row in $line.Split("`n").Split([environment]::NewLine)) {
+				if ($row -notlike '*<c="*">*</c>*') { Write-Host -Object $row -ForegroundColor $DefaultColor }
+				else {
+					$match = ($row | Select-String '<c="(.*?)">(.*?)</c>' -AllMatches).Matches
+					$index = 0
+					$count = 0
+					
+					while ($count -le $match.Count) {
+						if ($count -lt $Match.Count) {
+							Write-Host -Object $row.SubString($index, ($match[$count].Index - $Index)) -ForegroundColor $DefaultColor -NoNewline
+							try { Write-Host -Object $match[$count].Groups[2].Value -ForegroundColor $match[$count].Groups[1].Value -NoNewline -ErrorAction Stop }
+							catch { Write-Host -Object $match[$count].Groups[2].Value -ForegroundColor $DefaultColor -NoNewline -ErrorAction Stop }
+							
+							$index = $match[$count].Index + $match[$count].Length
+							$count++
+						}
+						else {
+							Write-Host -Object $row.SubString($index) -ForegroundColor $DefaultColor
+							$count++
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -232,7 +232,7 @@
                 
                 if (-not (Get-DbaConfigValue -Name $OnceName))
                 {
-                    Write-Host $NewMessage -ForegroundColor $info_color -ErrorAction Ignore
+                    Write-HostColor -String $NewMessage -DefaultColor $info_color -ErrorAction Ignore
                     Set-DbaConfig -Name $OnceName -Value $True -Hidden -Silent -ErrorAction Ignore
                 }
             }
@@ -244,7 +244,7 @@
         }
         elseif ($developerMode)
         {
-            Write-Host $NewMessage -ForegroundColor $dev_color
+			Write-HostColor -String $NewMessage -DefaultColor $info_color -ErrorAction Ignore
         }
         
         if (($max_verbose -ge $Level) -and ($min_verbose -le $Level))


### PR DESCRIPTION
This introduces an internal command - `Write-HostColor` - that allows printing colored messages to the screen. This is now called by `Write-Message` allowing us to provide colored messages for the end user.

Example:
`Write-Message -Level Output -Message "Connecting to <c="green">$SqlInstance</c>"`