### PR TITLE
Output added for Copy-DbaLogin

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -164,6 +164,7 @@ function Copy-DbaLogin {
 					}
 
 					$copyLoginStatus.Status = "Skipped"
+					$copyLoginStatus.Notes = "Login doing migration"
 					$copyLoginStatus
 					continue
 				}
@@ -181,6 +182,7 @@ function Copy-DbaLogin {
 						}
 
 						$copyLoginStatus.Status = "Skipped"
+						$copyLoginStatus.Notes = "local machine name"
 						$copyLoginStatus
 						continue
 					}
@@ -197,6 +199,7 @@ function Copy-DbaLogin {
 					}
 
 					$copyLoginStatus.Status = "Skipped"
+					$copyLoginStatus.Notes = "Already exist on destination."
 					$copyLoginStatus
 					continue
 				}
@@ -206,6 +209,7 @@ function Copy-DbaLogin {
 						Write-Message -Level Warning -Message "$userName is the destination service account. Skipping drop."
 
 						$copyLoginStatus.Status = "Skipped"
+						$copyLoginStatus.Notes = "Destination service account"
 						$copyLoginStatus
 						continue
 					}
@@ -243,6 +247,7 @@ function Copy-DbaLogin {
 						}
 						catch {
 							$copyLoginStatus.Status = "Failed"
+							$copyLoginStatus.Notes = $_.Exception
 							$copyLoginStatus
 
 							Stop-Function -Message "Could not drop $userName" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Continue
@@ -336,6 +341,7 @@ function Copy-DbaLogin {
 							}
 							catch {
 								$copyLoginStatus.Status = "Failed"
+								$copyLoginStatus.Notes = $_.Exception
 								$copyLoginStatus
 
 								Stop-Function -Message "Failed to add $userName to $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Continue
@@ -361,6 +367,7 @@ function Copy-DbaLogin {
 						}
 						catch {
 							$copyLoginStatus.Status = "Failed"
+							$copyLoginStatus.Notes = $_.Exception
 							$copyLoginStatus
 
 							Stop-Function -Message "Failed to add $userName to $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Continue
@@ -371,6 +378,7 @@ function Copy-DbaLogin {
 						Write-Message -Level Warning -Message "$($sourceLogin.LoginType) logins not supported. $($sourceLogin.name) skipped."
 
 						$copyLoginStatus.Status = "Skipped"
+						$copyLoginStatus.Notes = "$($sourceLogin.LoginType) not supported"
 						$copyLoginStatus
 
 						continue
@@ -382,6 +390,7 @@ function Copy-DbaLogin {
 						}
 						catch {
 							$copyLoginStatus.Status = "Successful - but could not disable on destination"
+							$copyLoginStatus.Notes = $_.Exception
 							$copyLoginStatus
 
 							Stop-Function -Message "$userName disabled on source, could not be disabled on $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer
@@ -393,6 +402,7 @@ function Copy-DbaLogin {
 						}
 						catch {
 							$copyLoginStatus.Status = "Successful - but could not deny login on destination"
+							$copyLoginStatus.Notes = $_.Exception
 							$copyLoginStatus
 
 							Stop-Function -Message "$userName denied login on source, could not be denied login on $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer
@@ -418,6 +428,7 @@ function Copy-DbaLogin {
 						catch {
 							$copyLoginStatus.DestinationLogin = $NewLogin
 							$copyLoginStatus.Status = "Failed to rename"
+							$copyLoginStatus.Notes = $_.Exception
 							$copyLoginStatus
 
 							Stop-Function -Message "Issue renaming $userName to $NewLogin" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -135,13 +135,14 @@ function Copy-DbaLogin {
 				$userName = $sourceLogin.name
 
 				$copyLoginStatus = [pscustomobject]@{
-					SourceServer = $sourceServer.Name
+					SourceServer      = $sourceServer.Name
 					DestinationServer = $destServer.Name
-					SourceLogin = $userName
-					DestinationLogin = $userName
-					Type = $sourceLogin.LoginType
-					Status = $null
-					DateTime = [DbaDateTime](Get-Date)
+					SourceLogin       = $userName
+					DestinationLogin  = $userName
+					Type              = $sourceLogin.LoginType
+					Status            = $null
+					Notes             = $null
+					DateTime          = [DbaDateTime](Get-Date)
 				}
 
 				if ($Login -and $Login -notcontains $userName -or $ExcludeLogin -contains $userName) { continue }

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -39,29 +39,29 @@ function Copy-DbaLogin {
 			The login(s) to exclude - this list is autopopulated from the server
 
 		.PARAMETER SyncOnly
-		Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins or users. If a matching login does not exist on the destination, the login will be skipped.
-		Credential removal not currently supported for Syncs. TODO: Application role sync
-
-		.PARAMETER OutFile
-		Calls Export-SqlLogin and exports all logins to a T-SQL formatted file. This does not perform a copy, so no destination is required.
+			Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins or users. If a matching login does not exist on the destination, the login will be skipped.
+			Credential removal not currently supported for Syncs. TODO: Application role sync
 
 		.PARAMETER SyncSaName
-		Want to sync up the name of the sa account on the source and destination? Use this switch.
+			Want to sync up the name of the sa account on the source and destination? Use this switch.
 
-		.PARAMETER Force
-		Force drops and recreates logins. Logins that own jobs cannot be dropped at this time.
+		.PARAMETER OutFile
+			Calls Export-SqlLogin and exports all logins to a T-SQL formatted file. This does not perform a copy, so no destination is required.
 
-		.PARAMETER WhatIf
-		Shows what would happen if the command were to run. No actions are actually performed.
-
-		.PARAMETER Confirm
-		Prompts you for confirmation before executing any changing operations within the command.
-
-		.PARAMETER pipelogin
-		Takes the parameters required from a login object that has been piped ot the command
+		.PARAMETER PipeLogin
+			Takes the parameters required from a login object that has been piped ot the command
 
 		.PARAMETER LoginRenameHashtable
-		Takes a hash table that will pass to Rename-DbaLogin and update the login and mappings once the copy is completed.
+			Takes a hash table that will pass to Rename-DbaLogin and update the login and mappings once the copy is completed.
+
+		.PARAMETER WhatIf
+			Shows what would happen if the command were to run. No actions are actually performed.
+
+		.PARAMETER Confirm
+			Prompts you for confirmation before executing any changing operations within the command.
+
+		.PARAMETER Force
+			Force drops and recreates logins. Logins that own jobs cannot be dropped at this time.
 
 		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
@@ -118,13 +118,13 @@ function Copy-DbaLogin {
 		[object[]]$Login,
 		[object[]]$ExcludeLogin,
 		[switch]$SyncOnly,
+		[parameter(ParameterSetName = "Live")]
+		[switch]$SyncSaName,
 		[parameter(ParameterSetName = "File", Mandatory = $true)]
 		[string]$OutFile,
-		[parameter(ParameterSetName = "Live")]
-		[switch]$Force,
-		[switch]$SyncSaName,
 		[object]$PipeLogin,
 		[hashtable]$LoginRenameHashtable,
+		[switch]$Force,
 		[switch]$Silent
 	)
 

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -139,7 +139,7 @@ function Copy-DbaLogin {
 				if ($sourceLogin.id -eq 1) { continue }
 
 				if ($userName.StartsWith("##") -or $userName -eq 'sa') {
-					Write-Message -Level Output -Message "Skipping $userName"
+					Write-Message -Level Verbose -Message "Skipping $userName"
 					continue
 				}
 
@@ -169,7 +169,7 @@ function Copy-DbaLogin {
 					}
 					else {
 						if ($Pscmdlet.ShouldProcess("console", "Stating local login $userName since the source and destination server reside on the same machine.")) {
-							Write-Message -Level Output -Message "Copying local login $userName since the source and destination server reside on the same machine."
+							Write-Message -Level Verbose -Message "Copying local login $userName since the source and destination server reside on the same machine."
 						}
 					}
 				}
@@ -190,14 +190,14 @@ function Copy-DbaLogin {
 					if ($Pscmdlet.ShouldProcess($destination, "Dropping $userName")) {
 
 						# Kill connections, delete user
-						Write-Message -Level Output -Message "Attempting to migrate $userName"
-						Write-Message -Level Output -Message "Force was specified. Attempting to drop $userName on $destination"
+						Write-Message -Level Verbose -Message "Attempting to migrate $userName"
+						Write-Message -Level Verbose -Message "Force was specified. Attempting to drop $userName on $destination"
 
 						try {
 							$ownedDbs = $destServer.Databases | Where-Object Owner -eq $userName
 
 							foreach ($ownedDb in $ownedDbs) {
-								Write-Message -Level Output -Message "Changing database owner for $($ownedDb.name) from $userName to sa"
+								Write-Message -Level Verbose -Message "Changing database owner for $($ownedDb.name) from $userName to sa"
 								$ownedDb.SetOwner('sa')
 								$ownedDb.Alter()
 							}
@@ -205,7 +205,7 @@ function Copy-DbaLogin {
 							$ownedJobs = $destServer.JobServer.Jobs | Where-Object OwnerLoginName -eq $userName
 
 							foreach ($ownedJob in $ownedJobs) {
-								Write-Message -Level Output -Message "Changing job owner for $($ownedJob.name) from $userName to sa"
+								Write-Message -Level Verbose -Message "Changing job owner for $($ownedJob.name) from $userName to sa"
 								$ownedJob.Set_OwnerLoginName('sa')
 								$ownedJob.Alter()
 							}
@@ -216,7 +216,7 @@ function Copy-DbaLogin {
 							}
 							$login.Drop()
 
-							Write-Message -Level Output -Message "Successfully dropped $userName on $destination"
+							Write-Message -Level Verbose -Message "Successfully dropped $userName on $destination"
 						}
 						catch {
 							Stop-Function -Message "Could not drop $userName" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Continue
@@ -226,15 +226,15 @@ function Copy-DbaLogin {
 
 				if ($Pscmdlet.ShouldProcess($destination, "Adding SQL login $userName")) {
 
-					Write-Message -Level Output -Message "Attempting to add $userName to $destination"
+					Write-Message -Level Verbose -Message "Attempting to add $userName to $destination"
 					$destLogin = New-Object Microsoft.SqlServer.Management.Smo.Login($destServer, $userName)
 
-					Write-Message -Level Output -Message "Setting $userName SID to source username SID"
+					Write-Message -Level Verbose -Message "Setting $userName SID to source username SID"
 					$destLogin.Set_Sid($sourceLogin.Get_Sid())
 
 					$defaultDb = $sourceLogin.DefaultDatabase
 
-					Write-Message -Level Output -Message "Setting login language to $($sourceLogin.Language)"
+					Write-Message -Level Verbose -Message "Setting login language to $($sourceLogin.Language)"
 					$destLogin.Language = $sourceLogin.Language
 
 					if ($destServer.databases[$defaultDb] -eq $null) {
@@ -242,7 +242,7 @@ function Copy-DbaLogin {
 						$defaultDb = "master"
 					}
 
-					Write-Message -Level Output -Message "Set $userName defaultdb to $defaultDb"
+					Write-Message -Level Verbose -Message "Set $userName defaultdb to $defaultDb"
 					$destLogin.DefaultDatabase = $defaultDb
 
 					$checkexpiration = "ON"; $checkpolicy = "ON"
@@ -286,7 +286,7 @@ function Copy-DbaLogin {
 						try {
 							$destLogin.Create($hashedPass, [Microsoft.SqlServer.Management.Smo.LoginCreateOptions]::IsHashed)
 							$destLogin.Refresh()
-							Write-Message -Level Output -Message "Successfully added $userName to $destination"
+							Write-Message -Level Verbose -Message "Successfully added $userName to $destination"
 						}
 						catch {
 							try {
@@ -298,7 +298,7 @@ function Copy-DbaLogin {
 								$null = $destServer.ConnectionContext.ExecuteNonQuery($sql)
 
 								$destLogin = $destServer.logins[$userName]
-								Write-Message -Level Output -Message "Successfully added $userName to $destination"
+								Write-Message -Level Verbose -Message "Successfully added $userName to $destination"
 							}
 							catch {
 								Stop-Function -Message "Failed to add $userName to $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer -Continue
@@ -307,16 +307,16 @@ function Copy-DbaLogin {
 					}
 					# Attempt to add Windows User
 					elseif ($sourceLogin.LoginType -eq "WindowsUser" -or $sourceLogin.LoginType -eq "WindowsGroup") {
-						Write-Message -Level Output -Message "Adding as login type $($sourceLogin.LoginType)"
+						Write-Message -Level Verbose -Message "Adding as login type $($sourceLogin.LoginType)"
 						$destLogin.LoginType = $sourceLogin.LoginType
 
-						Write-Message -Level Output -Message "Setting language as $($sourceLogin.Language)"
+						Write-Message -Level Verbose -Message "Setting language as $($sourceLogin.Language)"
 						$destLogin.Language = $sourceLogin.Language
 
 						try {
 							$destLogin.Create()
 							$destLogin.Refresh()
-							Write-Message -Level Output -Message "Successfully added $userName to $destination"
+							Write-Message -Level Verbose -Message "Successfully added $userName to $destination"
 						}
 						catch {
 							Stop-Function -Message "Failed to add $userName to $destination" -Category InvalidOperation -InnerErrorRecord $_ -Target $destServer (or whatever applicable) -Continue
@@ -363,7 +363,7 @@ function Copy-DbaLogin {
 			} #end for each $sourceLogin
 		} #end function Copy-Login
 
-		Write-Message -Level Output -Message "Attempting to connect to SQL Servers.."
+		Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers.."
 		$sourceServer = Connect-SqlInstance -RegularUser -SqlInstance $Source -SqlCredential $SourceSqlCredential
 		$source = $sourceServer.DomainInstanceName
 
@@ -386,7 +386,7 @@ function Copy-DbaLogin {
 		$started = Get-Date
 
 		if ($Pscmdlet.ShouldProcess("console", "Showing time started message")) {
-			Write-Message -Level Output -Message "Migration started: $started"
+			Write-Message -Level Verbose -Message "Migration started: $started"
 		}
 
 		if ($Login) {
@@ -418,7 +418,7 @@ function Copy-DbaLogin {
 		}
 
 		if ($Pscmdlet.ShouldProcess("console", "Showing migration attempt message")) {
-			Write-Message -Level Output -Message "Attempting Login Migration"
+			Write-Message -Level Verbose -Message "Attempting Login Migration"
 		}
 
 		Copy-Login -sourceserver $sourceServer -destserver $destServer -Login $Login -Exclude $ExcludeLogin -Force $force
@@ -428,7 +428,7 @@ function Copy-DbaLogin {
 		$saName = $sa.Name
 
 		if ($saName -ne $destSa.name -and $SyncSaName) {
-			Write-Message -Level Output -Message "Changing sa username to match source ($saName)"
+			Write-Message -Level Verbose -Message "Changing sa username to match source ($saName)"
 
 			if ($Pscmdlet.ShouldProcess($destination, "Changing sa username to match source ($saName)")) {
 				$destSa.Rename($saName)
@@ -438,7 +438,7 @@ function Copy-DbaLogin {
 	}
 	end {
 		if ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
-			Write-Message -Level Output -Message "Login migration completed: $(Get-Date)"
+			Write-Message -Level Verbose -Message "Login migration completed: $(Get-Date)"
 			$totalTime = ($elapsed.Elapsed.toString().Split(".")[0])
 			$sourceServer.ConnectionContext.Disconnect()
 
@@ -446,7 +446,7 @@ function Copy-DbaLogin {
 				$destServer.ConnectionContext.Disconnect()
 			}
 
-			Write-Message -Level Output -Message "Total elapsed time: $totalTime"
+			Write-Message -Level Verbose -Message "Total elapsed time: $totalTime"
 		}
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlLogin
 	}

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -515,11 +515,6 @@ function Copy-DbaLogin {
 		if ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
 			Write-Message -Level Verbose -Message "Login migration completed: $(Get-Date)"
 			$totalTime = ($elapsed.Elapsed.toString().Split(".")[0])
-			$sourceServer.ConnectionContext.Disconnect()
-
-			if ($Destination.length -gt 0) {
-				$destServer.ConnectionContext.Disconnect()
-			}
 
 			Write-Message -Level Verbose -Message "Total elapsed time: $totalTime"
 		}

--- a/functions/Sync-DbaLoginPermission.ps1
+++ b/functions/Sync-DbaLoginPermission.ps1
@@ -1,482 +1,472 @@
 function Sync-DbaSqlLoginPermission {
-    <#
-.SYNOPSIS
-Copies SQL login permission from one server to another.
+	<#
+		.SYNOPSIS
+			Copies SQL login permission from one server to another.
 
-.DESCRIPTION
-Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins. If a matching login does not exist on the destination, the login will be skipped.
-Credential removal not currently supported for Syncs. TODO: Application role sync
+		.DESCRIPTION
+			Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins. If a matching login does not exist on the destination, the login will be skipped.
+			Credential removal not currently supported for Syncs. TODO: Application role sync
 
-THIS CODE IS PROVIDED "AS IS", WITH NO WARRANTIES.
+		.PARAMETER Source
+			Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER Source
-Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER SourceSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-.PARAMETER SourceSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
 
-$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			To connect as a different Windows user, run PowerShell as that user.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
-To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER Destination
+			Destination SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER Destination
-Destination SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER DestinationSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-.PARAMETER DestinationSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
 
-$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			To connect as a different Windows user, run PowerShell as that user.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
-To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER Login
+			Migrates ONLY specified logins. This list is auto-populated for tab completion. Multiple logins allowed.
 
-.PARAMETER Login
-Migrates ONLY specified logins. This list is auto-populated for tab completion. Multiple logins allowed.
+		.PARAMETER ExcludeLogin
+			Excludes specified logins. This list is auto-populated for tab completion.
 
-.PARAMETER ExcludeLogin
-Excludes specified logins. This list is auto-populated for tab completion.
+		.PARAMETER WhatIf
+			Shows what would happen if the command were to run. No actions are actually performed.
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run. No actions are actually performed.
+		.PARAMETER Confirm
+			Prompts you for confirmation before executing any changing operations within the command.
 
-.PARAMETER Confirm
-Prompts you for confirmation before executing any changing operations within the command.
+		.PARAMETER Silent 
+			Use this switch to disable any kind of verbose messages
 
-.NOTES
-Tags: Migration, Login
-Original Author: Chrissy LeMaire (@cl), netnerds.net
-Requires: sysadmin access on SQL Servers
-Limitations: Does not support Application Roles yet
+		.NOTES
+			Tags: Migration, Login
+			Original Author: Chrissy LeMaire (@cl), netnerds.net
+			Requires: sysadmin access on SQL Servers
+			Limitations: Does not support Application Roles yet
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Sync-DbaSqlLoginPermission
+		.LINK
+			https://dbatools.io/Sync-DbaSqlLoginPermission
 
-.EXAMPLE
-Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster
+		.EXAMPLE
+			Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster
 
-Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins or users. To copy logins and their permissions, use Copy-SqlLogin.
+			Syncs only SQL Server login permissions, roles, etc. Does not add or drop logins or users. To copy logins and their permissions, use Copy-SqlLogin.
 
-.EXAMPLE
-Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster -Exclude realcajun -SourceSqlCredential $scred -DestinationSqlCredential $dcred
+		.EXAMPLE
+			Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster -Exclude realcajun -SourceSqlCredential $scred -DestinationSqlCredential $dcred
 
-Authenticates to SQL Servers using SQL Authentication.
+			Authenticates to SQL Servers using SQL Authentication.
 
-Copies all login permissions except for realcajun. If a login already exists on the destination, the permissions will not be migrated.
+			Copies all login permissions except for realcajun. If a login already exists on the destination, the permissions will not be migrated.
 
-.EXAMPLE
-Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster -Login realcajun, netnerds
+		.EXAMPLE
+			Sync-DbaSqlLoginPermission -Source sqlserver2014a -Destination sqlcluster -Login realcajun, netnerds
 
-Copies permissions ONLY for logins netnerds and realcajun.
-#>
+			Copies permissions ONLY for logins netnerds and realcajun.
+	#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	Param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[object]$Source,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$SourceSqlCredential,
+		[parameter(Mandatory = $true)]
+		[object]$Destination,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$DestinationSqlCredential,
+		[object[]]$Login,
+		[object[]]$ExcludeLogin,
+		[switch]$Silent
+	)
+	begin {
 
-    [CmdletBinding(SupportsShouldProcess = $true)]
-    Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [object]$Source,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
-        [object]$Destination,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $DestinationSqlCredential,
-        [object[]]$Login,
-        [object[]]$ExcludeLogin
-    )
-    begin {
+		function Update-SqlPermissions {
+			[CmdletBinding()]
+			param (
+				[Parameter(Mandatory = $true)]
+				[ValidateNotNullOrEmpty()]
+				[object]$sourceserver,
+				[Parameter(Mandatory = $true)]
+				[ValidateNotNullOrEmpty()]
+				[object]$sourcelogin,
+				[Parameter(Mandatory = $true)]
+				[ValidateNotNullOrEmpty()]
+				[object]$destserver,
+				[Parameter(Mandatory = $true)]
+				[ValidateNotNullOrEmpty()]
+				[object]$destlogin
+			)
 
-        function Update-SqlPermissions {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [ValidateNotNullOrEmpty()]
-                [object]$sourceserver,
-                [Parameter(Mandatory = $true)]
-                [ValidateNotNullOrEmpty()]
-                [object]$sourcelogin,
-                [Parameter(Mandatory = $true)]
-                [ValidateNotNullOrEmpty()]
-                [object]$destserver,
-                [Parameter(Mandatory = $true)]
-                [ValidateNotNullOrEmpty()]
-                [object]$destlogin
-            )
+			$destination = $destserver.DomainInstanceName
+			$source = $sourceserver.DomainInstanceName
+			$username = $sourcelogin.name
 
-            $destination = $destserver.DomainInstanceName
-            $source = $sourceserver.DomainInstanceName
-            $username = $sourcelogin.name
+			# Server Roles: sysadmin, bulklogin, etc
+			foreach ($role in $sourceserver.roles) {
+				$rolename = $role.name
+				$destrole = $destserver.roles[$rolename]
+				if ($destrole -ne $null) {
+					try { $destrolemembers = $destrole.EnumMemberNames() }
+					catch { $destrolemembers = $destrole.EnumServerRoleMembers() }
+				}
+				try { $rolemembers = $role.EnumMemberNames() }
+				catch { $rolemembers = $role.EnumServerRoleMembers() }
+				if ($rolemembers -contains $username) {
+					if ($destrole -ne $null) {
+						If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role")) {
+							try {
+								$destrole.AddMember($username)
+								Write-Message -Level Verbose -Message "Added $username to $rolename server role."
+							}
+							catch {
+								Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -InnerErrorRecord $_
+							}
+						}
+					}
+				}
 
-            # Server Roles: sysadmin, bulklogin, etc
-            foreach ($role in $sourceserver.roles) {
-                $rolename = $role.name
-                $destrole = $destserver.roles[$rolename]
-                if ($destrole -ne $null) {
-                    try { $destrolemembers = $destrole.EnumMemberNames() }
-                    catch { $destrolemembers = $destrole.EnumServerRoleMembers() }
-                }
-                try { $rolemembers = $role.EnumMemberNames() }
-                catch { $rolemembers = $role.EnumServerRoleMembers() }
-                if ($rolemembers -contains $username) {
-                    if ($destrole -ne $null) {
-                        If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role")) {
-                            try {
-                                $destrole.AddMember($username)
-                                Write-Output "Added $username to $rolename server role."
-                            }
-                            catch {
-                                Write-Warning "Failed to add $username to $rolename server role."
-                                Write-Exception $_
-                            }
-                        }
-                    }
-                }
-
-                # Remove for Syncs
-                if ($rolemembers -notcontains $username -and $destrolemembers -contains $username -and $destrole -ne $null) {
-                    If ($Pscmdlet.ShouldProcess($destination, "Removing $username from $rolename server role")) {
-                        try {
-                            $destrole.DropMember($username)
-                            Write-Output "Removed $username from $rolename server role on $($destserver.name)."
-                        }
-                        catch {
-                            Write-Warning "Failed to remove $username from $rolename server role on $($destserver.name)."
-                            Write-Exception $_
-                        }
-                    }
-                }
-            }
-
-            $ownedjobs = $sourceserver.JobServer.Jobs | Where-Object { $_.OwnerLoginName -eq $username }
-            foreach ($ownedjob in $ownedjobs) {
-                if ($destserver.JobServer.Jobs[$ownedjob.name] -ne $null) {
-                    If ($Pscmdlet.ShouldProcess($destination, "Changing job owner to $username for $($ownedjob.name)")) {
-                        try {
-                            Write-Output "Changing job owner to $username for $($ownedjob.name)"
-                            $destownedjob = $destserver.JobServer.Jobs | Where-Object { $_.name -eq $ownedjobs.name }
-                            $destownedjob.set_OwnerLoginName($username)
-                            $destownedjob.Alter()
-                        }
-                        catch {
-							Write-Warning "Could not change job owner for $($ownedjob.name)"
-                            Write-Exception $_
-                        }
-                    }
-                }
-            }
-
-            if ($sourceserver.versionMajor -ge 9 -and $destserver.versionMajor -ge 9) {
-                # These operations are only supported by SQL Server 2005 and above.
-                # Securables: Connect SQL, View any database, Administer Bulk Operations, etc.
-
-                $perms = $sourceserver.EnumServerPermissions($username)
-                foreach ($perm in $perms) {
-                    $permstate = $perm.permissionstate
-                    if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
-                    else { $grantwithgrant = $false }
-                    $permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
-                    If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username")) {
-                        try {
-                            $destserver.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
-                            Write-Output "Successfully performed $permstate $($perm.permissiontype) to $username"
-                        }
-                        catch {
-                            Write-Warning "Failed to $permstate $($perm.permissiontype) to $username"
-                            Write-Exception $_
-                        }
-                    }
-
-                    # for Syncs
-                    $destperms = $destserver.EnumServerPermissions($username)
-                    foreach ($perm in $destperms) {
-                        $permstate = $perm.permissionstate
-                        $sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
-                        if ($sourceperm -eq $null) {
-                            If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username")) {
-                                try {
-                                    $permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
-                                    if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
-                                    else { $grantwithgrant = $false }
-                                    $destserver.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
-                                    Write-Output "Successfully revoked $($perm.permissiontype) from $username"
-                                }
-                                catch {
-                                    Write-Warning "Failed to revoke $($perm.permissiontype) from $username"
-                                    Write-Exception $_
-                                }
-                            }
-                        }
-                    }
-                }
-
-                # Credential mapping. Credential removal not currently supported for Syncs.
-                $logincredentials = $sourceserver.credentials | Where-Object { $_.Identity -eq $sourcelogin.name }
-                foreach ($credential in $logincredentials) {
-                    if ($destserver.Credentials[$credential.name] -eq $null) {
-                        If ($Pscmdlet.ShouldProcess($destination, "Adding $($credential.name) to $username")) {
-                            try {
-                                $newcred = New-Object Microsoft.SqlServer.Management.Smo.Credential($destserver, $credential.name)
-                                $newcred.identity = $sourcelogin.name
-                                $newcred.Create()
-                                Write-Output "Successfully created credential for $username"
-                            }
-                            catch {
-                                Write-Warning "Failed to create credential for $username"
-                                Write-Exception $_
-                            }
-                        }
-                    }
-                }
-            }
-
-            if ($destserver.versionMajor -lt 9) { Write-Warning "Database mappings skipped when destination is SQL Server 2000"; continue }
-
-            # For Sync, if info doesn't exist in EnumDatabaseMappings, then no big deal.
-            foreach ($db in $destlogin.EnumDatabaseMappings()) {
-                $dbname = $db.dbname
-                $destdb = $destserver.databases[$dbname]
-                $sourcedb = $sourceserver.databases[$dbname]
-                $dbusername = $db.username
-                $dblogin = $db.loginName
-
-                if ($sourcedb -ne $null -and $sourcedb.IsAccessible) {
-                    if ($sourcedb.users[$dbusername] -eq $null -and $destdb.users[$dbusername] -ne $null) {
-                        If ($Pscmdlet.ShouldProcess($destination, "Dropping $dbusername from $dbname on destination.")) {
-                            try {
-                                if ($destdb.schemas.owner -contains $dbusername) {
-                                    Write-Output "$dbusername (login: $dblogin) in $dbname owns a schema. Drop skipped."
-                                }
-                                else {
-                                    $destdb.users[$dbusername].Drop()
-                                    Write-Output "Dropped user $dbusername (login: $dblogin) from $dbname on destination."
-                                    Write-Exception $_
-                                }
-                            }
-                            catch {
-                                Write-Warning "Failed to drop $dbusername ($dblogin) from $dbname on destination."
-                                Write-Exception $_
-                            }
-                        }
-                    }
-
-                    # Remove user from role. Role removal not currently supported for Syncs.
-                    # TODO: reassign if dbo, application roles
-                    foreach ($destrole in $destdb.roles) {
-                        $destrolename = $destrole.name
-                        $sourcerole = $sourcedb.roles[$destrolename]
-                        if ($sourcerole -ne $null) {
-                            if ($sourcerole.EnumMembers() -notcontains $dbusername -and $destrole.EnumMembers() -contains $dbusername) {
-                                if ($dbusername -ne "dbo") {
-                                    If ($Pscmdlet.ShouldProcess($destination, "Dropping $username from $destrolename database role on $dbname")) {
-                                        try {
-                                            $destrole.DropMember($dbusername)
-                                            $destdb.Alter()
-                                            Write-Output "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
-                                        }
-                                        catch {
-											Write-Warning "Failed to remove $dbusername from $destrolename database role on $dbname."
-                                            Write-Exception $_
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    # Remove Connect, Alter Any Assembly, etc
-                    $destperms = $destdb.EnumDatabasePermissions($username)
-                    $perms = $sourcedb.EnumDatabasePermissions($username)
-                    # for Syncs
-                    foreach ($perm in $destperms) {
-                        $permstate = $perm.permissionstate
-                        $sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
-                        if ($sourceperm -eq $null) {
-                            If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username on $dbname on $destination")) {
-                                try {
-                                    $permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
-                                    if ($permstate -eq "GrantWithGrant") {
-                                        $grantwithgrant = $true
-                                        $permstate = "grant"
-                                    }
-                                    else {
-                                        $grantwithgrant = $false
-                                    }
-                                    $destdb.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
-                                    Write-Output "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
-                                }
-                                catch {
-                                    Write-Warning "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination"
-                                    Write-Exception $_
-                                }
-                            }
-                        }
-                    }
-                }
+				# Remove for Syncs
+				if ($rolemembers -notcontains $username -and $destrolemembers -contains $username -and $destrole -ne $null) {
+					If ($Pscmdlet.ShouldProcess($destination, "Removing $username from $rolename server role")) {
+						try {
+							$destrole.DropMember($username)
+							Write-Message -Level Verbose -Message "Removed $username from $rolename server role on $($destserver.name)."
+						}
+						catch {
+							Stop-Function -Message "Failed to remove $username from $rolename server role on $($destserver.name)." -Target $role -InnerErrorRecord $_
+						}
+					}
+				}
 			}
 
-            # Adding database mappings and securables
-            foreach ($db in $sourcelogin.EnumDatabaseMappings()) {
-                $dbname = $db.dbname
-                $destdb = $destserver.databases[$dbname]
-                $sourcedb = $sourceserver.databases[$dbname]
-                $dbusername = $db.username; $dblogin = $db.loginName
+			$ownedjobs = $sourceserver.JobServer.Jobs | Where-Object { $_.OwnerLoginName -eq $username }
+			foreach ($ownedjob in $ownedjobs) {
+				if ($destserver.JobServer.Jobs[$ownedjob.name] -ne $null) {
+					If ($Pscmdlet.ShouldProcess($destination, "Changing job owner to $username for $($ownedjob.name)")) {
+						try {
+							Write-Message -Level Verbose -Message "Changing job owner to $username for $($ownedjob.name)"
+							$destownedjob = $destserver.JobServer.Jobs | Where-Object { $_.name -eq $ownedjobs.name }
+							$destownedjob.set_OwnerLoginName($username)
+							$destownedjob.Alter()
+						}
+						catch {
+							Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -InnerErrorRecord $_
+						}
+					}
+				}
+			}
 
-                if ($destdb -ne $null) {
-                    if (!$destdb.IsAccessible) {
-                        Write-Output "Database [$($destdb.Name)] is not accessible. Skipping"
-                        Continue
-                    }
+			if ($sourceserver.versionMajor -ge 9 -and $destserver.versionMajor -ge 9) {
+				# These operations are only supported by SQL Server 2005 and above.
+				# Securables: Connect SQL, View any database, Administer Bulk Operations, etc.
 
-                    if ($destdb.users[$dbusername] -eq $null) {
-                        If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname")) {
-                            $sql = $sourceserver.databases[$dbname].users[$dbusername].script() | Out-String
-                            $sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
-                            try {
-                                $destdb.ExecuteNonQuery($sql)
-                                Write-Output "Added user $dbusername (login: $dblogin) to $dbname"
-                            }
-                            catch {
-                                Write-Warning "Failed to add $dbusername ($dblogin) to $dbname on $destination."
-                                Write-Exception $_
-                            }
-                        }
-                    }
+				$perms = $sourceserver.EnumServerPermissions($username)
+				foreach ($perm in $perms) {
+					$permstate = $perm.permissionstate
+					if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
+					else { $grantwithgrant = $false }
+					$permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
+					If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username")) {
+						try {
+							$destserver.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
+							Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username"
+						}
+						catch {
+							Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -InnerErrorRecord $_
+						}
+					}
 
-                    # Db owner
-                    If ($sourcedb.owner -eq $username -and $destdb.owner -ne $username) {
-                        If ($Pscmdlet.ShouldProcess($destination, "Changing $dbname dbowner to $username")) {
-                            try {
-                                $result = Update-SqlDbOwner $sourceserver $destserver -dbname $dbname
-                                Write-Output "Changed $($destdb.name) owner to $($sourcedb.owner)."
-                            }
-                            catch {
-                                Write-Warning "Failed to update $($destdb.name) owner to $($sourcedb.owner)."
-                            }
-                        }
-                    }
+					# for Syncs
+					$destperms = $destserver.EnumServerPermissions($username)
+					foreach ($perm in $destperms) {
+						$permstate = $perm.permissionstate
+						$sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
+						if ($sourceperm -eq $null) {
+							If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username")) {
+								try {
+									$permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
+									if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
+									else { $grantwithgrant = $false }
+									$destserver.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
+									Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username"
+								}
+								catch {
+									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -InnerErrorRecord $_
+								}
+							}
+						}
+					}
+				}
 
-                    # Database Roles: db_owner, db_datareader, etc
-                    foreach ($role in $sourcedb.roles) {
-                        if ($role.EnumMembers() -contains $username) {
-                            $rolename = $role.name
-                            $destdbrole = $destdb.roles[$rolename]
-                            if ($destdbrole -ne $null -and $dbusername -ne "dbo" -and $destdbrole.EnumMembers() -notcontains $username) {
-                                If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename database role on $dbname")) {
-                                    try {
-                                        $destdbrole.AddMember($username)
-                                        $destdb.Alter()
-                                        Write-Output "Added $username to $rolename database role on $dbname."
+				# Credential mapping. Credential removal not currently supported for Syncs.
+				$logincredentials = $sourceserver.credentials | Where-Object { $_.Identity -eq $sourcelogin.name }
+				foreach ($credential in $logincredentials) {
+					if ($destserver.Credentials[$credential.name] -eq $null) {
+						If ($Pscmdlet.ShouldProcess($destination, "Adding $($credential.name) to $username")) {
+							try {
+								$newcred = New-Object Microsoft.SqlServer.Management.Smo.Credential($destserver, $credential.name)
+								$newcred.identity = $sourcelogin.name
+								$newcred.Create()
+								Write-Message -Level Verbose -Message "Successfully created credential for $username"
+							}
+							catch {
+								Stop-Function -Message "Failed to create credential for $username" -Target $credential -InnerErrorRecord $_
+							}
+						}
+					}
+				}
+			}
 
-                                    }
-                                    catch {
-                                        Write-Warning "Failed to add $username to $rolename database role on $dbname."
-                                        Write-Exception $_
-                                    }
-                                }
-                            }
-                        }
-                    }
+			if ($destserver.versionMajor -lt 9) {
+				Stop-Function -Message "Database mappings skipped when destination is SQL Server 2000" -Continue
+			}
 
-                    # Connect, Alter Any Assembly, etc
-                    $perms = $sourcedb.EnumDatabasePermissions($username)
-                    foreach ($perm in $perms) {
-                        $permstate = $perm.permissionstate
-                        if ($permstate -eq "GrantWithGrant") {
-                            $grantwithgrant = $true
-                            $permstate = "grant"
-                        }
-                        else {
-                            $grantwithgrant = $false
-                        }
+			# For Sync, if info doesn't exist in EnumDatabaseMappings, then no big deal.
+			foreach ($db in $destlogin.EnumDatabaseMappings()) {
+				$dbname = $db.dbname
+				$destdb = $destserver.databases[$dbname]
+				$sourcedb = $sourceserver.databases[$dbname]
+				$dbusername = $db.username
+				$dblogin = $db.loginName
 
-                        $permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
-                        If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username on $dbname")) {
-                            try {
-                                $destdb.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
-                                Write-Output "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
-                            }
-                            catch {
-                                Write-Warning "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname."
-                                Write-Exception $_
-                            }
-                        }
-                    }
-                }
-            }
-        }
+				if ($sourcedb -ne $null -and $sourcedb.IsAccessible) {
+					if ($sourcedb.users[$dbusername] -eq $null -and $destdb.users[$dbusername] -ne $null) {
+						If ($Pscmdlet.ShouldProcess($destination, "Dropping $dbusername from $dbname on destination.")) {
+							try {
+								if ($destdb.schemas.owner -contains $dbusername) {
+									Write-Message -Level Verbose -Message "$dbusername (login: $dblogin) in $dbname owns a schema. Drop skipped."
+								}
+								else {
+									$destdb.users[$dbusername].Drop()
+									Write-Message -Level Verbose -Message "Dropped user $dbusername (login: $dblogin) from $dbname on destination."
+								}
+							}
+							catch {
+								Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -InnerErrorRecord $_
+							}
+						}
+					}
 
-        function Sync-Only {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
+					# Remove user from role. Role removal not currently supported for Syncs.
+					# TODO: reassign if dbo, application roles
+					foreach ($destrole in $destdb.roles) {
+						$destrolename = $destrole.name
+						$sourcerole = $sourcedb.roles[$destrolename]
+						if ($sourcerole -ne $null) {
+							if ($sourcerole.EnumMembers() -notcontains $dbusername -and $destrole.EnumMembers() -contains $dbusername) {
+								if ($dbusername -ne "dbo") {
+									If ($Pscmdlet.ShouldProcess($destination, "Dropping $username from $destrolename database role on $dbname")) {
+										try {
+											$destrole.DropMember($dbusername)
+											$destdb.Alter()
+											Write-Message -Level Verbose -Message "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
+										}
+										catch {
+											Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -InnerErrorRecord $_
+										}
+									}
+								}
+							}
+						}
+					}
+
+					# Remove Connect, Alter Any Assembly, etc
+					$destperms = $destdb.EnumDatabasePermissions($username)
+					$perms = $sourcedb.EnumDatabasePermissions($username)
+					# for Syncs
+					foreach ($perm in $destperms) {
+						$permstate = $perm.permissionstate
+						$sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
+						if ($sourceperm -eq $null) {
+							If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username on $dbname on $destination")) {
+								try {
+									$permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
+									if ($permstate -eq "GrantWithGrant") {
+										$grantwithgrant = $true
+										$permstate = "grant"
+									}
+									else {
+										$grantwithgrant = $false
+									}
+									$destdb.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
+									Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
+								}
+								catch {
+									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -InnerErrorRecord $_
+								}
+							}
+						}
+					}
+				}
+			}
+
+			# Adding database mappings and securables
+			foreach ($db in $sourcelogin.EnumDatabaseMappings()) {
+				$dbname = $db.dbname
+				$destdb = $destserver.databases[$dbname]
+				$sourcedb = $sourceserver.databases[$dbname]
+				$dbusername = $db.username; $dblogin = $db.loginName
+
+				if ($destdb -ne $null) {
+					if (!$destdb.IsAccessible) {
+						Write-Message -Level Verbose -Message "Database [$($destdb.Name)] is not accessible. Skipping"
+						Continue
+					}
+
+					if ($destdb.users[$dbusername] -eq $null) {
+						If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname")) {
+							$sql = $sourceserver.databases[$dbname].users[$dbusername].script() | Out-String
+							$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
+							try {
+								$destdb.ExecuteNonQuery($sql)
+								Write-Message -Level Verbose -Message "Added user $dbusername (login: $dblogin) to $dbname"
+							}
+							catch {
+								Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -InnerErrorRecord $_
+							}
+						}
+					}
+
+					# Db owner
+					If ($sourcedb.owner -eq $username -and $destdb.owner -ne $username) {
+						If ($Pscmdlet.ShouldProcess($destination, "Changing $dbname dbowner to $username")) {
+							try {
+								$result = Update-SqlDbOwner $sourceserver $destserver -dbname $dbname
+								Write-Message -Level Verbose -Message "Changed $($destdb.name) owner to $($sourcedb.owner)."
+							}
+							catch {
+								Stop-Function -Message "Failed to update $($destdb.name) owner to $($sourcedb.owner)." -Target $db -InnerErrorRecord $_
+							}
+						}
+					}
+
+					# Database Roles: db_owner, db_datareader, etc
+					foreach ($role in $sourcedb.roles) {
+						if ($role.EnumMembers() -contains $username) {
+							$rolename = $role.name
+							$destdbrole = $destdb.roles[$rolename]
+							if ($destdbrole -ne $null -and $dbusername -ne "dbo" -and $destdbrole.EnumMembers() -notcontains $username) {
+								If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename database role on $dbname")) {
+									try {
+										$destdbrole.AddMember($username)
+										$destdb.Alter()
+										Write-Message -Level Verbose -Message "Added $username to $rolename database role on $dbname."
+
+									}
+									catch {
+										Stop-Function -Message "Failed to add $username to $rolename database role on $dbname." -Target $db -InnerErrorRecord $_
+									}
+								}
+							}
+						}
+					}
+
+					# Connect, Alter Any Assembly, etc
+					$perms = $sourcedb.EnumDatabasePermissions($username)
+					foreach ($perm in $perms) {
+						$permstate = $perm.permissionstate
+						if ($permstate -eq "GrantWithGrant") {
+							$grantwithgrant = $true
+							$permstate = "grant"
+						}
+						else {
+							$grantwithgrant = $false
+						}
+
+						$permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
+						If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username on $dbname")) {
+							try {
+								$destdb.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
+								Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
+							}
+							catch {
+								Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -InnerErrorRecord $_
+							}
+						}
+					}
+				}
+			}
+		}
+
+		function Sync-Only {
+			[CmdletBinding()]
+			param (
+				[Parameter(Mandatory = $true)]
 				[ValidateNotNullOrEmpty()]
-                [object]$sourceserver,
-                [object]$destserver,
-                [array]$Logins,
-                [array]$Exclude
-            )
+				[object]$sourceserver,
+				[object]$destserver,
+				[array]$Logins,
+				[array]$Exclude
+			)
 
-            $source = $sourceserver.DomainInstanceName;
-            $destination = $destserver.DomainInstanceName
+			$source = $sourceserver.DomainInstanceName;
+			$destination = $destserver.DomainInstanceName
 
-            try {
-                $sa = ($destserver.logins | Where-Object { $_.id -eq 1 }).Name
-            }
-            catch {
-                $sa = "sa"
-            }
+			try {
+				$sa = ($destserver.logins | Where-Object { $_.id -eq 1 }).Name
+			}
+			catch {
+				$sa = "sa"
+			}
 
-            foreach ($sourcelogin in $sourceserver.logins) {
+			foreach ($sourcelogin in $sourceserver.logins) {
 
-                $username = $sourcelogin.name
-                $currentlogin = $sourceserver.ConnectionContext.truelogin
-                if ($Logins -ne $null -and $Logins -notcontains $username) { continue }
-                if ($exclude -contains $username -or $username.StartsWith("##") -or $username -eq $sa) { continue }
+				$username = $sourcelogin.name
+				$currentlogin = $sourceserver.ConnectionContext.truelogin
+				if ($Logins -ne $null -and $Logins -notcontains $username) { continue }
+				if ($exclude -contains $username -or $username.StartsWith("##") -or $username -eq $sa) { continue }
 
-                if ($currentlogin -eq $username) {
-                    Write-Warning "Sync does not modify the permissions of the current user. Skipping."
-                    continue
-                }
+				if ($currentlogin -eq $username) {
+					Write-Message -Level Warning -Message "Sync does not modify the permissions of the current user. Skipping."
+					continue
+				}
 
-                $servername = Resolve-NetBiosName $sourceserver
-                $userbase = ($username.Split("\")[0]).ToLower()
-                if ($servername -eq $userbase -or $username.StartsWith("NT ")) { continue }
-                if (($destlogin = $destserver.Logins.Item($username)) -eq $null) { continue }
+				$servername = Resolve-NetBiosName $sourceserver
+				$userbase = ($username.Split("\")[0]).ToLower()
+				if ($servername -eq $userbase -or $username.StartsWith("NT ")) { continue }
+				if (($destlogin = $destserver.Logins.Item($username)) -eq $null) { continue }
 
-                Update-SqlPermissions -sourceserver $sourceserver -sourcelogin $sourcelogin -destserver $destserver -destlogin $destlogin
-            }
-        }
+				Update-SqlPermissions -sourceserver $sourceserver -sourcelogin $sourcelogin -destserver $destserver -destlogin $destlogin
+			}
+		}
 
-        if ($source -eq $destination) { throw "Source and Destination SQL Servers are the same. Quitting." }
+		if ($source -eq $destination) { throw "Source and Destination SQL Servers are the same. Quitting." }
 
-        Write-Output "Attempting to connect to SQL Servers.."
-        $sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
+		Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers.."
+		$sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
 
-        $source = $sourceserver.DomainInstanceName
-        $destination = $destserver.DomainInstanceName
+		$source = $sourceserver.DomainInstanceName
+		$destination = $destserver.DomainInstanceName
 
-        if ($sourceserver.versionMajor -lt 8 -or $destserver.versionMajor -lt 8) { throw "SQL Server 7 and below not supported. Quitting." }
+		if ($sourceserver.versionMajor -lt 8 -or $destserver.versionMajor -lt 8) { throw "SQL Server 7 and below not supported. Quitting." }
 
-        if (!$Login) {
-            $logins = $sourceserver.Logins.Name
-        }
+		if (!$Login) {
+			$logins = $sourceserver.Logins.Name
+		}
 
-        if ($Pscmdlet.ShouldProcess("console", "Showing sync start message")) {
-            Write-Output "Syncing Login Permissions"
-        }
-    }
-    process {
-        if ($pipelinevariable.Length -gt 0) {
-            $Source = $pipelinevariable[0].parent.name
-            $logins = $pipelinevariable.name
-        }
+		if ($Pscmdlet.ShouldProcess("console", "Showing sync start message")) {
+			Write-Message -Level Verbose -Message "Syncing Login Permissions"
+		}
+	}
+	process {
+		if ($pipelinevariable.Length -gt 0) {
+			$Source = $pipelinevariable[0].parent.name
+			$logins = $pipelinevariable.name
+		}
 
-        Sync-Only -sourceserver $sourceserver -destserver $destserver -Logins $logins -Exclude $ExcludeLogin
-    }
+		Sync-Only -sourceserver $sourceserver -destserver $destserver -Logins $logins -Exclude $ExcludeLogin
+	}
 	end {
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Sync-DbaSqlLoginPermission
 	}

--- a/functions/Sync-DbaLoginPermission.ps1
+++ b/functions/Sync-DbaLoginPermission.ps1
@@ -129,7 +129,7 @@ function Sync-DbaSqlLoginPermission {
 								Write-Message -Level Verbose -Message "Added $username to $rolename server role."
 							}
 							catch {
-								Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -InnerErrorRecord $_
+								Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -ErrorRecord $_
 							}
 						}
 					}
@@ -143,7 +143,7 @@ function Sync-DbaSqlLoginPermission {
 							Write-Message -Level Verbose -Message "Removed $username from $rolename server role on $($destserver.name)."
 						}
 						catch {
-							Stop-Function -Message "Failed to remove $username from $rolename server role on $($destserver.name)." -Target $role -InnerErrorRecord $_
+							Stop-Function -Message "Failed to remove $username from $rolename server role on $($destserver.name)." -Target $role -ErrorRecord $_
 						}
 					}
 				}
@@ -160,7 +160,7 @@ function Sync-DbaSqlLoginPermission {
 							$destownedjob.Alter()
 						}
 						catch {
-							Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -InnerErrorRecord $_
+							Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -ErrorRecord $_
 						}
 					}
 				}
@@ -182,7 +182,7 @@ function Sync-DbaSqlLoginPermission {
 							Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username"
 						}
 						catch {
-							Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -InnerErrorRecord $_
+							Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -ErrorRecord $_
 						}
 					}
 
@@ -201,7 +201,7 @@ function Sync-DbaSqlLoginPermission {
 									Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username"
 								}
 								catch {
-									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -InnerErrorRecord $_
+									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -ErrorRecord $_
 								}
 							}
 						}
@@ -220,7 +220,7 @@ function Sync-DbaSqlLoginPermission {
 								Write-Message -Level Verbose -Message "Successfully created credential for $username"
 							}
 							catch {
-								Stop-Function -Message "Failed to create credential for $username" -Target $credential -InnerErrorRecord $_
+								Stop-Function -Message "Failed to create credential for $username" -Target $credential -ErrorRecord $_
 							}
 						}
 					}
@@ -252,7 +252,7 @@ function Sync-DbaSqlLoginPermission {
 								}
 							}
 							catch {
-								Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -InnerErrorRecord $_
+								Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -ErrorRecord $_
 							}
 						}
 					}
@@ -272,7 +272,7 @@ function Sync-DbaSqlLoginPermission {
 											Write-Message -Level Verbose -Message "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
 										}
 										catch {
-											Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -InnerErrorRecord $_
+											Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -ErrorRecord $_
 										}
 									}
 								}
@@ -302,7 +302,7 @@ function Sync-DbaSqlLoginPermission {
 									Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
 								}
 								catch {
-									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -InnerErrorRecord $_
+									Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -ErrorRecord $_
 								}
 							}
 						}
@@ -332,7 +332,7 @@ function Sync-DbaSqlLoginPermission {
 								Write-Message -Level Verbose -Message "Added user $dbusername (login: $dblogin) to $dbname"
 							}
 							catch {
-								Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -InnerErrorRecord $_
+								Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -ErrorRecord $_
 							}
 						}
 					}
