### PR TITLE
Style & language cleanup for Backup-DbaDatabaseCertificate help

### DIFF
--- a/functions/Backup-DbaDatabaseCertificate.ps1
+++ b/functions/Backup-DbaDatabaseCertificate.ps1
@@ -7,8 +7,7 @@ function Backup-DbaDatabaseCertificate {
 			Exports database certificates from SQL Server using SMO and outputs the .cer and .pvk files.
 
 		.PARAMETER SqlInstance
-			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and recieve pipeline input to allow the function
-			to be executed against multiple SQL Server instances.
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
 		
 		.PARAMETER SqlCredential
 			SqlCredential object to connect as. If not specified, current Windows login will be used.
@@ -37,14 +36,14 @@ function Backup-DbaDatabaseCertificate {
 		.PARAMETER CertificateCollection 
 			Internal parameter to support pipeline input.
 
-		.PARAMETER Confirm 
-			Prompts you for confirmation before executing any changing operations within the command. 
+		.PARAMETER Confirm
+			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-		.PARAMETER Silent 
-			Use this switch to disable any kind of verbose messages.
+		.PARAMETER Silent
+			If this switch is enabled, the internal messaging functions will be silenced.
 
-		.PARAMETER WhatIf 
-			Shows what would happen if the command were to run. No actions are actually performed. 
+		.PARAMETER WhatIf
+			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
 		.NOTES
 			Original Author: Jess Pomfret (@jpomfret)


### PR DESCRIPTION
Fixes # 

Changes proposed in this pull request:
 - Clean up comment-based help for Backup-DbaDatabaseCertificate
 - Bring comment-based help style in line with templates

How to test this code: 
- [ ] Review help text 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers
