### PR TITLE
Invoke-Command -> Invoke-Command2

### DIFF
--- a/functions/Clear-DbaSqlConnectionPool.ps1
+++ b/functions/Clear-DbaSqlConnectionPool.ps1
@@ -64,11 +64,11 @@ Clears all connection pools on workstation27
 				Write-Verbose "Clearing all pools on remote computer $Computer"
 				if ($credential)
 				{
-					Invoke-Command -ComputerName $computer -Credential $Credential -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
+					Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
 				}
 				else
 				{
-					Invoke-Command -ComputerName $computer -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
+					Invoke-Command2 -ComputerName $computer -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
 				}
 			}
 			else
@@ -76,11 +76,11 @@ Clears all connection pools on workstation27
 				Write-Verbose "Clearing all local pools"
 				if ($credential)
 				{
-					Invoke-Command -Credential $Credential -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
+					Invoke-Command2 -Credential $Credential -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
 				}
 				else
 				{
-					Invoke-Command -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
+					Invoke-Command2 -ScriptBlock { [System.Data.SqlClient.SqlConnection]::ClearAllPools() }
 				}
 			}
 		}

--- a/functions/Get-DbaMsdtc.ps1
+++ b/functions/Get-DbaMsdtc.ps1
@@ -10,6 +10,9 @@ Requires: Windows administrator access on Servers
 
 .PARAMETER ComputerName
 The SQL Server (or server in general) that you're connecting to.
+	
+.PARAMETER Credential
+Credential object used to connect to the computer as a different user.
 
 .NOTES
 Tags: WSMan, CIM
@@ -68,25 +71,21 @@ Get DTC status for all the computers where the MSDTC Service is not running
 .EXAMPLE
 Get-DbaMsdtc -ComputerName srv0042 | Out-Gridview
 
-
 Get DTC status for the computer srv0042 and show in a grid view
