### PR TITLE
Get-DbaAvailabilityGroup blown up and cleaned up

### DIFF
--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -38,19 +38,14 @@ function Get-DbaAvailabilityGroup {
 			Returns basic information on all the Availability Group(s) found on sqlserver2014a
 
 		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
 
-			Show only server name, availability groups and role
+			Shows basic information on the Availability Group AG-a on sqlserver2014a
 
 		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a | Select *
 
 			Returns full object properties on all Availability Group(s) on sqlserver2014a
-
-		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
-
-			Shows basic information on the Availability Group AG-a on sqlserver2014a
 
 		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -1,74 +1,74 @@
-Function Get-DbaAvailabilityGroup {
+function Get-DbaAvailabilityGroup {
 	<#
-.SYNOPSIS 
-Outputs information of the Availabilty Group(s) found on the server.
+		.SYNOPSIS 
+			Outputs information of the Availability Group(s) found on the server.
 
-.DESCRIPTION
-By default outputs a small set of information around the Availability Group found on the server.
+		.DESCRIPTION
+			By default outputs a small set of information around the Availability Group found on the server.
 
-.PARAMETER SqlInstance
-The SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2012 or higher.
+		.PARAMETER SqlInstance
+			The SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2012 or higher.
 
-.PARAMETER SqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
 
-.PARAMETER Detailed
-Output is expanded with more information around each Availability Group replica found on the server.
+		.PARAMETER Detailed
+			Output is expanded with more information around each Availability Group replica found on the server.
 
-.PARAMETER AvailabilityGroups
-Specify the Availability Group name that you want to get information on.
+		.PARAMETER AvailabilityGroup
+			Specify the Availability Group name that you want to get information on.
 
-.PARAMETER Simple
-Show only server name, availability groups and role.
+		.PARAMETER Simple
+			Show only server name, availability groups and role.
 
-.PARAMETER Detailed
-Shows detailed information about the AGs including EndpointUrl and BackupPriority.
+		.PARAMETER Detailed
+			Shows detailed information about the AGs including EndpointUrl and BackupPriority.
 
-.PARAMETER IsPrimary
-Returns true or false for the server passed in.
+		.PARAMETER IsPrimary
+			Returns true or false for the server passed in.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER WhatIf 
+			Shows what would happen if the command were to run. No actions are actually performed. 
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Confirm 
+			Prompts you for confirmation before executing any changing operations within the command. 
 
-.NOTES
-Tags: DisasterRecovery, Backup
-Original Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
+		.NOTES
+			Tags: DisasterRecovery, AG, AvailabilityGroup
+			Original Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		.LINK
+			https://dbatools.io/Get-DbaAvailabilityGroup
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+		.EXAMPLE
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a
 
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+			Returns basic information on all the Availability Group(s) found on sqlserver2014a
 
-.LINK
-https://dbatools.io/Get-DbaAvailabilityGroup
+		.EXAMPLE   
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Simple
 
-.EXAMPLE
-Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a
-Returns basic information on all the Availability Group(s) found on sqlserver2014a
+			Show only server name, availability groups and role
 
-.EXAMPLE   
-Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Simple
-Show only server name, availability groups and role
+		.EXAMPLE   
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Detailed
 
-.EXAMPLE   
-Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Detailed
-Returns basic information plus additional info on each replica for all Availability Group(s) on sqlserver2014a
+			Returns basic information plus additional info on each replica for all Availability Group(s) on sqlserver2014a
 
-.EXAMPLE   
-Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
-Shows basic information on the Availability Group AG-a on sqlserver2014a
-	
-.EXAMPLE   
-Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary
-Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
-#>
+		.EXAMPLE   
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
+
+			Shows basic information on the Availability Group AG-a on sqlserver2014a
+			
+		.EXAMPLE   
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary
+
+			Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
+	#>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -97,7 +97,7 @@ function Get-DbaAvailabilityGroup {
 					Select-DefaultView -InputObject $ag -Property $defaults
 				}
 				else {
-					$defaults = 'ComputerName','InstanceName','SqlInstance','LocalReplicaRole','Name as AvailabilityGroup','PrimaryReplicaServerName as PrimaryReplica','Replicas', 'AutomatedBackupPreference'
+					$defaults = 'ComputerName','InstanceName','SqlInstance','LocalReplicaRole','Name as AvailabilityGroup','PrimaryReplicaServerName as PrimaryReplica','Replicas', 'AutomatedBackupPreference', AvailabilityDatabases, AvailabilityGroupListeners
 
 					$replicas = $ag.AvailabilityReplicas.Name -join ","
 					Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name Replicas -Value $replicas

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -95,7 +95,7 @@ function Get-DbaAvailabilityGroup {
 			}
 
 			if ($server.IsHadrEnabled -eq $false) {
-				Stop-Function "Availability Group (HADR) is not configured for this instance" -Target $serverName -Continue
+				Stop-Function -Message "Availability Group (HADR) is not configured for the instance: $serverName" -Target $serverName -Continue
 			}
 
 			if ($AvailabilityGroup) {
@@ -108,10 +108,8 @@ function Get-DbaAvailabilityGroup {
 			}
 
 			if (!$agReplicas) {
-				Write-Warning "[$serverName] Availability Groups not found"
-				continue
+				Stop-Function -Message "[$serverName] Availability Groups not found" -Target $serverName -Continue
 			}
-
 
 			foreach ($r in $agReplicas) {
 				$agCollection += [pscustomobject]@{

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -27,11 +27,8 @@ function Get-DbaAvailabilityGroup {
 		.PARAMETER IsPrimary
 			Returns true or false for the server passed in.
 
-		.PARAMETER WhatIf 
-			Shows what would happen if the command were to run. No actions are actually performed. 
-
-		.PARAMETER Confirm 
-			Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Silent 
+			Use this switch to disable any kind of verbose messages
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup
@@ -69,15 +66,18 @@ function Get-DbaAvailabilityGroup {
 
 			Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
 	#>
-	[CmdletBinding(SupportsShouldProcess = $true)]
-	Param (
+	[CmdletBinding()]
+	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstanceParameter[]]$SqlInstance,
-		[object]$SqlCredential,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$SqlCredential,
+		[object[]]$AvailabilityGroup,
 		[switch]$Simple,
 		[switch]$Detailed,
-		[switch]$IsPrimary
+		[switch]$IsPrimary,
+		[switch]$Silent
 	)
 
 	begin {

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -1,6 +1,6 @@
 function Get-DbaAvailabilityGroup {
 	<#
-		.SYNOPSIS 
+		.SYNOPSIS
 			Outputs information of the Availability Group(s) found on the server.
 
 		.DESCRIPTION
@@ -10,7 +10,7 @@ function Get-DbaAvailabilityGroup {
 			The SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2012 or higher.
 
 		.PARAMETER SqlCredential
-			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
 
 		.PARAMETER Detailed
 			Output is expanded with more information around each Availability Group replica found on the server.
@@ -27,7 +27,7 @@ function Get-DbaAvailabilityGroup {
 		.PARAMETER IsPrimary
 			Returns true or false for the server passed in.
 
-		.PARAMETER Silent 
+		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
@@ -46,22 +46,22 @@ function Get-DbaAvailabilityGroup {
 
 			Returns basic information on all the Availability Group(s) found on sqlserver2014a
 
-		.EXAMPLE   
+		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Simple
 
 			Show only server name, availability groups and role
 
-		.EXAMPLE   
+		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -Detailed
 
 			Returns basic information plus additional info on each replica for all Availability Group(s) on sqlserver2014a
 
-		.EXAMPLE   
+		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
 
 			Shows basic information on the Availability Group AG-a on sqlserver2014a
-			
-		.EXAMPLE   
+
+		.EXAMPLE
 			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary
 
 			Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
@@ -106,13 +106,13 @@ function Get-DbaAvailabilityGroup {
 			else {
 				$agReplicas += $server.AvailabilityGroups.AvailabilityReplicas
 			}
-			
+
 			if (!$agReplicas) {
 				Write-Warning "[$serverName] Availability Groups not found"
 				continue
 			}
-			
-			
+
+
 			foreach ($r in $agReplicas) {
 				$agCollection += [pscustomobject]@{
 					AvailabilityGroup           = $r.Parent.Name
@@ -132,7 +132,7 @@ function Get-DbaAvailabilityGroup {
 					ReadonlyRoutingList         = $r.ReadonlyRoutingList -join ","
 				}
 			}
-			
+
 			$server.ConnectionContext.Disconnect()
 		}
 	}
@@ -144,11 +144,11 @@ function Get-DbaAvailabilityGroup {
 		if ($IsPrimary) {
 			return ($agCollection | Where-Object { $_.ReplicaName -in $SqlInstance -and $_.Role -ne 'Unknown' } | Select-Object ReplicaName, AvailabilityGroup, @{ Name="IsPrimary"; Expression= { $_.Role -eq "Primary" } } )
 		}
-		
+
 		if ($Simple) {
 			return $agCollection | Select-Object ReplicaName, AvailabilityGroup, Role
 		}
-		
+
 		if ($Detailed) {
 			return $agCollection
 		}


### PR DESCRIPTION
Fixes #978 

Changes proposed in this pull request:
 - Cleaned this command up by rewriting it for the most part. 💣 
 - Cleaned up help and removed unwanted parameters
 - Cleaned up output to be full AG object for SMO, but only have default set of properties output
 - Adjusted logic to determine primary replica based on SMO properties (this needs to be tested to verify it works on 2012 up to 2016 property BEFORE IT IS MERGED)

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  SQL Server 2012

Has been tested on maximum requirements:
- [ ]  SQL Server 2016
- [ ]  Windows Server 2012 R2

Tests for tester:
- [ ] `Get-DbaAvailabilityGroup -SqlInstance Server1`
- [ ] `Get-DbaAvailabilityGroup -SqlInstance Server1 -IsPrimary`
- [ ] `Get-DbaAvailabilityGroup - SqlInstance Server1 -AvailabilityGroup AG1`

Verify output and no errors.
