### PR TITLE
Job Functions - better align with rest of module

### DIFF
--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -247,7 +247,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 			
 			# Create the job object
 			try {
-				$smoJob = New-Object Microsoft.SqlServer.Management.Smo.Agent.Job($server.JobServer, $Job)
+				$currentjob = New-Object Microsoft.SqlServer.Management.Smo.Agent.Job($server.JobServer, $Job)
 			}
 			catch {
 				Stop-Function -Message "Something went wrong creating the job. `n$($_.Exception.Message)" -Target $Job -Continue -InnerErrorRecord $_
@@ -257,38 +257,38 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 			# Settings the options for the job
 			if ($Disabled) {
 				Write-Message -Message "Setting job to disabled" -Level Verbose
-				$smoJob.IsEnabled = $false
+				$currentjob.IsEnabled = $false
 			}
 			else {
 				Write-Message -Message "Setting job to enabled" -Level Verbose
-				$smoJob.IsEnabled = $true
+				$currentjob.IsEnabled = $true
 			}
 			
 			if ($Description.Length -ge 1) {
 				Write-Message -Message "Setting job description" -Level Verbose
-				$smoJob.Description = $Description
+				$currentjob.Description = $Description
 			}
 			
 			if ($StartStepId -ge 1) {
 				Write-Message -Message "Setting job start step id" -Level Verbose
-				$smoJob.StartStepID = $StartStepId
+				$currentjob.StartStepID = $StartStepId
 			}
 			
 			if ($Category.Length -ge 1) {
 				Write-Message -Message "Setting job category" -Level Verbose
-				$smoJob.Category = $Category
+				$currentjob.Category = $Category
 			}
 			
 			if ($CategoryId -ge 1) {
 				Write-Message -Message "Setting job category id" -Level Verbose
-				$smoJob.CategoryID = $CategoryId
+				$currentjob.CategoryID = $CategoryId
 			}
 			
 			if ($OwnerLogin.Length -ge 1) {
 				# Check if the login name is present on the instance
 				if ($server.Logins.Name -contains $OwnerLogin) {
 					Write-Message -Message "Setting job owner login name to $OwnerLogin" -Level Verbose
-					$smoJob.OwnerLoginName = $OwnerLogin
+					$currentjob.OwnerLoginName = $OwnerLogin
 				}
 				else {
 					Stop-Function -Message "The owner $OwnerLogin does not exist on instance $instance" -Target $Job -Continue
@@ -297,7 +297,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 			
 			if ($EventLogLevel -ge 0) {
 				Write-Message -Message "Setting job event log level" -Level Verbose
-				$smoJob.EventLogLevel = $EventLogLevel
+				$currentjob.EventLogLevel = $EventLogLevel
 			}
 			
 			if ($EmailOperator) {
@@ -305,10 +305,10 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 					# Check if the operator name is present
 					if ($server.JobServer.Operators.Name -contains $EmailOperator) {
 						Write-Message -Message "Setting job e-mail level" -Level Verbose
-						$smoJob.EmailLevel = $EmailLevel
+						$currentjob.EmailLevel = $EmailLevel
 						
 						Write-Message -Message "Setting job e-mail operator" -Level Verbose
-						$smoJob.OperatorToEmail = $EmailOperator
+						$currentjob.OperatorToEmail = $EmailOperator
 					}
 					else {
 						Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $Job -Continue
@@ -324,10 +324,10 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 					# Check if the operator name is present
 					if ($server.JobServer.Operators.Name -contains $NetsendOperator) {
 						Write-Message -Message "Setting job netsend level" -Level Verbose
-						$smoJob.NetSendLevel = $NetsendLevel
+						$currentjob.NetSendLevel = $NetsendLevel
 						
 						Write-Message -Message "Setting job netsend operator" -Level Verbose
-						$smoJob.OperatorToNetSend = $NetsendOperator
+						$currentjob.OperatorToNetSend = $NetsendOperator
 					}
 					else {
 						Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $Job -Continue
@@ -343,10 +343,10 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 					# Check if the operator name is present
 					if ($server.JobServer.Operators.Name -contains $PageOperator) {
 						Write-Message -Message "Setting job pager level" -Level Verbose
-						$smoJob.PageLevel = $PageLevel
+						$currentjob.PageLevel = $PageLevel
 						
 						Write-Message -Message "Setting job pager operator" -Level Verbose
-						$smoJob.OperatorToPage = $PageOperator
+						$currentjob.OperatorToPage = $PageOperator
 					}
 					else {
 						Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $Job -Continue
@@ -359,7 +359,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 			
 			if ($DeleteLevel -ge 0) {
 				Write-Message -Message "Setting job delete level" -Level Verbose
-				$smoJob.DeleteLevel = $DeleteLevel
+				$currentjob.DeleteLevel = $DeleteLevel
 			}
 			#endregion job options
 			
@@ -369,21 +369,21 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 					Write-Message -Message "Creating the job" -Level Verbose
 					
 					# Create the job
-					$smoJob.Create()
+					$currentjob.Create()
 					
-					Write-Message -Message "Job created with UID $($smoJob.JobID)" -Level Verbose
+					Write-Message -Message "Job created with UID $($currentjob.JobID)" -Level Verbose
 					
 					# Make sure the target is set for the job
 					Write-Message -Message "Applying the target (local) to job $Job" -Level Verbose
-					$smoJob.ApplyToTargetServer("(local)")
+					$currentjob.ApplyToTargetServer("(local)")
 					
 					# If a schedule needs to be attached
 					if ($Schedule) {
-						Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -Schedule $Schedule -SqlCredential $SqlCredential
+						Set-DbaAgentJob -SqlInstance $instance -Job $currentjob -Schedule $Schedule -SqlCredential $SqlCredential
 					}
 					
 					if ($ScheduleId) {
-						Set-DbaAgentJob -SqlInstance $instance -Job $smoJob -ScheduleId $ScheduleId -SqlCredential $SqlCredential
+						Set-DbaAgentJob -SqlInstance $instance -Job $currentjob -ScheduleId $ScheduleId -SqlCredential $SqlCredential
 					}
 				}
 				catch {
@@ -392,7 +392,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 			}
 			
 			# Return the job
-			$smoJob
+			$currentjob
 		}
 	}
 	

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -197,7 +197,7 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 		
 		foreach ($instance in $sqlinstance) {
 			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
 			try {
 				$Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
@@ -351,7 +351,7 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 					# Execute
 					if ($PSCmdlet.ShouldProcess($instance, "Creating the job step $StepName")) {
 						try {
-							Write-Message -Message "Creating the job step" -Level Output
+							Write-Message -Message "Creating the job step" -Level Verbose
 							
 							# Create the job step
 							$JobStep.Create()
@@ -363,14 +363,14 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 					}
 					
 					# Return the job step
-					return $JobStep
+					$JobStep
 				}
 			} # foreach object job
 		} # foreach object instance
 	} # process
 	
 	end {
-		Write-Message -Message "Finished creating job step(s)." -Level Output
+		Write-Message -Message "Finished creating job step(s)." -Level Verbose
 	}
 }
 

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -420,7 +420,7 @@ function New-DbaAgentSchedule {
 
 		foreach ($instance in $sqlinstance) {
 			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
 			try {
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
@@ -533,7 +533,7 @@ function New-DbaAgentSchedule {
 						# Create the schedule
 						if ($PSCmdlet.ShouldProcess($SqlInstance, "Adding the schedule $Schedule to job $j on $instance")) {
 							try {
-								Write-Message -Message "Adding the schedule $Schedule to job $j" -Level Output
+								Write-Message -Message "Adding the schedule $Schedule to job $j" -Level Verbose
 
 								$JobSchedule.Create()
 
@@ -620,7 +620,7 @@ function New-DbaAgentSchedule {
 				# Create the schedule
 				if ($PSCmdlet.ShouldProcess($SqlInstance, "Adding the schedule $schedule on $instance")) {
 					try {
-						Write-Message -Message "Adding the schedule $schedule on instance $instance" -Level Output
+						Write-Message -Message "Adding the schedule $schedule on instance $instance" -Level Verbose
 
 						$schedule.Create()
 
@@ -631,7 +631,7 @@ function New-DbaAgentSchedule {
 					}
 
 					# Output the job schedule
-					return $JobSchedule
+					$JobSchedule
 				}
 			}
 		} # foreach object instance

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -94,7 +94,7 @@ Removes the job from multiple servers using pipe line
         foreach ($instance in $sqlinstance) {
 
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Output
+            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
@@ -111,7 +111,7 @@ Removes the job from multiple servers using pipe line
                 else {   
                     # Get the job
                     try {
-                        $smoJob = $Server.JobServer.Jobs[$j] 
+                        $currentjob = $Server.JobServer.Jobs[$j] 
                     }
                     catch {
                         Stop-Function -Message "Something went wrong creating the job. `n$($_.Exception.Message)" -Target $instance -Continue
@@ -120,7 +120,7 @@ Removes the job from multiple servers using pipe line
                     # Delete the history
                     if (-not $KeepHistory) {
                         Write-Message -Message "Purging job history" -Level Verbose
-                        $smoJob.PurgeHistory()
+                        $currentjob.PurgeHistory()
                     }
 
                     # Execute 
@@ -131,12 +131,12 @@ Removes the job from multiple servers using pipe line
                             if ($KeepUnusedSchedule) {
                                 # Drop the job keeping the unused schedules
                                 Write-Message -Message "Removing job keeping unused schedules" -Level Verbose
-                                $smoJob.Drop($true) 
+                                $currentjob.Drop($true) 
                             }
                             else {
                                 # Drop the job removing the unused schedules
                                 Write-Message -Message "Removing job removing unused schedules" -Level Verbose
-                                $smoJob.Drop($false) 
+                                $currentjob.Drop($false) 
                             }
                     
                         }

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -87,7 +87,7 @@ Remove the job step from the job on multiple servers using pipeline
 		foreach ($instance in $sqlinstance) {
 			
 			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
 			try {
 				$Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -87,7 +87,7 @@ Remove the schedule on multiple servers using pipe line
 
 		foreach ($instance in $sqlinstance) {
 			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
 			try {
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -259,7 +259,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
         foreach ($instance in $sqlinstance) {
 			
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Output
+            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
@@ -490,7 +490,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     # Execute 
                     if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
                         try {
-                            Write-Message -Message ("Changing the job") -Level Output
+                            Write-Message -Message ("Changing the job") -Level Verbose
 							
                             # Change the job
                             $smojob.Alter()
@@ -506,6 +506,6 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
     } # Process
 	
     end {
-        Write-Message -Message "Finished changing job(s)." -Level Output
+        Write-Message -Message "Finished changing job(s)." -Level Verbose
     }
 }

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -202,7 +202,7 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
 		foreach ($instance in $sqlinstance) {
 			
 			# Try connecting to the instance
-			Write-Message -Message "Attempting to connect to $instance" -Level Output
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
 			try {
 				$Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
@@ -226,7 +226,7 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
 						# Get the job step
 						$JobStep = $Server.JobServer.Jobs[$j].JobSteps[$StepName]
 						
-						Write-Message -Message "Modifying job $j on $instance" -Level Output
+						Write-Message -Message "Modifying job $j on $instance" -Level Verbose
 						
 						#region job step options
 						# Setting the options for the job step
@@ -327,7 +327,7 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
 						# Execute 
 						if ($PSCmdlet.ShouldProcess($instance, "Changing the job step $StepName for job $j")) {
 							try {
-								Write-Message -Message "Changing the job step $StepName for job $j" -Level Output
+								Write-Message -Message "Changing the job step $StepName for job $j" -Level Verbose
 								
 								# Change the job step
 								$JobStep.Alter()
@@ -344,6 +344,6 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
 	} # process
 	
 	end {
-		Write-Message -Message "Finished changing job step(s)" -Level Output
+		Write-Message -Message "Finished changing job step(s)" -Level Verbose
 	}
 }

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -323,7 +323,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
             foreach ($j in $Job) {
 
                 # Try connecting to the instance
-                Write-Message -Message "Attempting to connect to $instance" -Level Output
+                Write-Message -Message "Attempting to connect to $instance" -Level Verbose
                 try {
                     $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 }
@@ -421,7 +421,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
                         if ($PSCmdlet.ShouldProcess($instance, "Changing the schedule $ScheduleName for job $j on $instance")) {
                             try {
                                 # Excute the query and save the result
-                                Write-Message -Message "Changing the schedule $ScheduleName for job $j" -Level Output
+                                Write-Message -Message "Changing the schedule $ScheduleName for job $j" -Level Verbose
                         
                                 $JobSchedule.Alter()
                         
@@ -438,6 +438,6 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
     } # process
 
     end {
-        Write-Message -Message "Finished changing the job schedule(s)."-Level Output
+        Write-Message -Message "Finished changing the job schedule(s)."-Level Verbose
     }
 }


### PR DESCRIPTION
The AgentJob functions used a lot of Output which is nice but unfortunately does not align with the rest of the behavior of commands. I kept it in the Remove for now, but the Remove should output objects like Remove-DbaDatabase 