-
-
-
 #>
 	
 	[CmdletBinding()]
 	Param (
 		[Parameter(ValueFromPipeline = $true)]
 		[Alias('cn', 'host', 'Server')]
-		[string[]]$Computername = $env:COMPUTERNAME,
+		[dbainstanceparameter[]]$Computername = $env:COMPUTERNAME,
 		[PSCredential][System.Management.Automation.CredentialAttribute()]
-		$Credential
+		$Credential,
+		[switch]$Silent
 	)
 	
 	begin {
-		$functionName = (Get-PSCallstack)[0].Command
-		$ComputerName = $ComputerName | foreach-Object { $_.split("\")[0] } | Select-Object -Unique
+		$ComputerName = $ComputerName.ComputerName | Select-Object -Unique
 		$query = "Select * FROM Win32_Service WHERE Name = 'MSDTC'"
 		$DTCSecurity = {
 			Get-ItemProperty -Path HKLM:\Software\Microsoft\MSDTC\Security |
@@ -107,18 +106,18 @@ Get DTC status for the computer srv0042 and show in a grid view
 			$CIDHash = @{ }
 			if (Test-PSRemoting -ComputerName $Computer) {
 				$dtcservice = $null
-				Write-Verbose "$functionName - Getting DTC on $computer via WSMan"
+				Write-Message -Level Verbose -Message "Getting DTC on $computer via WSMan"
 				$dtcservice = Get-Ciminstance -ComputerName $Computer -Query $query
 				if ($null -eq $dtcservice) {
 					Write-Warning "$functionName - Can't connect to CIM on $Computer via WSMan"
 				}
 				
-				Write-Verbose "$functionName - Getting MSDTC Security Registry Values on $Computer"
+				Write-Message -Level Verbose -Message "Getting MSDTC Security Registry Values on $Computer"
 				$reg = Invoke-Command2 -ComputerName $Computer -ScriptBlock $DTCSecurity
 				if ($null -eq $reg) {
 					Write-Warning "$functionName - Can't connect to MSDTC Security registry on $Computer"
 				}
-				Write-Verbose "$functionName - Getting MSDTC CID Registry Values on $Computer"
+				Write-Message -Level Verbose -Message "Getting MSDTC CID Registry Values on $Computer"
 				$CIDs = Invoke-Command2 -ComputerName $Computer -ScriptBlock $DTCCIDs
 				if ($null -ne $CIDs) {
 					foreach ($key in $CIDs) { $CIDHash.Add($key.Data, $key.CID) }
@@ -128,9 +127,9 @@ Get DTC status for the computer srv0042 and show in a grid view
 				}
 			}
 			else {
-				Write-Verbose "$functionName - PSRemoting is not enabled on $Computer"
+				Write-Message -Level Verbose -Message "PSRemoting is not enabled on $Computer"
 				try {
-					Write-Verbose "$functionName - Failed To get DTC via WinRM. Getting DTC on $computer via DCom"
+					Write-Message -Level Verbose -Message "Failed To get DTC via WinRM. Getting DTC on $computer via DCom"
 					$SessionParams = @{ }
 					$SessionParams.ComputerName = $Computer
 					$SessionParams.SessionOption = (New-CimSessionOption -Protocol Dcom)

--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -1,5 +1,4 @@
-function Get-DbaPrivilege
-{
+function Get-DbaPrivilege {
   <#
       .SYNOPSIS
       Gets the users with local privileges on one or more computersr. 
@@ -14,17 +13,18 @@ function Get-DbaPrivilege
 
       .PARAMETER Credential
       Credential object used to connect to the computer as a different user.
+	
+	  .PARAMETER Silent 
+	  Use this switch to disable any kind of verbose messages
 
       .NOTES
       Author: Klaas Vandenberghe ( @PowerDBAKlaas )
       Tags: Privilege
-      dbatools PowerShell module (https://dbatools.io)
-      Copyright (C) 2016 Chrissy LeMaire
-      This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-      This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-      You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
-
-      .LINK
+      Website: https://dbatools.io
+	  Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+	  License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+      
+	.LINK
       https://dbatools.io/Get-DbaPrivilege
 
       .EXAMPLE
@@ -43,92 +43,89 @@ function Get-DbaPrivilege
       Gets the local privileges on computers sql1 and sql2, and shows them in a grid view.
 
   #>
-  [CmdletBinding()]
-  Param (
-    [parameter(ValueFromPipeline)]
-    [Alias("cn","host","Server")]
-    [string[]]$ComputerName = $env:COMPUTERNAME,
-    [PSCredential] [System.Management.Automation.CredentialAttribute()]$Credential
-  )
-
-  BEGIN
-  {
-    $ResolveSID = @"
+	[CmdletBinding()]
+	Param (
+		[parameter(ValueFromPipeline)]
+		[Alias("cn", "host", "Server")]
+		[dbainstanceparameter[]]$ComputerName = $env:COMPUTERNAME,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$Credential,
+		[switch]$Silent
+	)
+	
+	begin {
+		$ResolveSID = @"
     function Convert-SIDToUserName ([string] `$SID ) {
       `$objSID = New-Object System.Security.Principal.SecurityIdentifier (`"`$SID`") 
       `$objUser = `$objSID.Translate( [System.Security.Principal.NTAccount]) 
       `$objUser.Value
     }
 "@
-    $FunctionName = (Get-PSCallstack)[0].Command
-    $ComputerName = $ComputerName | ForEach-Object {$_.split("\")[0]} | Select-Object -Unique
-  }
-  PROCESS
-  {
-    foreach ($computer in $ComputerName)
-    {
-      Write-Verbose "$FunctionName - Connecting to $computer"
-      if ( Test-PSRemoting -ComputerName $Computer )
-      {
-        Write-Verbose "$FunctionName - Getting Privileges on $Computer"
-        $Priv = $null
-        $Priv = Invoke-Command -ComputerName $computer -ScriptBlock {$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("") ; secedit /export /cfg $temp\secpolByDbatools.cfg > $NULL ;
-        Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -match "SeBatchLogonRight" -or $_ -match 'SeManageVolumePrivilege' -or $_ -match 'SeLockMemoryPrivilege' }}
-
-          Write-Verbose "$FunctionName - Getting Batch Logon Privileges on $Computer"
-          $BL = Invoke-Command -ComputerName $computer -ArgumentList $ResolveSID -ScriptBlock { 
-            Param( $ResolveSID )
-            . ([ScriptBlock]::Create($ResolveSID))
-            $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("") ;
-            (Get-Content $temp\secpolByDbatools.cfg | Where-Object {$_ -match "SeBatchLogonRight"}).substring(20).split(",").replace("`*","") |
-          ForEach-Object { Convert-SIDToUserName -SID $_ } } -ErrorAction SilentlyContinue
-        if ( $BL.count -eq 0 )
-        {
-          Write-Verbose "$FunctionName - No users with Batch Logon Rights on $computer"
-        }
-
-          Write-Verbose "$FunctionName - Getting Instant File Initialization Privileges on $Computer"
-          $IFI = Invoke-Command -ComputerName $computer -ArgumentList $ResolveSID -ScriptBlock { 
-            Param( $ResolveSID )
-            . ([ScriptBlock]::Create($ResolveSID))
-            $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("") ;
-            (Get-Content $temp\secpolByDbatools.cfg | Where-Object {$_ -like 'SeManageVolumePrivilege*'}).substring(26).split(",").replace("`*","") |
-          ForEach-Object { Convert-SIDToUserName -SID $_ } } -ErrorAction SilentlyContinue
-        if ( $IFI.count -eq 0 )
-        {
-          Write-Verbose "$FunctionName - No users with Instant File Initialization Rights on $computer"
-        }
-
-          Write-Verbose "$FunctionName - Getting Lock Pages in Memory Privileges on $Computer"
-          $LPIM = Invoke-Command -ComputerName $computer -ArgumentList $ResolveSID -ScriptBlock { 
-            Param( $ResolveSID )
-            . ([ScriptBlock]::Create($ResolveSID))
-            $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("") ;
-            (Get-Content $temp\secpolByDbatools.cfg | Where-Object {$_ -like 'SeLockMemoryPrivilege*'}).substring(24).split(",").replace("`*","") |
-          ForEach-Object { Convert-SIDToUserName -SID $_ } } -ErrorAction SilentlyContinue
-
-        if ( $LPIM.count -eq 0 )
-        {
-          Write-Verbose "$FunctionName - No users with Lock Pages in Memory Rights on $computer"
-        }
-        $users = @() + $BL + $IFI + $LPIM | Select-Object -Unique
-        $users | ForEach-Object {
-          [PSCustomObject]@{
-            ComputerName = $computer
-            User = $_
-            LogonAsBatchPrivilege = $BL -contains $_
-            InstantFileInitializationPrivilege = $IFI -contains $_
-            LockPagesInMemoryPrivilege = $LPIM -contains $_
-          }
-        }
-        Write-Verbose "$FunctionName - Removing secpol file on $computer"
-        Invoke-Command -ComputerName $computer -ScriptBlock {$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("") ; Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL }
-      }
-      else
-      {
-        Write-Warning "$FunctionName - Failed to connect to $Computer"
-      }
-
-    }
-  }
+		$ComputerName = $ComputerName.ComputerName | Select-Object -Unique
+	}
+	process {
+		foreach ($computer in $ComputerName) {
+			Write-Message -Level Verbose -Message "Connecting to $computer"
+			if (Test-PSRemoting -ComputerName $Computer) {
+				Write-Message -Level Verbose -Message "Getting Privileges on $Computer"
+				$Priv = $null
+				$Priv = Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock {
+					$temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); secedit /export /cfg $temp\secpolByDbatools.cfg > $NULL;
+					Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -match "SeBatchLogonRight" -or $_ -match 'SeManageVolumePrivilege' -or $_ -match 'SeLockMemoryPrivilege' }
+				}
+				
+				Write-Message -Level Verbose -Message "Getting Batch Logon Privileges on $Computer"
+				$BL = Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $ResolveSID -ScriptBlock {
+					Param ($ResolveSID)
+					. ([ScriptBlock]::Create($ResolveSID))
+					$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
+					(Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -match "SeBatchLogonRight" }).substring(20).split(",").replace("`*", "") |
+					ForEach-Object { Convert-SIDToUserName -SID $_ }
+				} -ErrorAction SilentlyContinue
+				if ($BL.count -eq 0) {
+					Write-Message -Level Verbose -Message "No users with Batch Logon Rights on $computer"
+				}
+				
+				Write-Message -Level Verbose -Message "Getting Instant File Initialization Privileges on $Computer"
+				$ifi = Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $ResolveSID -ScriptBlock {
+					Param ($ResolveSID)
+					. ([ScriptBlock]::Create($ResolveSID))
+					$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
+					(Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeManageVolumePrivilege*' }).substring(26).split(",").replace("`*", "") |
+					ForEach-Object { Convert-SIDToUserName -SID $_ }
+				} -ErrorAction SilentlyContinue
+				if ($ifi.count -eq 0) {
+					Write-Message -Level Verbose -Message "No users with Instant File Initialization Rights on $computer"
+				}
+				
+				Write-Message -Level Verbose -Message "Getting Lock Pages in Memory Privileges on $Computer"
+				$lpim = Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $ResolveSID -ScriptBlock {
+					Param ($ResolveSID)
+					. ([ScriptBlock]::Create($ResolveSID))
+					$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
+					(Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeLockMemoryPrivilege*' }).substring(24).split(",").replace("`*", "") |
+					ForEach-Object { Convert-SIDToUserName -SID $_ }
+				} -ErrorAction SilentlyContinue
+				
+				if ($lpim.count -eq 0) {
+					Write-Message -Level Verbose -Message "No users with Lock Pages in Memory Rights on $computer"
+				}
+				$users = @() + $BL + $ifi + $lpim | Select-Object -Unique
+				$users | ForEach-Object {
+					[PSCustomObject]@{
+						ComputerName = $computer
+						User = $_
+						LogonAsBatchPrivilege = $BL -contains $_
+						InstantFileInitializationPrivilege = $ifi -contains $_
+						LockPagesInMemoryPrivilege = $lpim -contains $_
+					}
+				}
+				Write-Message -Level Verbose -Message "Removing secpol file on $computer"
+				Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ScriptBlock { $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL }
+			}
+			else {
+				Write-Message -Level Warning -Message "Failed to connect to $Computer"
+			}
+		}
+	}
 }

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -697,14 +697,14 @@ The script will show a message that the copy destination has not been supplied a
                             try {
                                 # If the destination server is remote and the credential is set
                                 if (-not $IsDestinationLocal -and $DestinationCredential) {
-                                    Invoke-Command -ComputerName $DestinationServerName -Credential $DestinationCredential -ScriptBlock {
+                                    Invoke-Command2 -ComputerName $DestinationServerName -Credential $DestinationCredential -ScriptBlock {
                                         Write-Message -Message "Creating copy destination folder $CopyDestinationFolder" -Level Verbose
                                         New-Item -Path $CopyDestinationFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
                                     }
                                 }
                                 # If the server is local and the credential is set
                                 elseif ($DestinationCredential) {
-                                    Invoke-Command -ScriptBlock -Credential $DestinationCredential {
+                                    Invoke-Command2 -ScriptBlock -Credential $DestinationCredential {
                                         Write-Message -Message "Creating copy destination folder $CopyDestinationFolder" -Level Verbose
                                         New-Item -Path $CopyDestinationFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
                                     }

--- a/internal/Invoke-Command2.ps1
+++ b/internal/Invoke-Command2.ps1
@@ -1,35 +1,50 @@
 ﻿function Invoke-Command2 {
+<#
+	.SYNOPSIS
+		Wrapper function that calls Invoke-Command and gracefully handles credentials.
+	
+	.DESCRIPTION
+		Wrapper function that calls Invoke-Command and gracefully handles credentials.
+	
+	.PARAMETER ComputerName
+		Default: $env:COMPUTERNAME
+		The computer to invoke the scriptblock on.
+	
+	.PARAMETER Credential
+		The credentials to use.
+		Can accept $null on older PowerShell versions, since it expects type object, not PSCredential
+	
+	.PARAMETER ScriptBlock
+		The code to run on the targeted system
+	
+	.PARAMETER ArgumentList
+		Any arguments to pass to the scriptblock being run
+	
+	.PARAMETER Raw
+		Passes through the raw return data, rather than prettifying stuff.
+	
+	.EXAMPLE
+		PS C:\> Invoke-Command2 -ComputerName sql2014 -Credential $Credential -ScriptBlock { dir }
+		
+		Executes the scriptblock '{ dir }' on the computer sql2014 using the credentials stored in $Credential.
+		If $Credential is null, no harm done.
+#>
 	[CmdletBinding()]
 	param (
-		[object]$ComputerName=$env:COMPUTERNAME,
+		[DbaInstanceParameter]$ComputerName = $env:COMPUTERNAME,
 		[object]$Credential,
 		[scriptblock]$ScriptBlock,
 		[object[]]$ArgumentList,
-		[switch]$Silent
+		[switch]$Raw
 	)
 	
-	try {
-		if ([dbavalidate]::IsLocalhost($ComputerName)) {
-			if ($Credential) {
-				Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop
-			}
-			else {
-				Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -ErrorAction Stop
-			}
-			
-		}
-		else {
-			if ($Credential) {
-				Invoke-Command -ScriptBlock $ScriptBlock -ComputerName $ComputerName -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop |
-				Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
-			}
-			else {
-				Invoke-Command -ScriptBlock $ScriptBlock -ComputerName $ComputerName -ArgumentList $ArgumentList -ErrorAction Stop |
-				Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
-			}
-		}
+	$InvokeCommandSplat = @{
+		ScriptBlock = $ScriptBlock
 	}
-	catch {
-		Stop-Function -Message $_ -InnerErrorRecord $_
-	}
+	if ($ArgumentList) { $InvokeCommandSplat["ArgumentList"] = $ArgumentList }
+	if (-not $ComputerName.IsLocalhost) { $InvokeCommandSplat["ComputerName"] = $ComputerName.ComputerName }
+	if ($Credential) { $InvokeCommandSplat["Credential"] = $Credential }
+	
+	if ($Raw) { Invoke-Command @InvokeCommandSplat }
+	else { Invoke-Command @InvokeCommandSplat | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName }
 }

--- a/internal/Invoke-ManagedComputerCommand.ps1
+++ b/internal/Invoke-ManagedComputerCommand.ps1
@@ -41,16 +41,7 @@ Internal command
 		
 	try
 	{
-		if ($credential.username -ne $null)
-		{
-			$result = Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop
-		}
-		else
-		{
-			$result = Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -ErrorAction Stop
-		}
-		
-		Write-Message -Level Verbose -Message "Local connection for $ComputerName succeeded"
+		Invoke-Command2 -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ErrorAction Stop
 	}
 	catch
 	{
@@ -62,19 +53,10 @@ Internal command
 			$hostname = [System.Net.Dns]::gethostentry($ipaddr)
 			$hostname = $hostname.HostName
 			
-			if ($credential.username -ne $null)
-			{
-				$result = Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -Credential $Credential -ComputerName $hostname -ErrorAction Stop
-			}
-			else
-			{
-				$result = Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -ComputerName $hostname -ErrorAction Stop
-			}
+			Invoke-Command2 -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -ComputerName $hostname -ErrorAction Stop
 		}
-		catch{
+		catch {
 			throw "SqlWmi connection failed: $_"
 		}
 	}
-	
-	$result | Select-Object * -ExcludeProperty PSComputerName, RunSpaceID, PSShowComputerName
 }


### PR DESCRIPTION
Invoke-Command's behavior when it comes to empty credentials has changed over the versions. This means that older systems will prompt if we pass an empty $credential and leave ppl frustrated.

I created Invoke-Command2 to help detect credential and then pass it only when required. It also passes the ComputerName only when the host is not local.

I encourage everyone to use Invoke-Command2 - if you find the results are unusual, slap on a -Raw which removes the `Select * -ExcludeProperty PSComptuerName, etc` that Invoke-Command2 does by default to clean up output.