### PR TITLE
History/Restore pipe fix

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -361,9 +361,9 @@ function Restore-DbaDatabase {
                 }
                 if ("BackupSetGUID" -notin $f.PSobject.Properties.name) {
                     #This line until Get-DbaBackupHistory gets fixed
-                    $f = $f | Select-Object *, @{ Name = "BackupSetGUID"; Expression = { $_.BackupSetupID } }
+                    #$f = $f | Select-Object *, @{ Name = "BackupSetGUID"; Expression = { $_.BackupSetupID } }
                     #This one once it's sorted:
-                    #$f = $f | Select-Object *, @{Name="BackupSetGUID";Expression={$_.BackupSetID}}
+                    $f = $f | Select-Object *, @{Name="BackupSetGUID";Expression={$_.BackupSetID}}
                 }
                 if ($f.BackupPath -like 'http*' -and '' -eq $AzureCredential) {
                     Stop-Function -Message "At least one Azure backup passed in, and no Credential supplied. Stopping"

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -267,7 +267,7 @@
             $ErrVar | Should be BeNullOrEmpty
         }
         It "SHould have restore everything" {
-            ($results.RestorComplete -contains $false | Should be $False
+            ($results.RestorComplete -contains $false) | Should be $False
         }
 
     }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -249,12 +249,14 @@
         }
 
     }
+
     Context "Backup DB For next test" {
-        $results = Backup-DbaDatabase -SqlInstance localhost host -Database RestoreTimeClean
-        It "Should return successful restore" {
+        $results = Backup-DbaDatabase -SqlInstance localhost -Database RestoreTimeClean -BackupDirectory C:\temp\backups
+        It "Should return successful backup" {
 			$results.BackupComplete | Should Be $true
 		}
     }
+
     Context "All user databases are removed post continue test" {
         $results = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
         It "Should say the status was dropped" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -266,17 +266,10 @@
 
     Context "Check Get-DbaBackupHistory pipes into Restore-DbaDatabase" {
         $history = Get-DbaBackupHistory -SqlInstance localhost -Database RestoreTimeClean -Last
-        $results = $history | Restore-DbaDatabase -SqlInstance localhost -WithReplace -WarningVariable WarnVar -ErrorVariable ErrVar -TrustDbBackupHistory
-        It "Should have no warnings" {
-            $WarnVar | Should be BeNullOrEmpty
-        }
-        It "Should have no errors" {
-            $ErrVar | Should be BeNullOrEmpty
-        }
-        It "SHould have restore everything" {
+        $results = $history | Restore-DbaDatabase -SqlInstance localhost -WithReplace -TrustDbBackupHistory
+        It "Should have restored everything successfully" {
             ($results.RestorComplete -contains $false) | Should be $False
         }
-
     }
 
     Context "All user databases are removed post history test" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -249,7 +249,12 @@
         }
 
     }
-
+    Context "Backup DB For next test" {
+        $results = Backup-DbaDatabase -SqlInstance localhost host -Database RestoreTimeClean
+        It "Should return successful restore" {
+			$results.RestoreComplete | Should Be $true
+		}
+    }
     Context "All user databases are removed post continue test" {
         $results = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
         It "Should say the status was dropped" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -252,7 +252,7 @@
     Context "Backup DB For next test" {
         $results = Backup-DbaDatabase -SqlInstance localhost host -Database RestoreTimeClean
         It "Should return successful restore" {
-			$results.RestoreComplete | Should Be $true
+			$results.BackupComplete | Should Be $true
 		}
     }
     Context "All user databases are removed post continue test" {


### PR DESCRIPTION
Piping from Get-DbaBackupHistory to Restore-DbaDatabase wasn't working.

Now is, and there's a test to keep an eye on it for future developments

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

