### PR TITLE
Was-Bound - Multiplayer upgrades

### DIFF
--- a/internal/Was-Bound.ps1
+++ b/internal/Was-Bound.ps1
@@ -1,5 +1,4 @@
-﻿
-function Was-Bound
+﻿function Was-Bound
 {
     <#
         .SYNOPSIS
@@ -9,10 +8,14 @@ function Was-Bound
             Helperfunction that tests, whether a parameter was bound.
         
         .PARAMETER ParameterName
-            The name of the parameter that is tested for being bound.
+            The name(s) of the parameter that is tested for being bound.
+			By default, the check is true when AT LEAST one was bound.
     
         .PARAMETER Not
-            Rverses the result. Returns true if NOT bound and false if bound.
+            Reverses the result. Returns true if NOT bound and false if bound.
+	
+		.PARAMETER And
+			All specified parameters must be present, rather than at least one of them.
         
         .PARAMETER BoundParameters
             The hashtable of bound parameters. Is automatically inherited from the calling function via default value. Needs not be bound explicitly.
@@ -24,23 +27,49 @@ function Was-Bound
             }
     
             Snippet as part of a function. Will check whether the parameter "Day" was bound. If yes, whatever logic is in the conditional will be executed.
-        
-        .NOTES
-            Additional information about the function.
+	
+		.EXAMPLE
+			Was-Bound -Not 'Login', 'Spid', 'ExcludeSpid', 'Host', 'Program', 'Database'
+	
+			Returns whether none of the parameters above were specified.
+	
+		.EXAMPLE
+			Was-Bound -And 'Login', 'Spid', 'ExcludeSpid', 'Host', 'Program', 'Database' 
+	
+			Returns whether any of the specified parameters was not bound
     #>
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true, Position = 0)]
-        [string]
+        [string[]]
         $ParameterName,
         
         [Alias('Reverse')]
         [switch]
-        $Not,
+		$Not,
+		
+		[switch]
+		$And,
         
         [object]
         $BoundParameters = (Get-PSCallStack)[0].InvocationInfo.BoundParameters
-    )
-    
-    return ((-not $Not) -eq $BoundParameters.ContainsKey($ParameterName))
+	)
+	
+	if ($And) {
+		$test = $true
+	}
+	else {
+		$test = $false
+	}
+	
+	foreach ($name in $ParameterName) {
+		if ($And) {
+			if (-not $BoundParameters.ContainsKey($name)) { $test = $false }
+		}
+		else {
+			if ($BoundParameters.ContainsKey($name)) { $test = $true }
+		}
+	}
+	
+	return ((-not $Not) -eq $test)
 }


### PR DESCRIPTION
Enables `Was-Bound` to understand multiple parameters as input.
Implements both `-And` and `-Or` logic (was any one bound or were all bound) as well as the negation.
Defaults to `-Or`