### PR TITLE
Restoreposition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ before_test:
   - ps: Install-Module -Name Pester -Repository PSGallery -Force | Out-Null
   # "Setting up the local SQL Server environments"
   - ps: .\Tests\appveyor.sqlserver.ps1
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
   #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ before_test:
   - ps: Install-Module -Name Pester -Repository PSGallery -Force | Out-Null
   # "Setting up the local SQL Server environments"
   - ps: .\Tests\appveyor.sqlserver.ps1
-  
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
   #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -276,7 +276,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                         Stop-Function -Message "$dbname does not exist on $source." -Continue
                     }
 
-                    $lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IncludeCopyOnly:$IncludeCopyOnly -raw
+                    $lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IncludeCopyOnly:$IncludeCopyOnly #-raw
                     if ($CopyFile) {
                         try {
                             Write-Message -Level Verbose -Message "Gathering information for file copy"
@@ -285,14 +285,14 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                             if (Test-Bound "IgnoreLogBackup"){
                                 Write-Message -Level Verbose -Message "Skipping Log backups as requested"
                                 $lastbackup = @()
-                                $lastbackup += $full = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IncludeCopyOnly:$IncludeCopyOnly -raw	-LastFull
-                                $diff = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IncludeCopyOnly:$IncludeCopyOnly -raw -LastDiff
+                                $lastbackup += $full = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IncludeCopyOnly:$IncludeCopyOnly -LastFull #-raw
+                                $diff = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -IncludeCopyOnly:$IncludeCopyOnly -LastDiff # -raw 
                                 if ($full.start -le $diff.start){
                                     $lastbackup += $diff
                                 }									
                             }
                             else {
-                                $lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IncludeCopyOnly:$IncludeCopyOnly -raw
+                                $lastbackup = Get-DbaBackupHistory -SqlInstance $sourceserver -Database $dbname -Last -IncludeCopyOnly:$IncludeCopyOnly #-raw
                             }
                                 
                             foreach ($backup in $lastbackup) {
@@ -355,7 +355,7 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                         $restoreresult = "Restore not located on shared location"
                         $dbccresult = "Skipped"
                     }
-                    elseif ((Test-DbaSqlPath -SqlInstance $destserver -Path $lastbackup[0].Path) -eq $false) {
+                    elseif (($lastbackup[0].Path | Foreach{Test-DbaSqlPath -SqlInstance $destserver -Path $_}) -eq $false) {
                         Write-Message -Level Verbose -Message "SQL Server cannot find backup"
                         $fileexists = $false
                         $restoreresult = "Skipped"
@@ -387,10 +387,10 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                                 Write-Message -Level Verbose -Message "Performing restore"
                                 $startRestore = Get-Date
                                 if ($verifyonly) {
-                                    $restoreresult = $lastbackup | Restore-DbaDatabase -SqlInstance $destserver -RestoredDatababaseNamePrefix $prefix -DestinationFilePrefix $Prefix -DestinationDataDirectory $datadirectory -DestinationLogDirectory $logdirectory -VerifyOnly:$VerifyOnly -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
+                                    $restoreresult = $lastbackup | Restore-DbaDatabase -SqlInstance $destserver -RestoredDatababaseNamePrefix $prefix -DestinationFilePrefix $Prefix -DestinationDataDirectory $datadirectory -DestinationLogDirectory $logdirectory -VerifyOnly:$VerifyOnly -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential -TrustDbBackupHistory
                                 }
                                 else {
-                                    $restoreresult = $lastbackup | Restore-DbaDatabase -SqlInstance $destserver -RestoredDatababaseNamePrefix $prefix -DestinationFilePrefix $Prefix -DestinationDataDirectory $datadirectory -DestinationLogDirectory $logdirectory -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
+                                    $restoreresult = $lastbackup | Restore-DbaDatabase -SqlInstance $destserver -RestoredDatababaseNamePrefix $prefix -DestinationFilePrefix $Prefix -DestinationDataDirectory $datadirectory -DestinationLogDirectory $logdirectory -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential -TrustDbBackupHistory
                                 }
 								
                                 $endRestore = Get-Date

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -334,7 +334,14 @@ Copies the backup files for sql2014 databases to sql2016 default backup location
                             $copysuccess = $false
                         }
                     }
-                    #if ($null -eq $lastbackup)
+                    if ($null -eq $lastbackup) {
+                        Write-Message -Level Verbose -Message "No backups exist for this database"
+                        $lastbackup = @{ Path = "No backups exist for this database" }
+                        $fileexists = $false
+                        $restoreresult = "Skipped"
+                        $dbccresult = "Skipped"
+
+                    }
                     if (!$copysuccess) {
                         Write-Message -Level Verbose -Message "Failed to copy backups"
                         $lastbackup = @{ Path = "Failed to copy backups" }

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -169,6 +169,9 @@ function Get-FilteredRestoreFile {
             $ServerName, $databaseName = $Database.Name.split(',').trim()
 
             Write-verbose "dbname = $databasename"
+            foreach ($bk in $AllSQLBackupdetails) {
+                Write-Message -level verbose -Message "Server $serverName = $($_.ServerName) - dbname $databasename = $($_.DatabaseName) - Type = $($_.Type)"
+            }
             $SQLBackupdetails = $AllSQLBackupdetails | Where-Object {$_.ServerName -eq $ServerName -and $_.DatabaseName -eq $DatabaseName.trim()}
             #If we're continuing a restore, then we aren't going to be needing a full backup....
             $TlogStartlsn = 0

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -180,7 +180,7 @@ function Get-FilteredRestoreFile {
                     break
                 }
                 #This scans for striped full backups to build the results
-                $Results += $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq "Database" -and $_.FirstLSN -eq $FullBackup.FirstLSN}
+                $Results += $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq "Database" -and $_.FirstLSN -eq $FullBackup.FirstLSN -and $_.BackupSetGUID -eq $FullBackup.BackupSetGUID}
             }
             else {
                 Write-Message -Level VeryVerbose -Message "Continuing restore, setting fake fullbackup"

--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -169,9 +169,6 @@ function Get-FilteredRestoreFile {
             $ServerName, $databaseName = $Database.Name.split(',').trim()
 
             Write-verbose "dbname = $databasename"
-            foreach ($bk in $AllSQLBackupdetails) {
-                Write-Message -level verbose -Message "Server $serverName = $($_.ServerName) - dbname $databasename = $($_.DatabaseName) - Type = $($_.Type)"
-            }
             $SQLBackupdetails = $AllSQLBackupdetails | Where-Object {$_.ServerName -eq $ServerName -and $_.DatabaseName -eq $DatabaseName.trim()}
             #If we're continuing a restore, then we aren't going to be needing a full backup....
             $TlogStartlsn = 0

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -278,34 +278,4 @@
             Foreach ($db in $results) { $db.Status | Should Be "Dropped" }
         }
     }
-
-    Context "Setup Backup file containing multiple backups for testing" {
-        $results = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak -DatabaseName MultiRestore
-        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Full -BackupFile c:\temp\multiple.bak
-        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Full -BackupFile c:\temp\multiple.bak
-        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Log -BackupFile c:\temp\multiple.trn
-        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Log -BackupFile c:\temp\multiple.trn
-    }
-
-    Context "Testing that Restore-DbaDatabase handles positional databases from files" {
-        $results = Get-ChildItem c:\temp -file | Where-Object {$_.name -like '*multiple*'} | Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore  -WithReplace
-        It "Should restore cleanly" {
-            ($results.RestoreComplete -contains $false) | Should Be $false
-        }      
-        It "Should have restored 3 files" {
-            $results.count | Should be 3
-        }
-    }
-
-    Context "Testing that Restore-DbaDatabase handles positional databases from history" {
-        $results = Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore -Last| Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore  -WithReplace -TrustDbBackupHistory
-        It "Should restore cleanly" {
-            ($results.RestoreComplete -contains $false) | Should Be $false
-        }      
-        It "Should have restored 3 files" {
-            $results.count | Should be 3
-        }
-    }
-
-
 }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -279,4 +279,33 @@
         }
     }
 
