### PR TITLE
Output added for Copy-DbaServerTrigger

### DIFF
--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -117,7 +117,7 @@ function Copy-DbaServerTrigger {
 		foreach ($trigger in $serverTriggers) {
 			$triggerName = $trigger.Name
 			
-			if ($triggers.length -gt 0 -and $triggers -notcontains $triggerName) {
+			if ($ServerTrigger -and $triggerName -notin $ServerTrigger -or $triggerName -in $ExcludeServerTrigger) {
 				continue
 			}
 

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -99,8 +99,13 @@ function Copy-DbaServerTrigger {
 		$source = $sourceserver.DomainInstanceName
 		$destination = $destserver.DomainInstanceName
 
-		if ($sourceserver.versionMajor -lt 9 -or $destserver.versionMajor -lt 9) {
+		if ($sourceserver.VersionMajor -lt 9 -or $destserver.VersionMajor -lt 9) {
 			throw "Server Triggers are only supported in SQL Server 2005 and above. Quitting."
+		}
+
+		if ($destServer.VersionMajor -lt $sourceServer.VersionMajor) {
+			Stop-Function -Message "Migration from version $($destServer.VersionMajor) to version $($sourceServer.VersionMajor) is not supported."
+			return
 		}
 
 		$servertriggers = $sourceserver.Triggers

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -145,8 +145,10 @@ function Copy-DbaServerTrigger {
 				try {
 					Write-Message -Level Verbose -Message "Copying server trigger $triggerName"
 					$sql = $trigger.Script() | Out-String
+					$sql = $sql -replace "CREATE TRIGGER", "`nGO`nCREATE TRIGGER"
+					$sql = $sql -replace "ENABLE TRIGGER", "`nGO`nENABLE TRIGGER"
 					Write-Message -Level Debug -Message $sql
-					$destServer.Query($sql)
+					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 				}
 				catch {
 					Stop-Function -Message "Issue creating trigger on destination" -Target $triggerName -ErrorRecord $_

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -1,77 +1,80 @@
-function Copy-DbaServerTrigger
-{
-<#
-.SYNOPSIS 
-Copy-DbaServerTrigger migrates server triggers from one SQL Server to another. 
+function Copy-DbaServerTrigger {
+	<#
+		.SYNOPSIS
+			Copy-DbaServerTrigger migrates server triggers from one SQL Server to another.
 
-.DESCRIPTION
-By default, all triggers are copied. The -ServerTriggers parameter is autopopulated for command-line completion and can be used to copy only specific triggers.
+		.DESCRIPTION
+			By default, all triggers are copied. The -ServerTrigger parameter is autopopulated for command-line completion and can be used to copy only specific triggers.
 
-If the trigger already exists on the destination, it will be skipped unless -Force is used. 
+			If the trigger already exists on the destination, it will be skipped unless -Force is used.
 
-.PARAMETER Source
-Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER Source
+			Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER Destination
-Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+		.PARAMETER SourceSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-.PARAMETER SourceSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
 
-$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter. 
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			To connect as a different Windows user, run PowerShell as that user.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER Destination
+			Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-.PARAMETER DestinationSqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+		.PARAMETER DestinationSqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter. 
+			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. 	
-To connect as a different Windows user, run PowerShell as that user.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			To connect as a different Windows user, run PowerShell as that user.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER ServerTrigger
+			The Server Trigger(s) to process - this list is auto populated from the server. If unspecified, all Server Triggers will be processed.
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER ExcludeServerTrigger
+			The Server Trigger(s) to exclude - this list is auto populated from the server
 
-.PARAMETER Force
-Drops and recreates the Trigger if it exists
+		.PARAMETER WhatIf
+			Shows what would happen if the command were to run. No actions are actually performed.
 
-.NOTES
-Tags: Migration
-Author: Chrissy LeMaire (@cl), netnerds.net
-Requires: sysadmin access on SQL Servers
+		.PARAMETER Confirm
+			Prompts you for confirmation before executing any changing operations within the command.
 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+		.PARAMETER Force
+			Drops and recreates the Trigger if it exists
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+		.NOTES
+			Tags: Migration
+			Author: Chrissy LeMaire (@cl), netnerds.net
+			Requires: sysadmin access on SQL Servers
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Copy-DbaServerTrigger
+		.LINK
+			https://dbatools.io/Copy-DbaServerTrigger
 
-.EXAMPLE   
-Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster
+		.EXAMPLE
+			Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster
 
-Copies all server triggers from sqlserver2014a to sqlcluster, using Windows credentials. If triggers with the same name exist on sqlcluster, they will be skipped.
+			Copies all server triggers from sqlserver2014a to sqlcluster, using Windows credentials. If triggers with the same name exist on sqlcluster, they will be skipped.
 
-.EXAMPLE   
-Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -ServerTrigger tg_noDbDrop -SourceSqlCredential $cred -Force
+		.EXAMPLE
+			Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -ServerTrigger tg_noDbDrop -SourceSqlCredential $cred -Force
 
-Copies a single trigger, the tg_noDbDrop trigger from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a trigger with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
+			Copies a single trigger, the tg_noDbDrop trigger from sqlserver2014a to sqlcluster, using SQL credentials for sqlserver2014a and Windows credentials for sqlcluster. If a trigger with the same name exists on sqlcluster, it will be dropped and recreated because -Force was used.
 
-.EXAMPLE   
-Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
+		.EXAMPLE
+			Copy-DbaServerTrigger -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
-Shows what would happen if the command were executed using force.
-#>
+			Shows what would happen if the command were executed using force.
+	#>
 	[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 	param (
 		[parameter(Mandatory = $true)]
@@ -87,65 +90,55 @@ Shows what would happen if the command were executed using force.
 
 		$sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
-		
+
 		$source = $sourceserver.DomainInstanceName
 		$destination = $destserver.DomainInstanceName
-		
-		if ($sourceserver.versionMajor -lt 9 -or $destserver.versionMajor -lt 9)
-		{
+
+		if ($sourceserver.versionMajor -lt 9 -or $destserver.versionMajor -lt 9) {
 			throw "Server Triggers are only supported in SQL Server 2005 and above. Quitting."
 		}
-		
+
 		$servertriggers = $sourceserver.Triggers
 		$desttriggers = $destserver.Triggers
-		
+
 	}
 	process {
 
-		foreach ($trigger in $servertriggers)
-		{
+		foreach ($trigger in $servertriggers) {
 			$triggername = $trigger.name
 			if ($triggers.length -gt 0 -and $triggers -notcontains $triggername) { continue }
-			
-			if ($desttriggers.name -contains $triggername)
-			{
-				if ($force -eq $false)
-				{
+
+			if ($desttriggers.name -contains $triggername) {
+				if ($force -eq $false) {
 					Write-Warning "Server trigger $triggername exists at destination. Use -Force to drop and migrate."
 					continue
 				}
-				else
-				{
-					If ($Pscmdlet.ShouldProcess($destination, "Dropping server trigger $triggername and recreating"))
-					{
-						try
-						{
+				else {
+					If ($Pscmdlet.ShouldProcess($destination, "Dropping server trigger $triggername and recreating")) {
+						try {
 							Write-Verbose "Dropping server trigger $triggername"
 							$destserver.triggers[$triggername].Drop()
 						}
-						catch { 
-							Write-Exception $_ 
+						catch {
+							Write-Exception $_
 							continue
 						}
 					}
 				}
 			}
 
-			If ($Pscmdlet.ShouldProcess($destination, "Creating server trigger $triggername"))
-			{
-				try
-				{
+			If ($Pscmdlet.ShouldProcess($destination, "Creating server trigger $triggername")) {
+				try {
 					Write-Output "Copying server trigger $triggername"
 					$sql = $trigger.Script() | Out-String
 					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
 					$sql = $sql -replace "CREATE TRIGGER", "`nGO`nCREATE TRIGGER"
 					$sql = $sql -replace "ENABLE TRIGGER", "`nGO`nENABLE TRIGGER"
-					
+
 					Write-Verbose $sql
 					$destserver.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
 				}
-				catch
-				{
+				catch {
 					Write-Exception $_
 				}
 			}

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -145,8 +145,6 @@ function Copy-DbaServerTrigger {
 					Write-Output "Copying server trigger $triggerName"
 					$sql = $trigger.Script() | Out-String
 					$sql = $sql -replace [Regex]::Escape("'$source'"), "'$destination'"
-					$sql = $sql -replace "CREATE TRIGGER", "`nGO`nCREATE TRIGGER"
-					$sql = $sql -replace "ENABLE TRIGGER", "`nGO`nENABLE TRIGGER"
 
 					Write-Verbose $sql
 					$destServer.Query($sql)

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -79,11 +79,16 @@ function Copy-DbaServerTrigger {
 	param (
 		[parameter(Mandatory = $true)]
 		[DbaInstanceParameter]$Source,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$SourceSqlCredential,
 		[parameter(Mandatory = $true)]
 		[DbaInstanceParameter]$Destination,
-		[System.Management.Automation.PSCredential]$SourceSqlCredential,
-		[System.Management.Automation.PSCredential]$DestinationSqlCredential,
-		[switch]$Force
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$DestinationSqlCredential,
+		[object[]]$ServerTrigger,
+		[object[]]$ExcludeServerTrigger,
+		[switch]$Force,
+		[switch]$Silent
 	)
 
 	begin {

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -149,7 +149,7 @@ function Copy-DbaServerTrigger {
 					$sql = $sql -replace "ENABLE TRIGGER", "`nGO`nENABLE TRIGGER"
 
 					Write-Verbose $sql
-					$destServer.ConnectionContext.ExecuteNonQuery($sql) | Out-Null
+					$destServer.Query($sql)
 				}
 				catch {
 					Write-Exception $_


### PR DESCRIPTION
Changes proposed in this pull request:
 - formatted help
 - Add message system
 - Add logic to handle reverse copy, copying from higher version to lower version of SQL Server
 - update camelCase
 - Add output object
 - All output changed to verbose
 - removed End block code for closing connection and output text.
 - removed regex replace for source and destination as it is not needed.

![image](https://user-images.githubusercontent.com/11204251/27709434-b24ef492-5ce1-11e7-9d35-0bc9f8e4e1e3.png)
