### PR TITLE
Cleanup Add-DbaComputerCertificate help

### DIFF
--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -46,12 +46,12 @@
     .EXAMPLE
       Add-DbaComputerCertificate -ComputerName Server1 -Path C:\temp\cert.cer
 
-      Adds the local C:\temp\cer.cer to the remote server Server1 in LocalMachine\My (Personal)
+      Adds the local C:\temp\cer.cer to the remote server Server1 in LocalMachine\My (Personal).
 
     .EXAMPLE
       Add-DbaComputerCertificate -Path C:\temp\cert.cer
 
-      Adds the local C:\temp\cer.cer to the local computer's LocalMachine\My (Personal) certificate store
+      Adds the local C:\temp\cer.cer to the local computer's LocalMachine\My (Personal) certificate store.
 
 #>
   [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]

--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -27,13 +27,13 @@
     .PARAMETER Folder
       Certificate folder. Default is My (Personal).
     
-		.PARAMETER WhatIf
-		  If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
-		.PARAMETER Confirm
-			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-		.PARAMETER Silent
+    .PARAMETER Silent
       If this switch is enabled, the internal messaging functions will be silenced.
         
     .NOTES

--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -13,22 +13,22 @@
       Allows you to login to $ComputerName using alternative credentials.
 
     .PARAMETER Password
-      The password for the certificate, if it is password protected
+      The password for the certificate, if it is password protected.
 
     .PARAMETER Certificate
       The target certificate object.
 
     .PARAMETER Path
-      The local path to the target certificate object
+      The local path to the target certificate object.
 
     .PARAMETER Store
-      Certificate store - defaults to LocalMachine
+      Certificate store. Default is LocalMachine.
 
     .PARAMETER Folder
-      Certificate folder - defaults to My (Personal)
+      Certificate folder. Default is My (Personal).
     
 		.PARAMETER WhatIf
-			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+		  If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
 		.PARAMETER Confirm
 			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.

--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -1,60 +1,57 @@
 ﻿function Add-DbaComputerCertificate {
   <#
-.SYNOPSIS
-Adds a computer certificate - useful for older systems.
+    .SYNOPSIS
+      Adds a computer certificate - useful for older systems.
 
-.DESCRIPTION
-Adds a computer certificate from a local or remote computer.
+    .DESCRIPTION
+      Adds a computer certificate from a local or remote computer.
 
-.PARAMETER ComputerName
-The target SQL Server. Defaults to localhost.
+    .PARAMETER ComputerName
+      The target SQL Server. Defaults to localhost.
 
-.PARAMETER Credential
-Allows you to login to $ComputerName using alternative credentials.
+    .PARAMETER Credential
+      Allows you to login to $ComputerName using alternative credentials.
 
-.PARAMETER Password
-The password for the certificate, if it is password protected
+    .PARAMETER Password
+      The password for the certificate, if it is password protected
 
-.PARAMETER Certificate
-The target certificate object.
+    .PARAMETER Certificate
+      The target certificate object.
 
-.PARAMETER Path
-The local path to the target certificate object
+    .PARAMETER Path
+      The local path to the target certificate object
 
-.PARAMETER Store
-Certificate store - defaults to LocalMachine
+    .PARAMETER Store
+      Certificate store - defaults to LocalMachine
 
-.PARAMETER Folder
-Certificate folder - defaults to My (Personal)
-	
-.PARAMETER Silent 
-Use this switch to disable any kind of verbose messages
+    .PARAMETER Folder
+      Certificate folder - defaults to My (Personal)
+    
+		.PARAMETER WhatIf
+			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER Confirm
+			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Silent
+      If this switch is enabled, the internal messaging functions will be silenced.
+        
+    .NOTES
+      Tags: Certificate
 
-.PARAMETER Silent 
-If this switch is enabled, the internal messaging functions will be silenced.
+      Website: https://dbatools.io
+      Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+      License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.NOTES
-Tags: Certificate
+    .EXAMPLE
+      Add-DbaComputerCertificate -ComputerName Server1 -Path C:\temp\cert.cer
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+      Adds the local C:\temp\cer.cer to the remote server Server1 in LocalMachine\My (Personal)
 
-.EXAMPLE
-Add-DbaComputerCertificate -ComputerName Server1 -Path C:\temp\cert.cer
+    .EXAMPLE
+      Add-DbaComputerCertificate -Path C:\temp\cert.cer
 
-Adds the local C:\temp\cer.cer to the remote server Server1 in LocalMachine\My (Personal)
-
-.EXAMPLE
-Add-DbaComputerCertificate -Path C:\temp\cert.cer
-
-Adds the local C:\temp\cer.cer to the local computer's LocalMachine\My (Personal) certificate store
+      Adds the local C:\temp\cer.cer to the local computer's LocalMachine\My (Personal) certificate store
 
 #>
   [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Clean up comment-based help for Add-DbaComputerCertificate
 - Bring comment-based help style in line with templates

How to test this code: 
- [ ] Review help text 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers