### PR TITLE
Adjust CMS commands for format and add TEPP Group parameter

### DIFF
--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -1,188 +1,200 @@
 function Get-DbaRegisteredServerName {
-    <#
-.SYNOPSIS
-Gets list of SQL Server names stored in SQL Server Central Management Server.
+	<#
+		.SYNOPSIS
+			Gets list of SQL Server names stored in SQL Server Central Management Server.
 
-.DESCRIPTION
-Returns a simple array of server names. Be aware of the dynamic parameter 'Group', which can be used to limit results to one or more groups you have created on the CMS. See get-help for examples.
+		.DESCRIPTION
+			Returns a simple array of server names. Be aware of the dynamic parameter 'Group', which can be used to limit results to one or more groups you have created on the CMS. See get-help for examples.
 
-.PARAMETER SqlInstance
-The SQL Server instance. 
+		.PARAMETER SqlInstance
+			The SQL Server instance.
 
-.PARAMETER SqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
-$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
-Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. To connect as a different Windows user, run PowerShell as that user.
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
 
-.PARAMETER Group
-Auto-populated list of groups in SQL Server Central Management Server. You can specify one or more, comma separated.
-		
-.PARAMETER NoCmsServer
-By default, the Central Management Server name is included in the list. Use -NoCmsServer to exclude the CMS itself.
-	
-.PARAMETER NetBiosName
-Returns just the NetBios names of each server.
-	
-.PARAMETER IpAddr
-Returns just the ip addresses of each server.
-	
-.NOTES 
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
+			To use:
+			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. To connect as a different Windows user, run PowerShell as that user.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+		.PARAMETER Group
+			Auto-populated list of groups in SQL Server Central Management Server. You can specify one or more, comma separated.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+		.PARAMETER NoCmsServer
+			By default, the Central Management Server name is included in the list. Use -NoCmsServer to exclude the CMS itself.
 
-.LINK
-https://dbatools.io/Get-DbaRegisteredServerName
+		.PARAMETER NetBiosName
+			Returns just the NetBios names of each server.
 
-.EXAMPLE 
-Get-DbaRegisteredServerName -SqlInstance sqlserver2014a
+		.PARAMETER IpAddr
+			Returns just the ip addresses of each server.
 
-Gets a list of all server names from the Central Management Server on sqlserver2014a, using Windows Credentials
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
 
-.EXAMPLE 
-Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -SqlCredential $credential
+		.NOTES
+			Tags: RegisteredServer,CMS
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-Gets a list of all server names from the Central Management Server on sqlserver2014a, using SQL Authentication
-		
-.EXAMPLE 
-Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting
-	
-Gets a list of server names in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
-	
-.EXAMPLE 
-Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddr
-	
-Gets a list of server IP addresses in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
-	
-#>
-    [CmdletBinding(DefaultParameterSetName = "Default")]
-    Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter]$SqlInstance,
-        [object]$SqlCredential,
-        [switch]$NoCmsServer,
-        [parameter(ParameterSetName = "NetBios")]
-        [switch]$NetBiosName,
-        [parameter(ParameterSetName = "IP")]
-        [switch]$IpAddr
-    )
+		.LINK
+			https://dbatools.io/Get-DbaRegisteredServerName
 
-    begin {
-        $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        $sqlconnection = $server.ConnectionContext.SqlConnectionObject
-		
-        try {
-            $cmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection)
-        }
-        catch {
-            throw "Cannot access Central Management Server"
-        }
-    }
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a
 
