### PR TITLE
IgnoreLogBackup option is now a bit more useful!

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -266,7 +266,18 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
 						Stop-Function -Message "$dbname does not exist on $source." -Continue
 					}
 					
-					$lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IgnoreCopyOnly:$ignorecopyonly -raw
+					if (Was-Bound "IgnoreLogBackup"){
+						Write-Message -Level Verbose -Message "Skipping Log backups as requested"
+						$lastbackup = @()
+						$lastbackup += $full = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw	-LastFull
+						$diff = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw -LastDiff
+						if ($full.start -le $diff.start){
+							$lastbackup += $diff
+						}									
+					}
+					else {
+						$lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IgnoreCopyOnly:$ignorecopyonly -raw
+					}
 					if ($CopyFile) {
 						try {
 							Write-Message -Level Verbose -Message "Gathering information for file copy"


### PR DESCRIPTION
Fixes an issue raised in slack by @js0505 that he was stuck checking log files running Test-DbaLastBackup even with the IgnoreLogBackup option

Changes proposed in this pull request:
 - Actually ignores log backups from the backup history
 - 
 - 

How to test this code: 
- [ ] @js0505 has confirmed this works.
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

