### PR TITLE
Updated test dba compression

### DIFF
--- a/functions/Test-DbaCompression.ps1
+++ b/functions/Test-DbaCompression.ps1
@@ -1,12 +1,5 @@
 ﻿function Test-DbaCompression {
 <#
-	.SYNOPSIS
-		Returns tables and indexes with preferred compression setting.
-	
-	 .BUGIFIX
-        I am aware that there is an issue with very large databases, I am working on
-        a fix for that.
-    
      .DESCRIPTION
 		This function returns the results of a fulle table/index compression analysis.
         This function returns the best option to date for either NONE, Page, or Row Compression.
@@ -36,11 +29,6 @@
 		Use this if you want the function to throw terminating errors you want to catch.
 	
 	.EXAMPLE
-		
-		
-		Returns all user database files and free space information for the local host
-	
-	.EXAMPLE
 		Test-DbaCompression -SqlInstance ServerA -Database DBName | Out-GridView
 		Returns results of all potential compression options for a single database 
         with the recommendation of either Page or Row into and nicely formated GridView
@@ -60,8 +48,13 @@
 	    This produces a full analysis of all your servers listed and is pushed to a csv for you to 
         analyize.
 
+    .EXAMPLE
+        Test-DbaCompression -SqlInstance $svr1,$svr2 | Export-Csv -Path C:\temp\CompressionAnalysisPAC.csv -Append
+        This produces a full analysis of all your servers listed and is pushed to a csv for you to 
+        analyize.
+
 	.NOTES
-		
+		Original Author: Jason Squires (twitter: @js_0505)
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
@@ -96,213 +89,240 @@
 	begin {
 		Write-Message -Level System -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
 		$sql = "SET NOCOUNT ON;
+            if object_id('tempdb..##tmpCompression')  is not null 
+            drop table ##tmpCompression
+            if object_id('tempdb..##tmpEstimateRow')  is not null 
+            drop table ##tmpEstimateRow
+            if object_id('tempdb..##tmpEstimatePage') is not null 
+            drop table ##tmpEstimatePage
 
-CREATE TABLE ##tmpCompression ([Schema] sysname
-	,[Table_Name] sysname
-	,[Index_Name] sysname NULL
-	,[Partition] int
-	,[Index_ID] int
-	,[Index_Type] VARCHAR(12)
-	,[Percent_Scan] smallint
-	,[Percent_Update] smallint
-	,[ROW_estimate_Pct_of_orig] bigint
-	,[PAGE_estimate_Pct_of_orig] bigint
-	,[Compression_Type_Recommendation] VARCHAR(7)
-	,size_cur bigint
-	,size_req bigint
-);
+            CREATE TABLE ##tmpCompression ([Schema] sysname
+	        ,[Table_Name] sysname
+	        ,[Index_Name] sysname NULL
+	        ,[Partition] int
+	        ,[Index_ID] int
+	        ,[Index_Type] VARCHAR(12)
+	        ,[Percent_Scan] smallint
+	        ,[Percent_Update] smallint
+	        ,[ROW_estimate_Pct_of_orig] bigint
+	        ,[PAGE_estimate_Pct_of_orig] bigint
+	        ,[Compression_Type_Recommendation] VARCHAR(7)
+	        ,size_cur bigint
+	        ,size_req bigint
+            );
 
-CREATE TABLE ##tmpEstimateRow (
-	objname sysname
-	,schname sysname
-	,indid int
-	,partnr int
-	,size_cur bigint
-	,size_req bigint
-	,sample_cur bigint
-	,sample_req bigint
-);
+            CREATE TABLE ##tmpEstimateRow (
+	            objname sysname
+	            ,schname sysname
+	            ,indid int
+	            ,partnr int
+	            ,size_cur bigint
+	            ,size_req bigint
+	            ,sample_cur bigint
+	            ,sample_req bigint
+            );
 
-CREATE TABLE ##tmpEstimatePage (
-	objname sysname
-	,schname sysname
-	,indid int
-	,partnr int
-	,size_cur bigint
-	,size_req bigint
-	,sample_cur bigint
-	,sample_req bigint
-);
+            CREATE TABLE ##tmpEstimatePage (
+	            objname sysname
+	            ,schname sysname
+	            ,indid int
+	            ,partnr int
+	            ,size_cur bigint
+	            ,size_req bigint
+	            ,sample_cur bigint
+	            ,sample_req bigint
+            );
 
