### PR TITLE
appveyor msbuild logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ dbatools.psprojs
 bin/dbatools.dll
 bin/dbatools.xml
 bin/dbatools.pdb
+
+# VIM backup files
+*~
+
+# msbuild log file
+msbuild.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ test:
   # only assemblies to test
   assemblies:
     only:
-      bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
+      - bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
 
 test_script:
   # "Installing nuget and PSScriptAnalyzer"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,12 @@ before_test:
   # "Setting up the local SQL Server environments"
   - ps: .\Tests\appveyor.sqlserver.ps1
   
+test:
+  # only assemblies to test
+  assemblies:
+    only:
+      bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
+
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
   #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,17 +26,12 @@ before_test:
   # "Setting up the local SQL Server environments"
   - ps: .\Tests\appveyor.sqlserver.ps1
   
-test:
-  # only assemblies to test
-  assemblies:
-    only:
-      - bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
-
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
   #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
   #- ps: Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
   - ps: Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null
+  - vstest.console /logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
   # "Test with native PS version"
   - ps: .\Tests\appveyor.pester.ps1
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ environment:
 # Set alternative clone folder
 clone_folder: c:\github\dbatools
 
+artifacts:
+  - path: msbuild.log
+    name: MSBuild Log
+
 before_test:
    # grab appveyor lab files
   - ps: .\Tests\appveyor.prep.ps1

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -86,17 +86,20 @@ if ($ImportLibrary) {
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
 				$msbuildOptions = ""
 				if($env:APPVEYOR -eq 'True') {
-					Write-Host "msbuild output will be logged to appveyor console"
-					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"' 
+					# This doesn't seem to work. Keep it here for now
+					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
+					
+					if (-not (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll")) {
+						throw "msbuild logger not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
+					}
 				}
-				gci $env
 
 				if (-not (Test-Path $msbuild)) {
 					throw "msbuild not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
 				}
 				
 				Write-Verbose -Message "Building the library"
-				$null = & $msbuild "$libraryBase\projects\dbatools\dbatools.sln" $msbuildOptions
+				& $msbuild "$libraryBase\projects\dbatools\dbatools.sln" $msbuildOptions
 				
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -84,13 +84,18 @@ if ($ImportLibrary) {
 				$start = Get-Date
 				$system = [Appdomain]::CurrentDomain.GetAssemblies() | Where-Object FullName -like "System, *"
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
-				
+				$msbuildOptions = ""
+				if($env:APPVEYOR -eq 'True') {
+					Write-Debug "msbuild output will be logged to appveyor console"
+					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"' 
+				}
+
 				if (-not (Test-Path $msbuild)) {
 					throw "msbuild not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
 				}
 				
 				Write-Verbose -Message "Building the library"
-				$null = & $msbuild "$libraryBase\projects\dbatools\dbatools.sln"
+				$null = & $msbuild "$libraryBase\projects\dbatools\dbatools.sln" $msbuildOptions
 				
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -86,9 +86,10 @@ if ($ImportLibrary) {
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
 				$msbuildOptions = ""
 				if($env:APPVEYOR -eq 'True') {
-					Write-Debug "msbuild output will be logged to appveyor console"
+					Write-Host "msbuild output will be logged to appveyor console"
 					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"' 
 				}
+				gci $env
 
 				if (-not (Test-Path $msbuild)) {
 					throw "msbuild not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -86,17 +86,12 @@ if ($ImportLibrary) {
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
 				$msbuildOptions = ""
 				if($env:APPVEYOR -eq 'True') {
-<<<<<<< HEAD
 					# This doesn't seem to work. Keep it here for now
 					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
 					
 					if (-not (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll")) {
 						throw "msbuild logger not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
 					}
-=======
-					Write-Output "msbuild output will be logged to appveyor console"
-					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"' 
->>>>>>> zippy1981/enhancements/appveyoyMsbuildLogging
 				}
 
 				if (-not (Test-Path $msbuild)) {

--- a/bin/projects/dbatools/msbuild.rsp
+++ b/bin/projects/dbatools/msbuild.rsp
@@ -1,0 +1,9 @@
+#Appveyor msbuild response file
+
+# No Banner
+/nologo
+# We just want errors displayed
+/ConsoleLoggerParameters:NoSummary;Verbosity=quiet
+# Log to a file and set options
+/filelogger
+/fileloggerparameters:Verbosity=detailed


### PR DESCRIPTION
 Changes proposed in this pull request:
 - Logging to figure out what's wrong with the failing build in #1523
 - Appveyor will log msbuild errors
 - 

How to test this code: 
- [ ] Make sure I didn't break anything.
- [ ] Make sure there is msbuild gobblygook in appvoyer.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