+    Context "Setup Backup file containing multiple backups for testing" {
+        $results = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak -DatabaseName MultiRestore
+        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Full -BackupFile c:\temp\multiple.bak
+        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Full -BackupFile c:\temp\multiple.bak
+        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Log -BackupFile c:\temp\multiple.trn
+        $null = Backup-DbaDatabase -SqlInstance localhost -Database MultiRestore -Log -BackupFile c:\temp\multiple.trn
+    }
+
+    Context "Testing that Restore-DbaDatabase handles positional databases from files" {
+        $results = Get-ChildItem c:\temp -file | Where-Object {$_.name -like '*multiple*'} | Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore  -WithReplace
+        It "Should restore cleanly" {
+            ($results.RestoreComplete -contains $false) | Should Be $false
+        }      
+        It "Should have restored 3 files" {
+            $results.count | Should be 3
+        }
+    }
+
+    Context "Testing that Restore-DbaDatabase handles positional databases from history" {
+        $results = Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore -Last| Get-DbaBackupHistory -SqlInstance localhost -Database MultiRestore  -WithReplace -TrustDbBackupHistory
+        It "Should restore cleanly" {
+            ($results.RestoreComplete -contains $false) | Should Be $false
+        }      
+        It "Should have restored 3 files" {
+            $results.count | Should be 3
+        }
+    }
+
+
 }

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -36,25 +36,5 @@
 		}
 		$null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
 	}
