### PR TITLE
Fixed SQL query for Get-DbaTempdbUsage function

### DIFF
--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -38,54 +38,89 @@ Function Get-DbaTempdbUsage {
 	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential][System.Management.Automation.CredentialAttribute()]$SqlCredential,
+		[object[]]$SqlInstance,
+		[System.Management.Automation.PSCredential]$SqlCredential,
 		[switch]$Silent
 	)
 	
 	process {
 		foreach ($instance in $SqlInstance) {
 			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
 			}
 			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+				Stop-Function -Message "Failed to connect to: $instance" -Continue -Target $Instance
 			}
 			
 			if ($server.VersionMajor -le 9) {
 				Stop-Function -Message "This function is only supported in SQL Server 2008 or higher." -Continue
 			}
 			
-			$sql = "SELECT SERVERPROPERTY('MachineName') AS ComputerName, 
-							       ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName, 
-							       SERVERPROPERTY('ServerName') AS SqlInstance, 
-							       t.session_id AS Spid, 
-							       r.command AS StatementCommand, 
-							       r.start_time AS StartTime, 
-							       t.user_objects_alloc_page_count * 8 AS UserObjectAllocatedSpace, 
-							       t.user_objects_dealloc_page_count * 8 AS UserObjectDeallocatedSpace, 
-							       t.internal_objects_alloc_page_count * 8 AS InternalObjectAllocatedSpace, 
-							       t.internal_objects_dealloc_page_count * 8 AS InternalObjectDeallocatedSpace, 
-							       r.reads AS RequestedReads, 
-							       r.writes AS RequestedWrites, 
-							       r.logical_reads AS RequestedLogicalReads, 
-							       r.cpu_time AS RequestedCPUTime, 
-							       s.is_user_process AS IsUserProcess, 
-							       s.[status] AS Status, 
-							       DB_NAME(r.database_id) AS [Database], 
-							       s.login_name AS LoginName, 
-							       s.original_login_name AS OriginalLoginName, 
-							       s.nt_domain AS NTDomain, 
-							       s.nt_user_name AS NTUserName, 
-							       s.[host_name] AS HostName, 
-							       s.[program_name] AS ProgramName, 
-							       s.login_time AS LoginTime, 
-							       s.last_request_start_time AS LastRequestedStartTime, 
-							       s.last_request_end_time AS LastRequestedEndTime 
-							FROM sys.dm_db_session_space_usage AS t 
-							INNER JOIN sys.dm_exec_sessions AS s ON s.session_id = t.session_id 
-							INNER JOIN sys.dm_exec_requests AS r ON r.session_id = s.session_id
-							WHERE t.user_objects_alloc_page_count + t.user_objects_dealloc_page_count + t.internal_objects_alloc_page_count + t.internal_objects_dealloc_page_count > 0"
+            $sql = "SELECT  SERVERPROPERTY('MachineName') AS ComputerName,
+        ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName,
+        SERVERPROPERTY('ServerName') AS SqlInstance,
+        t.session_id AS Spid,
+        r.command AS StatementCommand,
+        SUBSTRING(   est.[text],
+                     (r.statement_start_offset / 2) + 1,
+                     ((CASE r.statement_end_offset
+                            WHEN-1
+                            THEN DATALENGTH(est.[text])
+                            ELSE
+                            r.statement_end_offset
+                       END - r.statement_start_offset
+                      ) / 2
+                     ) + 1
+                 ) AS QueryText,
+        QUOTENAME(DB_NAME(r.database_id)) + N'.' + QUOTENAME(OBJECT_SCHEMA_NAME(est.objectid, est.dbid)) + N'.'
+        + QUOTENAME(OBJECT_NAME(est.objectid, est.dbid)) AS ProcedureName,
+        r.start_time AS StartTime,
+        tdb.UserObjectAllocated * 8 AS CurrentUserAllocatedKB,
+        (t.user_objects_alloc_page_count + tdb.UserObjectAllocated) * 8 AS TotalUserAllocatedKB,
+        tdb.UserObjectDeallocated * 8 AS UserDeallocatedKB,
+        (t.user_objects_dealloc_page_count + tdb.UserObjectDeallocated) * 8 AS TotalUserDeallocatedKB,
+        tdb.InternalObjectAllocated * 8 AS InternalAllocatedKB,
+        (t.internal_objects_alloc_page_count + tdb.InternalObjectAllocated) * 8 AS TotalInternalAllocatedKB,
+        tdb.InternalObjectDeallocated * 8 AS InternalDeallocatedKB,
+        (t.internal_objects_dealloc_page_count + tdb.InternalObjectDeallocated) * 8 AS TotalInternalDeallocatedKB,
+        r.reads AS RequestedReads,
+        r.writes AS RequestedWrites,
+        r.logical_reads AS RequestedLogicalReads,
+        r.cpu_time AS RequestedCPUTime,
+        s.is_user_process AS IsUserProcess,
+        s.[status] AS [Status],
+        DB_NAME(r.database_id) AS [Database],
+        s.login_name AS LoginName,
+        s.original_login_name AS OriginalLoginName,
+        s.nt_domain AS NTDomain,
+        s.nt_user_name AS NTUserName,
+        s.[host_name] AS HostName,
+        s.[program_name] AS ProgramName,
+        s.login_time AS LoginTime,
+        s.last_request_start_time AS LastRequestedStartTime,
+        s.last_request_end_time AS LastRequestedEndTime
+FROM    sys.dm_db_session_space_usage AS t
+INNER JOIN sys.dm_exec_sessions AS s
+    ON s.session_id = t.session_id
+LEFT JOIN sys.dm_exec_requests AS r
+    ON r.session_id = s.session_id
+LEFT JOIN
+          (   SELECT    _tsu.session_id,
+                        _tsu.request_id,
+                        SUM(_tsu.user_objects_alloc_page_count)       AS UserObjectAllocated,
+                        SUM(_tsu.user_objects_dealloc_page_count)     AS UserObjectDeallocated,
+                        SUM(_tsu.internal_objects_alloc_page_count)   AS InternalObjectAllocated,
+                        SUM(_tsu.internal_objects_dealloc_page_count) AS InternalObjectDeallocated
+              FROM      tempdb.sys.dm_db_task_space_usage AS _tsu
+              GROUP BY  _tsu.session_id,
+                        _tsu.request_id
+          ) AS tdb
+    ON  tdb.session_id = r.session_id
+   AND  tdb.request_id = r.request_id
+OUTER APPLY sys.dm_exec_sql_text(r.[sql_handle]) AS est
+WHERE   t.session_id != @@SPID
+  AND   (tdb.UserObjectAllocated - tdb.UserObjectDeallocated + tdb.InternalObjectAllocated - tdb.InternalObjectDeallocated) != 0
+OPTION (RECOMPILE);"
 			
 			$server.ConnectionContext.ExecuteWithResults($sql).Tables
 		}

--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -38,18 +38,18 @@ Function Get-DbaTempdbUsage {
 	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[object[]]$SqlInstance,
-		[System.Management.Automation.PSCredential]$SqlCredential,
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]$SqlCredential,
 		[switch]$Silent
 	)
 	
 	process {
 		foreach ($instance in $SqlInstance) {
 			try {
-				$server = Connect-SqlServer -SqlServer $instance -SqlCredential $sqlcredential
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
 			}
 			catch {
-				Stop-Function -Message "Failed to connect to: $instance" -Continue -Target $Instance
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 			
 			if ($server.VersionMajor -le 9) {


### PR DESCRIPTION
Should take into account currently running sessions and parallel queries

Fixes #1104  

Changes proposed in this pull request:
 - fixed SQL query to account for tempdb usage in currently running queries
 - Aggregates parallel queries to stop "false duplicates" showing
 - Added more information and columns to the result set

How to test this code: 
- [ ] Run on an active or inactive SQL Instance, should return sessions using tempdb, system or user.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

