### PR TITLE
Get sql mangaement object fixes

### DIFF
--- a/functions/Get-DbaSqlManagementObject.ps1
+++ b/functions/Get-DbaSqlManagementObject.ps1
@@ -42,7 +42,6 @@
 			Returns just the version specified. If the version does not exist then it will return nothing.
 		
 	#>
-	#>
 	[CmdletBinding()]
 	param (
 		[parameter(ValueFromPipeline)]
@@ -54,15 +53,21 @@
 		[switch]$Silent
 	)
 	
-	begin {
+	begin
+	{
+		if (!$VersionNumber)
+		{
+			$VersionNumber = 0	
+		}
 		$scriptblock = {
 			$VersionNumber = [int]$args[0]
 			
 			Write-Verbose "Checking currently loaded SMO version"
 			$loadedversion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }
 			
-			if ($loadedversion) {
-				$loadedversion = (($loadedversion.FullName -Split ", ")[1]).TrimStart("Version=")
+			if ($loadedversion)
+			{
+				$loadedversion = $loadedversion | foreach { ((Split-Path (Split-Path $_.Location) -Leaf) -split "__")[0] }
 			}
 			
 			Write-Verbose "Looking for SMO in the Global Assembly Cache"
@@ -77,7 +82,7 @@
 					[PSCustomObject]@{
 						ComputerName = $env:COMPUTERNAME
 						Version = $currentversion
-						Loaded = $currentversion -eq $loadedversion
+						Loaded = $loadedversion -contains $currentversion
 						LoadTemplate = "Add-Type -AssemblyName `"Microsoft.SqlServer.Smo, Version=$($array[0]), Culture=neutral, PublicKeyToken=89845dcd8080cc91`""
 					}
 				}
@@ -89,7 +94,7 @@
 						[PSCustomObject]@{
 							ComputerName = $env:COMPUTERNAME
 							Version = $currentversion
-							Loaded = $currentversion -eq $loadedversion
+							Loaded = $loadedversion -contains $currentversion
 							LoadTemplate = "Add-Type -AssemblyName `"Microsoft.SqlServer.Smo, Version=$($array[0]), Culture=neutral, PublicKeyToken=89845dcd8080cc91`""
 						}
 					}
@@ -104,7 +109,7 @@
 				Invoke-Command2 -ComputerName $computer -ScriptBlock $scriptblock -Credential $Credential -ArgumentList $VersionNumber -ErrorAction Stop
 			}
 			catch {
-				Stop-Function -Continue -Message "Faiure" -ErrorRecord $_ -Target $ComputerName
+				Stop-Function -Continue -Message "Failure" -ErrorRecord $_ -Target $ComputerName
 			}
 		}
 	}


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Fixed a typo where the bottom message has Faiure and I added the l for Failure
 - Added the ability to see that multiple versions are loaded.
 - 

How to test this code: 
- [X] Run with and without multiple machines 
- [X] Load multiple versions of SMO using the LoadTemplate from this function 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [X ]  SQL Server vNext
- [X ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

