### PR TITLE
Get-DbaDatabase: add catch for multiple statuses

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -199,7 +199,7 @@
                     ($_.Owner -in $Owner -or !$Owner) -and 
                     $_.ReadOnly -in $Readonly -and 
                     $_.IsSystemObject -in $DBType -and 
-                    ((Compare-Object @($_.Status.tostring().split(', ')) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
+                    ((Compare-Object @($_.Status.tostring().split(',').trim()) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
                     $_.RecoveryModel -in $RecoveryModel -and 
                     $_.EncryptionEnabled -in $Encrypt
                 }

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -199,7 +199,7 @@
                     ($_.Owner -in $Owner -or !$Owner) -and 
                     $_.ReadOnly -in $Readonly -and 
                     $_.IsSystemObject -in $DBType -and 
-                    ((Compare-Object $_.Status $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
+                    ((Compare-Object @($_.Status.tostring().split(', ')) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
                     $_.RecoveryModel -in $RecoveryModel -and 
                     $_.EncryptionEnabled -in $Encrypt
                 }

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -199,7 +199,7 @@
                     ($_.Owner -in $Owner -or !$Owner) -and 
                     $_.ReadOnly -in $Readonly -and 
                     $_.IsSystemObject -in $DBType -and 
-                    $_.Status -in $Status -and 
+                    ((Compare-Object $_.Status $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
                     $_.RecoveryModel -in $RecoveryModel -and 
                     $_.EncryptionEnabled -in $Encrypt
                 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - Db with multiple statuses, like 'offline','autoclosed' are handled too
 - 
 - 

How to test this code: 
- [ ] 
- [ ] 

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

