### PR TITLE
Add CreateDate to default view of Get-DbaLogin function

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -133,7 +133,7 @@ function Get-DbaLogin {
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
 
-				Select-DefaultView -InputObject $serverLogin -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, LastLogin, HasAccess, IsLocked, IsDisabled
+				Select-DefaultView -InputObject $serverLogin -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled
 			} #foreach serverlogin
 		} #foreach instance
 	} #process


### PR DESCRIPTION
Fixes # 1479

Changes proposed in this pull request:
 - Adds the "CreateDate" property to the default view when running Get-DbaLogin 

How to test this code: 
- Run Get-DbaLogin
- Verify that CreateDate shows up in default output of the function.