### PR TITLE
Correct issue with Force and login does not exist

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -219,7 +219,7 @@ function Copy-DbaLogin {
 					continue
 				}
 
-				if ($Login -ne $null -and $force) {
+				if ($destServer.Logins.Item($userName) -ne $null -and $force) {
 					if ($userName -eq $destServer.ServiceAccount) {
 						Write-Message -Level Warning -Message "$userName is the destination service account. Skipping drop."
 


### PR DESCRIPTION
Fixes #1628

Correctly validates that the login does exist on the destination server before trying to drop it.
