### PR TITLE
Read-DbaTraceFile - added enhancements - fixes #1624

### DIFF
--- a/functions/Read-DbaTraceFile.ps1
+++ b/functions/Read-DbaTraceFile.ps1
@@ -1,4 +1,4 @@
-﻿function Read-DbaTraceFile {
+function Read-DbaTraceFile {
 	<#
 .SYNOPSIS
 Reads a trace file from specied SQL Server Database
@@ -144,13 +144,12 @@ Reads the tracefile C:\traces\big.trc, stored on the sql2016 sql server.
 Filters only results where LinkServerName = myls and StartTime is greater than '5/30/2017 4:27:52 PM'.
 
 #>
-	[CmdletBinding(DefaultParameterSetName = "Default")]
+	[CmdletBinding()]
 	Param (
-		[parameter(Position = 0, Mandatory = $true)]
+		[parameter(Position = 0, Mandatory, ValueFromPipeline)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstanceParameter[]]$SqlInstance,
 		[PSCredential][System.Management.Automation.CredentialAttribute()]$SqlCredential,
-		[parameter(Mandatory = $true)]
 		[string[]]$Path,
 		[string[]]$Database,
 		[string[]]$Login,
@@ -231,21 +230,30 @@ Filters only results where LinkServerName = myls and StartTime is greater than '
 		
 		foreach ($instance in $sqlinstance) {
 			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
 			}
 			catch {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 				return
 			}
 			
-			$exists = Test-DbaSqlPath -SqlInstance $server -Path $file
-			
-			if (!$exists) {
-				Write-Message -Level Warning -Message "Path does not exist" -Target $file
-				Continue
+			if (Was-Bound -Parameter Path) {
+				$currentpath = $path
+			}
+			else {
+				$currentpath = $server.ConnectionContext.ExecuteScalar("Select path from sys.traces where is_default = 1")
 			}
 			
-			foreach ($file in $path) {
+			foreach ($file in $currentpath) {
+				Write-Message -Level Verbose -Message "Parsing $file"
+				
+				$exists = Test-DbaSqlPath -SqlInstance $server -Path $file
+				
+				if (!$exists) {
+					Write-Message -Level Warning -Message "Path does not exist" -Target $file
+					Continue
+				}
+				
 				$sql = "select SERVERPROPERTY('MachineName') AS ComputerName, 
 								   ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName, 
 								   SERVERPROPERTY('ServerName') AS SqlInstance,


### PR DESCRIPTION
Fixes #1624 

Changes proposed in this pull request:
 - Added support for pipeline
 - Added default path when its not bound
 - 

How to test this code: 
- [ ] `$servers | Read-DbaTraceFile`
- [ ] `Read-DbaTraceFile -SqlInstance sql2005`
- [ ] `Read-DbaTraceFile -SqlInstance sql2005 -Path 'C:\Program Files\Microsoft SQL Server\MSSQL.1\MSSQL\LOG\log_286.trc'`

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [x]  SQL Server 2000 -rejects