-
-	Context "Setup removes, restores and backups on the local drive for Test-DbaLastBackup for multi position tests" {
-		$null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
-
-		$null = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak -WithReplace
-		$db = Get-DbaDatabase -SqlInstance localhost -Database singlerestore
-		$null = $db | Backup-DbaDatabase -Type Full -BackupFileName TestLast.bak
-		$null = $db | Backup-DbaDatabase -Type Full -BackupFileName TestLast.bak
-		$null = $db | Backup-DbaDatabase -Type Differential
-		$null = $db | Backup-DbaDatabase -Type Log
-	}
-
-	Context "Testing that it works with multiple backups in one file"{
-		$results = Test-DbaLastBackup -SqlInstance localhost -Database singlerestore
-		
-        It "Should return success" {
-			$results.RestoreResult | Should Be "Success"
-			$results.DbccResult | Should Be "Success"
-        }
-	}
 	
 }

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -36,5 +36,25 @@
 		}
 		$null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
 	}
+
+	Context "Setup removes, restores and backups on the local drive for Test-DbaLastBackup for multi position tests" {
+		$null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
+
+		$null = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak -WithReplace
+		$db = Get-DbaDatabase -SqlInstance localhost -Database singlerestore
+		$null = $db | Backup-DbaDatabase -Type Full -BackupFileName TestLast.bak
+		$null = $db | Backup-DbaDatabase -Type Full -BackupFileName TestLast.bak
+		$null = $db | Backup-DbaDatabase -Type Differential
+		$null = $db | Backup-DbaDatabase -Type Log
+	}
+
+	Context "Testing that it works with multiple backups in one file"{
+		$results = Test-DbaLastBackup -SqlInstance localhost -Database singlerestore
+		
+        It "Should return success" {
+			$results.RestoreResult | Should Be "Success"
+			$results.DbccResult | Should Be "Success"
+        }
+	}
 	
 }


### PR DESCRIPTION
Fixes #1736 #1715  

Changes proposed in this pull request:
 - Issues with file positions fixed.
 - Test-DbaLastBackup now uses TrustDbBackupHistory so should be a bit quicker
 - Now tests if the db doesn't have a backup

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

