### PR TITLE
Copy-DbaDatabase, fix for #1615

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1004,6 +1004,7 @@ function Copy-DbaDatabase {
 						try {
 							$null = Set-DbaDatabaseOwner -SqlInstance $destServer -Database $dbName -TargetLogin $dbOwner -Silent
 						} catch {
+							Write-Message -Level Warning -Message "Failed to update database owner"
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #1615  
Let's go with "if there is a cmdlet and is not an internal one, use it instead" ?

Changes proposed in this pull request:
 - instead of fixing update-sqldbowner, let's go with the "standard" Set-DbaDatabaseOwner

How to test this code: 
- [ ] copy-dbadatabase -backuprestore with a source db owner, verify that the destination owner is not the user copy-dbadatabase is running from, but correctly the one set on the source




