### PR TITLE
Output added for Copy-DbaServerAuditSpecification

### DIFF
--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -175,7 +175,7 @@ function Copy-DbaServerAuditSpecification {
 				try {
 					Write-Message -Level Verbose -Message "Copying server audit $auditSpecName"
 					$sql = $auditSpec.Script() | Out-String
-					Write-Message -Level Derbug -Message $sql
+					Write-Message -Level Debug -Message $sql
 					$destServer.Query($sql)
 
 					$copyAuditSpecStatus.Status = "Successful"

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -174,7 +174,9 @@ function Copy-DbaServerAuditSpecification {
 			if ($Pscmdlet.ShouldProcess($destination, "Creating server audit $auditSpecName")) {
 				try {
 					Write-Message -Level Verbose -Message "Copying server audit $auditSpecName"
-					$destServer.ConnectionContext.ExecuteNonQuery($auditSpec.Script()) | Out-Null
+					$sql = $auditSpec.Script() | Out-String
+					Write-Message -Level Derbug -Message $sql
+					$destServer.Query($sql)
 
 					$copyAuditSpecStatus.Status = "Successful"
 					$copyAuditSpecStatus

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -1,157 +1,143 @@
-function Copy-DbaServerAuditSpecification
-{
-<#
-.SYNOPSIS 
-Copy-DbaServerAuditSpecification migrates server audit specifications from one SQL Server to another. 
+function Copy-DbaServerAuditSpecification {
+	<#
+		.SYNOPSIS 
+			Copy-DbaServerAuditSpecification migrates server audit specifications from one SQL Server to another. 
 
-.DESCRIPTION
-By default, all audits are copied. The -ServerAuditSpecification parameter is autopopulated for command-line completion and can be used to copy only specific audits.
+		.DESCRIPTION
+			By default, all audits are copied. The -ServerAuditSpecification parameter is autopopulated for command-line completion and can be used to copy only specific audits.
 
-If the audit specification already exists on the destination, it will be skipped unless -Force is used. 
+			If the audit specification already exists on the destination, it will be skipped unless -Force is used. 
 
-.PARAMETER Source
-Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER Source
+			Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER Destination
-Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER SourceSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-.PARAMETER SourceSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
 
-$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+		To connect as a different Windows user, run PowerShell as that user.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER Destination
+			Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER DestinationSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+		.PARAMETER DestinationSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			To connect as a different Windows user, run PowerShell as that user.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER ServerAuditSpecification
+			The Server Audit Specification(s) to process - this list is auto populated from the server. If unspecified, all Server Audit Specifications will be processed.
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER ExcludeServerAuditSpecification
+			The Server Audit Specification(s) to exclude - this list is auto populated from the server
 
-.PARAMETER Force
-Drops and recreates the Audit Specification if it exists
+		.PARAMETER WhatIf 
+			Shows what would happen if the command were to run. No actions are actually performed. 
 
-.NOTES
-Tags: Migration
-Author: Chrissy LeMaire (@cl), netnerds.net
-Requires: sysadmin access on SQL Servers
+		.PARAMETER Confirm 
+			Prompts you for confirmation before executing any changing operations within the command. 
 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+		.PARAMETER Force
+			Drops and recreates the Audit Specification if it exists
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		.PARAMETER Silent 
+			Use this switch to disable any kind of verbose messages
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+		.NOTES
+			Tags: Migration,ServerAudit
+			Author: Chrissy LeMaire (@cl), netnerds.net
+			Requires: sysadmin access on SQL Servers
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Copy-DbaServerAuditSpecification
+		.LINK
+			https://dbatools.io/Copy-DbaServerAuditSpecification
 
-.EXAMPLE   
-Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster
+		.EXAMPLE   
+			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster
 
-Copies all server audits from sqlserver2014a to sqlcluster, using Windows credentials. If audits with the same name exist on sqlcluster, they will be skipped.
+			Copies all server audits from sqlserver2014a to sqlcluster, using Windows credentials. If audits with the same name exist on sqlcluster, they will be skipped.
 
-.EXAMPLE   
-Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -ServerAuditSpecification tg_noDbDrop -SourceSqlCredential $cred -Force
+		.EXAMPLE   
+			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -ServerAuditSpecification tg_noDbDrop -SourceSqlCredential $cred -Force
 
-Copies a single audit, the tg_noDbDrop audit from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an audit with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
+			Copies a single audit, the tg_noDbDrop audit from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an audit with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
-.EXAMPLE   
-Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+		.EXAMPLE   
+			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
-Shows what would happen if the command were executed using force.
-#>
+			Shows what would happen if the command were executed using force.
+	#>
 	[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 	param (
 		[parameter(Mandatory = $true)]
 		[DbaInstanceParameter]$Source,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$SourceSqlCredential,
 		[parameter(Mandatory = $true)]
 		[DbaInstanceParameter]$Destination,
-		[System.Management.Automation.PSCredential]$SourceSqlCredential,
-		[System.Management.Automation.PSCredential]$DestinationSqlCredential,
-		[switch]$Force
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$DestinationSqlCredential,
+		[object[]]$ServerAuditSpecification,
+		[object[]]$ExcludeServerAuditSpecification,
+		[switch]$Force,
+		[switch]$Silent
 	)
 
 	begin {
 
 		$sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
-		
 		$source = $sourceserver.DomainInstanceName
 		$destination = $destserver.DomainInstanceName
-		
 		if (!(Test-SqlSa -SqlInstance $sourceserver -SqlCredential $SourceSqlCredential)) { throw "Not a sysadmin on $source. Quitting." }
 		if (!(Test-SqlSa -SqlInstance $destserver -SqlCredential $DestinationSqlCredential)) { throw "Not a sysadmin on $destination. Quitting." }
-		
-		if ($sourceserver.versionMajor -lt 10 -or $destserver.versionMajor -lt 10)
-		{
+		if ($sourceserver.versionMajor -lt 10 -or $destserver.versionMajor -lt 10) {
 			throw "Server Audit Specifications are only supported in SQL Server 2008 and above. Quitting."
-			
 		}
-		
 		$serverauditspecs = $sourceserver.ServerAuditSpecifications
 		$destaudits = $destserver.ServerAuditSpecifications
-		
 	}
 	process {
 
-		foreach ($auditspec in $serverauditspecs)
-		{
+		foreach ($auditspec in $serverauditspecs) {
 			$auditspecname = $auditspec.name
 			if ($auditspecs.length -gt 0 -and $auditspecs -notcontains $auditspecname) { continue }
-			
 			$destserver.Audits.Refresh()
-			
-			if ($destserver.Audits.Name -notcontains $auditspec.AuditName)
-			{
+			if ($destserver.Audits.Name -notcontains $auditspec.AuditName) {
 				Write-Warning "Audit $($auditspec.AuditName) does not exist on $Destination. Skipping $auditspecname."
 				continue
 			}
-			
-			if ($destaudits.name -contains $auditspecname)
-			{
-				if ($force -eq $false)
-				{
+			if ($destaudits.name -contains $auditspecname) {
+				if ($force -eq $false) {
 					Write-Warning "Server audit $auditspecname exists at destination. Use -Force to drop and migrate."
 					continue
 				}
-				else
-				{
-					If ($Pscmdlet.ShouldProcess($destination, "Dropping server audit $auditspecname and recreating"))
-					{
-						try
-						{
+				else {
+					If ($Pscmdlet.ShouldProcess($destination, "Dropping server audit $auditspecname and recreating")) {
+						try {
 							Write-Verbose "Dropping server audit $auditspecname"
 							$destserver.ServerAuditSpecifications[$auditspecname].Drop()
 						}
-						catch { 
-							Write-Exception $_ 
-							continue
+						catch {
+							Write-Exception $_ 							continue
 						}
 					}
 				}
 			}
-			
-			If ($Pscmdlet.ShouldProcess($destination, "Creating server audit $auditspecname"))
-			{
-				try
-				{
+			If ($Pscmdlet.ShouldProcess($destination, "Creating server audit $auditspecname")) {
+				try {
 					Write-Output "Copying server audit $auditspecname"
 					$destserver.ConnectionContext.ExecuteNonQuery($auditspec.Script()) | Out-Null
 				}
-				catch
-				{
+				catch {
 					Write-Exception $_
 				}
 			}

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -1,12 +1,12 @@
 function Copy-DbaServerAuditSpecification {
 	<#
-		.SYNOPSIS 
-			Copy-DbaServerAuditSpecification migrates server audit specifications from one SQL Server to another. 
+		.SYNOPSIS
+			Copy-DbaServerAuditSpecification migrates server audit specifications from one SQL Server to another.
 
 		.DESCRIPTION
 			By default, all audits are copied. The -ServerAuditSpecification parameter is autopopulated for command-line completion and can be used to copy only specific audits.
 
-			If the audit specification already exists on the destination, it will be skipped unless -Force is used. 
+			If the audit specification already exists on the destination, it will be skipped unless -Force is used.
 
 		.PARAMETER Source
 			Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -14,9 +14,9 @@ function Copy-DbaServerAuditSpecification {
 		.PARAMETER SourceSqlCredential
 			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
 
-			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 		To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER Destination
@@ -25,9 +25,9 @@ function Copy-DbaServerAuditSpecification {
 		.PARAMETER DestinationSqlCredential
 			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
 
-			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 			To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER ServerAuditSpecification
@@ -36,16 +36,16 @@ function Copy-DbaServerAuditSpecification {
 		.PARAMETER ExcludeServerAuditSpecification
 			The Server Audit Specification(s) to exclude - this list is auto populated from the server
 
-		.PARAMETER WhatIf 
-			Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER WhatIf
+			Shows what would happen if the command were to run. No actions are actually performed.
 
-		.PARAMETER Confirm 
-			Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Confirm
+			Prompts you for confirmation before executing any changing operations within the command.
 
 		.PARAMETER Force
 			Drops and recreates the Audit Specification if it exists
 
-		.PARAMETER Silent 
+		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
@@ -60,17 +60,17 @@ function Copy-DbaServerAuditSpecification {
 		.LINK
 			https://dbatools.io/Copy-DbaServerAuditSpecification
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster
 
 			Copies all server audits from sqlserver2014a to sqlcluster, using Windows credentials. If audits with the same name exist on sqlcluster, they will be skipped.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -ServerAuditSpecification tg_noDbDrop -SourceSqlCredential $cred -Force
 
 			Copies a single audit, the tg_noDbDrop audit from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If an audit with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Copy-DbaServerAuditSpecification -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
 			Shows what would happen if the command were executed using force.
@@ -93,55 +93,69 @@ function Copy-DbaServerAuditSpecification {
 
 	begin {
 
-		$sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
-		$destserver = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
-		$source = $sourceserver.DomainInstanceName
-		$destination = $destserver.DomainInstanceName
-		if (!(Test-SqlSa -SqlInstance $sourceserver -SqlCredential $SourceSqlCredential)) { throw "Not a sysadmin on $source. Quitting." }
-		if (!(Test-SqlSa -SqlInstance $destserver -SqlCredential $DestinationSqlCredential)) { throw "Not a sysadmin on $destination. Quitting." }
-		if ($sourceserver.versionMajor -lt 10 -or $destserver.versionMajor -lt 10) {
+		$sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
+		$destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
+		$source = $sourceServer.DomainInstanceName
+		$destination = $destServer.DomainInstanceName
+
+		if (!(Test-SqlSa -SqlInstance $sourceServer -SqlCredential $SourceSqlCredential)) {
+			throw "Not a sysadmin on $source. Quitting."
+		}
+
+		if (!(Test-SqlSa -SqlInstance $destServer -SqlCredential $DestinationSqlCredential)) {
+			throw "Not a sysadmin on $destination. Quitting."
+		}
+
+		if ($sourceServer.versionMajor -lt 10 -or $destServer.versionMajor -lt 10) {
 			throw "Server Audit Specifications are only supported in SQL Server 2008 and above. Quitting."
 		}
-		$serverauditspecs = $sourceserver.ServerAuditSpecifications
-		$destaudits = $destserver.ServerAuditSpecifications
+
+		$serverAuditSpecs = $sourceServer.ServerAuditSpecifications
+		$destAudits = $destServer.ServerAuditSpecifications
 	}
 	process {
 
-		foreach ($auditspec in $serverauditspecs) {
-			$auditspecname = $auditspec.name
-			if ($auditspecs.length -gt 0 -and $auditspecs -notcontains $auditspecname) { continue }
-			$destserver.Audits.Refresh()
-			if ($destserver.Audits.Name -notcontains $auditspec.AuditName) {
-				Write-Warning "Audit $($auditspec.AuditName) does not exist on $Destination. Skipping $auditspecname."
+		foreach ($auditSpec in $serverAuditSpecs) {
+			$auditSpecName = $auditSpec.Name
+
+			if ($auditSpecs.length -gt 0 -and $auditSpecs -notcontains $auditSpecName) {
 				continue
 			}
-			if ($destaudits.name -contains $auditspecname) {
+
+			$destServer.Audits.Refresh()
+
+			if ($destServer.Audits.Name -notcontains $auditSpec.AuditName) {
+				Write-Warning "Audit $($auditSpec.AuditName) does not exist on $Destination. Skipping $auditSpecName."
+				continue
+			}
+
+			if ($destAudits.name -contains $auditSpecName) {
 				if ($force -eq $false) {
-					Write-Warning "Server audit $auditspecname exists at destination. Use -Force to drop and migrate."
+					Write-Warning "Server audit $auditSpecName exists at destination. Use -Force to drop and migrate."
 					continue
 				}
 				else {
-					If ($Pscmdlet.ShouldProcess($destination, "Dropping server audit $auditspecname and recreating")) {
+					if ($Pscmdlet.ShouldProcess($destination, "Dropping server audit $auditSpecName and recreating")) {
 						try {
-							Write-Verbose "Dropping server audit $auditspecname"
-							$destserver.ServerAuditSpecifications[$auditspecname].Drop()
+							Write-Verbose "Dropping server audit $auditSpecName"
+							$destServer.ServerAuditSpecifications[$auditSpecName].Drop()
 						}
 						catch {
-							Write-Exception $_ 							continue
+							Write-Exception $_
+							continue
 						}
 					}
 				}
 			}
-			If ($Pscmdlet.ShouldProcess($destination, "Creating server audit $auditspecname")) {
+			if ($Pscmdlet.ShouldProcess($destination, "Creating server audit $auditSpecName")) {
 				try {
-					Write-Output "Copying server audit $auditspecname"
-					$destserver.ConnectionContext.ExecuteNonQuery($auditspec.Script()) | Out-Null
+					Write-Output "Copying server audit $auditSpecName"
+					$destServer.ConnectionContext.ExecuteNonQuery($auditSpec.Script()) | Out-Null
 				}
 				catch {
 					Write-Exception $_
 				}
 			}
-
 		}
 	}
 	end {

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -4,7 +4,7 @@ function Copy-DbaServerAuditSpecification {
 			Copy-DbaServerAuditSpecification migrates server audit specifications from one SQL Server to another.
 
 		.DESCRIPTION
-			By default, all audits are copied. The -ServerAuditSpecification parameter is autopopulated for command-line completion and can be used to copy only specific audits.
+			By default, all audits are copied. The -ServerAuditSpec parameter is autopopulated for command-line completion and can be used to copy only specific audits.
 
 			If the audit specification already exists on the destination, it will be skipped unless -Force is used.
 
@@ -30,10 +30,10 @@ function Copy-DbaServerAuditSpecification {
 			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 			To connect as a different Windows user, run PowerShell as that user.
 
-		.PARAMETER ServerAuditSpecification
+		.PARAMETER ServerAuditSpec
 			The Server Audit Specification(s) to process - this list is auto populated from the server. If unspecified, all Server Audit Specifications will be processed.
 
-		.PARAMETER ExcludeServerAuditSpecification
+		.PARAMETER ExcludeServerAuditSpec
 			The Server Audit Specification(s) to exclude - this list is auto populated from the server
 
 		.PARAMETER WhatIf
@@ -85,8 +85,8 @@ function Copy-DbaServerAuditSpecification {
 		[DbaInstanceParameter]$Destination,
 		[PSCredential][System.Management.Automation.CredentialAttribute()]
 		$DestinationSqlCredential,
-		[object[]]$ServerAuditSpecification,
-		[object[]]$ExcludeServerAuditSpecification,
+		[object[]]$ServerAuditSpec,
+		[object[]]$ExcludeServerAuditSpec,
 		[switch]$Force,
 		[switch]$Silent
 	)
@@ -118,7 +118,7 @@ function Copy-DbaServerAuditSpecification {
 		foreach ($auditSpec in $serverAuditSpecs) {
 			$auditSpecName = $auditSpec.Name
 
-			if ($auditSpecs.length -gt 0 -and $auditSpecs -notcontains $auditSpecName) {
+			if ($ServerAuditSpec -and $auditSpecName -notin $ServerAuditSpec -or $auditSpecName -in $ExcludeServerAuditSpec) {
 				continue
 			}
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - formatted help
 - Add message system
 - Add logic to handle reverse copy, copying from higher version to lower version of SQL Server
 - update camelCase
 - Add output object
 - All output changed to verbose
 - removed End block code for closing connection and output text.
 - removed regex replace for source and destination as it is not needed.

![image](https://user-images.githubusercontent.com/11204251/27707156-e6202c3a-5cd9-11e7-8afb-a864f0f79c89.png)

On reverse copy on versions:
![image](https://user-images.githubusercontent.com/11204251/27707172-f548e92c-5cd9-11e7-8ccf-169af8b137dd.png)
