### PR TITLE
Added parameter for enabled

### DIFF
--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -4,11 +4,12 @@ FUNCTION Get-DbaAgentJob {
 			Gets SQL Agent Job information for each instance(s) of SQL Server.
 
 		.DESCRIPTION
-			The Get-DbaAgentJob returns connected SMO object for SQL Agent Job information for each instance(s) of SQL Server.
+			The Get-DbaAgentJob returns connected SMO object for SQL Agent Job information for each instance(s) of SQL Server. The default behavior
+			is to return enabled jobs only.
 
 		.PARAMETER SqlInstance
-			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and recieve pipeline input to allow the function
-			to be executed against multiple SQL Server instances.
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and recieve pipeline input 
+			to allow the function to be executed against multiple SQL Server instances.
 
 		.PARAMETER SqlCredential
 			SqlCredential object to connect as. If not specified, current Windows login will be used.
@@ -20,7 +21,7 @@ FUNCTION Get-DbaAgentJob {
 			The job(s) to exclude - this list is auto populated from the server.
 
 		.PARAMETER IncludeDisabled
-			Default is to only return enabled jobs, switch will also return disabled jobs.
+			Switch will include the disabled jobs in output.
 
 		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
@@ -39,17 +40,27 @@ FUNCTION Get-DbaAgentJob {
 		.EXAMPLE
 			Get-DbaAgentJob -SqlInstance localhost
 
-			Returns all SQL Agent Job on the local default SQL Server instance
+			Returns all enabled SQL Agent Jobs on the local default SQL Server instance
 
 		.EXAMPLE
 			Get-DbaAgentJob -SqlInstance localhost, sql2016
 
-			Returns all SQl Agent Job for the local and sql2016 SQL Server instances
+			Returns all enabled SQl Agent Jobs for the local and sql2016 SQL Server instances
 
+		.EXAMPLE
+			Get-DbaAgentJob -SqlInstance localhost -Job BackupData, BackupDiff
+
+			Returns all enabled SQL Agent Jobs named BackupData and BackupDiff from the local SQL Server instance.
+
+		.EXAMPLE
+			Get-DbaAgentJob -SqlInstance localhost -ExcludeJob BackupDiff
+
+			Returns all enabled SQl Agent Jobs for the local SQL Server instances, except the BackupDiff Job.
+			
 		.EXAMPLE
 			Get-DbaAgentJob -SqlInstance localhost -IncludeDisabled
 
-			Includes disabled SQl Agent Jobs in the returned set for the local SQL Server instances
+			Returns all SQl Agent Jobs for the local SQL Server instances, including disabled jobs.
 	#>
 	[CmdletBinding()]
 	param (
@@ -90,7 +101,7 @@ FUNCTION Get-DbaAgentJob {
 			foreach ($agentJob in $jobs) {
 				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.NetName
 				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name InstanceName -value $agentJob.Parent.Parent.ServiceName
-				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName
+				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName			
 				
 				Select-DefaultView -InputObject $agentJob -Property ComputerName, InstanceName, SqlInstance, Name, Category, OwnerLoginName, 'IsEnabled as Enabled', LastRunDate, DateCreated, HasSchedule, OperatorToEmail
 			}

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -19,8 +19,8 @@ FUNCTION Get-DbaAgentJob {
 		.PARAMETER ExcludeJob
 			The job(s) to exclude - this list is auto populated from the server.
 
-		.PARAMETER Enabled
-			True will return only enabled jobs, false will return disabled jobs.
+		.PARAMETER IncludeDisabled
+			Default is to only return enabled jobs, switch will also return disabled jobs.
 
 		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
@@ -47,9 +47,9 @@ FUNCTION Get-DbaAgentJob {
 			Returns all SQl Agent Job for the local and sql2016 SQL Server instances
 
 		.EXAMPLE
-			Get-DbaAgentJob -SqlInstance localhost -Enabled True
+			Get-DbaAgentJob -SqlInstance localhost -IncludeDisabled
 
-			Returns all enabled SQl Agent Job for the local SQL Server instances
+			Includes disabled SQl Agent Jobs in the returned set for the local SQL Server instances
 	#>
 	[CmdletBinding()]
 	param (
@@ -60,8 +60,7 @@ FUNCTION Get-DbaAgentJob {
 		$SqlCredential,
 		[object[]]$Job,
 		[object[]]$ExcludeJob,
-		[ValidateSet('True', 'False')]
-		[string]$Enabled,
+		[switch]$IncludeDisabled,
 		[switch]$Silent
 	)
 
@@ -77,19 +76,15 @@ FUNCTION Get-DbaAgentJob {
 			}
 
 			$jobs = $server.JobServer.Jobs
-			if ($Enabled) {
-				if($Enabled -eq 'True') { 
-					$jobs = $Jobs | Where-Object IsEnabled -eq $true
-				} else {
-					$jobs = $Jobs | Where-Object IsEnabled -eq $false
-				}
-			}
 			
 			if ($Job) {
 				$jobs = $jobs | Where-Object Name -In $Job
 			}
 			if ($ExcludeJob) {
 				$jobs = $jobs | Where-Object Name -NotIn $ExcludeJob
+			}
+			if (!$IncludeDisabled -and !$job) {
+					$jobs = $Jobs | Where-Object IsEnabled -eq $true
 			}
 			
 			foreach ($agentJob in $jobs) {

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -101,9 +101,11 @@ FUNCTION Get-DbaAgentJob {
 			foreach ($agentJob in $jobs) {
 				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.NetName
 				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name InstanceName -value $agentJob.Parent.Parent.ServiceName
-				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName			
+				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName	
+				Add-Member -InputObject $agentJob -MemberType NoteProperty -Name ScheduleName -value $agentJob.JobSchedules.Name	
+
 				
-				Select-DefaultView -InputObject $agentJob -Property ComputerName, InstanceName, SqlInstance, Name, Category, OwnerLoginName, 'IsEnabled as Enabled', LastRunDate, DateCreated, HasSchedule, OperatorToEmail
+				Select-DefaultView -InputObject $agentJob -Property ComputerName, InstanceName, SqlInstance, Name, Category, OwnerLoginName, 'IsEnabled as Enabled', LastRunDate, DateCreated, HasSchedule, ScheduleName, OperatorToEmail
 			}
 		}
 	}

--- a/install.ps1
+++ b/install.ps1
@@ -28,7 +28,7 @@ try {
 		if ($PSCommandPath.Length -gt 0) {
 			$path = Split-Path $PSCommandPath
 			if ($path -match "github") {
-				Write-Output "Looks like this isntaller is run from your GitHub Repo, defaulting to psmodulepath"
+				Write-Output "Looks like this installer is run from your GitHub Repo, defaulting to psmodulepath"
 				$path = $localpath
 			}
 		}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 -  Add parameter for Enabled

How to test this code: 
- [ ]  Get-DbaAgentJob -SqlInstance localhost -Enabled True
Returns all enabled jobs from localhost
- [ ]  Get-DbaAgentJob -SqlInstance localhost -Enabled False
Returns all disabled jobs from localhost

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

