### PR TITLE
Out-DbaDataTable fix

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -310,7 +310,7 @@
 		'Install-DbaFirstResponderKit',
 		'Backup-DbaDatabaseMasterKey',
 		'Get-DbaAgentJobHistory',
-		'Get-DbaSsisEnvironment'
+		'Get-DbaSsisEnvironmentVariable'
 	)
 	
 	# Cmdlets to export from this module

--- a/functions/Out-DbaDataTable.ps1
+++ b/functions/Out-DbaDataTable.ps1
@@ -271,7 +271,12 @@ Function Out-DbaDataTable {
 							}
 						}
 						
-						if ($property.value.length -gt 0) {
+                        try {
+                            $propValueLength = $property.value.length
+                        } catch {
+                            $propValueLength = 0
+                        }
+						if ($propValueLength -gt 0) {
 							if ($property.value.ToString() -eq 'System.Object[]') {
 								$datarow.Item($property.Name) = $property.value -join ", "
 							}

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -304,7 +304,7 @@ Function Write-DbaDataTable {
             'System.TimeSpan' = 'nvarchar(30)';
             'System.String' = 'nvarchar(MAX)';
             'System.Char' = 'nvarchar(1)'
-            'System.DateTime' = 'datetime';
+            'System.DateTime' = 'datetime2';
             'System.Boolean' = 'bit';
             'System.Guid' = 'uniqueidentifier';
             'Int32' = 'int';
@@ -321,7 +321,7 @@ Function Write-DbaDataTable {
             'TimeSpan' = 'nvarchar(30)';
             'String' = 'nvarchar(MAX)';
             'Char' = 'nvarchar(1)'
-            'DateTime' = 'datetime';
+            'DateTime' = 'datetime2';
             'Boolean' = 'bit';
             'Bool' = 'bit';
             'Guid' = 'uniqueidentifier';


### PR DESCRIPTION
Fixes #1485 

Changes proposed in this pull request:
- Besides fixing #1485 I also noticed a datetime overflow issue with Write-DbaDataTable when piping from Get-DbaDatabase so I updated Write-DbaDataTable to use datetime2 instead of datetime. 

How to test this code: 
- [ ] Get-DbaDatabase -SqlInstance sql2016 | Out-DbaDataTable

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

