### PR TITLE
Fix Copy-DbaDatabase instance names and tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,5 @@ test_script:
   # "Collecting and uploading results"
   - ps: .\Tests\appveyor.pester.ps1 -Finalize
 
-on_finish:
- - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish: this is for RDPing into the box when all else fails.
+# - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,4 +42,4 @@ test_script:
   - ps: .\Tests\appveyor.pester.ps1 -Finalize
 
 #on_finish:
- - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1')
+ - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,6 @@ test_script:
 
   # "Collecting and uploading results"
   - ps: .\Tests\appveyor.pester.ps1 -Finalize
-
+ 
 #on_finish: this is for RDPing into the box when all else fails.it s
 # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,19 +27,14 @@ before_test:
   - ps: .\Tests\appveyor.sqlserver.ps1
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
-  #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
-  #- ps: Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
   - ps: Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null
   - vstest.console /logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
    
   # "Test with native PS version"
   - ps: .\Tests\appveyor.pester.ps1
-  
-  # "Test with PS version 3" - Removed because it's not a true test. Even PS4+ .Where() works
-  # - ps: powershell.exe -version 3.0 -executionpolicy bypass -noprofile -file .\Tests\appveyor.pester.ps1
 
   # "Collecting and uploading results"
   - ps: .\Tests\appveyor.pester.ps1 -Finalize
 
-#on_finish:
+on_finish:
  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,10 @@
 ﻿# See http://www.appveyor.com/docs/appveyor-yml for many more options
-
 build: false
 
 # Set build info
 environment: 
   environment: development
   version: 0.8.$(appveyor_build_number)
-  
-# Install prereqs
-# install:
-# - cinst pester
 
 # Set alternative clone folder
 clone_folder: c:\github\dbatools
@@ -25,6 +20,7 @@ before_test:
   - ps: Install-Module -Name Pester -Repository PSGallery -Force | Out-Null
   # "Setting up the local SQL Server environments"
   - ps: .\Tests\appveyor.sqlserver.ps1
+
 test_script:
   # "Installing nuget and PSScriptAnalyzer"
   - ps: Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,5 @@ test_script:
   # "Collecting and uploading results"
   - ps: .\Tests\appveyor.pester.ps1 -Finalize
 
-#on_finish: this is for RDPing into the box when all else fails.
+#on_finish: this is for RDPing into the box when all else fails.it s
 # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -1,8 +1,8 @@
 ﻿Describe "Copy-DbaDatabase Integration Tests" -Tags "Integrationtests" {
     # constants
-    $Sql2008R2SP2 = "localhost\sql2008r2sp2"
-    $Sql2016 = "localhost\sql2016"
-    $Instances = @( $Sql2008R2SP2, $Sql2016 )        
+    $sql2008 = "localhost\sql2008"
+    $sql2016 = "localhost\sql2016"
+    $Instances = @( $sql2008, $sql2016 )        
     $BackupLocation = "C:\github\appveyor-lab\singlerestore\singlerestore.bak"    
     $NetworkPath = "C:\temp"
 
@@ -12,19 +12,19 @@
     }
     
     # Restore and set owner for Single Restore
