### PR TITLE
Help style and language cleanup, GPL language standardization

### DIFF
--- a/functions/Connect-DbaSqlServer.ps1
+++ b/functions/Connect-DbaSqlServer.ps1
@@ -1,162 +1,168 @@
 Function Connect-DbaSqlServer {
     <#
-.SYNOPSIS
-Creates an efficient SMO SQL Server object.
+    .SYNOPSIS
+        Creates an efficient SMO SQL Server object.
 
-.DESCRIPTION
-This command is efficient because it initializes properties that do not cause enumeration by default. It also supports both Windows and SQL Server authentication methods and detects which to use based upon the provided credentials. 
+    .DESCRIPTION
+        This command is efficient because it initializes properties that do not cause enumeration by default. It also supports both Windows and SQL Server authentication methods, and detects which to use based upon the provided credentials. 
 
-By default, this command also sets the connection's ApplicationName property  to "dbatools PowerShell module - dbatools.io - custom connection". If you're doing anything that requires profiling, you can look for this client name.
+        By default, this command also sets the connection's ApplicationName property  to "dbatools PowerShell module - dbatools.io - custom connection". If you're doing anything that requires profiling, you can look for this client name.
 
-Alternatively, you can pass in whichever client name you'd like using the -ClientName parameter. There are a ton of other parameters for you to explore as well.
-	
-See https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx
-and https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnectionstringbuilder.aspx
-and https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.aspx
+        Alternatively, you can pass in whichever client name you'd like using the -ClientName parameter. There are a ton of other parameters for you to explore as well.
+            
+        See https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx
+        and https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnectionstringbuilder.aspx,
+        and https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.aspx
 
-To execute SQL commands, you can use $server.ConnectionContext.ExecuteReader($sql) or $server.Databases['master'].ExecuteNonQuery($sql)
+        To execute SQL commands, you can use $server.ConnectionContext.ExecuteReader($sql) or $server.Databases['master'].ExecuteNonQuery($sql)
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+    .PARAMETER SqlInstance
+        SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
 
-.PARAMETER Credential
-Credential object used to connect to the SQL Server Instance as a different user. This can be a Windows or SQL Server account. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
+    .PARAMETER Credential
+        Credential object used to connect to the SQL Server Instance as a different user. This can be a Windows or SQL Server account. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
 
-.PARAMETER Database
-The database(s) to process - this list is auto-populated from the server.
+    .PARAMETER Database
+        The database(s) to process. This list is auto-populated from the server.
 
-.PARAMETER AccessToken	
-Gets or sets the access token for the connection.
-	
-.PARAMETER AppendConnectionString	
-Appends to the current connection string. Note that you cannot pass authentication information using this method. Use -SqlInstance and optionally -SqlCredential to set authentication information.
+    .PARAMETER AccessToken	
+        Gets or sets the access token for the connection.
+        
+    .PARAMETER AppendConnectionString	
+        Appends to the current connection string. Note that you cannot pass authentication information using this method. Use -SqlInstance and optionally -SqlCredential to set authentication information.
 
-.PARAMETER ApplicationIntent	
-Declares the application workload type when connecting to a server. Possible values are ReadOnly and ReadWrite. 
-	
-.PARAMETER BatchSeparator	
-A string to separate groups of SQL statements being executed. By default, this is "GO".
-	
-.PARAMETER ClientName
-By default, this command sets the client's ApplicationName property to "dbatools PowerShell module - dbatools.io - custom connection" if you're doing anything that requires profiling, you can look for this client name. Using -ClientName allows you to set your own custom client application name.
+    .PARAMETER ApplicationIntent	
+        Declares the application workload type when connecting to a server.
+        
+        Valid values are "ReadOnly" and "ReadWrite". 
+        
+    .PARAMETER BatchSeparator	
+        A string to separate groups of SQL statements being executed. By default, this is "GO".
+        
+    .PARAMETER ClientName
+        By default, this command sets the client's ApplicationName property to "dbatools PowerShell module - dbatools.io - custom connection" if you're doing anything that requires profiling, you can look for this client name. Using -ClientName allows you to set your own custom client application name.
 
-.PARAMETER ConnectTimeout	
-The length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error.
+    .PARAMETER ConnectTimeout	
+        The length of time (in seconds) to wait for a connection to the server before terminating the attempt and generating an error.
 
-Valid values are greater than or equal to 0 and less than or equal to 2147483647.
+        Valid values are integers between 0 and 2147483647.
 
-When opening a connection to a Azure SQL Database, set the connection timeout to 30 seconds.
-	
-.PARAMETER EncryptConnection	
-When true, SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed. Recognized values are true, false, yes, and no. For more information, see Connection String Syntax.
+        When opening a connection to a Azure SQL Database, set the connection timeout to 30 seconds.
+        
+    .PARAMETER EncryptConnection	
+        If this switch is enabled, SQL Server uses SSL encryption for all data sent between the client and server if the server has a certificate installed.
+        
+        For more information, see Connection String Syntax. https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/connection-string-syntax
 
-Beginning in .NET Framework 4.5, when TrustServerCertificate is false and Encrypt is true, the server name (or IP address) in a SQL Server SSL certificate must exactly match the server name (or IP address) specified in the connection string. Otherwise, the connection attempt will fail. For information about support for certificates whose subject starts with a wildcard character (*), see Accepted wildcards used by server certificates for server authentication.
-	
-.PARAMETER FailoverPartner	
-The name of the failover partner server where database mirroring is configured.
+        Beginning in .NET Framework 4.5, when TrustServerCertificate is false and Encrypt is true, the server name (or IP address) in a SQL Server SSL certificate must exactly match the server name (or IP address) specified in the connection string. Otherwise, the connection attempt will fail. For information about support for certificates whose subject starts with a wildcard character (*), see Accepted wildcards used by server certificates for server authentication. https://support.microsoft.com/en-us/help/258858/accepted-wildcards-used-by-server-certificates-for-server-authenticati
+        
+    .PARAMETER FailoverPartner	
+        The name of the failover partner server where database mirroring is configured.
 
-If the value of this key is "" (an empty string), then Initial Catalog must be present, and its value must not be "".
+        If the value of this key is "" (an empty string), then Initial Catalog must be present in the connection string, and its value must not be "".
 
-The server name can be 128 characters or less.
-	
-If you specify a failover partner but the failover partner server is not configured for database mirroring and the primary server (specified with the Server keyword) is not available, then the connection will fail.
+        The server name can be 128 characters or less.
+        
+        If you specify a failover partner but the failover partner server is not configured for database mirroring and the primary server (specified with the Server keyword) is not available, then the connection will fail.
 
-If you specify a failover partner and the primary server is not configured for database mirroring, the connection to the primary server (specified with the Server keyword) will succeed if the primary server is available.
+        If you specify a failover partner and the primary server is not configured for database mirroring, the connection to the primary server (specified with the Server keyword) will succeed if the primary server is available.
 
 
-.PARAMETER IsActiveDirectoryUniversalAuth	
-If this switch is set, the connection will be configured to use Azure Active Directory authentication.
+    .PARAMETER IsActiveDirectoryUniversalAuth	
+        If this switch is enabled, the connection will be configured to use Azure Active Directory authentication.
 
-.PARAMETER LockTimeout	
-Sets the time in seconds required for the connection to time out when the current transaction is locked.
-	
-.PARAMETER MaxPoolSize	
-Sets the maximum number of connections allowed in the connection pool for this specific connection string.
-	
-.PARAMETER MinPoolSize	
-Sets the minimum number of connections allowed in the connection pool for this specific connection string.
-	
-.PARAMETER MultipleActiveResultSets	
-When used, an application can maintain multiple active result sets (MARS). When false, an application must process or cancel all result sets from one batch before it can execute any other batch on that connection.
+    .PARAMETER LockTimeout	
+        Sets the time in seconds required for the connection to time out when the current transaction is locked.
+        
+    .PARAMETER MaxPoolSize	
+        Sets the maximum number of connections allowed in the connection pool for this specific connection string.
+        
+    .PARAMETER MinPoolSize	
+        Sets the minimum number of connections allowed in the connection pool for this specific connection string.
+        
+    .PARAMETER MultipleActiveResultSets	
+        If this switch is enabled, an application can maintain multiple active result sets (MARS).
+        
+        If this switch is not enabled, an application must process or cancel all result sets from one batch before it can execute any other batch on that connection.
 
-.PARAMETER MultiSubnetFailover	
-If your application is connecting to an AlwaysOn availability group (AG) on different subnets, setting MultiSubnetFailover provides faster detection of and connection to the (currently) active server. For more information about SqlClient support for Always On Availability Groups, see https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery
+    .PARAMETER MultiSubnetFailover	
+        If this switch is enabled, and your application is connecting to an AlwaysOn availability group (AG) on different subnets, detection of and connection to the currently active server will be faster. For more information about SqlClient support for Always On Availability Groups, see https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery
 
-.PARAMETER NetworkProtocol	
-Connect explicitly using "TcpIp","NamedPipes","Multiprotocol","AppleTalk","BanyanVines","Via","SharedMemory" and "NWLinkIpxSpx"
+    .PARAMETER NetworkProtocol	
+        Explicitly sets the network protocol used to connect to the server.
+        
+        Valid values are "TcpIp","NamedPipes","Multiprotocol","AppleTalk","BanyanVines","Via","SharedMemory" and "NWLinkIpxSpx"
 
-.PARAMETER NonPooledConnection	
-Request a non-pooled connection.
+    .PARAMETER NonPooledConnection	
+        If this switch is enabled, a non-pooled connection will be requested.
 
-.PARAMETER PacketSize	
-Sets the size in bytes of the network packets used to communicate with an instance of SQL Server. Must match at server.
-	
-.PARAMETER PooledConnectionLifetime	
-When a connection is returned to the pool, its creation time is compared with the current time, and the connection is destroyed if that time span (in seconds) exceeds the value specified by Connection Lifetime. This is useful in clustered configurations to force load balancing between a running server and a server just brought online.
+    .PARAMETER PacketSize	
+        Sets the size in bytes of the network packets used to communicate with an instance of SQL Server. Must match at server.
+        
+    .PARAMETER PooledConnectionLifetime	
+        When a connection is returned to the pool, its creation time is compared with the current time and the connection is destroyed if that time span (in seconds) exceeds the value specified by Connection Lifetime. This is useful in clustered configurations to force load balancing between a running server and a server just brought online.
 
-A value of zero (0) causes pooled connections to have the maximum connection timeout.
-	
-.PARAMETER SqlExecutionModes	
-The SqlExecutionModes enumeration contains values that are used to specify whether the commands sent to the referenced connection to the server are executed immediately or saved in a buffer.
+        A value of zero (0) causes pooled connections to have the maximum connection timeout.
+        
+    .PARAMETER SqlExecutionModes	
+        The SqlExecutionModes enumeration contains values that are used to specify whether the commands sent to the referenced connection to the server are executed immediately or saved in a buffer.
 
-Valid values include "CaptureSql", "ExecuteAndCaptureSql" and "ExecuteSql".
+        Valid values include "CaptureSql", "ExecuteAndCaptureSql" and "ExecuteSql".
 
-.PARAMETER StatementTimeout	
-Sets the number of seconds a statement is given to run before failing with a timeout error.
+    .PARAMETER StatementTimeout	
+        Sets the number of seconds a statement is given to run before failing with a timeout error.
 
-.PARAMETER TrustServerCertificate	
-When this switch is set, the channel will be encrypted while bypassing walking the certificate chain to validate trust.
+    .PARAMETER TrustServerCertificate	
+        When this switch is enabled, the channel will be encrypted while bypassing walking the certificate chain to validate trust.
 
-.PARAMETER WorkstationId	
-Sets the name of the workstation connecting to SQL Server.
-	
-.NOTES
-dbatools PowerShell module (https://dbatools.io)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
+    .PARAMETER WorkstationId	
+        Sets the name of the workstation connecting to SQL Server.
+        
+    .NOTES
+        dbatools PowerShell module (https://dbatools.io)
+   		Website: https://dbatools.io
+		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+    
+    .LINK
+        https://dbatools.io/Connect-DbaSqlServer
 
-.LINK
- https://dbatools.io/Connect-DbaSqlServer
+    .EXAMPLE
+        Connect-DbaSqlServer -SqlInstance sql2014
 
-.EXAMPLE
-Connect-DbaSqlServer -SqlInstance sql2014
+        Creates an SMO Server object that connects using Windows Authentication
 
-Creates an SMO Server object that connects using Windows Authentication
+    .EXAMPLE
+        $wincred = Get-Credential ad\sqladmin
+        Connect-DbaSqlServer -SqlInstance sql2014 -Credential $wincred
 
-.EXAMPLE
-$wincred = Get-Credential ad\sqladmin
-Connect-DbaSqlServer -SqlInstance sql2014 -Credential $wincred
+        Creates an SMO Server object that connects using alternative Windows credentials
 
-Creates an SMO Server object that connects using alternative Windows credentials
+    .EXAMPLE
+        $sqlcred = Get-Credential sqladmin
+        $server = Connect-DbaSqlServer -SqlInstance sql2014 -Credential $sqlcred
 
-.EXAMPLE
-$sqlcred = Get-Credential sqladmin
-$server = Connect-DbaSqlServer -SqlInstance sql2014 -Credential $sqlcred
+        Login to sql2014 as SQL login sqladmin.
 
-Login to sql2014 as SQL login sqladmin.
+    .EXAMPLE
+        $server = Connect-DbaSqlServer -SqlInstance sql2014 -ClientName "my connection"
 
-.EXAMPLE
-$server = Connect-DbaSqlServer -SqlInstance sql2014 -ClientName "mah connection"
+        Creates an SMO Server object that connects using Windows Authentication and uses the client name "my connection". So when you open up profiler or use extended events, you can search for "my connection".
 
-Creates an SMO Server object that connects using Windows Authentication and uses the client name "mah connection". So when you open up profiler or use extended events, you can search for "mah connection".
+    .EXAMPLE
+        $server = Connect-DbaSqlServer -SqlInstance sql2014 -AppendConnectionString "Packet Size=4096;AttachDbFilename=C:\MyFolder\MyDataFile.mdf;User Instance=true;"
 
-.EXAMPLE
-$server = Connect-DbaSqlServer -SqlInstance sql2014 -AppendConnectionString "Packet Size=4096;AttachDbFilename=C:\MyFolder\MyDataFile.mdf;User Instance=true;"
+        Creates an SMO Server object that connects to sql2014 using Windows Authentication, then it sets the packet size (this can also be done via -PacketSize) and other connection attributes.
 
-Creates an SMO Server object that connects to sql2014 using Windows Authentication, then it sets the packet size (this can also be done via -PacketSize) and other connection attributes.
+    .EXAMPLE
+        $server = Connect-DbaSqlServer -SqlInstance sql2014 -NetworkProtocol TcpIp -MultiSubnetFailover
 
-.EXAMPLE
-$server = Connect-DbaSqlServer -SqlInstance sql2014 -NetworkProtocol TcpIp -MultiSubnetFailover
+        Creates an SMO Server object that connects using Windows Authentication that uses TCP/IP and has MultiSubnetFailover enabled.
 
-Creates an SMO Server object that connects using Windows Authentication that uses TCP/IP and has MultiSubnetFailover enabled.
+    .EXAMPLE
+        $server = Connect-DbaSqlServer sql2016 -ApplicationIntent ReadOnly
 
-.EXAMPLE
-$server = Connect-DbaSqlServer sql2016 -ApplicationIntent ReadOnly
-
-Connects with ReadOnly ApplicationIntent.
-	
+        Connects with ReadOnly ApplicationIntent.	
 #>	
     [CmdletBinding()]
     param (


### PR DESCRIPTION
Fixes # 

Style & language cleanup for Connect-DbaSqlServer help

Changes proposed in this pull request:
 - Clean up comment-based help for Connect-DbaSqlServer
 - Bring comment-based help style in line with templates

How to test this code: 
- [x] Review help text 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

