### PR TITLE
Output added for Copy-DbaCustomError

### DIFF
--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -1,78 +1,87 @@
 function Copy-DbaCustomError {
     <#
-.SYNOPSIS 
-Copy-DbaCustomError migrates custom errors (user defined messages) from one SQL Server to another. 
+		.SYNOPSIS 
+			Copy-DbaCustomError migrates custom errors (user defined messages), by the customer error ID, from one SQL Server to another.
 
-.DESCRIPTION
-By default, all  custom errors are copied. The -CustomError parameter is autopopulated for command-line completion and can be used to copy only specific custom errors.
+		.DESCRIPTION
+			By default, all custom errors are copied. The -CustomError parameter is auto-populated for command-line completion and can be used to copy only specific custom errors.
 
-If the custom error already exists on the destination, it will be skipped unless -Force is used. Interesting fact, if you drop the us_english version, all the other languages will be dropped for that specific ID as well.
+			If the custom error already exists on the destination, it will be skipped unless -Force is used. Interesting fact, if you drop the us_english version, all the other languages will be dropped for that specific ID as well.
 
-Also, the us_english version must be created first.
-	
-.PARAMETER Source
-Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+			Also, the us_english version must be created first.
+			
+		.PARAMETER Source
+			Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER Destination
-Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER SourceSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-.PARAMETER SourceSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
 
-$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			To connect as a different Windows user, run PowerShell as that user.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER Destination
+			Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER DestinationSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+		.PARAMETER DestinationSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			To connect as a different Windows user, run PowerShell as that user.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER CustomError
+			The customer error(s) to process - this list is auto populated from the server. If unspecified, all customer errors will be processed.
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER ExcludeCustomError
+			The custom error(s) to exclude - this list is auto populated from the server
 
-.PARAMETER Force
-Drops and recreates the XXXXX if it exists
+		.PARAMETER WhatIf 
+			Shows what would happen if the command were to run. No actions are actually performed. 
 
-.NOTES
-Tags: Migration
-Author: Chrissy LeMaire (@cl), netnerds.net
-Requires: sysadmin access on SQL Servers
+		.PARAMETER Confirm 
+			Prompts you for confirmation before executing any changing operations within the command. 
 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+		.PARAMETER Force
+			Drops and recreates the XXXXX if it exists
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		.PARAMETER Silent 
+			Use this switch to disable any kind of verbose messages
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+		.NOTES
+			Tags: Migration, CustomError
+			Author: Chrissy LeMaire (@cl), netnerds.net
+			Requires: sysadmin access on SQL Servers
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Copy-DbaCustomError
+		.LINK
+			https://dbatools.io/Copy-DbaCustomError
 
-.EXAMPLE   
-Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster
+		.EXAMPLE   
+			Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster
 
-Copies all server custom errors from sqlserver2014a to sqlcluster, using Windows credentials. If custom errors with the same name exist on sqlcluster, they will be skipped.
+			Copies all server custom errors from sqlserver2014a to sqlcluster, using Windows credentials. If custom errors with the same name exist on sqlcluster, they will be skipped.
 
-.EXAMPLE   
-Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster -ServerTrigger 60000 -SourceSqlCredential $cred -Force
+		.EXAMPLE
+			Copy-DbaCustomError -Source sqlserver2014a -SourceSqlCredential $scred -Destination sqlcluster -DestinationSqlCredential $dcred -CustomError 60000 -Force
 
-Copies a single custom error, the custom error with ID number 6000 from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a custom error with the same name exists on sqlcluster, it will be updated because -Force was used.
+			Copies a single custom error, the custom error with ID number 60000 from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a custom error with the same name exists on sqlcluster, it will be updated because -Force was used.
 
-.EXAMPLE   
-Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+		.EXAMPLE
+			Copy-DbaCustomError -Source slserver2014a -Destination sqlcluster -ExcludeCustomError 60000 -Force
 
-Shows what would happen if the command were executed using force.
-#>
+			Copies all the custom errors found on sqlserver2014a, except the custom error with ID number 60000. If a custom error with the same name exists on sqlcluster, it will be updated because -Force was used.
+
+		.EXAMPLE   
+			Copy-DbaCustomError -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+
+			Shows what would happen if the command were executed using force.
+	#>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
         [parameter(Mandatory = $true)]

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -157,9 +157,6 @@ function Copy-DbaCustomError {
         }
     }
     end {
-        $sourceServer.ConnectionContext.Disconnect()
-        $destServer.ConnectionContext.Disconnect()
-        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) { Write-Output "Custom error migration finished" }
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlCustomError
     }
 } 

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -161,9 +161,8 @@ function Copy-DbaCustomError {
 				try {
 					Write-Message -Level Verbose -Message "Copying custom error $customErrorId $language"
 					$sql = $currentCustomError.Script() | Out-String
-					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					Write-Message -Level Debug -Message $sql
-					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+					$destServer.Query($sql)
 
 					$copyCustomErrorStatus.Status = "Successful"
 					$copyCustomErrorStatus

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -86,13 +86,17 @@ function Copy-DbaCustomError {
     param (
         [parameter(Mandatory = $true)]
         [DbaInstanceParameter]$Source,
+        [PSCredential][System.Management.Automation.CredentialAttribute()]
+        $SourceSqlCredential,
         [parameter(Mandatory = $true)]
-        [DbaInstanceParameter]$Destination,
-        [System.Management.Automation.PSCredential]$SourceSqlCredential,
-        [System.Management.Automation.PSCredential]$DestinationSqlCredential,
-        [switch]$Force
+        [DbaInstanceParameter]$Destination,      
+        [PSCredential][System.Management.Automation.CredentialAttribute()]
+        $DestinationSqlCredential,
+        [object[]]$CustomError,
+		[object[]]$ExcludeCustomError,
+        [switch]$Force,
+        [switch]$Silent
     )
-
 	
     begin {
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - formatted help
 - Add message system
 - update camelCase
 - Add output object
 - All output changed to verbose
 - removed End block code for closing connection and output text.
 - removed regex replace for source and destination as it is not needed.

![image](https://user-images.githubusercontent.com/11204251/27258130-7d42c81a-53b7-11e7-9a25-bfdeffdac62e.png)
