### PR TITLE
Get-DbaDatabase: add null for nonexisting property

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -190,7 +190,7 @@
             }
 
             $Readonly = switch ( $Access ) { 'Readonly' { @($true) } 'ReadWrite' { @($false) } default { @($true,$false)} }
-			$Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true,$false)} }
+			$Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true,$false,$null)} }
 
 			$inputobject = $server.Databases |
                 Where-Object {


### PR DESCRIPTION
Fixes #1780

Changes proposed in this pull request:
 - when EncryptionEnabled does not exist, $null is valid too
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

