### PR TITLE
Get-DbaDatabase - add LogReuseWaitStatus to default view

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -228,7 +228,7 @@
 			}
 
 			$defaults =  'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel',
-                         'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner',
+                         'LogReuseWaitStatus','Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner',
                          'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup',
                          'LastLogBackupDate as LastLogBackup'
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add the LogResuseWaitStatus to the default view.

### Approach
<!-- How does this change solve that purpose -->
The log reuse is one of the most common values to check for databases in SQL Server. This is used to check why the log file is filling up or growing out of control in most cases.

Being that we provide the last log backup it makes sense to also include this value. I chose to add the property alongside the recovery model as it is most directly related to that property.

### Commands to test
<!-- if these are the examples in the help just not it as such -->
`Get-DbaDatabase -SqlInstance -Database master`
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![image](https://user-images.githubusercontent.com/11204251/28496461-985bc670-6f31-11e7-8665-7206473cdca2.png)

