### PR TITLE
Fix minor spelling typo in install message: "isntaller"

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,7 @@ try {
 		if ($PSCommandPath.Length -gt 0) {
 			$path = Split-Path $PSCommandPath
 			if ($path -match "github") {
-				Write-Output "Looks like this isntaller is run from your GitHub Repo, defaulting to psmodulepath"
+				Write-Output "Looks like this installer is run from your GitHub Repo, defaulting to psmodulepath"
 				$path = $localpath
 			}
 		}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - 
 -  Fix trivial misspelling ("isntaller ")
 - Has not been tested in any way (I am new to this project and do not know how to use it, which is why I was looking at the install.ps1 file, and happened to notice the misspelling)

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

