### PR TITLE
Fixes/backup issue 1481

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -237,7 +237,9 @@ sql credential dbatoolscred registered on the sql2016 instance
 				Write-Message -Level Verbose -Message "$dbname is in $($Database.RecoveryModel) recovery model"
 			}
 			
-			if ($Database.RecoveryModel -eq 'Simple' -and $Type -eq 'Log') {
+			# Fixes one-off cases of StackOverflowException crashes, see issue 1481 
+			$dbRecovery = $Database.RecoveryModel.ToString()
+ 			if ($dbRecovery -ne 'Simple' -and $Type -eq 'Log') {
 				$failreason = "$database is in simple recovery mode, cannot take log backup"
 				$failures += $failreason
 				Write-Message -Level Warning -Message "$failreason"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -239,7 +239,7 @@ sql credential dbatoolscred registered on the sql2016 instance
 			
 			# Fixes one-off cases of StackOverflowException crashes, see issue 1481 
 			$dbRecovery = $Database.RecoveryModel.ToString()
- 			if ($dbRecovery -ne 'Simple' -and $Type -eq 'Log') {
+ 			if ($dbRecovery -eq 'Simple' -and $Type -eq 'Log') {
 				$failreason = "$database is in simple recovery mode, cannot take log backup"
 				$failures += $failreason
 				Write-Message -Level Warning -Message "$failreason"


### PR DESCRIPTION
Fixes #1481 

Changes proposed in this pull request:
 Crash is caused by the cast of the enum to a string. Explicitly calling ToString avoids this exception
 - 
 - 

How to test this code: 
- [Perform Backup-DbaDatabase on a system exhibiting the StackOverflowException to see if it fixes the problem, or perform the command on a system not exhibiting the exception to make sure the change doesn't break anything] 
- [ ] 

Has been tested on minimum requirements:
- [x ]  Powershell 5
- [x ]  Windows 2012 R2
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [x ]  Powershell 5
- [x ]  Windows 2012 R2
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