-    $DatabaseName = ( Restore-DbaDatabase -SqlInstance $Sql2008R2SP2 -Path $BackupLocation ).DatabaseName
-    Set-DbaDatabaseOwner -SqlInstance $Sql2008R2SP2 -Database $DatabaseName -TargetLogin sa
+    $DatabaseName = ( Restore-DbaDatabase -SqlInstance $sql2008 -Path $BackupLocation ).DatabaseName
+    Set-DbaDatabaseOwner -SqlInstance $sql2008 -Database $DatabaseName -TargetLogin sa
 
 
     # no matter where I put the import, this stop-message fails.
     Context "Restores database with the same properties." {
         It "Should copy a database and retain its name, recovery model, and status." {
             
-            $db1 = Get-DbaDatabase -SqlInstance $Sql2008R2SP2 -Database $DatabaseName
+            $db1 = Get-DbaDatabase -SqlInstance $sql2008 -Database $DatabaseName
 
-            Copy-DbaDatabase -Source $Sql2008R2SP2 -Destination $Sql2016 -Database $DatabaseName -BackupRestore -NetworkShare $NetworkPath
+            Copy-DbaDatabase -Source $sql2008 -Destination $sql2016 -Database $DatabaseName -BackupRestore -NetworkShare $NetworkPath
             
-            $db2 = Get-DbaDatabase -SqlInstance $Sql2016 -Database $DatabaseName            
+            $db2 = Get-DbaDatabase -SqlInstance $sql2016 -Database $DatabaseName            
             $db2 | Should Not BeNullOrEmpty
             
             # Compare its valuable.

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Copy-DbaDatabase Integration Tests" -Tags "Integrationtests" {
     # constants
-    $sql2008 = "localhost\sql2008"
+    $sql2008 = "localhost"
     $sql2016 = "localhost\sql2016"
     $Instances = @( $sql2008, $sql2016 )        
     $BackupLocation = "C:\github\appveyor-lab\singlerestore\singlerestore.bak"    

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Copy-DbaDatabase Integration Tests" -Tags "Integrationtests" {
     # constants
-    $sql2008 = "localhost"
+    $sql2008 = "localhost\sql2008r2sp2"
     $sql2016 = "localhost\sql2016"
     $Instances = @( $sql2008, $sql2016 )        
     $BackupLocation = "C:\github\appveyor-lab\singlerestore\singlerestore.bak"    

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -59,4 +59,5 @@
 		foreach ($instance in $instances) {
 			Get-DbaDatabase -SqlInstance $instance -NoSystemDb | Remove-DbaDatabase -Confirm:$false
 		}
-	}
+    }
+}

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Remove-DbaDatabase Integration Tests" -Tags "Integrationtests" {
 	Context "Should not munge system databases unless explicitly told to." {
-        $sql2008 = "localhost"
+        $sql2008 = "localhost\sql2008r2sp2"
         $dbs = @( "master", "model", "tempdb", "msdb" )
         
 		It "Should not attempt to remove system databases." {                        
@@ -24,7 +24,7 @@
     }
     Context "Should remove user databases and return useful errors if it cannot." {
         It "Should remove a non system database." {
-            $null = Remove-DbaDatabase -SqlInstance $sql2008 -Database singlerestore
+            Remove-DbaDatabase -SqlInstance $sql2008 -Database singlerestore
             Restore-DbaDatabase -SqlInstance $sql2008 -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
             $db = Get-DbaDatabase -SqlInstance $sql2008 -Database SingleRestore
             $db | Should Exist

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Remove-DbaDatabase Integration Tests" -Tags "Integrationtests" {
 	Context "Should not attempt to remove system databases and skip them if provided" {
-        $sql2008 = "localhost\sql2008r2sp2"
+        $sql2008 = localhost
         $dbs = @( "master", "model", "tempdb", "msdb" )
         
 		It "Should not attempt to remove system databases." {                        
@@ -20,6 +20,13 @@
                 $db2.Status | Should Be $db1.Status
                 $db2.IsAccessible | Should Be $db1.IsAccessible                
             } 
-        }               
+        }
+        
+        It "Should remove a non system database when asked to." {
+            Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
+            Remove-DbaDatabase -SqlInstance localhost -Database singlerestore
+            $db = Get-DbaDatabase -Database singlerestore
+            $db | Should Be NullOrEmpty
+        }
 	}
 }

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿Describe "Remove-DbaDatabase Integration Tests" -Tags "Integrationtests" {
-	Context "Should not attempt to remove system databases and skip them if provided" {
+	Context "Should not munge system databases unless explicitly told to." {
         $sql2008 = "localhost"
         $dbs = @( "master", "model", "tempdb", "msdb" )
         
@@ -21,11 +21,15 @@
                 $db2.IsAccessible | Should Be $db1.IsAccessible                
             } 
         }
-        
-        It "Should remove a non system database when asked to." {
+    }
+    Context "Should remove user databases and return useful errors if it cannot." {
+        It "Should remove a non system database." {
+            $null = Remove-DbaDatabase -SqlInstance $sql2008 -Database singlerestore
             Restore-DbaDatabase -SqlInstance $sql2008 -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
+            $db = Get-DbaDatabase -SqlInstance $sql2008 -Database SingleRestore
+            $db | Should Exist
             Remove-DbaDatabase -SqlInstance $sql2008 -Database singlerestore
-            $db = Get-DbaDatabase -Database singlerestore
+            $db = Get-DbaDatabase SqlInstance $sql2008 -Database singlerestore
             $db | Should Be NullOrEmpty
         }
 	}

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Remove-DbaDatabase Integration Tests" -Tags "Integrationtests" {
 	Context "Should not attempt to remove system databases and skip them if provided" {
-        $sql2008 = localhost
+        $sql2008 = "localhost"
         $dbs = @( "master", "model", "tempdb", "msdb" )
         
 		It "Should not attempt to remove system databases." {                        
@@ -23,8 +23,8 @@
         }
         
         It "Should remove a non system database when asked to." {
-            Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
-            Remove-DbaDatabase -SqlInstance localhost -Database singlerestore
+            Restore-DbaDatabase -SqlInstance $sql2008 -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
+            Remove-DbaDatabase -SqlInstance $sql2008 -Database singlerestore
             $db = Get-DbaDatabase -Database singlerestore
             $db | Should Be NullOrEmpty
         }

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -1,22 +1,22 @@
 ﻿Describe "Remove-DbaDatabase Integration Tests" -Tags "Integrationtests" {
 	Context "Should not attempt to remove system databases and skip them if provided" {
-        $Sql2008 = "localhost\sql2008r2sp2"
+        $sql2008 = "localhost\sql2008r2sp2"
         $dbs = @( "master", "model", "tempdb", "msdb" )
         
 		It "Should not attempt to remove system databases." {                        
             foreach ($db in $dbs) { 
-                $db1 = Get-DbaDatabase -SqlInstance $Sql2008 -Database $db
-                Remove-DbaDatabase -SqlInstance $Sql2008 -Database $db
-                $db2 = Get-DbaDatabase -SqlInstance $Sql2008 -Database $db
+                $db1 = Get-DbaDatabase -SqlInstance $sql2008 -Database $db
+                Remove-DbaDatabase -SqlInstance $sql2008 -Database $db
+                $db2 = Get-DbaDatabase -SqlInstance $sql2008 -Database $db
                 $db2.Name | Should Be $db1.Name
             } 
         }
 
         It "Should not take system databases offline or change their status." {
             foreach ($db in $dbs) { 
-                $db1 = Get-DbaDatabase -SqlInstance $Sql2008 -Database $db
-                Remove-DbaDatabase -SqlInstance $Sql2008 -Database $db 
-                $db2 = Get-DbaDatabase -SqlInstance $Sql2008 -Database $db                
+                $db1 = Get-DbaDatabase -SqlInstance $sql2008 -Database $db
+                Remove-DbaDatabase -SqlInstance $sql2008 -Database $db 
+                $db2 = Get-DbaDatabase -SqlInstance $sql2008 -Database $db                
                 $db2.Status | Should Be $db1.Status
                 $db2.IsAccessible | Should Be $db1.IsAccessible                
             } 

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -7,7 +7,7 @@
 	Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 	
     Context "Properly restores a database on the local drive using Path" {
-        $null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase
+        $null = Get-DbaDatabase -SqlInstance localhost -NoSystemDb | Remove-DbaDatabase -Confirm:$false
         $results = Restore-DbaDatabase -SqlInstance localhost -Path C:\github\appveyor-lab\singlerestore\singlerestore.bak
         It "Should Return the proper backup file location" {
             $results.BackupFile | Should Be "C:\github\appveyor-lab\singlerestore\singlerestore.bak"


### PR DESCRIPTION
Changes proposed in this pull request:
 - Updated Copy-DbaDatabase tests with additional steps.
 - Updated Copy-DbaDatabase to support naming conventions used in the project.

How to test this code: 
- [ ] Verify appveyor comes back successful for all commands.

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