@@ -345,7 +345,7 @@ function Sync-DbaSqlLoginPermission {
 								Write-Message -Level Verbose -Message "Changed $($destdb.name) owner to $($sourcedb.owner)."
 							}
 							catch {
-								Stop-Function -Message "Failed to update $($destdb.name) owner to $($sourcedb.owner)." -Target $db -InnerErrorRecord $_
+								Stop-Function -Message "Failed to update $($destdb.name) owner to $($sourcedb.owner)." -Target $db -ErrorRecord $_
 							}
 						}
 					}
@@ -364,7 +364,7 @@ function Sync-DbaSqlLoginPermission {
 
 									}
 									catch {
-										Stop-Function -Message "Failed to add $username to $rolename database role on $dbname." -Target $db -InnerErrorRecord $_
+										Stop-Function -Message "Failed to add $username to $rolename database role on $dbname." -Target $db -ErrorRecord $_
 									}
 								}
 							}
@@ -390,7 +390,7 @@ function Sync-DbaSqlLoginPermission {
 								Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
 							}
 							catch {
-								Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -InnerErrorRecord $_
+								Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -ErrorRecord $_
 							}
 						}
 					}

--- a/internal/Update-SqlPermissions.ps1
+++ b/internal/Update-SqlPermissions.ps1
@@ -42,7 +42,7 @@ function Update-SqlPermissions {
 						Write-Message -Level Verbose -Message "Added $username to $rolename server role."
 					}
 					catch {
-						Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -InnerErrorRecord $_
+						Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -ErrorRecord $_
 					}
 				}
 			}
