### PR TITLE
TEPP for configuration system / TEPP Bugfix

### DIFF
--- a/functions/Get-DbaConfig.ps1
+++ b/functions/Get-DbaConfig.ps1
@@ -7,6 +7,10 @@
 		.DESCRIPTION
 			Retrieves configuration elements by name.
 			Can be used to search the existing configuration list.
+	
+		.PARAMETER FullName
+			Default: "*"
+			Search for configurations using the full name
 		
 		.PARAMETER Name
 			Default: "*"
@@ -34,20 +38,34 @@
 			Author: Friedrich Weinmann
             Tags: Config
     #>
-    [CmdletBinding()]
-    Param (
+    [CmdletBinding(DefaultParameterSetName = "FullName")]
+	Param (
+		[Parameter(ParameterSetName = "FullName", Position = 0)]
+		[string]
+		$FullName = "*",
+		
+		[Parameter(ParameterSetName = "Module", Position = 1)]
         [string]
         $Name = "*",
-        
+		
+		[Parameter(ParameterSetName = "Module", Position = 0)]
         [string]
         $Module = "*",
         
         [switch]
         $Force
     )
-    
-    $Name = $Name.ToLower()
-    $Module = $Module.ToLower()
-    
-    [Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Values | Where-Object { ($_.Name -like $Name) -and ($_.Module -like $Module) -and ((-not $_.Hidden) -or ($Force)) } | Sort-Object Module, Name
+	
+	switch ($PSCmdlet.ParameterSetName) {
+		"Module" {
+			$Name = $Name.ToLower()
+			$Module = $Module.ToLower()
+			
+			[Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Values | Where-Object { ($_.Name -like $Name) -and ($_.Module -like $Module) -and ((-not $_.Hidden) -or ($Force)) } | Sort-Object Module, Name
+		}
+		
+		"FullName" {
+			[Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Values | Where-Object { ("$($_.Module).$($_.Name)" -like $FullName) -and ((-not $_.Hidden) -or ($Force)) } | Sort-Object Module, Name
+		}
+	}
 }

--- a/internal/New-DbaTeppCompletionResult.ps1
+++ b/internal/New-DbaTeppCompletionResult.ps1
@@ -1,4 +1,4 @@
-﻿function New-DbaTeppCompletionResult
+﻿function global:New-DbaTeppCompletionResult
 {
     <#
         .SYNOPSIS
@@ -79,3 +79,5 @@
         return New-Object System.Management.Automation.CompletionResult($CompletionText, $listItemToUse, $CompletionResultType, $toolTipToUse.Trim())
     }
 }
+
+(Get-Item Function:\New-DbaTeppCompletionResult).Visibility = "Private"

--- a/internal/Where-DbaObject.ps1
+++ b/internal/Where-DbaObject.ps1
@@ -1,4 +1,4 @@
-﻿function Where-DbaObject
+﻿function global:Where-DbaObject
 {
     <#
         .SYNOPSIS
@@ -142,3 +142,5 @@
         
     }
 }
+
+(Get-Item Function:\Where-DbaObject).Visibility = "Private"

--- a/internal/dynamicparams/config.ps1
+++ b/internal/dynamicparams/config.ps1
@@ -1,0 +1,77 @@
+﻿#region Tepp Data return: FullName
+$ScriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["config"].LastExecution = $start
+	
+	foreach ($name in ([Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Keys | Where-DbaObject -Like "$wordToComplete*" | Sort-Object)) {
+		New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+	}
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["config"].LastDuration = (Get-Date) - $start	
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name config
+#endregion Tepp Data return: FullName
+
+#region Tepp Data return: Name
+$ScriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastExecution = $start
+	
+	foreach ($name in ([Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Values.Name | Select-Object -Unique | Where-DbaObject -Like "$wordToComplete*" | Sort-Object)) {
+		New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+	}
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastDuration = (Get-Date) - $start
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name configname
+#endregion Tepp Data return: Name
+
+#region Tepp Data return: Module
+$ScriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configmodule"].LastExecution = $start
+	
+	foreach ($name in ([Sqlcollaborative.Dbatools.Configuration.Config]::Cfg.Values.Module | Select-Object -Unique | Where-DbaObject -Like "$wordToComplete*" | Sort-Object )) {
+		New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+	}
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configmodule"].LastDuration = (Get-Date) - $start
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name configmodule
+#endregion Tepp Data return: Module

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -40,4 +40,10 @@ foreach ($function in $functions) {
 
 #region Explicit TEPP
 Register-DbaTeppArgumentCompleter -Command "Find-DbaCommand" -Parameter Tag -Name tag
+Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter FullName -Name config
+Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter Name -Name configname
+Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter Module -Name configmodule
+Register-DbaTeppArgumentCompleter -Command "Get-DbaConfigValue" -Parameter Name -Name config
+Register-DbaTeppArgumentCompleter -Command "Set-DbaConfig" -Parameter Name -Name config
+Register-DbaTeppArgumentCompleter -Command "Set-DbaConfig" -Parameter Module -Name configmodule
 #endregion Explicit TEPP


### PR DESCRIPTION
# Features
 - Added TEPP for the Configuration system commands
 - Added `-FullName` parameter to `Get-DbaConfig`. The legacy remnants made the usage less intuitive using `-Module` and `-Name` parameters

# Fixes
Fixed TEPP autocompletion being not shown when doing regular module import.
 - Internal commands could not be accessed.

Worked around that by making the commands publicly available but invisible / inaccessible to the user
 - Functions `Where-DbaObject` and `New-DbaTeppCompletionResult` were scoped to global, rather than local
 - The same functions were then set to visibility `"private"`

This makes them available to all code but not to users.