### PR TITLE
Get-DbaDatabase make over

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -1,4 +1,4 @@
-function Get-DbaDatabase {
+﻿function Get-DbaDatabase {
 	<#
 		.SYNOPSIS
 			Gets SQL Database information for each database that is present in the target instance(s) of SQL Server.
@@ -196,50 +196,53 @@ function Get-DbaDatabase {
                 Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
 
 			if ($NoFullBackup -or $NoFullBackupSince) {
-				if ($NoFullBackup) {
-					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastFull -IgnoreCopyOnly).Database
+				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)
+				if ($null -ne $NoFullBackupSince) {
+					$dabsWithinScope = ($dabs | Where-Object End -lt $NoFullBackupSince)
+					
+					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' }
+				} else {
+					$inputObject = $inputObject | Where-Object { $_.name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
 				}
-				else {
-					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastFull -IgnoreCopyOnly -Since $NoFullBackupSince).Database
-				}
-				$inputobject = $inputObject | where-object { $_.name -notin $dabs -and $_.name -ne 'tempdb' }
+				
 			}
 			if ($NoLogBackup -or $NoLogBackupSince) {
-				if ($NoLogBackup) {
-					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastLog -IgnoreCopyOnly).Database
+				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog -IgnoreCopyOnly)
+				if ($null -ne $NoLogBackupSince) {
+					$dabsWithinScope = ($dabs | Where-Object End -lt $NoLogBackupSince)
+					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
+				} else {
+					$inputobject = $inputObject | Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
 				}
-				else {
-					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastLog -IgnoreCopyOnly -Since $NoLogBackupSince).Database
-				}
-				$inputobject = $inputObject | where-object { $_.name -notin $dabs -and $_.name -ne 'tempdb' -and $_.RecoveryModel -ne 'simple' }
 			}
 
-			if ($null -ne $NoFullBackupSince) {
-				$inputobject = $inputobject | Where-Object LastBackupdate -lt $NoFullBackupSince
-			}
-			elseif ($null -ne $NoLogBackupSince) {
-				$inputobject = $inputobject | Where-Object LastBackupdate -lt $NoLogBackupSince
-			}
+			
+			
 			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
 
 			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
 				$defaults += ('Notes')
 			}