@@ -56,7 +56,7 @@ function Update-SqlPermissions {
 					Write-Message -Level Verbose -Message "Removed $username from $destrolename server role on $($destserver.name)."
 				}
 				catch {
-					Stop-Function -Message "Failed to remove $username from $destrolename server role on $($destserver.name)." -Target $role -InnerErrorRecord $_
+					Stop-Function -Message "Failed to remove $username from $destrolename server role on $($destserver.name)." -Target $role -ErrorRecord $_
 				}
 			}
 		}
@@ -73,7 +73,7 @@ function Update-SqlPermissions {
 					$destownedjob.Alter()
 				}
 				catch {
-					Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -InnerErrorRecord $_
+					Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -ErrorRecord $_
 				}
 			}
 		}
@@ -95,7 +95,7 @@ function Update-SqlPermissions {
 					Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username"
 				}
 				catch {
-					Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -InnerErrorRecord $_
+					Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -ErrorRecord $_
 				}
 			}
 
@@ -114,7 +114,7 @@ function Update-SqlPermissions {
 							Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username"
 						}
 						catch {
-							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -InnerErrorRecord $_
+							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -ErrorRecord $_
 						}
 					}
 				}
@@ -133,7 +133,7 @@ function Update-SqlPermissions {
 						Write-Message -Level Verbose -Message "Successfully created credential for $username"
 					}
 					catch {
-						Stop-Function -Message "Failed to create credential for $username" -Target $credential -InnerErrorRecord $_
+						Stop-Function -Message "Failed to create credential for $username" -Target $credential -ErrorRecord $_
 					}
 				}
 			}
