### PR TITLE
Adds default name and subject if either is NULL. Fixes #1609

### DIFF
--- a/functions/New-DbaDatabaseCertificate.ps1
+++ b/functions/New-DbaDatabaseCertificate.ps1
@@ -86,13 +86,22 @@ Suppresses all prompts to install but prompts to securely enter your password an
 			}
 			
 			foreach ($db in $Database) {
-				
+
 				$smodb = $server.Databases[$db]
 				
 				if ($null -eq $smodb) {
 					Stop-Function -Message "Database '$db' does not exist on $instance" -Target $server -Continue
 				}
 				
+				if($null -eq $name) {
+					Write-Message -Level Verbose -Message "Name is NULL, setting it to '$db'"
+					$name = $db
+				}
+				if($null -eq $subject) {
+					Write-Message -Level Verbose -Message "Subject is NULL, setting it to '$db Database Certificate'"
+					$subject = "$db Database Certificate"
+				}
+
 				foreach ($cert in $name) {
 					if ($null -ne $smodb.Certificates[$cert]) {
 						Stop-Function -Message "Certificate '$cert' already exists in the $db database on $instance" -Target $smodb -Continue


### PR DESCRIPTION
Fixes #1609 

Changes proposed in this pull request:
 - If Name parameter is NULL make it the name of the database
 - If Subject parameter is NULL make it 'dbName Database Certificate'

How to test this code: 
- [ ] `New-DbaDatabaseCertificate -SqlInstance server1`

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