-			foreach ($db in $inputobject) {
-
-				$Notes = $null
-				if ($NoFullBackup -or $NoFullBackupSince) {
-					if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
-						$Notes = "Only CopyOnly backups"
+			
+			try {
+				foreach ($db in $inputobject) {
+					
+					$Notes = $null
+					if ($NoFullBackup -or $NoFullBackupSince) {
+						if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
+							$Notes = "Only CopyOnly backups"
+						}
 					}
+					Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
+					
+					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
+					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+					Select-DefaultView -InputObject $db -Property $defaults
 				}
-				Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
-
-				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
-				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-				Select-DefaultView -InputObject $db -Property $defaults
-
+			}
+			catch {
+				Stop-Message -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified. If so, please use parens (Get-DbaDatabase ....) | when working with commands that modify the collection such as Remove-DbaDatabase" -Continue
 			}
 		}
 	}

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -21,38 +21,42 @@ function Get-DbaDatabase {
 			The database(s) to exclude.
 
 		.PARAMETER NoUserDb
-			Returns all SQL Server System databases from the SQL Server instance(s) executed against.
+			Returns only databases that are not User Databases.
+            This parameter cannot be used together with -NoSystemDb.
 
 		.PARAMETER NoSystemDb
-			Returns SQL Server user databases from the SQL Server instance(s) executed against.
+			Returns only databases that are not System Databases.
+            This parameter cannot be used together with -NoUserDb.
 
 		.PARAMETER Status
-			Returns SQL Server databases in the status passed to the function.  Could include Emergency, Online, Offline, Recovering, Restoring, Standby or Suspect
-			statuses of databases from the SQL Server instance(s) executed against.
+			Returns SQL Server databases in the status(es) listed.
+            Could include Emergency, Online, Offline, Recovering, Restoring, Standby or Suspect.
+			
 
 		.PARAMETER Access
-			Returns SQL Server databases that are Read Only or all other Online databases from the SQL Server intance(s) executed against.
+			Returns SQL Server databases that are Read Only or Read/Write.
+            To collect both, don't use this parameter.
 
 		.PARAMETER Owner
-			Returns list of SQL Server databases owned by the specified logins
+			Returns list of databases owned by the specified logins.
 
 		.PARAMETER Encrypted
-			Returns list of SQL Server databases that have TDE enabled from the SQL Server instance(s) executed against.
+			Returns list of databases that have TDE enabled from the SQL Server instance(s) executed against.
 
 		.PARAMETER RecoveryModel
-			Returns list of SQL Server databases in Full, Simple or Bulk Logged recovery models from the SQL Server instance(s) executed against.
+			Returns list of databases in listed recovery models (Full, Simple or Bulk Logged).
 
 		.PARAMETER NoFullBackup
-			Returns databases without a full backup recorded by SQL Server. Will indicate those which only have CopyOnly full backups
+			Returns databases without a full backup recorded by SQL Server. Will indicate those which only have CopyOnly full backups.
 
 		.PARAMETER NoFullBackupSince
-			DateTime value. Returns list of SQL Server databases that haven't had a full backup since the passed iin DateTime
+			DateTime value. Returns list of databases that haven't had a full backup since the passed in DateTime.
 
 		.PARAMETER NoLogBackup
-			Returns databases without a Log backup recorded by SQL Server. Will indicate those which only have CopyOnly Log backups
+			Returns databases without a Log backup recorded by SQL Server. Will indicate those which only have CopyOnly Log backups.
 
 		.PARAMETER NoLogBackupSince
-			DateTime value. Returns list of SQL Server databases that haven't had a Log backup since the passed iin DateTime
+			DateTime value. Returns list of databases that haven't had a Log backup since the passed in DateTime.
 
 		.PARAMETER WhatIf
 			Shows what would happen if the command were to run. No actions are actually performed.
@@ -66,6 +70,8 @@ function Get-DbaDatabase {
 		.NOTES
 			Tags: Database
 			Original Author: Garry Bargsley (@gbargsley | http://blog.garrybargsley.com)
+            Author: Klaas Vandenberghe ( @PowerDbaKlaas )
+            Author: Simone Bizzotto ( @niphlod )
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
@@ -95,6 +101,7 @@ function Get-DbaDatabase {
 			Returns databases on multiple instances piped into the function
 	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]
+    [OutputType([Microsoft.SqlServer.Management.Smo.Database[]])]
 	Param (
 		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
 		[Alias("ServerInstance", "SqlServer")]
@@ -207,4 +214,3 @@ function Get-DbaDatabase {
 		}
 	}
 }
-

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -135,6 +135,7 @@ function Get-DbaDatabase {
 
 		foreach ($instance in $SqlInstance) {
 			try {
+			    Write-Message -Level Verbose -Message "Connecting to $instance"
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
 			}
 			catch {
@@ -152,13 +153,10 @@ function Get-DbaDatabase {
             }
 
             $Readonly = switch ( $Access ) { 'Readonly' { @($true) } 'ReadWrite' { @($false) } default { @($true,$false)} }
-
 			$Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true,$false)} }
 
-			if ($Database) {
-				$inputobject = $server.Databases |
-                    Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
-			}
+			$inputobject = $server.Databases |
+                Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
 
 			if ($NoFullBackup -or $NoFullBackupSince) {
 				if ($NoFullBackup) {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -99,6 +99,36 @@ function Get-DbaDatabase {
 			'localhost','sql2016' | Get-DbaDatabase
 
 			Returns databases on multiple instances piped into the function
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL1\SQLExpress -RecoveryModel full,Simple
+
+			Returns only the user databases in Full or Simple recovery model from SQL1\SQLExpress
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL1\SQLExpress -Status Normal
+
+			Returns only the user databases with status 'normal' from sql instance SQL1\SQLExpress
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL1\SQLExpress,SQL2 -ExcludeDatabase model,master
+
+			Returns all databases except master and model from sql instances SQL1\SQLExpress and SQL2
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL1\SQLExpress,SQL2 -Encrypted
+
+			Returns only encrypted databases from sql instances SQL1\SQLExpress and SQL2
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL1\SQLExpress,SQL2 -Access ReadOnly
+
+			Returns only read only databases from sql instances SQL1\SQLExpress and SQL2
+
+		.EXAMPLE
+			Get-DbaDatabase -SqlInstance SQL2,SQL3 -Database OneDB,OtherDB
+
+			Returns databases 'OneDb' and 'OtherDB' from sql instances SQL2 and SQL3 if the databases exist on those instances
 	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]
     [OutputType([Microsoft.SqlServer.Management.Smo.Database[]])]

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -197,10 +197,10 @@
                     ($_.Name -in $Database -or !$Database) -and 
                     ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and 
                     ($_.Owner -in $Owner -or !$Owner) -and 
-                    $_.ReadOnly -in $readonly -and 
+                    $_.ReadOnly -in $Readonly -and 
                     $_.IsSystemObject -in $DBType -and 
-                    $_.status -in $Status -and 
-                    $_.recoveryModel -in $recoverymodel -and 
+                    $_.Status -in $Status -and 
+                    $_.RecoveryModel -in $RecoveryModel -and 
                     $_.EncryptionEnabled -in $Encrypt
                 }
 

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -193,7 +193,7 @@
 			$Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true,$false)} }
 
 			$inputobject = $server.Databases |
