### PR TITLE
DbaInstanceParameter Added fallback for netname when not available

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 0, 15)
+$currentLibraryVersion = New-Object System.Version(0, 6, 0, 16)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -400,7 +400,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
                 case "microsoft.sqlserver.management.smo.server":
                     try
                     {
-                        _ComputerName = (string)tempInput.Properties["NetName"].Value;
+                        try { _ComputerName = (string)tempInput.Properties["NetName"].Value; }
+                        catch { _ComputerName = (string)tempInput.Properties["ComputerNamePhysicalNetBIOS"].Value; }
                         _InstanceName = (string)tempInput.Properties["InstanceName"].Value;
                         PSObject tempObject = new PSObject(tempInput.Properties["ConnectionContext"].Value);
 

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.0.14")]
-[assembly: AssemblyFileVersion("0.6.0.14")]
+[assembly: AssemblyVersion("0.6.0.16")]
+[assembly: AssemblyFileVersion("0.6.0.16")]


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - In SMO Versions where NetName is not available, it will fall back to using `ComputerNamePhysicalNetBIOS` instead