### PR TITLE
Backup-DbaDatabase - Returns "True" before each result

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -241,7 +241,7 @@ function Backup-DbaDatabase {
 			}
 			
 			if ($CopyOnly -ne $True) {
-				$CopyOnly -eq $false
+				$CopyOnly = $false
 			}
 			
 			$server.ConnectionContext.StatementTimeout  = 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1841)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Remove the True before each result.
Also this messes with CopyOnly 

### Approach
Change the "-eq" by the "=" on line 244 
https://github.com/sqlcollaborative/dbatools/blob/master/functions/Backup-DbaDatabase.ps1#L244

### Commands to test
Backup-DbaDatabase -SqlInstance "sql2016\StandardRTM" -BackupDirectory \\nas\sql -CompressBackup

### Screenshots
![image](https://user-images.githubusercontent.com/19521315/28497862-b8ee726e-6f88-11e7-8d48-4d610ec5f243.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