-INSERT INTO ##tmpCompression 
-([Schema]
-,[Table_Name]
-,[Index_Name]
-,[Partition]
-,[Index_ID]
-,[Index_Type]
-,[Percent_Scan]
-,[Percent_Update]
-)
-SELECT s.name AS [Schema], o.name AS [Table_Name], x.name AS [Index_Name],
-       i.partition_number AS [Partition], i.index_id AS [Index_ID], x.type_desc AS [Index_Type],
-       i.range_scan_count * 100.0 / (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) AS [Percent_Scan],
-       i.leaf_update_count * 100.0 / (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) AS [Percent_Update]
-FROM sys.dm_db_index_operational_stats (db_id(), NULL, NULL, NULL) i
-	INNER JOIN sys.objects o ON o.object_id = i.object_id
-	INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
-	INNER JOIN sys.indexes x ON x.object_id = i.object_id AND x.index_id = i.index_id
-WHERE (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) <> 0
-	AND objectproperty(i.object_id,'IsUserTable') = 1
-ORDER BY [Table_Name] ASC;
+            INSERT INTO ##tmpCompression 
+            ([Schema]
+            ,[Table_Name]
+            ,[Index_Name]
+            ,[Partition]
+            ,[Index_ID]
+            ,[Index_Type]
+            ,[Percent_Scan]
+            ,[Percent_Update]
+            )
+            SELECT s.name AS [Schema], o.name AS [Table_Name], x.name AS [Index_Name],
+                   i.partition_number AS [Partition], i.index_id AS [Index_ID], x.type_desc AS [Index_Type],
+                   i.range_scan_count * 100.0 / (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) AS [Percent_Scan],
+                   i.leaf_update_count * 100.0 / (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) AS [Percent_Update]
+            FROM sys.dm_db_index_operational_stats (db_id(), NULL, NULL, NULL) i
+	            INNER JOIN sys.objects o ON o.object_id = i.object_id
+	            INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
+	            INNER JOIN sys.indexes x ON x.object_id = i.object_id AND x.index_id = i.index_id
+            WHERE (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) <> 0
+	            AND objectproperty(i.object_id,'IsUserTable') = 1
+            ORDER BY [Table_Name] ASC;
 
