### PR TITLE
adding ola ignorelog back in

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -433,14 +433,14 @@ function Restore-DbaDatabase {
                         }
                         elseif ($MaintenanceSolutionBackup) {
                             Write-Verbose "$FunctionName : Ola Style Folder"
-                            $backupFiles += Get-OlaHRestoreFile -Path $p
+                            $backupFiles += Get-OlaHRestoreFile -Path $p -IgnoreLogBackup:$IgnoreLogBackup
                         }
                         else {
                             Write-Verbose "$FunctionName : Standard Directory"
                             $FileCheck = $backupFiles.count
                             $backupFiles += Get-DirectoryRestoreFile -Path $p
                             if ((($backupFiles.count) - $FileCheck) -eq 0) {
-                                $backupFiles += Get-OlaHRestoreFile -Path $p
+                                $backupFiles += Get-OlaHRestoreFile -Path $p -IgnoreLogBackup:$IgnoreLogBackup
                             }
                         }
                     }


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - reinstates the IgnoreLogBackup option for MaintenanceSolution restores. Looks like it went walkies during a refactor
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

