### PR TITLE
Fixing improper merge artifacts

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -207,8 +207,13 @@ function Get-DbaBackupHistory {
 						$Allbackups += $DiffDB
 					}
 					else {
-						Write-Verbose "No Diff found"
-						[bigint]$TLogStartLSN = $fulldb.FirstLsn
+						Write-Verbose "No Diff found"												
+						try { 
+							[bigint]$TLogStartLSN = $fulldb.FirstLsn 
+						}
+						catch {
+							continue
+						}
 					}
 					$Allbackups += $Logdb = Get-DbaBackupHistory -SqlInstance $server -Databases $db -raw:$raw | Where-object { $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$TLogstartLSN -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$Fulldb.CheckPointLSN }
 					$Allbackups | Sort-Object FirstLsn

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -281,44 +281,39 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                         try {
                             Write-Message -Level Verbose -Message "Gathering information for file copy"
                             $removearray = @()
-=======
-					if (Was-Bound "IgnoreLogBackup"){
-						Write-Message -Level Verbose -Message "Skipping Log backups as requested"
-						$lastbackup = @()
-						$lastbackup += $full = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw	-LastFull
-						$diff = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw -LastDiff
-						if ($full.start -le $diff.start){
-							$lastbackup += $diff
-						}									
-					}
-					else {
-						$lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IgnoreCopyOnly:$ignorecopyonly -raw
-					}
-					if ($CopyFile) {
-						try {
-							Write-Message -Level Verbose -Message "Gathering information for file copy"
-							$removearray = @()
->>>>>>> development
-							
+
+                            if (Was-Bound "IgnoreLogBackup"){
+                                Write-Message -Level Verbose -Message "Skipping Log backups as requested"
+                                $lastbackup = @()
+                                $lastbackup += $full = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw	-LastFull
+                                $diff = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IgnoreCopyOnly:$ignorecopyonly -raw -LastDiff
+                                if ($full.start -le $diff.start){
+                                    $lastbackup += $diff
+                                }									
+                            }
+                            else {
+                                $lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IgnoreCopyOnly:$ignorecopyonly -raw
+                            }
+                                
                             foreach ($backup in $lastbackup) {
                                 foreach ($file in $backup) {
                                     $filename = Split-Path -Path $file.FullName -Leaf
                                     Write-Message -Level Verbose -Message "Processing $filename"
 
                                     $sourcefile = Join-AdminUnc -servername $sourceserver.ComputerNamePhysicalNetBIOS -filepath $file.Path
-									
+                                    
                                     if ($destserver.ComputerNamePhysicalNetBIOS -ne $env:COMPUTERNAME) {
                                         $remotedestdirectory = Join-AdminUnc -servername $destserver.ComputerNamePhysicalNetBIOS -filepath $copyPath
                                     }
                                     else {
                                         $remotedestdirectory = $copyPath
                                     }
-									
+                                    
                                     $remotedestfile = "$remotedestdirectory\$filename"
                                     $localdestfile = "$copyPath\$filename"
                                     Write-Message -Level Verbose -Message "Destination directory is $destdirectory"
                                     Write-Message -Level Verbose -Message "Destination filename is $remotedestfile"
-									
+                                    
                                     try {
                                         Write-Message -Level Verbose -Message "Copying $sourcefile to $remotedestfile"
                                         Copy-Item -Path $sourcefile -Destination $remotedestfile -ErrorAction Stop


### PR DESCRIPTION
Had some issues with the VS Code merge, and even with testing it failed (must have had the command in memory already.)

This code removes the symbols that are traditionally used to delineate between the two branches being merged. 