### PR TITLE
Adding TEPP parameters

### DIFF
--- a/internal/dynamicparams/alert.ps1
+++ b/internal/dynamicparams/alert.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alert"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alert"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alert"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alert"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alert"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name alert
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alert"][$FullSmoName] = $server.JobServer.Alerts.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/alertcategory.ps1
+++ b/internal/dynamicparams/alertcategory.ps1
@@ -1,0 +1,82 @@
+#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alertcategory"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alertcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alertcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alertcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["alertcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name AlertCategory
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["alertcategory"][$FullSmoName] = $server.JobServer.AlertCategories.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/audit.ps1
+++ b/internal/dynamicparams/audit.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["audit"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["audit"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["audit"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["audit"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["audit"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Audit
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["audit"][$FullSmoName] = $server.Audits.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/auditspecification.ps1
+++ b/internal/dynamicparams/auditspecification.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["auditspecification"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["auditspecification"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["auditspecification"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["auditspecification"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["auditspecification"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name AuditSpecification
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["auditspecification"][$FullSmoName] = $server.AuditSpecifications.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/availabilitygroup.ps1
+++ b/internal/dynamicparams/availabilitygroup.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["availabilitygroup"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["availabilitygroup"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["availabilitygroup"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["availabilitygroup"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["availabilitygroup"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name AvailabilityGroup
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["availabilitygroup"][$FullSmoName] = $server.AvailabilityGroups.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/backupdevice.ps1
+++ b/internal/dynamicparams/backupdevice.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["backupdevice"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["backupdevice"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["backupdevice"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["backupdevice"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["backupdevice"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name BackupDevice
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["backupdevice"][$FullSmoName] = $server.BackupDevices.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/configname.ps1
+++ b/internal/dynamicparams/configname.ps1
@@ -1,0 +1,83 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["configname"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name ConfigName
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["configname"][$FullSmoName] = (Get-Member -InputObject $server.Configuration -MemberType Property -Force | Where-Object Name -NotIn 'Parent',
+		'Properties').Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/credential.ps1
+++ b/internal/dynamicparams/credential.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["credential"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["credential"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["credential"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["credential"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["credential"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Credential
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["credential"][$FullSmoName] = $server.Credentials.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/customerror.ps1
+++ b/internal/dynamicparams/customerror.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["customerror"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["customerror"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["customerror"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["customerror"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["customerror"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name CustomError
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["customerror"][$FullSmoName] = $server.UserDefinedMessages.ID
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/endpoint.ps1
+++ b/internal/dynamicparams/endpoint.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["endpoint"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["endpoint"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["endpoint"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["endpoint"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["endpoint"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Endpoint
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["endpoint"][$FullSmoName] = ($server.Endpoints | Where-Object IsSystemObject -eq $false).Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/jobcategory.ps1
+++ b/internal/dynamicparams/jobcategory.ps1
@@ -1,0 +1,82 @@
+#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["jobcategory"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["jobcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["jobcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["jobcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["jobcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name JobCategory
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["jobcategory"][$FullSmoName] = $server.JobServer.JobCategories.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/linkedserver.ps1
+++ b/internal/dynamicparams/linkedserver.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["linkedserver"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["linkedserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["linkedserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["linkedserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["linkedserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name LinkedServer
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["linkedserver"][$FullSmoName] = $server.LinkedServers.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/mailaccount.ps1
+++ b/internal/dynamicparams/mailaccount.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailaccount"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name MailAccount
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailaccount"][$FullSmoName] = $server.Mail.Accounts.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/mailprofile.ps1
+++ b/internal/dynamicparams/mailprofile.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailprofile"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailprofile"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailprofile"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailprofile"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailprofile"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name MailProfile
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailprofile"][$FullSmoName] = $server.Mail.Profiles.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/mailserver.ps1
+++ b/internal/dynamicparams/mailserver.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailserver"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["mailserver"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name MailServer
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["mailserver"][$FullSmoName] = $server.Mail.Accounts.MailServers.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/operatorcategory.ps1
+++ b/internal/dynamicparams/operatorcategory.ps1
@@ -1,0 +1,82 @@
+#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["operatorcategory"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["operatorcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["operatorcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["operatorcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["operatorcategory"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name OperatorCategory
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["operatorcategory"][$FullSmoName] = $server.JobServer.OperatorCategories.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/proxyaccount.ps1
+++ b/internal/dynamicparams/proxyaccount.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["proxyaccount"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["proxyaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["proxyaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["proxyaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["proxyaccount"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name ProxyAccount
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["proxyaccount"][$FullSmoName] = $server.JobServer.ProxyAccounts.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/resourcepool.ps1
+++ b/internal/dynamicparams/resourcepool.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["resourcepool"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["resourcepool"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["resourcepool"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["resourcepool"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["resourcepool"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name ResourcePool
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["resourcepool"][$FullSmoName] = ($server.ResourceGovernor.ResourcePools | Where-Object Name -NotIn 'internal','default').Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/schedule.ps1
+++ b/internal/dynamicparams/schedule.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["schedule"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["schedule"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["schedule"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["schedule"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["schedule"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Schedule
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["schedule"][$FullSmoName] = $server.JobServer.SharedSchedules.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/dynamicparams/servertrigger.ps1
+++ b/internal/dynamicparams/servertrigger.ps1
@@ -1,0 +1,82 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["servertrigger"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["servertrigger"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["servertrigger"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["servertrigger"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["servertrigger"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name ServerTrigger
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["servertrigger"][$FullSmoName] = $server.Triggers.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -126,6 +126,48 @@ foreach ($function in $functions) {
 	if ($function.Parameters.Keys -contains "LinkedServer") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeLinkedServer -Name LinkedServer
 	}
+
+	if ($function.Parameters.Keys -contains "ProxyAccount") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ProxyAccount -Name ProxyAccount
+	}
+	if ($function.Parameters.Keys -contains "ProxyAccount") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeProxyAccount -Name ProxyAccount
+	}
+
+	if ($function.Parameters.Keys -contains "ResourcePool") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ResourcePool -Name ResourcePool
+	}
+	if ($function.Parameters.Keys -contains "ResourcePool") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeResourcePool -Name ResourcePool
+	}
+
+	if ($function.Parameters.Keys -contains "Audit") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Audit -Name Audit
+	}
+	if ($function.Parameters.Keys -contains "Audit") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAudit -Name Audit
+	}
+
+	if ($function.Parameters.Keys -contains "AuditSpecification") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AuditSpecification -Name AuditSpecification
+	}
+	if ($function.Parameters.Keys -contains "AuditSpecification") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAuditSpecification -Name AuditSpecification
+	}
+
+	if ($function.Parameters.Keys -contains "ServerTrigger") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ServerTrigger -Name ServerTrigger
+	}
+	if ($function.Parameters.Keys -contains "ServerTrigger") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeServerTrigger -Name ServerTrigger
+	}
+
+	if ($function.Parameters.Keys -contains "Schedule") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Schedule -Name Schedule
+	}
+	if ($function.Parameters.Keys -contains "Schedule") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSchedule -Name Schedule
+	}
 }
 #endregion Automatic TEPP by parameter name
 

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -35,7 +35,7 @@ foreach ($function in $functions) {
 	if ($function.Parameters.Keys -contains "ExcludeSnapshot") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSnapshot -Name Snapshot
 	}
-	
+
 	if ($function.Parameters.Keys -contains "ConfigName") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ConfigName -Name ConfigName
 	}
@@ -49,19 +49,82 @@ foreach ($function in $functions) {
 	if ($function.Parameters.Keys -contains "Alert") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlert -Name Alert
 	}
-	
+
 	if ($function.Parameters.Keys -contains "AlertCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AlertCategory -Name AlertCategory
 	}
 	if ($function.Parameters.Keys -contains "AlertCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlertCategory -Name AlertCategory
 	}
-	
+
 	if ($function.Parameters.Keys -contains "JobCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter JobCategory -Name JobCategory
 	}
 	if ($function.Parameters.Keys -contains "JobCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeJobCategory -Name JobCategory
+	}
+
+	if ($function.Parameters.Keys -contains "AvailabilityGroup") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AvailabilityGroup -Name AvailabilityGroup
+	}
+	if ($function.Parameters.Keys -contains "AvailabilityGroup") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAvailabilityGroup -Name AvailabilityGroup
+	}
+
+	if ($function.Parameters.Keys -contains "BackupDevice") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter BackupDevice -Name BackupDevice
+	}
+	if ($function.Parameters.Keys -contains "BackupDevice") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeBackupDevice -Name BackupDevice
+	}
+
+	if ($function.Parameters.Keys -contains "Credential") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Credential -Name Credential
+	}
+	if ($function.Parameters.Keys -contains "Credential") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeCredential -Name Credential
+	}
+
+	if ($function.Parameters.Keys -contains "CustomError") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter CustomError -Name CustomError
+	}
+	if ($function.Parameters.Keys -contains "CustomError") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeCustomError -Name CustomError
+	}
+
+	if ($function.Parameters.Keys -contains "MailAccount") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailAccount -Name MailAccount
+	}
+	if ($function.Parameters.Keys -contains "MailAccount") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailAccount -Name MailAccount
+	}
+
+	if ($function.Parameters.Keys -contains "MailServer") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailServer -Name MailServer
+	}
+	if ($function.Parameters.Keys -contains "MailServer") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailServer -Name MailServer
+	}
+
+	if ($function.Parameters.Keys -contains "MailProfile") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailProfile -Name MailProfile
+	}
+	if ($function.Parameters.Keys -contains "MailProfile") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailProfile -Name MailProfile
+	}
+
+	if ($function.Parameters.Keys -contains "Endpoint") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Endpoint -Name Endpoint
+	}
+	if ($function.Parameters.Keys -contains "Endpoint") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeEndpoint -Name Endpoint
+	}
+
+	if ($function.Parameters.Keys -contains "LinkedServer") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter LinkedServer -Name LinkedServer
+	}
+	if ($function.Parameters.Keys -contains "LinkedServer") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeLinkedServer -Name LinkedServer
 	}
 }
 #endregion Automatic TEPP by parameter name

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -2,14 +2,14 @@
 
 #region Automatic TEPP by parameter name
 foreach ($function in $functions) {
-    if ($function.Parameters.Keys -contains "SqlInstance") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter SqlInstance -Name SqlInstance
-    }
-    if ($function.Parameters.Keys -contains "Database") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Database -Name Database
-    }
-    if ($function.Parameters.Keys -contains "ExcludeDatabase") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeDatabase -Name Database
+	if ($function.Parameters.Keys -contains "SqlInstance") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter SqlInstance -Name SqlInstance
+	}
+	if ($function.Parameters.Keys -contains "Database") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Database -Name Database
+	}
+	if ($function.Parameters.Keys -contains "ExcludeDatabase") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeDatabase -Name Database
 	}
 	if ($function.Parameters.Keys -contains "Job") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Job -Name Job
@@ -26,14 +26,42 @@ foreach ($function in $functions) {
 	if ($function.Parameters.Keys -contains "Operator") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Operator -Name Operator
 	}
-    if ($function.Parameters.Keys -contains "ExcludeOperator") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeOperator -Name Operator
-    }
-    if ($function.Parameters.Keys -contains "Snapshot") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Snapshot -Name Snapshot
-    }
+	if ($function.Parameters.Keys -contains "ExcludeOperator") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeOperator -Name Operator
+	}
+	if ($function.Parameters.Keys -contains "Snapshot") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Snapshot -Name Snapshot
+	}
 	if ($function.Parameters.Keys -contains "ExcludeSnapshot") {
-        Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSnapshot -Name Snapshot
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSnapshot -Name Snapshot
+	}
+	
+	if ($function.Parameters.Keys -contains "ConfigName") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ConfigName -Name ConfigName
+	}
+	if ($function.Parameters.Keys -contains "ConfigName") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeConfigName -Name ConfigName
+	}
+
+	if ($function.Parameters.Keys -contains "Alert") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Alert -Name Alert
+	}
+	if ($function.Parameters.Keys -contains "Alert") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlert -Name Alert
+	}
+	
+	if ($function.Parameters.Keys -contains "AlertCategory") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AlertCategory -Name AlertCategory
+	}
+	if ($function.Parameters.Keys -contains "AlertCategory") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlertCategory -Name AlertCategory
+	}
+	
+	if ($function.Parameters.Keys -contains "JobCategory") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter JobCategory -Name JobCategory
+	}
+	if ($function.Parameters.Keys -contains "JobCategory") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeJobCategory -Name JobCategory
 	}
 }
 #endregion Automatic TEPP by parameter name


### PR DESCRIPTION
This pretty much covers the basic set of dynamic parameters from a rough search, and ones for the Copy commands.

A few I'm not sure how to handle in a clean method that are missing from this PR...placing here for reference:
- Assembly (for each database)
- CMSGroup
- XEvent
- Policy (for PBM)
- DataCollection

Commands for the above:
```
Copy-SqlDatabaseAssembly.ps1
Copy-SqlCentralManagementServer.ps1
Get-SqlRegisteredServerName.ps1
Watch-SqlDbLogin.ps1
Copy-SqlDataCollector.ps1
Copy-SqlExtendedEvent.ps1
Get-DbaXEventsSession.ps1
Copy-SqlPolicyManagement.ps1
```

Some of the ones above you need a specific assembly to gather the info. I don't know if there may be any shortcuts or magic. If it is done the same way as you would any other function I can work on adding those.