### PR TITLE
Remove-DbaAgentSchedule -force is now required to remove schedule associated with job

### DIFF
--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -25,7 +25,7 @@ Shows what would happen if the command were to run. No actions are actually perf
 Prompts you for confirmation before executing any changing operations within the command.
 
 .PARAMETER Silent
-Use this switch to disable any kind of verbose messages
+Use this switch to disable any kind of verbose messages.
 
 .PARAMETER Force
 The force parameter will ignore some errors in the parameters and assume defaults.
@@ -33,7 +33,7 @@ It will also remove the any present schedules with the same name for the specifi
 
 .NOTES 
 Original Author: Sander Stad (@sqlstad, sqlstad.nl)
-Tags: Agent, Job, Job Step
+Tags: Agent, Job, Job Step, Schedule
 	
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
@@ -56,7 +56,7 @@ Remove multiple schedule
 
 .EXAMPLE   
 Remove-DbaAgentSchedule -SqlInstance sql1, sql2, sql3 -Schedule daily, weekly
-Remove the schedule on multiple servers for multiple scheukes
+Remove the schedule on multiple servers for multiple schedules
 
 .EXAMPLE   
 sql1, sql2, sql3 | Remove-DbaAgentSchedule -Schedule daily, weekly
@@ -102,7 +102,7 @@ Remove the schedule on multiple servers using pipe line
 					$jobCount = $Server.JobServer.SharedSchedules[$s].JobCount
 
 					# Check if the schedule is shared among other jobs
-					if ($jobCount -gt 1 -and -not $Force) {
+					if ($jobCount -ge 1 -and -not $Force) {
 						Stop-Function -Message "The schedule $s is shared connected to one or more jobs. If removal is neccesary use -Force." -Target $instance -Continue
 					}
 
@@ -111,7 +111,7 @@ Remove the schedule on multiple servers using pipe line
 						# Loop through each of the schedules and drop them
 						Write-Message -Message "Removing schedule $s on $instance" -Level Output
 
-						#Check if multiple jobs use the schedule
+						#Check if jobs use the schedule
 						if ($jobCount -ge 1) {
 							# Get the job object
 							$smoSchedules = $server.JobServer.SharedSchedules | Where-Object {($_.Name -eq $s)}


### PR DESCRIPTION
Fixes #1601 

Changes proposed in this pull request:
 - changed logic so -Force is required if schedule is attached to job

How to test this code: 
- [ ] `Remove-DbaAgentSchedule -SqlInstance server1 -Schedule test3` 
Where test3 schedule is attached to a job, schedule won't be removed since no -force specified
![image](https://user-images.githubusercontent.com/981370/28314144-679b2880-6b87-11e7-8cc1-bd01f8b7acb0.png)
- [ ] `Remove-DbaAgentSchedule -SqlInstance server1 -Schedule test3 -force` 
Where test3 schedule is attached to a job, schedule will be removed
![image](https://user-images.githubusercontent.com/981370/28314166-7650e8d8-6b87-11e7-9490-33dbd90a7d38.png)



Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

