### PR TITLE
Get-MaintenanceSolutionLog make over

### DIFF
--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -39,17 +39,32 @@ https://dbatools.io/Get-DbaMaintenanceSolutionLog
 .EXAMPLE 
 Get-DbaMaintenanceSolutionLog -SqlInstance sqlserver2014a
 
-Gets the outcome of the IndexOptimize job on sql instance sqlserver2014a
+Gets the outcome of the IndexOptimize job on sql instance sqlserver2014a.
 
 .EXAMPLE 
 Get-DbaMaintenanceSolutionLog -SqlInstance sqlserver2014a -SqlCredential $credential
 
-Gets the outcome of the IndexOptimize job on sqlserver2014a, using SQL Authentication
+Gets the outcome of the IndexOptimize job on sqlserver2014a, using SQL Authentication.
 		
 .EXAMPLE 
 'sqlserver2014a', 'sqlserver2020test' | Get-DbaMaintenanceSolutionLog
 	
 Gets the outcome of the IndexOptimize job on sqlserver2014a and sqlserver2020test.
+
+.EXAMPLE 
+Get-DbaMaintenanceSolutionLog -SqlInstance sqlserver2014a -Path 'D:\logs\maintenancesolution\'
+
+Gets the outcome of the IndexOptimize job on sqlserver2014a, reading the log files in their custom location.
+
+.EXAMPLE 
+Get-DbaMaintenanceSolutionLog -SqlInstance sqlserver2014a -Since '2017-07-18'
+
+Gets the outcome of the IndexOptimize job on sqlserver2014a, starting from july 18, 2017.
+
+.EXAMPLE 
+Get-DbaMaintenanceSolutionLog -SqlInstance sqlserver2014a -LogType IndexOptimize
+
+Gets the outcome of the IndexOptimize job on sqlserver2014a, the other options are not yet available! sorry
 	
 #>
 	[CmdletBinding(DefaultParameterSetName = "Default")]

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -108,7 +108,7 @@ Gets the outcome of the IndexOptimize job on sqlserver2014a and sqlserver2020tes
 					$fresh['Action'] = $Matches.action
 					$fresh['Options'] = $Matches.options
 				}
-				elseif ($fresh['Command'] -match '^UPDATE STATISTICS \[(?<database>[^\]]+)\]\.\[(?<schema>[^]]+)\]\.\[(?<table>[^\]]+)\] \[(?<stat>[^\]]+)\]') {
+				elseif ($fresh['Command'] -match 'UPDATE STATISTICS \[(?<database>[^\]]+)\]\.\[(?<schema>[^]]+)\]\.\[(?<table>[^\]]+)\] \[(?<stat>[^\]]+)\]') {
 					$fresh['Index'] = $null
 					$fresh['Statistics'] = $Matches.stat
 					$fresh['Schema'] = $Matches.Schema


### PR DESCRIPTION

Changes proposed in this pull request:
 - add path parameter
 - add since parameter
 - replace parsing logic
 - 
 - 
Thanks to @niphlod 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