-    process {
+			Gets a list of all server names from the Central Management Server on sqlserver2014a, using Windows Credentials
 
-        # see notes at Get-ParamSqlCmsGroups
-        Function Find-CmsGroup($CmsGrp, $base = '', $stopat) {
-            $results = @()
-            foreach ($el in $CmsGrp) {
-                if ($base -eq '') {
-                    $partial = $el.name
-                }
-                else {
-                    $partial = "$base\$($el.name)"
-                }
-                if ($partial -eq $stopat) {
-                    return $el
-                }
-                else {
-                    foreach ($group in $el.ServerGroups) {
-                        $results += Find-CmsGroup $group $partial $stopat
-                    }
-                }
-            }
-            return $results
-        }
-		
-        $servers = @()
-        if ($groups -ne $null) {
-            foreach ($group in $groups) {
-                $cms = Find-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups '' $group
-                $servers += ($cms.GetDescendantRegisteredServers()).servername
-            }
-        }
-        else {
-            $cms = $cmstore.ServerGroups["DatabaseEngineServerGroup"]
-            $servers = ($cms.GetDescendantRegisteredServers()).servername
-        }
-		
-        if ($NoCmsServer -eq $false) {
-            $servers += $SqlInstance.ComputerName
-        }
-    }
-    end {
-        if ($NetBiosName -or $IpAddr) {
-            $ipcollection = @()
-            $netbioscollection = @()
-            $processed = @()
-			
-            foreach ($server in $servers) {
-                if ($server -match '\\') {
-                    $server = $server.Split('\')[0]
-                }
-				
-                if ($processed -contains $server) { continue }
-                $processed += $server 
-				
-                try {
-                    Write-Verbose "Testing connection to $server and resolving IP address"
-                    $ipaddress = ((Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1).IPAddressToString
-                }
-                catch {
-                    Write-Warning "Could not resolve IP address for $server"
-                    continue
-                }
-				
-                if ($ipcollection -notcontains $ipaddress) { $ipcollection += $ipaddress }
-				
-                if ($NetBiosName) {
-                    try {
-                        $hostname = (Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=TRUE -ComputerName $ipaddress -ErrorAction SilentlyContinue).PSComputerName
-                        if ($hostname -is [array]) { $hostname = $hostname[0] }
-                        Write-Verbose "Hostname resolved to $hostname"
-                        if ($hostname -eq $null) { $hostname = (nbtstat -A $ipaddress | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim() }
-                    }
-                    catch {
-                        Write-Warning "Could not resolve NetBios name for $server"
-                        continue
-                    }
-					
-                    if ($netbioscollection -notcontains $hostname) { $netbioscollection += $hostname }
-                }
-            }
-			
-            if ($NetBiosName) {
-                return $netbioscollection
-            }
-            else {
-                return $ipcollection
-            }
-        }
-        else {
-            return $servers
-        }
-        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName
-    }
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -SqlCredential $credential
+
+			Gets a list of all server names from the Central Management Server on sqlserver2014a, using SQL Authentication
+
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting
+
+			Gets a list of server names in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
+
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddr
+
+			Gets a list of server IP addresses in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
+	#>
+	[CmdletBinding(DefaultParameterSetName = "Default")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Alias("Groups")]
+		[object[]]$Group,
+		[switch]$NoCmsServer,
+		[parameter(ParameterSetName = "NetBios")]
+		[switch]$NetBiosName,
+		[parameter(ParameterSetName = "IP")]
+		[switch]$IpAddr,
+		[switch]$Silent
+	)
+
+	begin {
+		try {
+			$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+		}
+		catch {
+			Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+		}
+
+		$sqlconnection = $server.ConnectionContext.SqlConnectionObject
+
+		try {
+			$cmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection)
+		}
+		catch {
+			Stop-Function -Message "Cannot access Central Management Server"
+			return
+		}
+	}
+
+	process {
+		if (Test-FunctionInterrupt) { return }
+
+		# see notes at Get-ParamSqlCmsGroups
+		function Find-CmsGroup($CmsGrp, $base = '', $stopat) {
+			$results = @()
+			foreach ($el in $CmsGrp) {
+				if ($base -eq '') {
+					$partial = $el.name
+				}
+				else {
+					$partial = "$base\$($el.name)"
+				}
+				if ($partial -eq $stopat) {
+					return $el
+				}
+				else {
+					foreach ($group in $el.ServerGroups) {
+						$results += Find-CmsGroup $group $partial $stopat
+					}
+				}
+			}
+			return $results
+		}
+
+		$servers = @()
+		if ($Group -ne $null) {
+			foreach ($currentGroup in $Group) {
+				$cms = Find-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups '' $currentGroup
+				$servers += ($cms.GetDescendantRegisteredServers()).ServerName
+			}
+		}
+		else {
+			$cms = $cmstore.ServerGroups["DatabaseEngineServerGroup"]
+			$servers = ($cms.GetDescendantRegisteredServers()).ServerName
+		}
+
+		if ($NoCmsServer -eq $false) {
+			$servers += $SqlInstance.ComputerName
+		}
+	}
+	end {
+		if ($NetBiosName -or $IpAddr) {
+			$ipcollection = @()
+			$netbioscollection = @()
+			$processed = @()
+
+			foreach ($server in $servers) {
+				if ($server -match '\\') {
+					$server = $server.Split('\')[0]
+				}
+
+				if ($processed -contains $server) { continue }
+				$processed += $server
+
+				try {
+					Write-Message -Level Verbose -Message "Testing connection to $server and resolving IP address"
+					$ipaddress = ((Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1).IPAddressToString
+				}
+				catch {
+					Stop-Function -Message "Could not resolve IP address for $server" -ErrorRecord $_ -Continue
+				}
+
+				if ($ipcollection -notcontains $ipaddress) {
+					$ipcollection += $ipaddress
+				}
+
+				if ($NetBiosName) {
+					try {
+						$hostName = (Get-DbaCmObject -ClassName Win32_NetworkAdapterConfiguration -ComputerName $ipaddress -SilentlyContinue | Where-Object IPEnabled -eq $true).PSComputerName
+
+						if ($hostname -is [array]) {
+							$hostname = $hostname[0]
+						}
+						Write-Message -Level Verbose -Message "Hostname resolved to $hostname"
+						if ($hostname -eq $null) {
+							$hostname = (nbtstat -A $ipaddress | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim()
+						}
+					}
+					catch {
+						Stop-Function -Message "Could not resolve NetBios name for $server" -ErrorRecord $_ -Continue
+					}
+
+					if ($netbioscollection -notcontains $hostname) {
+						$netbioscollection += $hostname
+					}
+				}
+			}
+
+			if ($NetBiosName) {
+				return $netbioscollection
+			}
+			else {
+				return $ipcollection
+			}
+		}
+		else {
+			return $servers
+		}
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName
+	}
 }

--- a/functions/Get-DbaRegisteredServersStore.ps1
+++ b/functions/Get-DbaRegisteredServersStore.ps1
@@ -1,53 +1,51 @@
 ﻿function Get-DbaRegisteredServersStore {
-<#
-.SYNOPSIS
-Returns a SQL Server Registered Server Store Object
+	<#
+		.SYNOPSIS
+			Returns a SQL Server Registered Server Store Object
 
-.DESCRIPTION
-Returns a SQL Server Registered Server Store object - useful for working with Central Management Store
+		.DESCRIPTION
+			Returns a SQL Server Registered Server Store object - useful for working with Central Management Store
 
-.PARAMETER SqlInstance
-SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function
-to be executed against multiple SQL Server instances.
+		.PARAMETER SqlInstance
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function
+			to be executed against multiple SQL Server instances.
 
-.PARAMETER SqlCredential
-	SqlCredential object to connect as. If not specified, current Windows login will be used.
+		.PARAMETER SqlCredential
+			SqlCredential object to connect as. If not specified, current Windows login will be used.
 
-.PARAMETER Silent
-Use this switch to disable any kind of verbose messages
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
 
-.NOTES
-Tags: RegisteredServer
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+		.NOTES
+			Tags: RegisteredServer,CMS
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Get-DbaRegisteredServersStore
+		.LINK
+			https://dbatools.io/Get-DbaRegisteredServersStore
 
-.EXAMPLE 
-Get-DbaRegisteredServersStore -SqlInstance sqlserver2014a
+		.EXAMPLE 
+			Get-DbaRegisteredServersStore -SqlInstance sqlserver2014a
 
-Returns a SQL Server Registered Server Store Object from sqlserver2014a 
+			Returns a SQL Server Registered Server Store Object from sqlserver2014a 
 
-.EXAMPLE 
-Get-DbaRegisteredServersStore -SqlInstance sqlserver2014a -SqlCredential (Get-Credential sqladmin)
+		.EXAMPLE 
+			Get-DbaRegisteredServersStore -SqlInstance sqlserver2014a -SqlCredential (Get-Credential sqladmin)
 
-Returns a SQL Server Registered Server Store Object from sqlserver2014a  by logging in with the sqladmin login
-	
-#>
+			Returns a SQL Server Registered Server Store Object from sqlserver2014a  by logging in with the sqladmin login
+	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstanceParameter[]]$SqlInstance,
-		[object]$SqlCredential,
+		[PSCredential]$SqlCredential,
 		[switch]$Silent
 	)
 	process {
 		foreach ($Instance in $SqlInstance) {
 			try {
-				Write-Message -Level Verbose -Message "Connecting to $instance"
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
 			}
 			catch {
@@ -60,7 +58,7 @@ Returns a SQL Server Registered Server Store Object from sqlserver2014a  by logg
 				$store = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection)
 			}
 			catch {
-				Stop-Function -Message "Cannot access Central Management Server" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+				Stop-Function -Message "Cannot access Central Management Server on $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 			
 			Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ComputerName -value $server.NetName

--- a/internal/dynamicparams/group.ps1
+++ b/internal/dynamicparams/group.ps1
@@ -1,0 +1,83 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"]) {
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+        
+        $parameterName,
+        
+        $wordToComplete,
+        
+        $commandAst,
+        
+        $fakeBoundParameter
+    )
+    
+    $start = Get-Date
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["group"].LastExecution = $start
+	
+	$server = $fakeBoundParameter['SqlInstance']
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['Source']
+	}
+	
+	if (-not $server) {
+		$server = $fakeBoundParameter['ComputerName']
+	}
+	
+	if (-not $server) { return }
+	
+    try
+    {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["group"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"][$parServer.FullSmoName.ToLower()])
+    {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["group"].LastDuration = (Get-Date) - $start
+        return
+    }
+    
+    try
+    {
+        $serverObject = Connect-SqlInstance -SqlInstance $parServer -SqlCredential $fakeBoundParameter['SqlCredential'] -ErrorAction Stop
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*"))
+        {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["group"].LastDuration = (Get-Date) - $start
+        return
+    }
+    catch
+    {
+        [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Scripts["group"].LastDuration = (Get-Date) - $start
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name Group
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+
+    $cms = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($server.ConnectionContext.SqlConnectionObject)
+	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["group"][$FullSmoName] = $cms.DatabaseEngineServerGroup.ServerGroups.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -39,134 +39,141 @@ foreach ($function in $functions) {
 	if ($function.Parameters.Keys -contains "ConfigName") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ConfigName -Name ConfigName
 	}
-	if ($function.Parameters.Keys -contains "ConfigName") {
+	if ($function.Parameters.Keys -contains "ExcludeConfigName") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeConfigName -Name ConfigName
 	}
 
 	if ($function.Parameters.Keys -contains "Alert") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Alert -Name Alert
 	}
-	if ($function.Parameters.Keys -contains "Alert") {
+	if ($function.Parameters.Keys -contains "ExcludeAlert") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlert -Name Alert
 	}
 
 	if ($function.Parameters.Keys -contains "AlertCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AlertCategory -Name AlertCategory
 	}
-	if ($function.Parameters.Keys -contains "AlertCategory") {
+	if ($function.Parameters.Keys -contains "ExcludeAlertCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAlertCategory -Name AlertCategory
 	}
 
 	if ($function.Parameters.Keys -contains "JobCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter JobCategory -Name JobCategory
 	}
-	if ($function.Parameters.Keys -contains "JobCategory") {
+	if ($function.Parameters.Keys -contains "ExcludeJobCategory") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeJobCategory -Name JobCategory
 	}
 
 	if ($function.Parameters.Keys -contains "AvailabilityGroup") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AvailabilityGroup -Name AvailabilityGroup
 	}
-	if ($function.Parameters.Keys -contains "AvailabilityGroup") {
+	if ($function.Parameters.Keys -contains "ExcludeAvailabilityGroup") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAvailabilityGroup -Name AvailabilityGroup
 	}
 
 	if ($function.Parameters.Keys -contains "BackupDevice") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter BackupDevice -Name BackupDevice
 	}
-	if ($function.Parameters.Keys -contains "BackupDevice") {
+	if ($function.Parameters.Keys -contains "ExcludeBackupDevice") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeBackupDevice -Name BackupDevice
 	}
 
 	if ($function.Parameters.Keys -contains "Credential") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Credential -Name Credential
 	}
-	if ($function.Parameters.Keys -contains "Credential") {
+	if ($function.Parameters.Keys -contains "ExcludeCredential") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeCredential -Name Credential
 	}
 
 	if ($function.Parameters.Keys -contains "CustomError") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter CustomError -Name CustomError
 	}
-	if ($function.Parameters.Keys -contains "CustomError") {
+	if ($function.Parameters.Keys -contains "ExcludeCustomError") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeCustomError -Name CustomError
 	}
 
 	if ($function.Parameters.Keys -contains "MailAccount") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailAccount -Name MailAccount
 	}
-	if ($function.Parameters.Keys -contains "MailAccount") {
+	if ($function.Parameters.Keys -contains "ExcludeMailAccount") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailAccount -Name MailAccount
 	}
 
 	if ($function.Parameters.Keys -contains "MailServer") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailServer -Name MailServer
 	}
-	if ($function.Parameters.Keys -contains "MailServer") {
+	if ($function.Parameters.Keys -contains "ExcludeMailServer") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailServer -Name MailServer
 	}
 
 	if ($function.Parameters.Keys -contains "MailProfile") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter MailProfile -Name MailProfile
 	}
