### PR TITLE
Change Get-DbaTable's input parameters to be additive.

### DIFF
--- a/functions/Get-DbaTable.ps1
+++ b/functions/Get-DbaTable.ps1
@@ -1,10 +1,10 @@
 ﻿function Get-DbaTable {
-	<#
+<#
 .SYNOPSIS
 Returns a summary of information on the tables
 
 .DESCRIPTION
-Shows table information around table row and data sizes and if it has any table type information. 
+Shows table information around table row and data sizes and if it has any table type information.
 
 .PARAMETER SqlInstance
 SQLServer name or SMO object representing the SQL Server to connect to. This can be a
@@ -23,33 +23,33 @@ The database(s) to exclude - this list is autopopulated from the server
 Switch parameter that when used will display system database information
 
 .PARAMETER Table
-Define a specific table you would like to query. You can specify up to three-part name like db.sch.tbl. 
+Define a specific table you would like to query. You can specify up to three-part name like db.sch.tbl.
 If the object has special characters please wrap them in square brackets [ ].
 This dbo.First.Table will try to find table named 'Table' on schema 'First' and database 'dbo'.
 The correct way to find table named 'First.Table' on schema 'dbo' is passing dbo.[First.Table]
 
-.PARAMETER Silent 
+.PARAMETER Silent
 Use this switch to disable any kind of verbose messages
-	
-.NOTES 
+
+.NOTES
 Tags: Database, Tables
 Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
-	
+
 .LINK
 https://dbatools.io/Get-DbaTable
-	
+
 .EXAMPLE
 Get-DbaTable -SqlInstance DEV01 -Database Test1
 Return all tables in the Test1 database
-	
+
 .EXAMPLE
 Get-DbaTable -SqlInstance DEV01 -Database MyDB -Table MyTable
 Return only information on the table MyTable from the database MyDB
-	
+
 .EXAMPLE
 Get-DbaTable -SqlInstance DEV01 -Table MyTable
 Returns information on table called MyTable if it exists in any database on the server, under any schema
@@ -77,51 +77,51 @@ Returns information on the CommandLog table in the DBA database on both instance
 		[string[]]$Table,
 		[switch]$Silent
 	)
-	
+
 	begin {
 		$fqtns = @()
-		
+
 		if ($Table) {
 			foreach ($t in $Table) {
-                $splitName = [regex]::Matches($t, "(\[.+?\])|([^\.]+)").Value
+				$splitName = [regex]::Matches($t, "(\[.+?\])|([^\.]+)").Value
 				$dotcount = $splitName.Count
 
-				$database = $NULL
+				$splitDb = $NULL
 				$Schema = $NULL
 
-                switch ($dotcount) {
-                    1 {
-                        $tbl = $t
-                    }
-                    2 {
-                        $schema = $splitName[0]
-                        $tbl = $splitName[1]
-                    }
-                    3 {
-                        $database = $splitName[0]
-		                $schema = $splitName[1]
-		                $tbl = $splitName[2]
-                    }
-                    default {
-                        Write-Message -Level Warning -Message "Please make sure that you are using up to three-part names. If your search value contains '.' character you must use [ ] to wrap the name. The value $t is not a valid name."
-                        Continue
-                    }
-                }
-                
-                if ($database -like "[[]*[]]") {
-                    $database = $database.Substring(1, ($database.Length -2))
-                }
+				switch ($dotcount) {
+					1 {
+						$tbl = $t
+					}
+					2 {
+						$schema = $splitName[0]
+						$tbl = $splitName[1]
+					}
+					3 {
+						$splitDb = $splitName[0]
+						$schema = $splitName[1]
+						$tbl = $splitName[2]
+					}
+					default {
+						Write-Message -Level Warning -Message "Please make sure that you are using up to three-part names. If your search value contains '.' character you must use [ ] to wrap the name. The value $t is not a valid name."
+						Continue
+					}
+				}
 
-                if ($schema -like "[[]*[]]") {
-                    $schema = $schema.Substring(1, ($schema.Length -2))
-                }
+				if ($splitDb -like "[[]*[]]") {
+					$splitDb = $splitDb.Substring(1, ($splitDb.Length - 2))
+				}
 
-                if ($tbl -like "[[]*[]]") {
-                    $tbl = $tbl.Substring(1, ($tbl.Length -2))
-                }
+				if ($schema -like "[[]*[]]") {
+					$schema = $schema.Substring(1, ($schema.Length - 2))
+				}
+
+				if ($tbl -like "[[]*[]]") {
+					$tbl = $tbl.Substring(1, ($tbl.Length - 2))
+				}
 
 				$fqtn = [PSCustomObject] @{
-					Database = $database
+					Database = $splitDb
 					Schema   = $Schema
 					Table    = $tbl
 				}
@@ -129,9 +129,9 @@ Returns information on the CommandLog table in the DBA database on both instance
 			}
 		}
 	}
