### PR TITLE
Get-DbaAgReplica - Initial Version

### DIFF
--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -30,27 +30,22 @@ function Get-DbaAgReplica {
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
 		.LINK
-			https://dbatools.io/Get-DbaAvailabilityGroup
+			https://dbatools.io/Get-DbaAgReplica
 
 		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a
+			Get-DbaAgReplica -SqlInstance sqlserver2014a
 
-			Returns basic information on all the Availability Group(s) found on sqlserver2014a
-
-		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
-
-			Shows basic information on the Availability Group AG-a on sqlserver2014a
+			Returns basic information on all the Availability Group(s) replica(s) found on sqlserver2014a
 
 		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a | Select *
+			Get-DbaAgReplica -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
 
-			Returns full object properties on all Availability Group(s) on sqlserver2014a
+			Shows basic information on the replica(s) found on Availability Group AG-a on sqlserver2014a
 
 		.EXAMPLE
-			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary
+			Get-DbaAgReplica -SqlInstance sqlserver2014a | Select *
 
-			Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
+			Returns full object properties on all Availability Group(s) replica(s) on sqlserver2014a
 	#>
 	[CmdletBinding()]
 	param (
@@ -62,7 +57,6 @@ function Get-DbaAgReplica {
 		[parameter(ValueFromPipeline = $true)]
 		[object[]]$AvailabilityGroup,
 		[object[]]$Replica,
-		[switch]$IsPrimary,
 		[switch]$Silent
 	)
 

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -1,0 +1,104 @@
+function Get-DbaAgReplica {
+	<#
+		.SYNOPSIS
+			Outputs the Availability Group(s)' Replica object found on the server.
+
+		.DESCRIPTION
+			Default view provides most common set of properties for information on the Availability Group(s)' Replica.
+
+		.PARAMETER SqlInstance
+			The SQL Server instance. Server version must be SQL Server version 2012 or higher.
+
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
+
+		.PARAMETER AvailabilityGroup
+			Specify the Availability Group name that you want to get information on.
+
+		.PARAMETER Replica
+			Specify the replica to pull information on, is dependent up name that you want to get information on.
+
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
+
+		.NOTES
+			Tags: DisasterRecovery, AG, AvailabilityGroup, Replica
+			Original Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
+
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Get-DbaAvailabilityGroup
+
+		.EXAMPLE
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a
+
+			Returns basic information on all the Availability Group(s) found on sqlserver2014a
+
+		.EXAMPLE
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a
+
+			Shows basic information on the Availability Group AG-a on sqlserver2014a
+
+		.EXAMPLE
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a | Select *
+
+			Returns full object properties on all Availability Group(s) on sqlserver2014a
+
+		.EXAMPLE
+			Get-DbaAvailabilityGroup -SqlInstance sqlserver2014a -AvailabilityGroup AG-a -IsPrimary
+
+			Returns true/false if the server, sqlserver2014a, is the primary replica for AG-a Availability Group
+	#>
+	[CmdletBinding()]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential][System.Management.Automation.CredentialAttribute()]
+		$SqlCredential,
+		[parameter(ValueFromPipeline = $true)]
+		[object[]]$AvailabilityGroup,
+		[object[]]$Replica,
+		[switch]$IsPrimary,
+		[switch]$Silent
+	)
+
+	process {
+		foreach ($serverName in $SqlInstance) {
+			try {
+				$server = Connect-SqlInstance -SqlInstance $serverName -SqlCredential $SqlCredential -MinimumVersion 11
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			if ($server.IsHadrEnabled -eq $false) {
+				Stop-Function -Message "Availability Group (HADR) is not configured for the instance: $serverName" -Target $serverName -Continue
+			}
+
+			$ags = $server.AvailabilityGroups
+			if ($AvailabilityGroup) {
+				$ags = $ags | Where-Object Name -in $AvailabilityGroup
+			}
+
+			foreach ($ag in $ags) {
+				$replicas = $ag.AvailabilityReplicas
+				if ($Replica -and $replicas.Name -notin $Replica) {
+					continue
+				}
+				foreach ($currentReplica in $replicas) {
+
+					Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name ComputerName -value $server.NetName
+					Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+					Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+
+					$defaults = 'ComputerName','InstanceName','SqlInstance','Parent as AvailabilityGroup','Name as Replica','AvailabilityMode','BackupPriority','EndpointUrl','SessionTimeout','FailoverMode','ReadonlyRoutingList'
+					Select-DefaultView -InputObject $currentReplica -Property $defaults
+				}
+			}
+		}
+	}
+}

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -80,10 +80,10 @@ function Get-DbaAgReplica {
 
 			foreach ($ag in $ags) {
 				$replicas = $ag.AvailabilityReplicas
-				if ($Replica -and $replicas.Name -notin $Replica) {
-					continue
-				}
 				foreach ($currentReplica in $replicas) {
+					if ($Replica -and $currentReplica.Name -notmatch $Replica) {
+						continue
+					}
 
 					Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name ComputerName -value $server.NetName
 					Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name InstanceName -value $server.ServiceName

--- a/tests/Get-DbaAgReplica.Tests.ps1
+++ b/tests/Get-DbaAgReplica.Tests.ps1
@@ -1,0 +1,25 @@
+Describe "Get-DbaAgReplica Unit Tests" -Tag "UnitTests" {
+	InModuleScope dbatools {
+		Context "Validate parameters" {
+			$params = (Get-ChildItem function:\Get-DbaAgReplica).Parameters	
+			it "should have a parameter named SqlInstance" {
+				$params.ContainsKey("SqlInstance") | Should Be $true
+			}
+			it "should have a parameter named Credential" {
+				$params.ContainsKey("SqlCredential") | Should Be $true
+			}
+			it "should have a parameter named Silent" {
+				$params.ContainsKey("Silent") | Should Be $true
+			}
+		}
+		Context "Validate input" {
+			it "Should throw message if SqlInstance is not accessible" {
+				mock Resolve-DbaNetworkName {$null}
+				{Get-DbaAgReplica -SqlInstance 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
+			}
+		}
+	}
+}
+Describe "Get-DbaAgReplica Integration Test" -Tag "Integrationtests" {
+	Write-Host "No integration test can be performed for this command"
+}

--- a/tests/Get-DbaAgReplica.Tests.ps1
+++ b/tests/Get-DbaAgReplica.Tests.ps1
@@ -22,4 +22,4 @@ Describe "Get-DbaAgReplica Unit Tests" -Tag "UnitTests" {
 }
 Describe "Get-DbaAgReplica Integration Test" -Tag "Integrationtests" {
 	Write-Host "No integration test can be performed for this command"
-}
+} 


### PR DESCRIPTION
Fixes #1712 (partly)

Changes proposed in this pull request:
 - new command
![image](https://user-images.githubusercontent.com/11204251/28365920-1b70e372-6c50-11e7-94cd-2f7a08ff2979.png)

How to test this code: 
- [ ] Have basic pester test included you can run. 
- [x] `Get-DbaAgReplica -SqlInstance server` (On that is SQL Server 2008 R2 or less)
- [x] `Get-DbaAgReplica -SqlInstance server` (One that does not have an AG)
- [x] `Get-DbaAgReplica -SqlInstance server` (One with an AG configured)
- [x] `Get-DbaAgReplica -SqlInstance server -AvailabilityGroup Ag1` (Server with multiple AGs)
- [x] `Get-DbaAgReplica -SqlInstance server -AvailabilityGroup Ag1 -Replica Replica1` (Server with multiple replicas)

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2012

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10