### PR TITLE
Fixing conflict markers

### DIFF
--- a/functions/Backup-DbaDatabaseMasterKey.ps1
+++ b/functions/Backup-DbaDatabaseMasterKey.ps1
@@ -1,4 +1,4 @@
-﻿Function Backup-DbaDatabaseMasterKey {
+Function Backup-DbaDatabaseMasterKey {
 	<#
 .SYNOPSIS
 Backs up specified database master key.
@@ -95,13 +95,8 @@ Logs into sql2016 with Windows credentials then backs up db1's keys to the \\nas
 				$Path = $server.BackupDirectory
 			}
 			
-<<<<<<< HEAD
-			if (!$backupdirectory) {
-				Stop-Function -Message "Backup directory discovery failed. Please explicitly specify -BackupDirectory" -Target $server -Continue
-=======
 			if (!$Path) {
-				Stop-Function -Message "Path discovery failed. Please expliticly specify -Path" -Target $server -Continue
->>>>>>> upstream/development
+				Stop-Function -Message "Path discovery failed. Please explicitly specify -Path" -Target $server -Continue
 			}
 			
 			if (!(Test-DbaSqlPath -SqlInstance $server -Path $Path)) {


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Fix to conflict markers
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

