### PR TITLE
Get-DbaUptime: fix error on case-sensitive SQL Server instance ( #1791 )

### DIFF
--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -106,7 +106,7 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 								
 				Write-Verbose "Getting Start times for $servername"
 				#Get TempDB creation date
-				$SQLStartTime = $server.Databases["TempDB"].CreateDate
+				$SQLStartTime = $server.Databases["tempdb"].CreateDate
 				$SQLUptime = New-TimeSpan -Start $SQLStartTime -End (Get-Date)
 				$SQLUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($SQLUptime.Days), $($SQLUptime.Hours), $($SQLUptime.Minutes), $($SQLUptime.Seconds)
 			}


### PR DESCRIPTION
Fixes #1791 

Changes proposed in this pull request:
 - correct case `TempDB` -> `tempdb` to fix failure on case-sensitive instance

How to test this code: 
- [ ] `Get-DbaUptime -SqlInstance Case-Sensitive-Instance`

Has been tested on minimum requirements:
- [ ]  Powershell 3
- [ ]  Windows 7
- [ ]  SQL Server 2000

Has been tested on maximum requirements:
- [ ]  SQL Server vNext
- [ ]  Windows 10
- [ ]  Azure Database

Tests for tester:
- [ ] Working/useful help content, including link to command on dbatools web site
- [ ] All examples work as advertised
- [ ] Does not contain template content
- [ ] Does not contain excessive/unnecessary amounts of comments
- [ ] Works remotely
- [ ] Works locally
- [ ] Works on lower versions or throws error specifying version not supported
- [ ] Works with named instances
- [ ] Works with clustered instances
- [ ] Handles offline/read only databases
- [ ] Supports multiple servers (at the command line or piped from Get-SqlRegisteredServerName)
- [ ] No un-handled errors which stop the command working with multiple servers