@@ -159,7 +159,7 @@ function Update-SqlPermissions {
 						Write-Message -Level Verbose -Message "Dropped user $dbusername (login: $dblogin) from $dbname on destination. User may own a schema."
 					}
 					catch {
-						Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -InnerErrorRecord $_
+						Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -ErrorRecord $_
 					}
 				}
 			}
@@ -179,7 +179,7 @@ function Update-SqlPermissions {
 									Write-Message -Level Verbose -Message "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
 								}
 								catch {
-									Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -InnerErrorRecord $_
+									Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -ErrorRecord $_
 								}
 							}
 						}
@@ -204,7 +204,7 @@ function Update-SqlPermissions {
 							Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
 						}
 						catch {
-							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -InnerErrorRecord $_
+							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -ErrorRecord $_
 						}
 					}
 				}
@@ -233,7 +233,7 @@ function Update-SqlPermissions {
 						Write-Message -Level Verbose -Message "Added user $dbusername (login: $dblogin) to $dbname"
 					}
 					catch {
-						Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -InnerErrorRecord $_
+						Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -ErrorRecord $_
 					}
 				}
 			}
@@ -291,7 +291,7 @@ function Update-SqlPermissions {
 						Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
 					}
 					catch {
-						Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -InnerErrorRecord $_
+						Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -ErrorRecord $_
 					}
 				}
 			}

