### PR TITLE
Adding .Query() to database, adding .Invoke() to server and database

### DIFF
--- a/internal/type-extensions.ps1
+++ b/internal/type-extensions.ps1
@@ -1,13 +1,42 @@
 # Implement query accelerator for the server object
 Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName Query -MemberType ScriptMethod -Value {
-    Param (
-        $Query,
+	Param (
+		$Query,
 		
-        $Database = "master",
-        
-        $AllTables = $false
-    )
-    
-    if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
-    else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
+		$Database = "master",
+		
+		$AllTables = $false
+	)
+	
+	if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
+	else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
+}
+
+Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName Invoke -MemberType ScriptMethod -Value {
+	Param (
+		$Command,
+		
+		$Database = "master"
+	)
+	
+	else { $this.Databases[$Database].ExecuteNonQuery($Command) }
+}
+
+Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Database -MemberName Query -MemberType ScriptMethod -Value {
+	Param (
+		$Query,
+		
+		$AllTables = $false
+	)
+	
+	if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
+	else { ($this.ExecuteWithResults($Query)).Tables[0] }
+}
+
+Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName Invoke -MemberType ScriptMethod -Value {
+	Param (
+		$Command
+	)
+	
+	else { $this.ExecuteNonQuery($Command) }
 }


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
 
### Purpose
 - Convenience of our BDFL
 - Pleasure of our BDFL
 - Mercy of our HBDFL
 - Grace of our BDFL
 - FOR PONY!!!
 - Accelerating and simplifying sql command execution against databases

### Features added
 - Adds `.Query("SELECT foo FROM bar")` to smo database objects, replacing `$db.ExecuteWithResults($Query)).Tables[0]`
 - Adds `.Query("SELECT foo FROM bar", $true)` to smo database objects, replacing `$db.ExecuteWithResults($Query)).Tables`
 - Adds `.Invoke($Command, $Database)` to smo server objects, replacing `$server.Databases[$Database].ExecuteNonQuery($Command)`
 - Adds `.Invoke($Command)` to smo database objects, replacing `$db.ExecuteNonQuery($Command)` (For uniformity reason, at this level it's not really much typing saved)