### PR TITLE
Help style & formatting cleanup for Copy-DbaAgentAlert

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -11,20 +11,20 @@
 		.PARAMETER Source
 			Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
 
-
 		.PARAMETER SourceSqlCredential
 			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
 			$scred = Get-Credential, then pass $scred object to the -SourceSqlCredential parameter.
 
 			Windows Authentication will be used if DestinationSqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
 			To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER Destination
-			Destination Sql Server. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+			Destination SQL Server. You must have sysadmin access and the server must be SQL Server 2000 or newer.
 
 		.PARAMETER DestinationSqlCredential
-			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
 			$dcred = Get-Credential, then pass this $dcred to the -DestinationSqlCredential parameter.
 
@@ -33,22 +33,22 @@
 			To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER Alert
-			The alert(s) to process - this list is auto-populated from the server. If unspecified, all alerts will be processed.
+			The alert(s) to process. This list is auto-populated from the server. If unspecified, all alerts will be processed.
 
 		.PARAMETER ExcludeAlert
-			The alert(s) to exclude - this list is auto-populated from the server
+			The alert(s) to exclude. This list is auto-populated from the server.
 
 		.PARAMETER IncludeDefaults
 			Copy SQL Agent defaults such as FailSafeEmailAddress, ForwardingServer, and PagerSubjectTemplate.
 
 		.PARAMETER WhatIf
-			Shows what would happen if the command were to run. No actions are actually performed.
+			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
 		.PARAMETER Confirm
-			Prompts you for confirmation before executing any changing operations within the command.
+			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
 		.PARAMETER Force
-			Drops and recreates the Alert if it exists.
+			If this switch is enabled, the Alert will be dropped and recreated on Destination.
 
 		.PARAMETER Silent
 			If this switch is enabled, the internal messaging functions will be silenced.


### PR DESCRIPTION
Fixes # 

Style & language cleanup for Copy-DbaAgentAlert help

Changes proposed in this pull request:
 - Clean up comment-based help for Copy-DbaAgentAlert
 - Bring comment-based help style in line with templates

How to test this code: 
- [ ] Review help text 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers
