### PR TITLE
Get-DbaLogin -- Only show `LastLogin` on versions > 2000

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -132,6 +132,10 @@ function Get-DbaLogin {
 					$sql = "SELECT MAX(login_time) AS [login_time] FROM sys.dm_exec_sessions WHERE login_name = '$($serverLogin.name)'"
 					Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $server.ConnectionContext.ExecuteScalar($sql)
 				}
+				else 
+				{
+					Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $null
+				}
 
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name ComputerName -Value $server.NetName
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -125,10 +125,14 @@ function Get-DbaLogin {
 
 			foreach ($serverLogin in $serverlogins) {
 				Write-Message -Level Verbose -Message "Processing $serverLogin on $instance"
-				Write-Message -Level Verbose -Message "Getting last login time"
-				$sql = "SELECT MAX(login_time) AS [login_time] FROM sys.dm_exec_sessions WHERE login_name = '$($serverLogin.name)'"
 
-				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $server.ConnectionContext.ExecuteScalar($sql)
+				if ($server.VersionMajor -gt 9) {
+					# There's no reliable method to get last login time with SQL Server 2000, so only show on 2005+
+					Write-Message -Level Verbose -Message "Getting last login time"
+					$sql = "SELECT MAX(login_time) AS [login_time] FROM sys.dm_exec_sessions WHERE login_name = '$($serverLogin.name)'"
+					Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $server.ConnectionContext.ExecuteScalar($sql)
+				}
+
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name ComputerName -Value $server.NetName
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
 				Add-Member -InputObject $serverLogin -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName


### PR DESCRIPTION
Fixes issue brought up in #1486 where SQL 2000 would throw an error.

Changes proposed in this pull request:
 - LastLogin not reliably tracked in SQL 2000, so only show on 2005+

How to test this code: 
- Run `Get-DbaLogin sql2000` (SQL 2000 instance), and don't see an exception :)