--- a/internal/Update-SqlPermissions.ps1
+++ b/internal/Update-SqlPermissions.ps1
@@ -1,11 +1,8 @@
-Function Update-SqlPermissions
-{
- <#
- 
-.SYNOPSIS
- Internal function. Updates permission sets, roles, database mappings on server and databases
-
- #>
+function Update-SqlPermissions {
+	<#
+		.SYNOPSIS
+			Internal function. Updates permission sets, roles, database mappings on server and databases
+	#>
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
@@ -19,357 +16,282 @@ Function Update-SqlPermissions
 		[object]$destserver,
 		[Parameter(Mandatory = $true)]
 		[ValidateNotNullOrEmpty()]
-		[object]$destlogin
+		[object]$destlogin,
+		[switch]$Silent
 	)
-	
+
 	$destination = $destserver.DomainInstanceName
 	$source = $sourceserver.DomainInstanceName
 	$username = $sourcelogin.name
-	
+
 	# Server Roles: sysadmin, bulklogin, etc
-	foreach ($role in $sourceserver.roles)
-	{
+	foreach ($role in $sourceserver.roles) {
 		$rolename = $role.name
 		$destrole = $destserver.roles[$rolename]
-		if ($destrole -ne $null)
-		{
+		if ($destrole -ne $null) {
 			try { $destrolemembers = $destrole.EnumMemberNames() }
 			catch { $destrolemembers = $destrole.EnumServerRoleMembers() }
 		}
 		try { $rolemembers = $role.EnumMemberNames() }
 		catch { $rolemembers = $role.EnumServerRoleMembers() }
-		if ($rolemembers -contains $username)
-		{
-			if ($destrole -ne $null)
-			{
-				If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role"))
-				{
-					try
-					{
+		if ($rolemembers -contains $username) {
+			if ($destrole -ne $null) {
+				If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role")) {
+					try {
 						$destrole.AddMember($username)
-						Write-Output "Added $username to $rolename server role."
+						Write-Message -Level Verbose -Message "Added $username to $rolename server role."
 					}
-					catch
-					{
-						Write-Warning "Failed to add $username to $rolename server role."
-						Write-Exception $_
+					catch {
+						Stop-Function -Message "Failed to add $username to $rolename server role." -Target $role -InnerErrorRecord $_
 					}
 				}
 			}
 		}
-		
+
 		# Remove for Syncs
-		if ($rolemembers -notcontains $username -and $destrolemembers -contains $username -and $destrole -ne $null)
-		{
-			If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role"))
-			{
-				try
-				{
+		if ($rolemembers -notcontains $username -and $destrolemembers -contains $username -and $destrole -ne $null) {
+			If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename server role")) {
+				try {
 					$destrole.DropMember($username)
-					Write-Output "Removed $username from $destrolename server role on $($destserver.name)."
+					Write-Message -Level Verbose -Message "Removed $username from $destrolename server role on $($destserver.name)."
 				}
-				catch
-				{
-					Write-Warning "Failed to remove $username from $destrolename server role on $($destserver.name)."
-					Write-Exception $_
+				catch {
+					Stop-Function -Message "Failed to remove $username from $destrolename server role on $($destserver.name)." -Target $role -InnerErrorRecord $_
 				}
 			}
 		}
 	}
-	
+
 	$ownedjobs = $sourceserver.JobServer.Jobs | Where-Object { $_.OwnerLoginName -eq $username }
-	foreach ($ownedjob in $ownedjobs)
-	{
-		if ($destserver.JobServer.Jobs[$ownedjob.name] -ne $null)
-		{
-			If ($Pscmdlet.ShouldProcess($destination, "Changing job owner to $username for $($ownedjob.name)"))
-			{
-				try
-				{
-					Write-Output "Changing job owner to $username for $($ownedjob.name)"
+	foreach ($ownedjob in $ownedjobs) {
+		if ($destserver.JobServer.Jobs[$ownedjob.name] -ne $null) {
+			If ($Pscmdlet.ShouldProcess($destination, "Changing job owner to $username for $($ownedjob.name)")) {
+				try {
+					Write-Message -Level Verbose -Message "Changing job owner to $username for $($ownedjob.name)"
 					$destownedjob = $destserver.JobServer.Jobs | Where-Object { $_.name -eq $ownedjobs.name }
 					$destownedjob.set_OwnerLoginName($username)
 					$destownedjob.Alter()
 				}
-				catch
-				{
-					Write-Warning "Could not change job owner for $($ownedjob.name)"
-					Write-Exception $_
+				catch {
+					Stop-Function -Message "Could not change job owner for $($ownedjob.name)" -Target $ownedJob -InnerErrorRecord $_
 				}
 			}
 		}
 	}
-	
-	if ($sourceserver.versionMajor -ge 9 -and $destserver.versionMajor -ge 9)
-	{
+
+	if ($sourceserver.versionMajor -ge 9 -and $destserver.versionMajor -ge 9) {
 		# These operations are only supported by SQL Server 2005 and above.
 		# Securables: Connect SQL, View any database, Administer Bulk Operations, etc.
-		
+
 		$perms = $sourceserver.EnumServerPermissions($username)
-		foreach ($perm in $perms)
-		{
+		foreach ($perm in $perms) {
 			$permstate = $perm.permissionstate
 			if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
 			else { $grantwithgrant = $false }
 			$permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
-			If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username"))
-			{
-				try
-				{
+			If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username")) {
+				try {
 					$destserver.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
-					Write-Output "Successfully performed $permstate $($perm.permissiontype) to $username"
+					Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username"
 				}
-				catch
-				{
-					Write-Warning "Failed to $permstate $($perm.permissiontype) to $username"
-					Write-Exception $_
+				catch {
+					Stop-Function -Message "Failed to $permstate $($perm.permissiontype) to $username" -Target $perm -InnerErrorRecord $_
 				}
 			}
-			
+
 			# for Syncs
 			$destperms = $destserver.EnumServerPermissions($username)
-			foreach ($perm in $destperms)
-			{
+			foreach ($perm in $destperms) {
 				$permstate = $perm.permissionstate
 				$sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
-				if ($sourceperm -eq $null)
-				{
-					If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username"))
-					{
-						try
-						{
+				if ($sourceperm -eq $null) {
+					If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username")) {
+						try {
 							$permset = New-Object Microsoft.SqlServer.Management.Smo.ServerPermissionSet($perm.permissiontype)
 							if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
 							else { $grantwithgrant = $false }
 							$destserver.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
-							Write-Output "Successfully revoked $($perm.permissiontype) from $username"
+							Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username"
 						}
-						catch
-						{
-							Write-Warning "Failed to revoke $($perm.permissiontype) from $username"
-							Write-Exception $_
+						catch {
+							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username" -Target $perm -InnerErrorRecord $_
 						}
 					}
 				}
 			}
 		}
-		
+
 		# Credential mapping. Credential removal not currently supported for Syncs.
 		$logincredentials = $sourceserver.credentials | Where-Object { $_.Identity -eq $sourcelogin.name }
-		foreach ($credential in $logincredentials)
-		{
-			if ($destserver.Credentials[$credential.name] -eq $null)
-			{
-				If ($Pscmdlet.ShouldProcess($destination, "Adding $($credential.name) to $username"))
-				{
-					try
-					{
+		foreach ($credential in $logincredentials) {
+			if ($destserver.Credentials[$credential.name] -eq $null) {
+				If ($Pscmdlet.ShouldProcess($destination, "Adding $($credential.name) to $username")) {
+					try {
 						$newcred = New-Object Microsoft.SqlServer.Management.Smo.Credential($destserver, $credential.name)
 						$newcred.identity = $sourcelogin.name
 						$newcred.Create()
-						Write-Output "Successfully created credential for $username"
+						Write-Message -Level Verbose -Message "Successfully created credential for $username"
 					}
-					catch
-					{
-						Write-Warning "Failed to create credential for $username"
-						Write-Exception $_
+					catch {
+						Stop-Function -Message "Failed to create credential for $username" -Target $credential -InnerErrorRecord $_
 					}
 				}
 			}
 		}
 	}
-	
-	if ($destserver.versionMajor -lt 9) { Write-Warning "Database mappings skipped when destination is SQL Server 2000"; continue }
-	
+
+	if ($destserver.versionMajor -lt 9) {
+		Write-Message -Level Warning -Message "Database mappings skipped when destination is SQL Server 2000"; continue
+	}
+
 	# For Sync, if info doesn't exist in EnumDatabaseMappings, then no big deal.
-	foreach ($db in $destlogin.EnumDatabaseMappings())
-	{
+	foreach ($db in $destlogin.EnumDatabaseMappings()) {
 		$dbname = $db.dbname
 		$destdb = $destserver.databases[$dbname]
 		$sourcedb = $sourceserver.databases[$dbname]
 		$dbusername = $db.username; $dblogin = $db.loginName
-		
-		if ($sourcedb -ne $null)
-		{
-			if ($sourcedb.users[$dbusername] -eq $null -and $destdb.users[$dbusername] -ne $null)
-			{
-				If ($Pscmdlet.ShouldProcess($destination, "Dropping $dbusername from $dbname on destination."))
-				{
-					try
-					{
+
+		if ($sourcedb -ne $null) {
+			if ($sourcedb.users[$dbusername] -eq $null -and $destdb.users[$dbusername] -ne $null) {
+				If ($Pscmdlet.ShouldProcess($destination, "Dropping $dbusername from $dbname on destination.")) {
+					try {
 						$destdb.users[$dbusername].Drop()
-						Write-Output "Dropped user $dbusername (login: $dblogin) from $dbname on destination. User may own a schema."
+						Write-Message -Level Verbose -Message "Dropped user $dbusername (login: $dblogin) from $dbname on destination. User may own a schema."
 					}
-					catch
-					{
-						Write-Warning "Failed to drop $dbusername ($dblogin) from $dbname on destination."
-						Write-Exception $_
+					catch {
+						Stop-Function -Message "Failed to drop $dbusername ($dblogin) from $dbname on destination." -Target $db -InnerErrorRecord $_
 					}
 				}
 			}
-			
+
 			# Remove user from role. Role removal not currently supported for Syncs.
 			# TODO: reassign if dbo, application roles
-			foreach ($destrole in $destdb.roles)
-			{
+			foreach ($destrole in $destdb.roles) {
 				$destrolename = $destrole.name
 				$sourcerole = $sourcedb.roles[$destrolename]
-				if ($sourcerole -ne $null)
-				{
-					if ($sourcerole.EnumMembers() -notcontains $dbusername -and $destrole.EnumMembers() -contains $dbusername)
-					{
-						if ($dbusername -ne "dbo")
-						{
-							If ($Pscmdlet.ShouldProcess($destination, "Dropping $username from $destrolename database role on $dbname"))
-							{
-								try
-								{
+				if ($sourcerole -ne $null) {
+					if ($sourcerole.EnumMembers() -notcontains $dbusername -and $destrole.EnumMembers() -contains $dbusername) {
+						if ($dbusername -ne "dbo") {
+							If ($Pscmdlet.ShouldProcess($destination, "Dropping $username from $destrolename database role on $dbname")) {
+								try {
 									$destrole.DropMember($dbusername)
 									$destdb.Alter()
-									Write-Output "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
+									Write-Message -Level Verbose -Message "Dropped username $dbusername (login: $dblogin) from $destrolename on $destination"
 								}
-								catch
-								{
-									Write-Warning "Failed to remove $dbusername from $destrolename database role on $dbname."
-									Write-Exception $_
+								catch {
+									Stop-Function -Message "Failed to remove $dbusername from $destrolename database role on $dbname." -Target $destrole -InnerErrorRecord $_
 								}
 							}
 						}
 					}
 				}
 			}
-			
+
 			# Remove Connect, Alter Any Assembly, etc
 			$destperms = $destdb.EnumDatabasePermissions($username)
 			$perms = $sourcedb.EnumDatabasePermissions($username)
 			# for Syncs
-			foreach ($perm in $destperms)
-			{
+			foreach ($perm in $destperms) {
 				$permstate = $perm.permissionstate
 				$sourceperm = $perms | Where-Object { $_.PermissionType -eq $perm.Permissiontype -and $_.PermissionState -eq $permstate }
-				if ($sourceperm -eq $null)
-				{
-					If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username on $dbname on $destination"))
-					{
-						try
-						{
+				if ($sourceperm -eq $null) {
+					If ($Pscmdlet.ShouldProcess($destination, "Performing Revoke on $($perm.permissiontype) for $username on $dbname on $destination")) {
+						try {
 							$permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
 							if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
 							else { $grantwithgrant = $false }
 							$destdb.PSObject.Methods["Revoke"].Invoke($permset, $username, $false, $grantwithgrant)
-							Write-Output "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
+							Write-Message -Level Verbose -Message "Successfully revoked $($perm.permissiontype) from $username on $dbname on $destination"
 						}
-						catch
-						{
-							Write-Warning "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination"
-							Write-Exception $_
+						catch {
+							Stop-Function -Message "Failed to revoke $($perm.permissiontype) from $username on $dbname on $destination" -Target $perm -InnerErrorRecord $_
 						}
 					}
 				}
 			}
 		}
 	}
-	
+
 	# Adding database mappings and securables
-	foreach ($db in $sourcelogin.EnumDatabaseMappings())
-	{
+	foreach ($db in $sourcelogin.EnumDatabaseMappings()) {
 		$dbname = $db.dbname
 		$destdb = $destserver.databases[$dbname]
 		$sourcedb = $sourceserver.databases[$dbname]
 		$dbusername = $db.username; $dblogin = $db.loginName
-		
-		if ($destdb -ne $null)
-		{
-			if (!$destdb.IsAccessible)
-			{
-				Write-Output "Database [$($destdb.Name)] is not accessible. Skipping"
+
+		if ($destdb -ne $null) {
+			if (!$destdb.IsAccessible) {
+				Write-Message -Level Verbose -Message "Database [$($destdb.Name)] is not accessible. Skipping"
 				Continue
 			}
-			if ($destdb.users[$dbusername] -eq $null)
-			{
-				If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname"))
-				{
+			if ($destdb.users[$dbusername] -eq $null) {
+				If ($Pscmdlet.ShouldProcess($destination, "Adding $dbusername to $dbname")) {
 					$sql = $sourceserver.databases[$dbname].users[$dbusername].script() | Out-String
 					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
-					try
-					{
+					try {
 						$destdb.ExecuteNonQuery($sql)
-						Write-Output "Added user $dbusername (login: $dblogin) to $dbname"
+						Write-Message -Level Verbose -Message "Added user $dbusername (login: $dblogin) to $dbname"
 					}
-					catch
-					{
-						Write-Warning "Failed to add $dbusername ($dblogin) to $dbname on $destination."
-						Write-Exception $_
+					catch {
+						Stop-Function -Message "Failed to add $dbusername ($dblogin) to $dbname on $destination." -Target $db -InnerErrorRecord $_
 					}
 				}
 			}
-			
+
 			# Db owner
-			If ($sourcedb.owner -eq $username)
-			{
-				If ($Pscmdlet.ShouldProcess($destination, "Changing $dbname dbowner to $username"))
-				{
-					try
-					{
+			If ($sourcedb.owner -eq $username) {
+				If ($Pscmdlet.ShouldProcess($destination, "Changing $dbname dbowner to $username")) {
+					try {
 						$result = Update-SqlDbOwner $sourceserver $destserver -dbname $dbname
-						if ($result -eq $true)
-						{
-							Write-Output "Changed $($destdb.name) owner to $($sourcedb.owner)."
+						if ($result -eq $true) {
+							Write-Message -Level Verbose -Message "Changed $($destdb.name) owner to $($sourcedb.owner)."
 						}
-						else { Write-Warning "Failed to update $($destdb.name) owner to $($sourcedb.owner)." }
+						else {
+							Write-Message -Level Warning -Message "Failed to update $($destdb.name) owner to $($sourcedb.owner)."
+						}
 					}
-					catch { Write-Warning "Failed to update $($destdb.name) owner to $($sourcedb.owner)." }
+					catch {
+						Write-Message -Level Warning -Message "Failed to update $($destdb.name) owner to $($sourcedb.owner)."
+					}
 				}
 			}
-			
+
 			# Database Roles: db_owner, db_datareader, etc
-			foreach ($role in $sourcedb.roles)
-			{
-				if ($role.EnumMembers() -contains $username)
-				{
+			foreach ($role in $sourcedb.roles) {
+				if ($role.EnumMembers() -contains $username) {
 					$rolename = $role.name
 					$destdbrole = $destdb.roles[$rolename]
-					
-					if ($destdbrole -ne $null -and $dbusername -ne "dbo" -and $destdbrole.EnumMembers() -notcontains $username)
-					{
-						If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename database role on $dbname"))
-						{
-							try
-							{
+
+					if ($destdbrole -ne $null -and $dbusername -ne "dbo" -and $destdbrole.EnumMembers() -notcontains $username) {
+						If ($Pscmdlet.ShouldProcess($destination, "Adding $username to $rolename database role on $dbname")) {
+							try {
 								$destdbrole.AddMember($username)
 								$destdb.Alter()
-								Write-Output "Added $username to $rolename database role on $dbname."
-								
+								Write-Message -Level Verbose -Message "Added $username to $rolename database role on $dbname."
+
 							}
-							catch
-							{
-								Write-Warning "Failed to add $username to $rolename database role on $dbname."
-								Write-Exception $_
+							catch {
+								Stop-Function -Message "Failed to add $username to $rolename database role on $dbname." -Target $role -InnerErroRecord $_
 							}
 						}
 					}
 				}
 			}
-			
+
 			# Connect, Alter Any Assembly, etc
 			$perms = $sourcedb.EnumDatabasePermissions($username)
-			foreach ($perm in $perms)
-			{
+			foreach ($perm in $perms) {
 				$permstate = $perm.permissionstate
 				if ($permstate -eq "GrantWithGrant") { $grantwithgrant = $true; $permstate = "grant" }
 				else { $grantwithgrant = $false }
 				$permset = New-Object Microsoft.SqlServer.Management.Smo.DatabasePermissionSet($perm.permissiontype)
-				If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username on $dbname"))
-				{
-					try
-					{
+				If ($Pscmdlet.ShouldProcess($destination, "Performing $permstate on $($perm.permissiontype) for $username on $dbname")) {
+					try {
 						$destdb.PSObject.Methods[$permstate].Invoke($permset, $username, $grantwithgrant)
-						Write-Output "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
+						Write-Message -Level Verbose -Message "Successfully performed $permstate $($perm.permissiontype) to $username on $dbname"
 					}
-					catch
-					{
-						Write-Warning "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname."
-						Write-Exception $_
+					catch {
+						Stop-Function -Message "Failed to perform $permstate on $($perm.permissiontype) for $username on $dbname." -Target $perm -InnerErrorRecord $_
 					}
 				}
 			}


### PR DESCRIPTION
Changes proposed in this pull request:
 - formatted help
 - Add message system
 - update few spots on camelCase (most had already been done by a previous PR)
 - Add output object
 - All output changed to verbose
 - Also adjusted Update and Sync commands to have message commands. They had output messages that affected the copy object for Copy command.
 - removed End block code for closing connection and output text.

## This needs to be tested before merging