-	if ($function.Parameters.Keys -contains "MailProfile") {
+	if ($function.Parameters.Keys -contains "ExcludeMailProfile") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeMailProfile -Name MailProfile
 	}
 
 	if ($function.Parameters.Keys -contains "Endpoint") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Endpoint -Name Endpoint
 	}
-	if ($function.Parameters.Keys -contains "Endpoint") {
+	if ($function.Parameters.Keys -contains "ExcludeEndpoint") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeEndpoint -Name Endpoint
 	}
 
 	if ($function.Parameters.Keys -contains "LinkedServer") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter LinkedServer -Name LinkedServer
 	}
-	if ($function.Parameters.Keys -contains "LinkedServer") {
+	if ($function.Parameters.Keys -contains "ExcludeLinkedServer") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeLinkedServer -Name LinkedServer
 	}
 
 	if ($function.Parameters.Keys -contains "ProxyAccount") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ProxyAccount -Name ProxyAccount
 	}
-	if ($function.Parameters.Keys -contains "ProxyAccount") {
+	if ($function.Parameters.Keys -contains "ExcludeProxyAccount") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeProxyAccount -Name ProxyAccount
 	}
 
 	if ($function.Parameters.Keys -contains "ResourcePool") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ResourcePool -Name ResourcePool
 	}
