### PR TITLE
Improved testing for if db should be overwritten

### DIFF
--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -105,7 +105,10 @@ Function Restore-DBFromFilteredArray {
             }
 
         }
-
+        else {
+            Write-Warning "$FunctionName - Database $DbName exists and will not be overwritten without the WithReplace switch"
+            return
+        }
         $MissingFiles = @()
         if ($TrustDbBackupHistory) {
             Write-Message -Level Verbose -Message "Trusted File checks"

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -18,7 +18,7 @@
     Context "Ensuring warning is thrown if database already exists" {
         $results = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak -WarningVariable warning
         It "Should warn" {
-            $warning | Should Match "exists and will not be overwritten"
+            $warning | Should Match "exists and WithReplace not specified, stopping"
         }
         It "Should not return object" {
             $results | Should Be $null


### PR DESCRIPTION
Better checking if a db needs to be forced close before a restore. 

Changed  warning message to user so needed to update pester test as well.

Fixes issues @potatoqualitee raised on slack


Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

