### PR TITLE
TEPP for Get-DbaProcess

### DIFF
--- a/internal/dynamicparams/processHostname.ps1
+++ b/internal/dynamicparams/processHostname.ps1
@@ -1,0 +1,41 @@
+﻿$scriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processhostname"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	if (-not $server) {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processhostname"].LastDuration = (Get-Date) - $start
+		return
+	}
+	$sqlCredential = $fakeBoundParameter['SqlCredential']
+	
+	try {
+		if ($sqlCredential) { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop }
+		else { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop }
+		
+		$instance.EnumProcesses().Host | Select-Object -Unique | Where-DbaObject -Like "$wordToComplete*" | ForEach-Object {
+			if (-not ([string]::IsNullOrWhiteSpace($_))) { New-DbaTeppCompletionResult -CompletionText $_ -ToolTip $_ }
+		}
+	}
+	catch {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processhostname"].LastDuration = (Get-Date) - $start
+		return
+	}
+	finally {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processhostname"].LastDuration = (Get-Date) - $start
+	}
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $scriptBlock -Name processhostname

--- a/internal/dynamicparams/processProgram.ps1
+++ b/internal/dynamicparams/processProgram.ps1
@@ -1,0 +1,41 @@
+﻿$scriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processprogram"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	if (-not $server) {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processprogram"].LastDuration = (Get-Date) - $start
+		return
+	}
+	$sqlCredential = $fakeBoundParameter['SqlCredential']
+	
+	try {
+		if ($sqlCredential) { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop  }
+		else { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop }
+		
+		$instance.EnumProcesses().Program | Select-Object -Unique | Where-DbaObject -Like "$wordToComplete*" | ForEach-Object {
+			if (-not ([string]::IsNullOrWhiteSpace($_))) { New-DbaTeppCompletionResult -CompletionText $_ -ToolTip $_ }
+		}
+	}
+	catch {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processprogram"].LastDuration = (Get-Date) - $start
+		return
+	}
+	finally {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processprogram"].LastDuration = (Get-Date) - $start
+	}
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $scriptBlock -Name processprogram

--- a/internal/dynamicparams/processSpid.ps1
+++ b/internal/dynamicparams/processSpid.ps1
@@ -1,0 +1,41 @@
+﻿$scriptBlock = {
+	param (
+		$commandName,
+		
+		$parameterName,
+		
+		$wordToComplete,
+		
+		$commandAst,
+		
+		$fakeBoundParameter
+	)
+	
+	$start = Get-Date
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processspid"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	if (-not $server) {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processspid"].LastDuration = (Get-Date) - $start
+		return
+	}
+	$sqlCredential = $fakeBoundParameter['SqlCredential']
+	
+	try {
+		if ($sqlCredential) { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop }
+		else { $instance = Connect-DbaSqlServer -SqlInstance $server -ErrorAction Stop }
+		
+		$instance.EnumProcesses().Spid | Select-Object -Unique | Where-DbaObject -Like "$wordToComplete*" | ForEach-Object {
+			if (-not ([string]::IsNullOrWhiteSpace($_))) { New-DbaTeppCompletionResult -CompletionText $_ -ToolTip $_ }
+		}
+	}
+	catch {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processspid"].LastDuration = (Get-Date) - $start
+		return
+	}
+	finally {
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["processspid"].LastDuration = (Get-Date) - $start
+	}
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $scriptBlock -Name processspid

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -44,6 +44,10 @@ Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter FullName -
 Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter Name -Name configname
 Register-DbaTeppArgumentCompleter -Command "Get-DbaConfig" -Parameter Module -Name configmodule
 Register-DbaTeppArgumentCompleter -Command "Get-DbaConfigValue" -Parameter Name -Name config
+Register-DbaTeppArgumentCompleter -Command "Get-DbaProcess" -Parameter Spid -Name processSpid
+Register-DbaTeppArgumentCompleter -Command "Get-DbaProcess" -Parameter ExcludeSpid -Name processSpid
+Register-DbaTeppArgumentCompleter -Command "Get-DbaProcess" -Parameter Hostname -Name processHostname
+Register-DbaTeppArgumentCompleter -Command "Get-DbaProcess" -Parameter Program -Name processProgram
 Register-DbaTeppArgumentCompleter -Command "Set-DbaConfig" -Parameter Name -Name config
 Register-DbaTeppArgumentCompleter -Command "Set-DbaConfig" -Parameter Module -Name configmodule
 #endregion Explicit TEPP


### PR DESCRIPTION
Introduces TEPP for Get-DbaProcess:
- Spid
- ExcludeSpid
- Hostname
- Program
This information is retrieved at runtime, since caching is not useful on something retrieving fairly shortlived information