### PR TITLE
Previous test was leaving a session in the db and breaking continue

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -508,7 +508,7 @@ function Restore-DbaDatabase {
         if (Test-FunctionInterrupt) { return }
 		
         if ($null -ne $DatabaseName) {
-            If (($null -ne $server.Databases[$DatabaseName]) -and ($WithReplace -eq $false)) {
+            If (($DatabaseName -in ($server.Databases.name)) -and ($WithReplace -eq $false)) {
                 Write-Warning "$FunctionName - $DatabaseName exists on Sql Instance $SqlInstance , must specify WithReplace to continue"
                 break
             }


### PR DESCRIPTION
SMO was leaving a connection in the db which was causing Continue operations to fail

Quick change to the logical conditional  checking for an existant db on target instance.

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

