### PR TITLE
Those who patch Get-DbaBackupHistory are doomed to repeat it.

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 0, 14)
+$currentLibraryVersion = New-Object System.Version(0, 6, 0, 15)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Database/BackupHistory.cs
+++ b/bin/projects/dbatools/dbatools/Database/BackupHistory.cs
@@ -123,5 +123,10 @@ namespace Sqlcollaborative.Dbatools.Database
         /// Was the backup performed with the CopyOnlyOption
         /// </summary>
         public Boolean IsCopyOnly;
+
+        /// <summary>
+        /// Recovery Fork backup was takeon
+        /// </summary>
+        public Guid LastRecoveryForkGUID;
     }
 }

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -258,9 +258,14 @@ function Get-DbaBackupHistory {
 				$backupSizeColumn = 'compressed_backup_size'
 			}
 			
-			$databases = $server.Databases
-			if ($Database) {
-				$databases = $databases | Where-Object Name -In $Database
+			$databases = @()
+			if ($null -ne $Database) {
+				ForEach ($db in $Database){
+					$databases += [PScustomObject]@{name = $db}
+				}
+			}
+			else {
+				$databases = $server.Databases	
 			}
 			if ($ExcludeDatabase) {
 				$databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
@@ -272,7 +277,7 @@ function Get-DbaBackupHistory {
 			foreach($b in $BackupTypeFilter) {
 				$BackupTypeFilterRight = "IN ('" + ($BackupTypeFilter -Join "','") + "')"
 			}
-			
+
 			if ($last) {
 				
 				foreach ($db in $databases) {
@@ -295,17 +300,19 @@ function Get-DbaBackupHistory {
 							continue
 						}
 					}
+					Write-Message -Level Verbose -Message "Tlogstart = $TlogStartLSN"
 					$Allbackups += $Logdb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $TLogstartLSN | Where-Object { 
-						$_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$TLogstartLSN -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$Fulldb.CheckPointLSN 
+						$_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$TLogstartLSN -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$Fulldb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $Fulldb.LastRecoveryForkGuid
 					}
-					$Allbackups | Sort-Object LastLsn
+					#This line does the output for -Last!!!
+					$Allbackups |  Sort-Object -Property LastLsn, Type
 				
 				}
 				continue
 			}
 			
 			if ($LastFull -or $LastDiff -or $LastLog) {
-				$sql = @()
+				#$sql = @()
 				if ($LastFull) {
 					$first = 'D'; $second = 'P'
 				}
@@ -317,13 +324,13 @@ function Get-DbaBackupHistory {
 				}
 				$databases = $databases | Select-Object -Unique
 				foreach ($db in $databases) {
-					Write-Message -Level Verbose -Message "Processing $db" -Target $db
+					Write-Message -Level Verbose -Message "Processing $($db.name)" -Target $db
 					$wherecopyonly = $null
 					if ($IgnoreCopyOnly) { $wherecopyonly = "AND is_copy_only='0'" }
 					if ($DeviceTypeFilter) {
 						$DevTypeFilterWhere = "AND mediafamily.device_type $DeviceTypeFilterRight"
 					}
-					$sql += "
+					$sql = "
 								SELECT
 									a.BackupSetRank,
 									a.Server,
@@ -348,7 +355,9 @@ function Get-DbaBackupHistory {
  									a.checkpoint_lsn as 'CheckpointLsn',
  									a.last_lsn as 'Lastlsn',
  									a.software_major_version,
-									a.DeviceType
+									a.DeviceType,
+									a.is_copy_only,
+									a.last_recovery_fork_guid
 								FROM (SELECT
 								  RANK() OVER (ORDER BY backupset.backup_start_date DESC) AS 'BackupSetRank',
 								  backupset.database_name AS [Database],
@@ -389,7 +398,8 @@ function Get-DbaBackupHistory {
 								  backupset.last_lsn,
 								  backupset.software_major_version,
 								  mediaset.software_name AS Software,
-								  backupset.is_copy_only
+								  backupset.is_copy_only,
+								  backupset.last_recovery_fork_guid
 								FROM msdb..backupmediafamily AS mediafamily
 								JOIN msdb..backupmediaset AS mediaset
 								  ON mediafamily.media_set_id = mediaset.media_set_id
@@ -404,7 +414,7 @@ function Get-DbaBackupHistory {
 								"
 				}
 				
-				$sql = $sql -join "; "
+				#$sql = $sql -join "; "
 			}
 			else {
 				if ($Force -eq $true) {
@@ -455,7 +465,8 @@ function Get-DbaBackupHistory {
 							  backupset.last_lsn as 'Lastlsn',
 							  backupset.software_major_version,
 							  mediaset.software_name AS Software,
-							backupset.is_copy_only"
+							  backupset.is_copy_only,
+							  backupset.last_recovery_fork_guid"
 				}
 				
 				$from = " FROM msdb..backupmediafamily mediafamily
@@ -481,7 +492,7 @@ function Get-DbaBackupHistory {
 					$wherearray += "backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
 				}
 				
-				if ($IgnoreCopyOnly) {
+				if ($IgnoreCopyOnly -eq $true) {
 					$wherearray += "is_copy_only='0'"
 				}
 				if ($DeviceTypeFilter) {
@@ -501,6 +512,10 @@ function Get-DbaBackupHistory {
 				
 				$sql = "$select $from $where ORDER BY backupset.backup_finish_date DESC"
 			}
+			#$sql = "$select $from $where ORDER BY backupset.backup_finish_date DESC"
+			Write-Message -Level SomewhatVerbose -Message "sql - $sql"
+			#Write-Message -Level SomewhatVerbose -Message "from - $from"
+			#Write-Message -Level SomewhatVerbose -Message "where - $where"
 			Write-Message -Level Debug -Message $sql
 			Write-Message -Level SomewhatVerbose -Message "Executing sql query"
 			$results = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-Object * -ExcludeProperty BackupSetRank, RowError, Rowstate, table, itemarray, haserrors
@@ -521,7 +536,7 @@ function Get-DbaBackupHistory {
 								from msdb.dbo.backupfile where backup_set_id='$($Group.group[0].BackupSetID)'"
 					
 					Write-Message -Level Debug -Message "FileSQL: $fileSql"
-					
+	
 					$historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
 					$historyObject.ComputerName = $server.NetName
 					$historyObject.InstanceName = $server.ServiceName
@@ -546,9 +561,10 @@ function Get-DbaBackupHistory {
 					$historyObject.LastLsn = $group.Group[0].Last_Lsn
 					$historyObject.SoftwareVersionMajor = $group.Group[0].Software_Major_Version
 					$historyObject.IsCopyOnly = if($group.Group[0].is_copy_only -eq 1){$true}else{$false}
+					$HistoryObject.LastRecoveryForkGuid = $group.Group[0].last_recovery_fork_guid
 					$groupResults += $historyObject
 				}
-				$groupResults | Sort-Object -Property End -Descending
+				$groupResults | Sort-Object -Property LastLsn, Type
 			}
 		}
 	}

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -300,7 +300,6 @@ function Get-DbaBackupHistory {
 							continue
 						}
 					}
-					Write-Message -Level Verbose -Message "Tlogstart = $TlogStartLSN"
 					$Allbackups += $Logdb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $TLogstartLSN | Where-Object { 
 						$_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$TLogstartLSN -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$Fulldb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $Fulldb.LastRecoveryForkGuid
 					}
@@ -512,10 +511,7 @@ function Get-DbaBackupHistory {
 				
 				$sql = "$select $from $where ORDER BY backupset.backup_finish_date DESC"
 			}
-			#$sql = "$select $from $where ORDER BY backupset.backup_finish_date DESC"
-			Write-Message -Level SomewhatVerbose -Message "sql - $sql"
-			#Write-Message -Level SomewhatVerbose -Message "from - $from"
-			#Write-Message -Level SomewhatVerbose -Message "where - $where"
+
 			Write-Message -Level Debug -Message $sql
 			Write-Message -Level SomewhatVerbose -Message "Executing sql query"
 			$results = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-Object * -ExcludeProperty BackupSetRank, RowError, Rowstate, table, itemarray, haserrors


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Database parameter now works for dbs that don't exist anymore
 - Outputs sorted on LastLsn, then Backup Type (fixes issues where LastLSN is the same)
 - Using LastRecoveryForkGUID to build up Last backup chain, was getting confused with test database examples, this carries through the backups
- backuphistory object now has a LastRecoveryForkGuid property
- revision number updated in library.ps1 so should recompiled the dll 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

