### PR TITLE
Export-DbaLogin, speedup enumeration

### DIFF
--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -120,7 +120,30 @@ function Export-DbaLogin {
 
 		Write-Message -Level Verbose -Message "Connecting to $sqlinstance"
 		$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $sqlcredential
-
+		
+		if ($NoDatabases -eq $false) {
+			# if we got a database or a list of databases passed
+			# and we need to enumerate mappings, login.enumdatabasemappings() takes forever
+			# the cool thing though is that database.enumloginmappings() is fast. A lot.
+			# if we get a list of databases passed (or even the default list of all the databases)
+			# we save outself a call to enumloginmappings if there is no map at all
+			$DbMapping = @()
+			$DbsToMap = $server.Databases
+			if ($Database) {
+				$DbsToMap = $DbsToMap | where Name -in $Database
+			}
+			foreach($db in $DbsToMap) {
+				$dbmap = $db.EnumLoginMappings()
+				foreach($el in $dbmap) {
+					$DbMapping += [pscustomobject]@{
+						Database = $db.Name
+						UserName = $el.Username
+						LoginName = $el.LoginName
+					}
+				}
+			}
+		}
+		
 		foreach ($sourceLogin in $server.Logins) {
 			$userName = $sourceLogin.name
 
@@ -266,13 +289,14 @@ function Export-DbaLogin {
 			}
 
 			if ($NoDatabases -eq $false) {
+				if ($userName -notin $DbMapping.LoginName) {
+					Write-Message -Level VeryVerbose -Message "Skipping as $userName is not mapped to an user of the databases"
+					continue
+				}
 				$dbs = $sourceLogin.EnumDatabaseMappings()
 				# Adding database mappings and securables
 				foreach ($db in $dbs) {
 					$dbName = $db.dbname
-					if ($database -and $dbName -notin $database) {
-						continue
-					}
 					$sourceDb = $server.Databases[$dbName]
 					$dbUserName = $db.username
 

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -130,9 +130,12 @@ function Export-DbaLogin {
 			$DbMapping = @()
 			$DbsToMap = $server.Databases
 			if ($Database) {
-				$DbsToMap = $DbsToMap | where Name -in $Database
+				$DbsToMap = $DbsToMap | Where-Object Name -in $Database 
 			}
 			foreach($db in $DbsToMap) {
+				if ($db.IsAccessible -eq $false) {
+					continue
+				}
 				$dbmap = $db.EnumLoginMappings()
 				foreach($el in $dbmap) {
 					$DbMapping += [pscustomobject]@{


### PR DESCRIPTION
Changes proposed in this pull request:
 - enums the database login mapping per instance, in order to save time enumerating login mappings which takes forever

How to test this code: 
- [ ] export before and after this PR, check that everything matches 
- [ ] export before and after this PR, passing a database (or a database list), check that everything matches (for the run including this PR, you can skip coffee break)