-DECLARE @schema sysname, @tbname sysname, @ixid int
-DECLARE cur CURSOR FAST_FORWARD FOR SELECT [Schema], [Table_Name], [Index_ID] FROM ##tmpCompression
-OPEN cur
-FETCH NEXT FROM cur INTO @schema, @tbname, @ixid
-WHILE @@FETCH_STATUS = 0
-BEGIN
-	--SELECT @schema, @tbname
-	INSERT INTO ##tmpEstimateRow
-	(objname 
-	,schname 
-	,indid 
-	,partnr 
-	,size_cur 
-	,size_req 
-	,sample_cur 
-	,sample_req 
-	)
-	EXEC ('sp_estimate_data_compression_savings ''' + @schema + ''', ''' + @tbname + ''', ''' + @ixid + ''', NULL, ''ROW''' );
-	INSERT INTO ##tmpEstimatePage
-	EXEC ('sp_estimate_data_compression_savings ''' + @schema + ''', ''' + @tbname + ''', ''' + @ixid + ''', NULL, ''PAGE''');
-	FETCH NEXT FROM cur INTO @schema, @tbname, @ixid
-END
-CLOSE cur
-DEALLOCATE cur;
+            DECLARE @schema sysname, @tbname sysname, @ixid int
+            DECLARE cur CURSOR FAST_FORWARD FOR SELECT [Schema], [Table_Name], [Index_ID] FROM ##tmpCompression
+            OPEN cur
+            FETCH NEXT FROM cur INTO @schema, @tbname, @ixid
+            WHILE @@FETCH_STATUS = 0
+            BEGIN
+	        
+            DECLARE @sql NVARCHAR(4000)
+            
+			SET @sql = '			
+				INSERT INTO ##tmpEstimateRow
+	            (objname 
+	            ,schname 
+	            ,indid 
+	            ,partnr 
+	            ,size_cur 
+	            ,size_req 
+	            ,sample_cur 
+	            ,sample_req 
+	            )
+				Exec (sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''ROW''') ;
+	        
+            EXECUTE sp_executesql @sql;
 
---SELECT * FROM ##tmpEstimateRow
---SELECT * FROM ##tmpEstimatePage;
+			SET @sql = '
+				INSERT INTO ##tmpEstimatePage
+	            (objname 
+	            ,schname 
+	            ,indid 
+	            ,partnr 
+	            ,size_cur 
+	            ,size_req 
+	            ,sample_cur 
+	            ,sample_req 
+	            )
+				Exec sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''PAGE''' ;
 
-WITH tmp_cte (objname, schname, indid, pct_of_orig_row, pct_of_orig_page, size_cur,size_req) 
-     AS (SELECT tr.objname, 
-                tr.schname, 
-                tr.indid, 
-                ( tr.sample_req * 100 ) / CASE 
-                                            WHEN tr.sample_cur = 0 THEN 1 
-                                            ELSE tr.sample_cur 
-                                          END AS pct_of_orig_row, 
-                ( tp.sample_req * 100 ) / CASE 
-                                            WHEN tp.sample_cur = 0 THEN 1 
-                                            ELSE tp.sample_cur 
-                                          END AS pct_of_orig_page,
-				tr.size_cur,
-				tr.size_req
-         FROM   ##tmpestimaterow tr 
-                INNER JOIN ##tmpestimatepage tp 
-                        ON tr.objname = tp.objname 
-                           AND tr.schname = tp.schname 
-                           AND tr.indid = tp.indid 
-                           AND tr.partnr = tp.partnr) 
-UPDATE ##tmpcompression 
-SET    [row_estimate_pct_of_orig] = tcte.pct_of_orig_row, 
-       [page_estimate_pct_of_orig] = tcte.pct_of_orig_page,
-	   size_cur=tcte.size_cur,
-	   size_req=tcte.size_req
-FROM   tmp_cte tcte, 
-       ##tmpcompression tcomp 
-WHERE  tcte.objname = tcomp.table_name 
-       AND tcte.schname = tcomp.[schema] 
-       AND tcte.indid = tcomp.index_id; 
+			EXECUTE sp_executesql @sql;
+	        FETCH NEXT FROM cur INTO @schema, @tbname, @ixid
 
-WITH tmp_cte2 (table_name, [schema], index_id, [compression_type_recommendation] 
-     ) 
-     AS (SELECT table_name, 
-                [schema], 
-                index_id, 
-                CASE 
-                  WHEN [row_estimate_pct_of_orig] >= 100 
-                       AND [page_estimate_pct_of_orig] >= 100 THEN 'NO_GAIN' 
-                  WHEN [percent_update] >= 10 THEN 'ROW' 
-                  WHEN [percent_scan] <= 1 
-                       AND [percent_update] <= 1 
-                       AND [row_estimate_pct_of_orig] < 
-                           [page_estimate_pct_of_orig] 
-                THEN 
-                  'ROW' 
-                  WHEN [percent_scan] <= 1 
-                       AND [percent_update] <= 1 
-                       AND [row_estimate_pct_of_orig] > 
-                           [page_estimate_pct_of_orig] 
-                THEN 
-                  'PAGE' 
-                  WHEN [percent_scan] >= 60 
-                       AND [percent_update] <= 5 THEN 'PAGE' 
-                  WHEN [percent_scan] <= 35 
-                       AND [percent_update] <= 5 THEN '?' 
-                  ELSE 'ROW' 
-                END 
-         FROM   ##tmpcompression) 
+            END
+            CLOSE cur
+            DEALLOCATE cur;
 
-UPDATE ##tmpcompression 
-SET    [compression_type_recommendation] = 
-       tcte2.[compression_type_recommendation] 
-FROM   tmp_cte2 tcte2, 
-       ##tmpcompression tcomp2 
-WHERE  tcte2.table_name = tcomp2.table_name 
-       AND tcte2.[schema] = tcomp2.[schema] 
-       AND tcte2.index_id = tcomp2.index_id; 
+            WITH tmp_cte (objname, schname, indid, pct_of_orig_row, pct_of_orig_page, size_cur,size_req) 
+                 AS (SELECT tr.objname, 
+                            tr.schname, 
+                            tr.indid, 
+                            ( tr.sample_req * 100 ) / CASE 
+                                                        WHEN tr.sample_cur = 0 THEN 1 
+                                                        ELSE tr.sample_cur 
+                                                      END AS pct_of_orig_row, 
+                            ( tp.sample_req * 100 ) / CASE 
+                                                        WHEN tp.sample_cur = 0 THEN 1 
+                                                        ELSE tp.sample_cur 
+                                                      END AS pct_of_orig_page,
+				            tr.size_cur,
+				            tr.size_req
+                     FROM   ##tmpestimaterow tr 
+                            INNER JOIN ##tmpestimatepage tp 
+                                    ON tr.objname = tp.objname 
+                                       AND tr.schname = tp.schname 
+                                       AND tr.indid = tp.indid 
+                                       AND tr.partnr = tp.partnr) 
+            UPDATE ##tmpcompression 
+            SET    [row_estimate_pct_of_orig] = tcte.pct_of_orig_row, 
+                   [page_estimate_pct_of_orig] = tcte.pct_of_orig_page,
+	               size_cur=tcte.size_cur,
+	               size_req=tcte.size_req
+            FROM   tmp_cte tcte, 
+                   ##tmpcompression tcomp 
+            WHERE  tcte.objname = tcomp.table_name 
+                   AND tcte.schname = tcomp.[schema] 
+                   AND tcte.indid = tcomp.index_id; 
 
-SET NOCOUNT ON;
-DECLARE @UpTime VARCHAR(12), @StartDate DATETIME, @sqlmajorver int, @sqlcmd NVARCHAR(500), @params NVARCHAR(500)
-SELECT @sqlmajorver = CONVERT(int, (@@microsoftversion / 0x1000000) & 0xff);
+            WITH tmp_cte2 (table_name, [schema], index_id, [compression_type_recommendation] 
+                 ) 
+                 AS (SELECT table_name, 
+                            [schema], 
+                            index_id, 
+                            CASE 
+                              WHEN [row_estimate_pct_of_orig] >= 100 
+                                   AND [page_estimate_pct_of_orig] >= 100 THEN 'NO_GAIN' 
+                              WHEN [percent_update] >= 10 THEN 'ROW' 
+                              WHEN [percent_scan] <= 1 
+                                   AND [percent_update] <= 1 
+                                   AND [row_estimate_pct_of_orig] < 
+                                       [page_estimate_pct_of_orig] 
+                            THEN 
+                              'ROW' 
+                              WHEN [percent_scan] <= 1 
+                                   AND [percent_update] <= 1 
+                                   AND [row_estimate_pct_of_orig] > 
+                                       [page_estimate_pct_of_orig] 
+                            THEN 
+                              'PAGE' 
+                              WHEN [percent_scan] >= 60 
+                                   AND [percent_update] <= 5 THEN 'PAGE' 
+                              WHEN [percent_scan] <= 35 
+                                   AND [percent_update] <= 5 THEN '?' 
+                              ELSE 'ROW' 
+                            END 
+                     FROM   ##tmpcompression) 
 
-IF @sqlmajorver = 9
-BEGIN
-	SET @sqlcmd = N'SELECT @StartDateOUT = login_time, @UpTimeOUT = DATEDIFF(mi, login_time, GETDATE()) FROM master..sysprocesses WHERE spid = 1';
-END
-ELSE
-BEGIN
-	SET @sqlcmd = N'SELECT @StartDateOUT = sqlserver_start_time, @UpTimeOUT = DATEDIFF(mi,sqlserver_start_time,GETDATE()) FROM sys.dm_os_sys_info';
-END
+            UPDATE ##tmpcompression 
+            SET    [compression_type_recommendation] = 
+                   tcte2.[compression_type_recommendation] 
+            FROM   tmp_cte2 tcte2, 
+                   ##tmpcompression tcomp2 
+            WHERE  tcte2.table_name = tcomp2.table_name 
+                   AND tcte2.[schema] = tcomp2.[schema] 
+                   AND tcte2.index_id = tcomp2.index_id; 
 
-SET @params = N'@StartDateOUT DATETIME OUTPUT, @UpTimeOUT VARCHAR(12) OUTPUT';
+            SET NOCOUNT ON;
+            DECLARE @UpTime VARCHAR(12), @StartDate DATETIME, @sqlmajorver int, @sqlcmd NVARCHAR(500), @params NVARCHAR(500)
+            SELECT @sqlmajorver = CONVERT(int, (@@microsoftversion / 0x1000000) & 0xff);
 
-EXECUTE sp_executesql @sqlcmd, @params, @StartDateOUT=@StartDate OUTPUT, @UpTimeOUT=@UpTime OUTPUT;
+            IF @sqlmajorver = 9
+            BEGIN
+	            SET @sqlcmd = N'SELECT @StartDateOUT = login_time, @UpTimeOUT = DATEDIFF(mi, login_time, GETDATE()) FROM master..sysprocesses WHERE spid = 1';
+            END
+            ELSE
+            BEGIN
+	            SET @sqlcmd = N'SELECT @StartDateOUT = sqlserver_start_time, @UpTimeOUT = DATEDIFF(mi,sqlserver_start_time,GETDATE()) FROM sys.dm_os_sys_info';
+            END
 
---SELECT @StartDate AS Collecting_Data_Since, CONVERT(VARCHAR(4),@UpTime/60/24) + 'd ' + CONVERT(VARCHAR(4),@UpTime/60%24) + 'h ' + CONVERT(VARCHAR(4),@UpTime%60) + 'm' AS Collecting_Data_For
+            SET @params = N'@StartDateOUT DATETIME OUTPUT, @UpTimeOUT VARCHAR(12) OUTPUT';
 
-SELECT 
-DBName = DB_Name()
-,[Schema] 
-,[Table_Name] 
-,[Index_Name] 
-,[Partition] 
-,[Index_ID] 
-,[Index_Type] 
-,[Percent_Scan] 
-,[Percent_Update] 
-,[ROW_estimate_Pct_of_orig] 
-,[PAGE_estimate_Pct_of_orig]
-,[Compression_Type_Recommendation] 
-,size_curKB = [size_cur]
-,size_reqKB = [size_req]
-FROM ##tmpCompression;
+            EXECUTE sp_executesql @sqlcmd, @params, @StartDateOUT=@StartDate OUTPUT, @UpTimeOUT=@UpTime OUTPUT;
 
-DROP TABLE ##tmpCompression
-DROP TABLE ##tmpEstimateRow
-DROP TABLE ##tmpEstimatePage;"
+            SELECT 
+            DBName = DB_Name()
+            ,[Schema] 
+            ,[Table_Name] 
+            ,[Index_Name] 
+            ,[Partition] 
+            ,[Index_ID] 
+            ,[Index_Type] 
+            ,[Percent_Scan] 
+            ,[Percent_Update] 
+            ,[ROW_estimate_Pct_of_orig] 
+            ,[PAGE_estimate_Pct_of_orig]
+            ,[Compression_Type_Recommendation] 
+            ,size_curKB = [size_cur]
+            ,size_reqKB = [size_req]
+            FROM ##tmpCompression;
+
+            DROP TABLE ##tmpCompression
+            DROP TABLE ##tmpEstimateRow
+            DROP TABLE ##tmpEstimatePage;"
 	}
 	
 	process {
 		
 		foreach ($instance in $SqlInstance) {
 			try {
-				Write-Message -Level VeryVerbose -Message "Connecting to $instance" -Target $instance
+				
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SourceSqlCredential
+
+            if ($server.versionMajor -lt 10)
+		    {
+			    Write-Warning "This function does not support versions lower than SQL Server 2008R2. Skipping server '$server'."
+			    continue
+		    }
+
 			}
 			catch {
-				Stop-Function -Message "Failed to process Instance $Instance" -ErrorRecord $_ -Target $instance -Continue
+				Stop-Function -Message "Failed to process Instance $instance" -Target $instance -ErrorRecord $_ -Continue
 			}
 			
             $Server.ConnectionContext.StatementTimeout = 0
@@ -314,10 +334,10 @@ DROP TABLE ##tmpEstimatePage;"
 					$dbs = $server.Databases | Where-Object Name -In $Database
 				}
 				elseif ($IncludeSystemDBs) {
-					$dbs = $server.Databases | Where-Object Status -eq 'Normal'
+					$dbs = $server.Databases | Where-Object { $_.IsAccessible -eq $true }
 				}
 				else {
-					$dbs = $server.Databases | Where-Object { $_.status -eq 'Normal' -and $_.IsSystemObject -eq 0 }
+					$dbs = $server.Databases | Where-Object { $_.IsAccessible -eq $true -and $_.IsSystemObject -eq 0 }
 				}
 				
 				if (Was-Bound "ExcludeDatabase") {
@@ -325,9 +345,8 @@ DROP TABLE ##tmpEstimatePage;"
 				}
 			}
 			catch {
-				Stop-Function -Message "Unable to gather databases for $instance" -ErrorRecord $_ -Continue
+				Stop-Function -Message "Unable to gather list of databases for $instance" -Target $instance -ErrorRecord $_ -Continue
 			}
-			
 
 			foreach ($db in $dbs) {
 				try {
@@ -339,8 +358,8 @@ DROP TABLE ##tmpEstimatePage;"
 						continue
 					    }
                     #Execute query against individual database and add to output
-                    foreach ($row in ($db.ExecuteWithResults($sql)).Tables.Rows) 
-                        {
+                    $data = $server.Query($sql,$db.Name)
+                    foreach ($row in $data) {
 						[pscustomobject]@{
 							ComputerName = $server.NetName
 							InstanceName = $server.ServiceName

--- a/functions/Test-DbaCompression.ps1
+++ b/functions/Test-DbaCompression.ps1
@@ -47,6 +47,16 @@
         }
 	    This produces a full analysis of all your servers listed and is pushed to a csv for you to 
         analyize.
+    
+    .EXAMPLE
+        $servers = 'Server1','Server2'
+
+        foreach-Object
+        {
+        Test-DbaCompression -SqlInstance $_ | Export-Csv -Path C:\temp\CompressionAnalysisPAC.csv -Append
+        }
+	    This produces a full analysis of all your servers listed and is pushed to a csv for you to 
+        analyize.
 
     .EXAMPLE
         Test-DbaCompression -SqlInstance $svr1,$svr2 | Export-Csv -Path C:\temp\CompressionAnalysisPAC.csv -Append
@@ -175,7 +185,7 @@
 	            ,sample_cur 
 	            ,sample_req 
 	            )
-				Exec (sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''ROW''') ;
+				Exec sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''ROW'';' ;
 	        
             EXECUTE sp_executesql @sql;
 
@@ -190,7 +200,7 @@
 	            ,sample_cur 
 	            ,sample_req 
 	            )
-				Exec sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''PAGE''' ;
+				Exec sp_estimate_data_compression_savings '''  + @schema + ''', ''' + @tbname + ''', ''' + convert(nvarchar,@ixid) + ''', NULL, ''PAGE'';' ;
 
 			EXECUTE sp_executesql @sql;
 	        FETCH NEXT FROM cur INTO @schema, @tbname, @ixid
@@ -358,7 +368,9 @@
 						continue
 					    }
                     #Execute query against individual database and add to output
+                                      
                     $data = $server.Query($sql,$db.Name)
+
                     foreach ($row in $data) {
 						[pscustomobject]@{
 							ComputerName = $server.NetName


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Updated Test-DbaCompression per WSMelton review

How to test this code: 
- [Test-DbaCompression -SqlInstance ServerA -Database DBName] 

Has been tested on minimum requirements:
- [x]  Powershell 3
- [x]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [x] Working/useful help content, including link to command on dbatools web site
- [x] All examples work as advertised
- [x] Does not contain template content
- [x] Does not contain excessive/unnecessary amounts of comments
- [x] Works remotely
- [x] Works locally
- [x] Works on lower versions or throws error specifying version not supported
- [x] Works with named instances
- [x] Works with clustered instances
- [x] Handles offline/read only databases
- [x] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [x] No un-handled errors which stop the command working with multiple servers