-	
+
 	process {
-		foreach ($instance in $sqlinstance) {	
+		foreach ($instance in $sqlinstance) {
 			try {
 				Write-Message -Level Verbose -Message "Connecting to $instance"
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
@@ -139,20 +139,20 @@ Returns information on the CommandLog table in the DBA database on both instance
 			catch {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
-			
-			#If IncludeSystemDBs is true, include systemdbs
-			#only look at online databases (Status equal normal)
+
 			try {
+				#only look at online databases (Status equal normal)
+				$dbs = $server.Databases | Where-Object { $_.Status -eq 'Normal' }
+
+				#If IncludeSystemDBs is false, exclude systemdbs
+				if (!$IncludeSystemDBs) {
+					$dbs = $dbs | Where-Object { !$_.IsSystemObject }
+				}
+
 				if ($Database) {
-					$dbs = $server.Databases | Where-Object { $Database -contains $_.Name -and $_.status -eq 'Normal' }
+					$dbs = $dbs | Where-Object { $Database -contains $_.Name }
 				}
-				elseif ($IncludeSystemDBs) {
-					$dbs = $server.Databases | Where-Object { $_.status -eq 'Normal' }
-				}
-				else {
-					$dbs = $server.Databases | Where-Object { $_.status -eq 'Normal' -and $_.IsSystemObject -eq 0 }
-				}
-				
+
 				if ($ExcludeDatabase) {
 					$dbs = $dbs | Where-Object { $ExcludeDatabase -notcontains $_.Name }
 				}
@@ -160,43 +160,63 @@ Returns information on the CommandLog table in the DBA database on both instance
 			catch {
 				Stop-Function -Message "Unable to gather dbs for $instance" -Target $instance -Continue -InnerErrorRecord $_
 			}
-			
+
 			foreach ($db in $dbs) {
 				Write-Message -Level Verbose -Message "Processing $db"
-				
-				$d = $server.Databases[$db]
-				
+				$skipped = $false
+
 				if ($fqtns.Count -gt 0) {
 					foreach ($fqtn in $fqtns) {
-						if ($fqtn.schema -ne $NULL) {
-							try {
-								$tables = $db.Tables | Where-Object { $_.name -eq $tbl -and $_.Schema -eq $schema }
+						# If the user specified a database in a three-part name, and it's not the
+						# database currently being processed, skip this table.
+						if ($fqtn.Database) {
+							if ($fqtn.Database -ne $db.Name) {
+								$skipped = $true
+								continue
 							}
-							catch {
-								Write-Message -Level Warning -Message "Could not find table name: $($fqtn.tbl) schema: $($fqtn.schema)" -ErrorRecord $_
+							else {
+								$skipped = $false
 							}
 						}
-						else {
-							try {
-								$tables = $db.Tables | Where-Object { $_.name -eq $tbl }
+
+						$tables = $db.Tables | Where-Object { $_.Name -eq $fqtn.Table }
+
+						if ($fqtn.Schema) {
+							$tables = $tables | Where-Object { $_.Schema -eq $fqtn.Schema }
+						}
+
+						if ($fqtn.Database) {
+							$tables = $tables | Where-Object { $_.Parent.Name -eq $fqtn.Database }
+						}
+
+						if ($tables.Count -eq 0) {
+							$outSchema = ""
+							if ($fqtn.Schema) {
+								$outSchema = ", schema: $($fqtn.Schema)"
 							}
-							catch {
-								Write-Message -Level Warning -Message "Could not find table name: $($fqtn.tbl)" -ErrorRecord $_
+
+							$outDatabase = ""
+							if ($fqtn.Database) {
+								$outDatabase = ", database: $($fqtn.Database)"
 							}
+
+							Write-Message -Level Verbose -Message "Could not find table. Instance: $($server.DomainInstanceName)$outDatabase$outSchema, name: $($fqtn.Table)"
 						}
 					}
 				}
 				else {
 					$tables = $db.Tables
 				}
-				
-				$tables | Add-Member -MemberType NoteProperty -Name ComputerName -Value $server.NetName
-				$tables | Add-Member -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
-				$tables | Add-Member -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
-				
-				$defaultprops = "ComputerName", "InstanceName", "SqlInstance", "Parent as Database", "Schema", "Name", "IndexSpaceUsed", "DataSpaceUsed", "RowCount", "HasClusteredIndex", "IsFileTable", "IsMemoryOptimized", "IsPartitioned", "FullTextIndex", "ChangeTrackingEnabled"
-				
-				Select-DefaultView -InputObject $tables -Property $defaultprops
+
+				if (!$skipped) {
+					$tables | Add-Member -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+					$tables | Add-Member -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
+					$tables | Add-Member -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
+
+					$defaultprops = "ComputerName", "InstanceName", "SqlInstance", "Parent as Database", "Schema", "Name", "IndexSpaceUsed", "DataSpaceUsed", "RowCount", "HasClusteredIndex", "IsFileTable", "IsMemoryOptimized", "IsPartitioned", "FullTextIndex", "ChangeTrackingEnabled"
+
+					Select-DefaultView -InputObject $tables -Property $defaultprops
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I started looking at this function because of https://github.com/sqlcollaborative/dbatools/issues/1593, but it looks like the problem described there actually got fixed, but the issue is still open.

However, when I ran it, I noticed some weird results (the last command below). If you specify both `-Database` and the database name as a three-part name in `-Table`, you still get results for that table from "database1", even though the `-Database` filter should exclude anything not from "database2"

```powershell
# -- I have a table with the name `table1` in multiple databases
# Shows two tables 
Get-DbaTable -SqlInstance bhamby -Table "table1"

# Also shows two tables 
Get-DbaTable -SqlInstance bhamby -Table "dbo.table1"

# Shows one table from the correct database
Get-DbaTable -SqlInstance bhamby -Table "database1.dbo.table1"

# Shows one table from the database listed in `-Table` (expected to get no results)
Get-DbaTable -SqlInstance bhamby -Table "database1.dbo.table1" -Database database2
```

Changes proposed in this pull request:
 - Changes the input parameters to be additive. Before, if you specified a database in both the table name (as a three-part name), and another database name in the `-Database` parameter, it would still show both copies of the table in the different databases.
 - If tables are not found, change try/catch to `if(count)`, because assignment of nothing will not trigger a throw. I changed the warning that there are no tables from `Warning` to `Verbose`... my thought is that, if a table isn't found, then just don't show it in the output. ﻿`¯\_(ツ)_/¯`
 - While processing, if a three-part name is specified, and it is not the database currently being processed, skip that table specification.
 - Formatted code with VS Code based on settings at https://dbatools.io/vscode/ (by the way, there needs to be a comma on the end of line 15 in the workspace settings listing on that page)


There was some discussion in Slack about how this should work (starting around [here](https://sqlcommunity.slack.com/archives/C1M2WEASG/p1499983857354510) (it's actually the message above that one, but the linking is weird because my question was a snippet))

How to test this code: 
- Run with various combinations of `-SqlInstance`, `-Database`, and `-Table` (with and without schema and database)