### PR TITLE
Test-DbaJobOwner address logic for validating login

### DIFF
--- a/functions/Test-DbaJobOwner.ps1
+++ b/functions/Test-DbaJobOwner.ps1
@@ -84,7 +84,8 @@ function Test-DbaJobOwner {
 			#Validate login
 			if (($server.Logins.Name) -notcontains $Login) {
 				if ($SqlInstance.count -eq 1) {
-					throw "Invalid login: $Login"
+					Stop-Function -Message "Invalid login: $Login"
+					return
 				}
 				else {
 					Write-Message -Level Warning -Message "$Login is not a valid login on $servername. Moving on."
@@ -103,7 +104,8 @@ function Test-DbaJobOwner {
 			}
 			
 			if ($server.logins[$Login].LoginType -eq 'WindowsGroup') {
-				throw "$Login is a Windows Group and can not be a job owner."
+				Stop-Function -Message "$Login is a Windows Group and can not be a job owner."
+				return
 			}
 			
 			#Get database list. If value for -Job is passed, massage to make it a string array.


### PR DESCRIPTION
Fixes #1529 

Changes proposed in this pull request:
 - Adjusted throw message to be stop-function (pretty output now)
 - Formatted the .DESCRIPTION a bit so it is easier to read and bring attention to output
 - Corrected a few camelCase format
 - Rearranged and adjusted logic for validating the `$Login`

Seems to be working now, in the sense that if you don't pass in a login then all jobs will output as false. If that is no the intended behavior let me know what it should be.
![image](https://user-images.githubusercontent.com/11204251/27740688-618d2d34-5d78-11e7-8612-126d31e98a6b.png)
