### PR TITLE
CopyOnly changes

### DIFF
--- a/bin/projects/dbatools/dbatools/Database/BackupHistory.cs
+++ b/bin/projects/dbatools/dbatools/Database/BackupHistory.cs
@@ -118,5 +118,10 @@ namespace Sqlcollaborative.Dbatools.Database
         /// The primary version number of the Sql Server
         /// </summary>
         public int SoftwareVersionMajor;
+        
+        /// <summary>
+        /// Was the backup performed with the CopyOnlyOption
+        /// </summary>
+        public Boolean IsCopyOnly;
     }
 }

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -36,9 +36,9 @@ If path does not exist Sql Server will attmept to create it. Folders are created
 
 File Names with be suffixed with x-of-y to enable identifying striped sets, where y is the number of files in the set and x is from 1 to you
 
-.PARAMETER NoCopyOnly
-By default function performs a Copy Only backup. These backups do not intefere with the restore chain of the database, so are safe to take.
-This switch indicates that you wish to take normal backups. Be aware that these WILL break your restore chains, so use at your own risk
+.PARAMETER CopyOnly
+By default function performs a normal backup, these backups  intefere with the restore chain of the database.
+This switch indicates that you wish to take CopyOnly backups. These backups will not intefere with the restore chain of the database.
 
 For more details please refer to this MSDN article - https://msdn.microsoft.com/en-us/library/ms191495.aspx 
 
@@ -128,7 +128,7 @@ sql credential dbatoolscred registered on the sql2016 instance
 		[object[]]$ExcludeDatabase,
 		[string[]]$BackupDirectory,
 		[string]$BackupFileName,
-		[switch]$NoCopyOnly,
+		[switch]$CopyOnly,
 		[ValidateSet('Full', 'Log', 'Differential', 'Diff', 'Database')]
 		[string]$Type = "Database",
 		[parameter(ParameterSetName = "NoPipe", Mandatory = $true, ValueFromPipeline = $true)]
@@ -253,7 +253,9 @@ sql credential dbatoolscred registered on the sql2016 instance
 				Write-Message -Level Warning -Message "$failreason"
 			}
 			
-			$copyonly = !$NoCopyOnly
+			if ($CopyOnly -ne $True) {
+				$CopyOnly -eq $false
+			}
 			
 			$server.ConnectionContext.StatementTimeout  = 0
 			$backup = New-Object Microsoft.SqlServer.Management.Smo.Backup

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -180,8 +180,13 @@ function Copy-DbaDatabase {
 		[switch]$Force,
 		[switch]$Silent
 	)
