### PR TITLE
Get-DbaTcpPort applied standard

### DIFF
--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -1,93 +1,86 @@
-Function Get-DbaTcpPort
-{
-<#
-.SYNOPSIS
-Returns the TCP port used by the specified SQL Server.
-	
-.DESCRIPTION
-By default, this command returns just the TCP port used by the specified SQL Server. 
-	
-If -Detailed is specified, server name, IPAddress (ipv4 and ipv6), port number and if the port assignment is static. 
-	
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+function Get-DbaTcpPort {
+	<#
+		.SYNOPSIS
+			Returns the TCP port used by the specified SQL Server.
+			
+		.DESCRIPTION
+			By default, this command returns just the TCP port used by the specified SQL Server. 
+				
+			If -Detailed is specified, server name, IPAddress (ipv4 and ipv6), port number and if the port assignment is static. 
+			
+		.PARAMETER SqlInstance
+			The SQL Server that you're connecting to.
 
-.PARAMETER Credential
-Credential object used to connect to the SQL Server as a different user
+		.PARAMETER Credential
+			Credential object used to connect to the SQL Server as a different user
 
-.PARAMETER Detailed
-Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers.
-	
-Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+		.PARAMETER Detailed
+			Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers.
+				
+			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-.PARAMETER NoIpv6
-Excludes IPv6 information when -Detailed is specified.
+		.PARAMETER NoIpv6
+			Excludes IPv6 information when -Detailed is specified.
 
-.NOTES
-Tags: SQLWMI
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+		.PARAMETER Silent 
+			Use this switch to disable any kind of verbose messages
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		.NOTES
+			Tags: SQLWMI, tcp
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+		.LINK
+			https://dbatools.io/Get-DbaTcpPort
 
-.LINK
-https://dbatools.io/Get-DbaTcpPort
+		.EXAMPLE
+			Get-DbaTcpPort -SqlInstance sqlserver2014a
 
-.EXAMPLE
-Get-DbaTcpPort -SqlInstance sqlserver2014a
+			Returns just the port number for the default instance on sqlserver2014a
 
-Returns just the port number for the default instance on sqlserver2014a
+		.EXAMPLE
+			Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
 
-.EXAMPLE
-Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
+			Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016
+			
+		.EXAMPLE   
+			Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -Detailed
 
-Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016
-	
-.EXAMPLE   
-Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -Detailed
+			Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016
+				
+			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016
-	
-Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+		.EXAMPLE   
+			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -NoIpV6 -Detailed -Verbose
 
-.EXAMPLE   
-Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -NoIpV6 -Detailed -Verbose
-
-Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014
-	
-#>
+			Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014
+	#>
 	[CmdletBinding()]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstanceParameter[]]$SqlInstance,
 		[Alias("SqlCredential")]
-		[PSCredential][System.Management.Automation.CredentialAttribute()]$Credential,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$Credential,
 		[switch]$Detailed,
 		[Alias("Ipv4")]
 		[switch]$NoIpv6
 	)
 	
-	PROCESS
-	{
-		foreach ($servername in $SqlInstance)
-		{
-			if ($detailed -eq $true)
-			{
-				try
-				{
+	PROCESS {
+		foreach ($servername in $SqlInstance) {
+			if ($detailed -eq $true) {
+				try {
 					$scriptblock = {
 						$servername = $args[0]
 						
 						Add-Type -AssemblyName Microsoft.VisualBasic
 						$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $servername
 						
-						foreach ($instance in $wmi.ServerInstances)
-						{
+						foreach ($instance in $wmi.ServerInstances) {
 							$allips = @()
 							$instancename = $instance.name
 							
@@ -95,21 +88,16 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 							$ips = $tcp.IPAddresses
 							
 							Write-Verbose "Parsing information for $($ips.count) IP addresses"
-							foreach ($ip in $ips)
-							{
+							foreach ($ip in $ips) {
 								$props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
 								
-								foreach ($prop in $props)
-								{
-									if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value))
-									{
+								foreach ($prop in $props) {
+									if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
 										$port = $prop.value
-										if ($prop.name -eq 'TcpPort')
-										{
+										if ($prop.name -eq 'TcpPort') {
 											$static = $true
 										}
-										else
-										{
+										else {
 											$static = $false
 										}
 										break
@@ -119,9 +107,9 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 								[PsCustomObject]@{
 									ComputerName = $servername
 									InstanceName = $instancename
-									IPAddress = $ip.Ipaddress.IPAddressToString
-									Port = $port
-									Static = $static
+									IPAddress    = $ip.Ipaddress.IPAddressToString
+									Port         = $port
+									Static       = $static
 								}
 							}
 						}
@@ -130,27 +118,23 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 					$resolved = Resolve-DbaNetworkName -ComputerName $servername -Verbose:$false
 					$fqdn = $resolved.FQDN
 					$computername = $resolved.ComputerName
-					try
-					{
+					try {
 						Write-Verbose "Trying with ComputerName ($computername)"
 						$someips = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $computername -ScriptBlock $scriptblock
 					}
-					catch
-					{
+					catch {
 						Write-Verbose "Trying with FQDN because ComputerName failed"
 						$someips = Invoke-ManagedComputerCommand -ComputerName $fqdn -ArgumentList $fqdn -ScriptBlock $scriptblock
 					}
 				}
-				catch
-				{
+				catch {
 					Write-Warning "Could not get detailed information for $servername"
 					Write-Warning $_.Exception.Message
 				}
 				
 				$cleanedup = $someips | Sort-Object IPAddress
 				
-				if ($NoIpv6)
-				{
+				if ($NoIpv6) {
 					$octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
 					[regex]$ipv4 = "^(?:$octet\.){3}$octet$"
 					$cleanedup = $cleanedup | Where-Object { $_.IPAddress -match $ipv4 }
@@ -159,26 +143,20 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 				$cleanedup
 			}
 			
-			if ($Detailed -eq $false -or ($Detailed -eq $true -and $someips -eq $null))
-			{
-				try
-				{
+			if ($Detailed -eq $false -or ($Detailed -eq $true -and $someips -eq $null)) {
+				try {
 					$server = Connect-SqlInstance -SqlInstance "TCP:$servername" -SqlCredential $Credential
 				}
-				catch
-				{
+				catch {
 					Write-Warning "Can't connect to $servername. Moving on."
 					Continue
 				}
 				
-				if ($server.VersionMajor -lt 9)
-				{
-					if ($servercount -eq 1)
-					{
+				if ($server.VersionMajor -lt 9) {
+					if ($servercount -eq 1) {
 						throw "SQL Server 2000 not supported."
 					}
-					else
-					{
+					else {
 						Write-Warning "SQL Server 2000 not supported. Skipping $servername."
 						Continue
 					}
@@ -190,7 +168,7 @@ Returns an object with server name, IPAddress (just ipv4), port and static ($tru
 				
 				[PSCustomObject]@{
 					Server = $servername
-					Port = $port
+					Port   = $port
 				}
 			}
 		}

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -83,7 +83,7 @@ function Get-DbaTcpPort {
 						foreach ($instance in $wmi.ServerInstances) {
 							$instanceName = $instance.Name
 							
-							$tcp = $instance.ServerProtocols | Where-Object { $_.DisplayName -eq "TCP/IP" }
+							$tcp = $instance.ServerProtocols | Where-Object Name -eq Tcp
 							$ips = $tcp.IPAddresses
 							
 							Write-Verbose "Parsing information for $($ips.count) IP addresses"

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -2,12 +2,12 @@ function Get-DbaTcpPort {
 	<#
 		.SYNOPSIS
 			Returns the TCP port used by the specified SQL Server.
-			
+
 		.DESCRIPTION
-			By default, this command returns just the TCP port used by the specified SQL Server. 
-				
-			If -Detailed is specified, server name, IPAddress (ipv4 and ipv6), port number and if the port assignment is static. 
-			
+			By default, this command returns just the TCP port used by the specified SQL Server.
+
+			If -Detailed is specified, server name, IPAddress (ipv4 and ipv6), port number and if the port assignment is static.
+
 		.PARAMETER SqlInstance
 			The SQL Server that you're connecting to.
 
@@ -16,13 +16,13 @@ function Get-DbaTcpPort {
 
 		.PARAMETER Detailed
 			Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers.
-				
+
 			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
 		.PARAMETER NoIpv6
 			Excludes IPv6 information when -Detailed is specified.
 
-		.PARAMETER Silent 
+		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
@@ -44,15 +44,15 @@ function Get-DbaTcpPort {
 			Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
 
 			Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016
-			
-		.EXAMPLE   
+
+		.EXAMPLE
 			Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -Detailed
 
 			Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016
-				
+
 			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -NoIpV6 -Detailed -Verbose
 
 			Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014
@@ -67,29 +67,30 @@ function Get-DbaTcpPort {
 		$Credential,
 		[switch]$Detailed,
 		[Alias("Ipv4")]
-		[switch]$NoIpv6
+		[switch]$NoIpv6,
+		[switch]$Silent
 	)
-	
+
 	process {
 		foreach ($serverName in $SqlInstance) {
 			if ($detailed -eq $true) {
 				try {
 					$scriptblock = {
 						$serverName = $args[0]
-						
+
 						Add-Type -AssemblyName Microsoft.VisualBasic
 						$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $serverName
-						
+
 						foreach ($instance in $wmi.ServerInstances) {
 							$instanceName = $instance.Name
-							
+
 							$tcp = $instance.ServerProtocols | Where-Object Name -eq Tcp
 							$ips = $tcp.IPAddresses
-							
-							Write-Verbose "Parsing information for $($ips.count) IP addresses"
+
+							Write-Message -Level Verbose -Message "Parsing information for $($ips.count) IP addresses"
 							foreach ($ip in $ips) {
 								$props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
-								
+
 								foreach ($prop in $props) {
 									if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
 										$port = $prop.value
@@ -102,72 +103,60 @@ function Get-DbaTcpPort {
 										break
 									}
 								}
-								
+
 								[PsCustomObject]@{
 									ComputerName = $serverName
 									InstanceName = $instanceName
-									IPAddress    = $ip.Ipaddress.IPAddressToString
+									IPAddress    = $ip.IPAddress.IPAddressToString
 									Port         = $port
 									Static       = $static
 								}
 							}
 						}
 					}
-					
+
 					$resolved = Resolve-DbaNetworkName -ComputerName $serverName -Verbose:$false
 					$fqdn = $resolved.FQDN
 					$computerName = $resolved.ComputerName
 					try {
-						Write-Verbose "Trying with ComputerName ($computerName)"
+						Write-Message -Level Verbose -Message "Trying with ComputerName ($computerName)"
 						$someIps = Invoke-ManagedComputerCommand -ComputerName $computerName -ArgumentList $computerName -ScriptBlock $scriptblock
 					}
 					catch {
-						Write-Verbose "Trying with FQDN because ComputerName failed"
+						Write-Message -Level Verbose -Message "Trying with FQDN because ComputerName failed"
 						$someIps = Invoke-ManagedComputerCommand -ComputerName $fqdn -ArgumentList $fqdn -ScriptBlock $scriptblock
 					}
 				}
 				catch {
-					Write-Warning "Could not get detailed information for $serverName"
-					Write-Warning $_.Exception.Message
+					Stop-Function -Message "Could not get detailed information" -Target $serverName -ErrorRecord $_
 				}
-				
+
 				$cleanedUp = $someIps | Sort-Object IPAddress
-				
+
 				if ($NoIpv6) {
 					$octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
 					[regex]$ipv4 = "^(?:$octet\.){3}$octet$"
 					$cleanedUp = $cleanedUp | Where-Object { $_.IPAddress -match $ipv4 }
 				}
-				
+
 				$cleanedUp
 			}
-			
+
 			if ($Detailed -eq $false -or ($Detailed -eq $true -and $someIps -eq $null)) {
 				try {
-					$server = Connect-SqlInstance -SqlInstance "TCP:$serverName" -SqlCredential $Credential
+					$server = Connect-SqlInstance -SqlInstance "TCP:$serverName" -SqlCredential $Credential -MinimumVersion 9
 				}
 				catch {
-					Write-Warning "Can't connect to $serverName. Moving on."
-					Continue
+					Stop-Function -Message "Can't connect. Moving on." -Target $serverName -ErrorRecord $_ -Continue
 				}
-				
-				if ($server.VersionMajor -lt 9) {
-					if ($serverCount -eq 1) {
-						throw "SQL Server 2000 not supported."
-					}
-					else {
-						Write-Warning "SQL Server 2000 not supported. Skipping $serverName."
-						Continue
-					}
-				}
-				
+
 				# WmiComputer can be unreliable :( Use T-SQL
 				$sql = "SELECT local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
-				$port = $server.ConnectionContext.ExecuteScalar($sql)
-				
+				$port = $server.Query($sql)
+
 				[PSCustomObject]@{
 					Server = $serverName
-					Port   = $port
+					Port   = $port.local_tcp_port
 				}
 			}
 		}

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -81,7 +81,6 @@ function Get-DbaTcpPort {
 						$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $serverName
 						
 						foreach ($instance in $wmi.ServerInstances) {
-							$allIps = @()
 							$instanceName = $instance.Name
 							
 							$tcp = $instance.ServerProtocols | Where-Object { $_.DisplayName -eq "TCP/IP" }

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -147,7 +147,7 @@ function Get-DbaTcpPort {
 					$server = Connect-SqlInstance -SqlInstance "TCP:$serverName" -SqlCredential $Credential -MinimumVersion 9
 				}
 				catch {
-					Stop-Function -Message "Can't connect. Moving on." -Target $serverName -ErrorRecord $_ -Continue
+					Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 				}
 
 				# WmiComputer can be unreliable :( Use T-SQL

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -19,7 +19,7 @@ function Get-DbaTcpPort {
 
 			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-		.PARAMETER NoIpv6
+		.PARAMETER ExcludeIpv6
 			Excludes IPv6 information when -Detailed is specified.
 
 		.PARAMETER Silent
@@ -67,7 +67,7 @@ function Get-DbaTcpPort {
 		$Credential,
 		[switch]$Detailed,
 		[Alias("Ipv4")]
-		[switch]$NoIpv6,
+		[switch]$ExcludeIpv6,
 		[switch]$Silent
 	)
 
@@ -133,7 +133,7 @@ function Get-DbaTcpPort {
 
 				$cleanedUp = $someIps | Sort-Object IPAddress
 
-				if ($NoIpv6) {
+				if ($ExcludeIpv6) {
 					$octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
 					[regex]$ipv4 = "^(?:$octet\.){3}$octet$"
 					$cleanedUp = $cleanedUp | Where-Object { $_.IPAddress -match $ipv4 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - Formatted help
 - Added Silent parameter
 - Add message commands
 - Update catch blocks
 - Removed version check for 2000 to use `-MinimumVersion` parameter for `Connect-SqlInstance`
 - Added Query() method and adjusted property reference for the column returned
 - Changed filter from `DisplayName -eq "TCP/IP"` to be `Name -eq Tcp`, just reads better.
 - Changed `NoIpv6` to `ExcludeIpv6` as referenced in #1586 
 - Adjusted camelCase
 - Removed array declaration that was not being used, that I could see and test still ran.