### PR TITLE
Get-DbaLastGoodCheckDb Missing -Message parameter

### DIFF
--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -103,7 +103,7 @@ Authenticates with SQL Server using alternative credentials.
 				Write-Message -Level Verbose -Message "Processing $db on $instances"
 
 				if ($db.IsAccessible -eq $false) {
-					Stop-Function "The database $db is not accessible. Skipping database." -Continue -Target $db
+					Stop-Function -Message "The database $db is not accessible. Skipping database." -Continue -Target $db
 				}
 
 				$sql = "DBCC DBINFO ([$($db.name)]) WITH TABLERESULTS"


### PR DESCRIPTION
Parameter -Message was missing on Stop-Function call.
When database is not accessible (for instance, offline) we can see the following ugly error:
![image](https://user-images.githubusercontent.com/19521315/28497642-fab8771c-6f83-11e7-8756-2d6429017024.png)

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1838)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Remove the ugly error by a pretty warning message.

### Approach
By adding the missing parameter the error has gone :-)

### Commands to test
Get-DbaLastGoodCheckDb -SqlInstance sql2008

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/19521315/28497662-686e1fd2-6f84-11e7-934c-c4527be4c93f.png)