-	if ($function.Parameters.Keys -contains "ResourcePool") {
+	if ($function.Parameters.Keys -contains "ExcludeResourcePool") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeResourcePool -Name ResourcePool
 	}
 
 	if ($function.Parameters.Keys -contains "Audit") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Audit -Name Audit
 	}
-	if ($function.Parameters.Keys -contains "Audit") {
+	if ($function.Parameters.Keys -contains "ExcludeAudit") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAudit -Name Audit
 	}
 
 	if ($function.Parameters.Keys -contains "AuditSpecification") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter AuditSpecification -Name AuditSpecification
 	}
-	if ($function.Parameters.Keys -contains "AuditSpecification") {
+	if ($function.Parameters.Keys -contains "ExcludeAuditSpecification") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeAuditSpecification -Name AuditSpecification
 	}
 
 	if ($function.Parameters.Keys -contains "ServerTrigger") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ServerTrigger -Name ServerTrigger
 	}
-	if ($function.Parameters.Keys -contains "ServerTrigger") {
+	if ($function.Parameters.Keys -contains "ExcludeServerTrigger") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeServerTrigger -Name ServerTrigger
 	}
 
 	if ($function.Parameters.Keys -contains "Schedule") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Schedule -Name Schedule
 	}
-	if ($function.Parameters.Keys -contains "Schedule") {
+	if ($function.Parameters.Keys -contains "ExcludeSchedule") {
 		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeSchedule -Name Schedule
+	}
+
+	if ($function.Parameters.Keys -contains "Group") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter Group -Name Group
+	}
+	if ($function.Parameters.Keys -contains "ExcludeGroup") {
+		Register-DbaTeppArgumentCompleter -Command $function.Name -Parameter ExcludeGroup -Name Group
 	}
 }
 #endregion Automatic TEPP by parameter name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can earse anything that is not applicable -->