-
 	begin {
+		if ($NoCopyOnly -eq $True){
+			$CopyOnly = $False
+		}
+		else {
+			$CopyOnly = $True
+		}
 		# Global Database Function
 		function Get-SqlFileStructure {
 			$dbcollection = @{ };
@@ -928,7 +933,7 @@ function Copy-DbaDatabase {
 						$fileName = "$dbName-$timeNow.bak"
 						$backupFile = Join-Path $NetworkShare $fileName
 
-						$backupTmpResult = Backup-DbaDatabase -SqlInstance $sourceServer -Database $dbName -backupDirectory (Split-Path -Path $backupFile -parent) -FileCount $numberfiles -NoCopyOnly:$NoCopyOnly
+						$backupTmpResult = Backup-DbaDatabase -SqlInstance $sourceServer -Database $dbName -backupDirectory (Split-Path -Path $backupFile -parent) -FileCount $numberfiles -CopyOnly:$CopyOnly
 						$backupResult = $BackupTmpResult.BackupComplete
 						if ($backupResult -eq $false) {
 							$serviceAccount = $sourceServer.ServiceAccount

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -381,7 +381,8 @@ function Get-DbaBackupHistory {
 								  backupset.checkpoint_lsn,
 								  backupset.last_lsn,
 								  backupset.software_major_version,
-								  mediaset.software_name AS Software
+								  mediaset.software_name AS Software,
+								  backupset.is_copy_only
 								FROM msdb..backupmediafamily AS mediafamily
 								JOIN msdb..backupmediaset AS mediaset
 								  ON mediafamily.media_set_id = mediaset.media_set_id
@@ -446,7 +447,8 @@ function Get-DbaBackupHistory {
 							  backupset.checkpoint_lsn as 'CheckpointLsn',
 							  backupset.last_lsn as 'Lastlsn',
 							  backupset.software_major_version,
-							  mediaset.software_name AS Software"
+							  mediaset.software_name AS Software,
+							backupset.is_copy_only"
 				}
 				
 				$from = " FROM msdb..backupmediafamily mediafamily
@@ -536,6 +538,7 @@ function Get-DbaBackupHistory {
 					$historyObject.CheckpointLsn = $group.Group[0].checkpoint_lsn
 					$historyObject.LastLsn = $group.Group[0].Last_Lsn
 					$historyObject.SoftwareVersionMajor = $group.Group[0].Software_Major_Version
+					$historyObject.IsCopyOnly = if($group.Group[0].is_copy_only -eq 1){$true}else{$false}
 					$groupResults += $historyObject
 				}
 				$groupResults | Sort-Object -Property End -Descending

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -275,10 +275,9 @@ function Get-DbaBackupHistory {
 					$allbackups += $Fulldb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType
 					$DiffDB = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType
 					if ($DiffDb.LastLsn -gt $Fulldb.LastLsn -and  $DiffDb.DatabaseBackupLSN -eq $Fulldb.CheckPointLSN ) {
+						Write-Message -Level Verbose "Valid Differential backup "
 						$Allbackups += $DiffDB
-
 						$TLogStartLSN = ($diffdb.FirstLsn -as [bigint])
-						$Allbackups += $DiffDB
 					}
 					else {
 						Write-Message -Level Verbose -Message "No Diff found"

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -9,6 +9,8 @@ function Get-DbaBackupHistory {
 		Returns backup history details for some or all databases on a SQL Server.
 		
 		You can even get detailed information (including file path) for latest full, differential and log files.
+
+		Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present
 		
 		Reference: http://www.sqlhub.com/2011/07/find-your-backup-history-in-sql-server.html
 	
@@ -25,8 +27,8 @@ function Get-DbaBackupHistory {
 	.PARAMETER ExcludeDatabase
 		The database(s) to not process.
 	
-	.PARAMETER IgnoreCopyOnly
-		If set, Get-DbaBackupHistory will ignore CopyOnly backups
+	.PARAMETER IncludeCopyOnly
+		By default Get-DbaBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them
 	
 	.PARAMETER Force
 		Returns a boatload of information, the way SQL Server returns it
@@ -151,7 +153,7 @@ function Get-DbaBackupHistory {
 		$ExcludeDatabase,
 		
 		[switch]
-		$IgnoreCopyOnly,
+		$IncludeCopyOnly,
 		
 		[Parameter(ParameterSetName = "NoLast")]
 		[switch]
@@ -198,6 +200,11 @@ function Get-DbaBackupHistory {
 		Write-Message -Level System -Message "Active Parameterset: $($PSCmdlet.ParameterSetName)"
 		Write-Message -Level System -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
 		
+		$IgnoreCopyOnly = $true
+		If ($IncludeCopyOnly -eq $True) {
+			$IgnoreCopyOnly = $false
+		}
+
 		$DeviceTypeMapping = @{
 			'Disk' = 2
 			'Permanent Disk Device' = 102


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Get-DbaBackupHistory now defaults to ignore CopyOnly databases
 - Get-DbaBackupHistory now outputs CopyOnly info
 - Backup-DbaDatabase now takes real backups not CopyOnly ones
 - Copy-DbaDatabase has been modified so the above doesn't change it's workings

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

