### PR TITLE
Fixes #1772. Correct name of Test-DbaOptimizeForAdHoc as used in documentation

### DIFF
--- a/functions/Test-DbaOptimizeForAdHoc.ps1
+++ b/functions/Test-DbaOptimizeForAdHoc.ps1
@@ -1,41 +1,40 @@
 Function Test-DbaOptimizeForAdHoc
 {
 <# 
-.SYNOPSIS 
-Displays information relating to SQL Server Optimize for AdHoc Workloads setting.  Works on SQL Server 2008-2016.
+	.SYNOPSIS 
+		Displays information relating to SQL Server Optimize for AdHoc Workloads setting.  Works on SQL Server 2008-2016.
 
-.DESCRIPTION 
-When this option is set, plan cache size is further reduced for single-use adhoc OLTP workload.
+	.DESCRIPTION 
+		When this option is set, plan cache size is further reduced for single-use ad hoc OLTP workload.
 
-More info: https://msdn.microsoft.com/en-us/library/cc645587.aspx
-http://www.sqlservercentral.com/blogs/glennberry/2011/02/25/some-suggested-sql-server-2008-r2-instance-configuration-settings/
+		More info: https://msdn.microsoft.com/en-us/library/cc645587.aspx
+		http://www.sqlservercentral.com/blogs/glennberry/2011/02/25/some-suggested-sql-server-2008-r2-instance-configuration-settings/
 
-These are just general recommendations for SQL Server and are a good starting point for setting the "optimize for adhoc workloads" option.
+		These are just general recommendations for SQL Server and are a good starting point for setting the "optimize for adhoc workloads" option.
 
-.PARAMETER SqlInstance
-Allows you to specify a comma separated list of servers to query.
+	.PARAMETER SqlInstance
+		A collection of one or more SQL Server instance names to query.
 
-.PARAMETER SqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
-$cred = Get-Credential, this pass this $cred to the param. 
+	.PARAMETER SqlCredential
+		Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
-Windows Authentication will be used if DestinationSqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.	
+		$cred = Get-Credential, this pass this $cred to the param. 
 
-.NOTES 
-Author: Brandon Abshire, netnerds.net
+		Windows Authentication will be used if SqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.	
 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	.NOTES 
+		Author: Brandon Abshire, netnerds.net
+		Website: https://dbatools.io
+		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK 
-https://dbatools.io/Test-DbaOptimizeAdHoc
+	.LINK 
+		https://dbatools.io/Test-DbaOptimizeForAdHoc
 
-.EXAMPLE   
-Test-DbaOptimizeAdHoc -SqlInstance sql2008, sqlserver2012
-Get Optimize for AdHoc Workloads setting for servers sql2008 and sqlserver2012 and also the recommended one.
+	.EXAMPLE   
+		Test-DbaOptimizeForAdHoc -SqlInstance sql2008, sqlserver2012
+		
+		Get Optimize for AdHoc Workloads setting for servers sql2008 and sqlserver2012 and also the recommended one.
 
 #>
 	[CmdletBinding()]
@@ -48,8 +47,8 @@ Get Optimize for AdHoc Workloads setting for servers sql2008 and sqlserver2012 a
 	
 	BEGIN
 	{
-        $notesAdHocZero = "Recommended configuration is 1"
-		$notesAsRecommended = "Configuration is as recommended"
+        $notesAdHocZero = "Recommended configuration is 1 (enabled)."
+		$notesAsRecommended = "Configuration is already set as recommended."
 	}
 	
 	PROCESS


### PR DESCRIPTION
Fixes #1772  

Changes proposed in this pull request:
 - Correct typos in Test-OptimizeForAdHoc help content
 - Bring comment-based help style in line with templates
 - Improve notes text output to user

How to test this code: 
- [ ] Review help text 
- [ ] Test against instances with Optmize for Ad Hoc Workloads both enabled & disabled to review output provided to user

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [X] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers
