### PR TITLE
Add verification that source database is accessible

### DIFF
--- a/internal/Update-SqlPermissions.ps1
+++ b/internal/Update-SqlPermissions.ps1
@@ -151,7 +151,7 @@ function Update-SqlPermissions {
 		$sourcedb = $sourceserver.databases[$dbname]
 		$dbusername = $db.username; $dblogin = $db.loginName
 
-		if ($sourcedb -ne $null) {
+		if ($sourcedb -ne $null -and $sourcedb.IsAccessible) {
 			if ($sourcedb.users[$dbusername] -eq $null -and $destdb.users[$dbusername] -ne $null) {
 				If ($Pscmdlet.ShouldProcess($destination, "Dropping $dbusername from $dbname on destination.")) {
 					try {


### PR DESCRIPTION
Adding this verification before removing the user in the destination database will ensure that the user is not removed, when the source database is in the offline/restoring state. It will also ensure that the script won't be accessing a non-accessible database.
Right now, if you are trying to copy a login using Copy-DBALogin function from a server where certain database is offline/restoring, this user will be completely removed from the same database on the destination server. The script will throw an error when trying to access the OFFLINE database.
Scenario, where it can be used: during a database migration that uses log backup chain, where last log backup has been taken WITH NORECOVERY. Databases will be restored on the target server, but will stay in a "Restoring" state on the source server. In current implementation, all the users will be stripped from the target databases when using Copy-DBALogin. Better option would be to keep them intact and afterwards fix them by using Repair-DBAOrphanUser (if needed).

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1813)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can earse anything that is not applicable -->
### Purpose
Fix an issue with an error when accessing OFFLINE database and preventing the script from removing users from the target database when source database is unavailable.

### Approach
Adding one more verification: the source database should be accessible before removing the user from the dest database

### Commands to test
```
$database = 'TestMigration'
$login = 'TestLogin'
$source = 'wpg1lsds01,7221'
$destination = 'wpg1lsds01,7220'
$backupfolder = 'D:\Temp\'

$currentdatetime = (Get-Date -Format s).Replace(":","")
$fullbackupfile = $backupfolder,$database,$currentdatetime,".bak" -join ""

Invoke-sqlcmd -ServerInstance $source -Query "IF db_id ('$database') IS NULL CREATE DATABASE [$database]; ALTER DATABASE [$database] SET RECOVERY FULL"
Invoke-sqlcmd -ServerInstance $source -Query "IF NOT EXISTS (SELECT * FROM sys.server_principals WHERE name = '$login') CREATE LOGIN [$login] WITH PASSWORD = 'df98gyh23rbAWER@'"
Invoke-sqlcmd -ServerInstance $source -Query "USE [$database] IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$login') CREATE USER [$login] FOR LOGIN [$login]"

Backup-SqlDatabase -ServerInstance $source -Database $database -BackupFile $fullbackupfile
Invoke-sqlcmd -ServerInstance $source -Query "ALTER DATABASE [$database] SET OFFLINE WITH ROLLBACK IMMEDIATE"

$fullbackupfile|Restore-DBADatabase -ServerInstance $destination -Database $database

Copy-DBALogin -Source $source -Destination $destination -Login $login
```

### Screenshots
n/a

### Learning
n/a