### Purpose
- Add TEPP for Group parameter with CMS/RegisteredServer command
- Applied format and standard to `Get-DbaRegisteredServerName`
- Included alias of previous parameter `Groups`

### Approach
Allows calling of `Get-DbaRegisteredServerName -SqlInstance sql2016a -Group xxx` to auto-populate the Groups found on the CMS.

Adjusting `Get-DbaRegisteredServerName` brings it to our standards for the module, in regard to format. I also adjusted the command to use `Get-DbaCmObject` instead of WMI command. Should allow it to run a bit more efficiently.

### Commands to test
```powershell
#Credential is SQL Login, member of sysadmin role
Get-DbaRegisteredServerName -SqlInstance sql2016 -Group Legacy -SqlCredential (Get-Credential heman)

Get-DbaRegisteredServerName -SqlInstance sql2016 -Group Legacy -NoCmsServer

Get-DbaRegisteredServerName -SqlInstance sql2016 -Group Legacy -IpAddr

Get-DbaRegisteredServerName -SqlInstance sql2016 -Group Legacy -NetBiosName
```

### Screenshots
Original command execution time (as accurate as `Measure-Command` can be), for version in 0.9.10

![image](https://user-images.githubusercontent.com/11204251/28483144-58424ee8-6e31-11e7-8f0f-a217ac88fb10.png)

Command execution time in this PR, not extreme but still a difference

![image](https://user-images.githubusercontent.com/11204251/28483189-94d25704-6e31-11e7-8ff5-ed02d6db642c.png)

Show TEPP command working for Group

![group_tepp](https://user-images.githubusercontent.com/11204251/28483225-d21e050e-6e31-11e7-9ce4-a6b6af78505c.gif)

Example commands:

![image](https://user-images.githubusercontent.com/11204251/28483374-7ceae09c-6e32-11e7-8db5-8eb95ad0afe7.png)
