### PR TITLE
Creates folder if doesn't exist fixes #1610

### DIFF
--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -73,6 +73,16 @@ Converts output from Invoke-DbaDiagnosticQuery to Excel worksheet(s) in the Docu
 				return
 			}
 		}
+
+		if(!$(Test-Path $Path)) {
+			try 
+			{				
+				New-Item $Path -ItemType Directory -ErrorAction Stop | Out-Null
+				Write-Message -Level Output -Message "Created directory $Path"
+			} catch {
+				Stop-Function -Message "Failed to create directory $Path" -Continue
+			}
+		}
 		
 		Function Remove-InvalidFileNameChars {
 			[CmdletBinding()]


### PR DESCRIPTION
Fixes #1610 

Changes proposed in this pull request:
 - creates folder if it doesn't exist

How to test this code: 
- [ ] `Invoke-DbaDiagnosticQuery -SqlInstance server1 | Export-DbaDiagnosticQuery -Path C:\Temp\Folder`
Where C:\Temp\Folder doesn't exists.

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

