### PR TITLE
Restore continue fix

### DIFF
--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -213,7 +213,7 @@ Function Restore-DBFromFilteredArray {
                         $filename = $filename + '.' + $extension
                     }
                     Write-Verbose "past the checks"
-                    if ($File.Type -eq 'L' -and $DestinationLogDirectory -ne '') {
+                    if (($File.Type -eq 'L' -or $File.filetype -eq 'L') -and $DestinationLogDirectory -ne '') {
                         $MoveFile.PhysicalFileName = $DestinationLogDirectory + '\' + $FileName					
                     }
                     else {

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -94,7 +94,9 @@ Function Restore-DBFromFilteredArray {
                     try {
                         Write-Message -Level Verbose -Message "Set $DbName single_user to kill processes"
                         Stop-DbaProcess -SqlInstance $Server -Databases $Dbname -WarningAction Silentlycontinue
-                        Invoke-DbaSqlcmd -ServerInstance:$SqlInstance -Credential:$SqlCredential -query "Alter database $DbName set offline with rollback immediate; alter database $DbName set restricted_user; Alter database $DbName set online with rollback immediate" -database master
+                        if ($Continue -eq $false) {
+                            Invoke-DbaSqlcmd -ServerInstance:$SqlInstance -Credential:$SqlCredential -query "Alter database $DbName set offline with rollback immediate; alter database $DbName set restricted_user; Alter database $DbName set online with rollback immediate" -database master
+                        }
                         $server.ConnectionContext.Connect()
                     }
                     catch {


### PR DESCRIPTION
Better killing of processes during a continuing restore.

Also fixes a small issue where Log redirection wasn't working under Get-BackupHistory pipeline. Different property names 🤦‍♂️ 

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