-                Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
+                Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.ReadOnly -in $readonly -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
 
 			if ($NoFullBackup -or $NoFullBackupSince) {
 				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -202,7 +202,7 @@
 					
 					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' }
 				} else {
-					$inputObject = $inputObject | Where-Object { $_.name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
+					$inputObject = $inputObject | Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
 				}
 				
 			}

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -115,7 +115,7 @@ function Get-DbaDatabase {
 		[ValidateSet('ReadOnly', 'ReadWrite')]
 		[string]$Access,
 		[ValidateSet('Full', 'Simple', 'BulkLogged')]
-		[string]$RecoveryModel = @('Full', 'Simple', 'BulkLogged'),
+		[string[]]$RecoveryModel = @('Full', 'Simple', 'BulkLogged'),
 		[switch]$NoFullBackup,
 		[datetime]$NoFullBackupSince,
 		[switch]$NoLogBackup,

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -105,22 +105,15 @@ function Get-DbaDatabase {
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
 		[Alias("SystemDbOnly")]
-		[parameter()]
 		[switch]$NoUserDb,
 		[Alias("UserDbOnly")]
-		[parameter()]
 		[switch]$NoSystemDb,
-		[parameter()]
 		[string[]]$Owner,
-		[parameter()]
 		[switch]$Encrypted,
-		[parameter()]
 		[ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
 		[string[]]$Status,
-		[parameter()]
 		[ValidateSet('ReadOnly', 'ReadWrite')]
 		[string]$Access,
-		[parameter()]
 		[ValidateSet('Full', 'Simple', 'BulkLogged')]
 		[string]$RecoveryModel,
 		[switch]$NoFullBackup,

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -157,14 +157,7 @@ function Get-DbaDatabase {
 
 			if ($Database) {
 				$inputobject = $server.Databases |
-                    Where-Object { $_.Name -in $Database -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
-			}
-			if ($Owner) {
-				$inputobject = $server.Databases | Where-Object Owner -in $Owner
-			}
-
-			if ($ExcludeDatabase) {
-				$inputobject = $inputobject | Where-Object Name -notin $ExcludeDatabase
+                    Where-Object { ($_.Name -in $Database -or !$Database) -and ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and ($_.Owner -in $Owner -or !$Owner) -and $_.IsSystemObject -in $DBType -and $_.status -in $Status -and $_.recoveryModel -in $recoverymodel -and $_.EncryptionEnabled -in $Encrypt }
 			}
 
 			if ($NoFullBackup -or $NoFullBackupSince) {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -46,13 +46,13 @@ function Get-DbaDatabase {
 			Returns databases without a full backup recorded by SQL Server. Will indicate those which only have CopyOnly full backups
 
 		.PARAMETER NoFullBackupSince
-			DateTime value. Returns list of SQL Server databases that haven't had a full backup since the passed in DateTime
+			DateTime value. Returns list of SQL Server databases that haven't had a full backup since the passed iin DateTime
 
 		.PARAMETER NoLogBackup
 			Returns databases without a Log backup recorded by SQL Server. Will indicate those which only have CopyOnly Log backups
 
 		.PARAMETER NoLogBackupSince
-			DateTime value. Returns list of SQL Server databases that haven't had a Log backup since the passed in DateTime
+			DateTime value. Returns list of SQL Server databases that haven't had a Log backup since the passed iin DateTime
 
 		.PARAMETER WhatIf
 			Shows what would happen if the command were to run. No actions are actually performed.
@@ -105,22 +105,22 @@ function Get-DbaDatabase {
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
 		[Alias("SystemDbOnly")]
-		[parameter(ParameterSetName = "NoUserDb")]
+		[parameter()]
 		[switch]$NoUserDb,
 		[Alias("UserDbOnly")]
-		[parameter(ParameterSetName = "NoSystemDb")]
+		[parameter()]
 		[switch]$NoSystemDb,
-		[parameter(ParameterSetName = "DbBackuOwner")]
+		[parameter()]
 		[string[]]$Owner,
-		[parameter(ParameterSetName = "Encrypted")]
+		[parameter()]
 		[switch]$Encrypted,
-		[parameter(ParameterSetName = "Status")]
+		[parameter()]
 		[ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
 		[string[]]$Status,
-		[parameter(ParameterSetName = "Access")]
+		[parameter()]
 		[ValidateSet('ReadOnly', 'ReadWrite')]
 		[string]$Access,
-		[parameter(ParameterSetName = "RecoveryModel")]
+		[parameter()]
 		[ValidateSet('Full', 'Simple', 'BulkLogged')]
 		[string]$RecoveryModel,
 		[switch]$NoFullBackup,
@@ -133,13 +133,13 @@ function Get-DbaDatabase {
 	begin {
 
 		if ($NoUserDb -and $NoSystemDb) {
-			Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue
+			Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue -Silent $Silent
 		}
 
 		if ($status.count -gt 0) {
 			foreach ($state in $status) {
 				if ($state -notin ('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')) {
-					Stop-Function -Message "$state is not a valid status ('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')" -Continue
+					Stop-Function -Message "$state is not a valid status ('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')" -Continue -Silent $Silent
 				}
 			}
 		}
@@ -202,54 +202,52 @@ function Get-DbaDatabase {
 			}
 
 			if ($NoFullBackup -or $NoFullBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)
-				if ($null -ne $NoFullBackupSince) {
-					$dabsWithinScope = ($dabs | Where-Object End -lt $NoFullBackupSince)
-					
-					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' }
-				} else {
-					$inputObject = $inputObject | Where-Object { $_.name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
+				if ($NoFullBackup) {
+					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastFull -IgnoreCopyOnly).Database
 				}
-				
+				else {
+					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastFull -IgnoreCopyOnly -Since $NoFullBackupSince).Database
+				}
+				$inputobject = $inputObject | where-object { $_.name -notin $dabs -and $_.name -ne 'tempdb' }
 			}
 			if ($NoLogBackup -or $NoLogBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog -IgnoreCopyOnly)
-				if ($null -ne $NoLogBackupSince) {
-					$dabsWithinScope = ($dabs | Where-Object End -lt $NoLogBackupSince)
-					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
-				} else {
-					$inputobject = $inputObject | Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
+				if ($NoLogBackup) {
+					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastLog -IgnoreCopyOnly).Database
 				}
+				else {
+					$dabs = (Get-DbaBackuphistory -SqlInstance $server -LastLog -IgnoreCopyOnly -Since $NoLogBackupSince).Database
+				}
+				$inputobject = $inputObject | where-object { $_.name -notin $dabs -and $_.name -ne 'tempdb' -and $_.RecoveryModel -ne 'simple' }
 			}
 
-			
-			
+			if ($null -ne $NoFullBackupSince) {
+				$inputobject = $inputobject | Where-Object LastBackupdate -lt $NoFullBackupSince
+			}
+			elseif ($null -ne $NoLogBackupSince) {
+				$inputobject = $inputobject | Where-Object LastBackupdate -lt $NoLogBackupSince
+			}
 			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner', 'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup', 'LastLogBackupDate as LastLogBackup'
 
 			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
 				$defaults += ('Notes')
 			}
-			
-			try {
-				foreach ($db in $inputobject) {
-					
-					$Notes = $null
-					if ($NoFullBackup -or $NoFullBackupSince) {
-						if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
-							$Notes = "Only CopyOnly backups"
-						}
+			foreach ($db in $inputobject) {
+
+				$Notes = $null
+				if ($NoFullBackup -or $NoFullBackupSince) {
+					if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
+						$Notes = "Only CopyOnly backups"
 					}
-					Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
-					
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-					Select-DefaultView -InputObject $db -Property $defaults
 				}
-			}
-			catch {
-				Stop-Message -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified. If so, please use parens (Get-DbaDatabase ....) | when working with commands that modify the collection such as Remove-DbaDatabase" -Continue
+				Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
+
+				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
+				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+				Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+				Select-DefaultView -InputObject $db -Property $defaults
+
 			}
 		}
 	}
 }
+


### PR DESCRIPTION
Fixes #1655

Changes proposed in this pull request:
 - filters are now added instead of only applying the last one
 - databases are piped to where only once (except when using backuphistory filters)


How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

