### PR TITLE
fixed library build command

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -90,7 +90,7 @@ if ($ImportLibrary) {
 				}
 				
 				Write-Verbose -Message "Building the library"
-				$null = & $msbuild "bin\projects\dbatools\dbatools.sln"
+				$null = & $msbuild "$libraryBase\projects\dbatools\dbatools.sln"
 				
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"


### PR DESCRIPTION
Fixes # 

Fixes the issue with building the library when importing the module from anywhere but the module root.
I really should have seen that one coming, looking at the error in retrospect ...