### PR TITLE
Asynchronous TEPP - fixed conflict with main connection

### DIFF
--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -129,7 +129,7 @@
         }
 		
 		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
-		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext, ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
 		
 		# Update cache for instance names
 		if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower()) {
@@ -253,7 +253,7 @@
 	}
 	
 	# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
-	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext, ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
 	
 	# Update cache for instance names
     if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower())


### PR DESCRIPTION
Was accidentally using the same connection as the connection returned to the calling function of `Connect-SqlInstance`, rather than a copy of it.

# Fixes
Fixes errors such as this:
```
Exception calling "ExecuteWithResults" with "1" argument(s): "There is already an open DataReader associated with this Command which must be closed first."
At line:447 char:6
+ ...             $historyObject.FileList = $server.ConnectionContext.Execu ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : InvalidOperationException
```