### PR TITLE
Add support for installing the development branch

### DIFF
--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -1,11 +1,5 @@
 Function Update-DbaTools
 {
-[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact="Low")]
-param(
-	[parameter(Mandatory=$false)]
-	[Alias("dev","devbranch")]
-	[switch]$Development
-)
 <#
 .SYNOPSIS
 Exported function. Updates dbatools. Deletes current copy and replaces it with freshest copy.
@@ -47,6 +41,12 @@ Update-DbaTools -dev
 Updates dbatools to the current development branch. Deletes current copy and replaces it with latest from github
 
 #>	
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact="Low")]
+param(
+	[parameter(Mandatory=$false)]
+	[Alias("dev","devbranch")]
+	[switch]$Development
+)
 	$MyModuleBase = (Get-Module -name dbatools).ModuleBase;
 	$InstallScript = join-path -path $MyModuleBase -ChildPath "install.ps1";
 	if($Development) {

--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -10,6 +10,12 @@ Exported function. Updates dbatools. Deletes current copy and replaces it with f
 .PARAMETER Development
 Installs the current development branch of dbatools instead of the latest release.
 
+.PARAMETER WhatIf
+Shows what would happen if the command were to run. No actions are actually performed.
+
+.PARAMETER Confirm
+Prompts you for confirmation before executing any changing operations within the command.
+
 .NOTES 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -1,11 +1,20 @@
-Function Update-Dbatools
+Function Update-DbaTools
 {
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact="Low")]
+param(
+	[parameter(Mandatory=$false)]
+	[Alias("dev","devbranch")]
+	[switch]$Development
+)
 <#
 .SYNOPSIS
 Exported function. Updates dbatools. Deletes current copy and replaces it with freshest copy.
 
 .DESCRIPTION
 Exported function. Updates dbatools. Deletes current copy and replaces it with freshest copy.
+
+.PARAMETER Development
+Installs the current development branch of dbatools instead of the latest release.
 
 .NOTES 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
@@ -28,10 +37,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 https://dbatools.io/Update-dbatools
 
 .EXAMPLE
-Update-dbatools
+Update-DbaTools
 
 Updates dbatools. Deletes current copy and replaces it with freshest copy.
-	
+
+.EXAMPLE
+Update-DbaTools -dev
+
+Updates dbatools to the current development branch. Deletes current copy and replaces it with latest from github
+
 #>	
-	Invoke-Expression (Invoke-WebRequest -UseBasicParsing https://dbatools.io/in).Content
+	$MyModuleBase = (Get-Module -name dbatools).ModuleBase;
+	$InstallScript = join-path -path $MyModuleBase -ChildPath "install.ps1";
+	if($Development) {
+		Write-Verbose "Installing dev/beta channel via $Installscript";
+		if ($PSCmdlet.ShouldProcess("development branch","Updating dbatools")) {
+			& $InstallScript -beta;
+		}
+	}
+	else {
+		Write-Verbose "Installing release version via $Installscript"
+		if ($PSCmdlet.ShouldProcess("release branch","Updating dbatools")) {
+			& $InstallScript;
+		}
+	}
 }


### PR DESCRIPTION
Change casing to match other dbatools cmdlets, add support for `WhatIf` and `Verbose`, allow user to select the development branch

Fixes # 

Changes proposed in this pull request:
 - Add `Whatif` support to Update-DbaTools
 - Add support for installing the beta/dev release of dbatools

How to test this code: 
- [ ] `Update-DbaTools -dev` (should install the current development branch)
- [ ] `Update-DbaTools` (should install the latest released version)

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [X]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X ] Working/useful help content, including link to command on dbatools web site
- [X] All examples work as advertised
- [X] Does not contain template content
- [X] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [X] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers