### PR TITLE
Copy-DbaLogin, fixes #303

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -296,8 +296,17 @@ function Copy-DbaLogin {
 					$destLogin.Language = $sourceLogin.Language
 
 					if ($destServer.databases[$defaultDb] -eq $null) {
-						Write-Message -Level Warning -Message "$defaultDb does not exist on destination. Setting defaultdb to master."
-						$defaultDb = "master"
+						# we end up here when the default database on source doesn't exist on dest
+						# if source login is a sysadmin, then set the default database to master
+						# if not, set it to tempdb (see #303)
+						try { $sourcesysadmins = $sourceServer.roles['sysadmin'].EnumMemberNames() }
+						catch { $sourcesysadmins = $sourceServer.roles['sysadmin'].EnumServerRoleMembers() }
+						if ($sourcesysadmins -contains $userName) {
+							$defaultDb = "master"
+						} else {
+							$defaultDb = "tempdb"
+						}
+						Write-Message -Level Warning -Message "$defaultDb does not exist on destination. Setting defaultdb to $defaultDb."
 					}
 
 					Write-Message -Level Verbose -Message "Set $userName defaultdb to $defaultDb"

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -299,6 +299,7 @@ function Copy-DbaLogin {
 						# we end up here when the default database on source doesn't exist on dest
 						# if source login is a sysadmin, then set the default database to master
 						# if not, set it to tempdb (see #303)
+						$OrigdefaultDb = $defaultDb
 						try { $sourcesysadmins = $sourceServer.roles['sysadmin'].EnumMemberNames() }
 						catch { $sourcesysadmins = $sourceServer.roles['sysadmin'].EnumServerRoleMembers() }
 						if ($sourcesysadmins -contains $userName) {
@@ -306,7 +307,7 @@ function Copy-DbaLogin {
 						} else {
 							$defaultDb = "tempdb"
 						}
-						Write-Message -Level Warning -Message "$defaultDb does not exist on destination. Setting defaultdb to $defaultDb."
+						Write-Message -Level Warning -Message "$OrigdefaultDb does not exist on destination. Setting defaultdb to $defaultDb."
 					}
 
 					Write-Message -Level Verbose -Message "Set $userName defaultdb to $defaultDb"

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -493,13 +493,6 @@ function Copy-DbaLogin {
 			}
 		}
 
-		$elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-		$started = Get-Date
-
-		if ($Pscmdlet.ShouldProcess("console", "Showing time started message")) {
-			Write-Message -Level Verbose -Message "Migration started: $started"
-		}
-
 		if ($Login) {
 			$LoginParms += @{ 'Logins' = $Login }
 		}
@@ -548,12 +541,6 @@ function Copy-DbaLogin {
 		}
 	}
 	end {
-		if ($Pscmdlet.ShouldProcess("console", "Showing time elapsed message")) {
-			Write-Message -Level Verbose -Message "Login migration completed: $(Get-Date)"
-			$totalTime = ($elapsed.Elapsed.toString().Split(".")[0])
-
-			Write-Message -Level Verbose -Message "Total elapsed time: $totalTime"
-		}
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Copy-SqlLogin
 	}
 }


### PR DESCRIPTION
Fixes #303 

Changes proposed in this pull request:
 - if the default database doesn't exist on destserver, use master if the login is a sysadmin, else tempdb

How to test this code: 
- Copy a login with a default database that doesn't exist on the destination and:
  - [ ] see that it gets "master" as default if it's a sysadmin
  - [ ] see that it gets "tempdb" as default  if it's not a sysadmin
- Copy a login with a default database that exist on the destination and:
  - [ ] see that it gets the proper database as default
