### PR TITLE
Get dbadatabase feature lastused

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -1,5 +1,5 @@
 ﻿function Get-DbaDatabase {
-	<#
+    <#
 		.SYNOPSIS
 			Gets SQL Database information for each database that is present in the target instance(s) of SQL Server.
 
@@ -139,58 +139,58 @@
 
 			Returns databases 'OneDb' and 'OtherDB' from sql instances SQL2 and SQL3 if the databases exist on those instances
 	#>
-	[CmdletBinding(DefaultParameterSetName = "Default")]
+    [CmdletBinding(DefaultParameterSetName = "Default")]
     [OutputType([Microsoft.SqlServer.Management.Smo.Database[]])]
-	Param (
-		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential]
-		$SqlCredential,
-		[Alias("Databases")]
-		[object[]]$Database,
-		[object[]]$ExcludeDatabase,
-		[Alias("SystemDbOnly")]
-		[switch]$NoUserDb,
-		[Alias("UserDbOnly")]
-		[switch]$NoSystemDb,
-		[string[]]$Owner,
-		[switch]$Encrypted,
-		[ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
-		[string[]]$Status = @('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect'),
-		[ValidateSet('ReadOnly', 'ReadWrite')]
-		[string]$Access,
-		[ValidateSet('Full', 'Simple', 'BulkLogged')]
-		[string[]]$RecoveryModel = @('Full', 'Simple', 'BulkLogged'),
-		[switch]$NoFullBackup,
-		[datetime]$NoFullBackupSince,
-		[switch]$NoLogBackup,
-		[datetime]$NoLogBackupSince,
-		[switch]$Silent,
-		[switch]$LastUsed
-	)
+    Param (
+        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]
+        $SqlCredential,
+        [Alias("Databases")]
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [Alias("SystemDbOnly")]
+        [switch]$NoUserDb,
+        [Alias("UserDbOnly")]
+        [switch]$NoSystemDb,
+        [string[]]$Owner,
+        [switch]$Encrypted,
+        [ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
+        [string[]]$Status = @('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect'),
+        [ValidateSet('ReadOnly', 'ReadWrite')]
+        [string]$Access,
+        [ValidateSet('Full', 'Simple', 'BulkLogged')]
+        [string[]]$RecoveryModel = @('Full', 'Simple', 'BulkLogged'),
+        [switch]$NoFullBackup,
+        [datetime]$NoFullBackupSince,
+        [switch]$NoLogBackup,
+        [datetime]$NoLogBackupSince,
+        [switch]$Silent,
+        [switch]$LastUsed
+    )
 
-	begin {
+    begin {
 
-		if ($NoUserDb -and $NoSystemDb) {
-			Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue -Silent $Silent
-		}
+        if ($NoUserDb -and $NoSystemDb) {
+            Stop-Function -Message "You cannot specify both NoUserDb and NoSystemDb" -Continue -Silent $Silent
+        }
 
-	}
-	process {
-		if (Test-FunctionInterrupt) { return }
+    }
+    process {
+        if (Test-FunctionInterrupt) { return }
 
-		foreach ($instance in $SqlInstance) {
-			try {
-			    Write-Message -Level Verbose -Message "Connecting to $instance"
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-			if($LastUsed){
-				## Get last used information from the DMV
+            if ($LastUsed) {
+                ## Get last used information from the DMV
                 $querylastused = "WITH agg AS
 				(
 				  SELECT 
@@ -222,97 +222,102 @@
 				GROUP BY
 				   dbname
 				ORDER BY 1;"
-                $dblastused = $server.ConnectionContext.ExecuteWithResults($querylastused).Tables[0]
-			}
-
-			if ($NoUserDb) {
-                $DBType = @($true)
-			}
-			elseif ($NoSystemDb) {
-                $DBType = @($false)
-			}
-            else {
-                $DBType = @($false,$true)
+                # put a function around this to enable Pester Testing and also to ease any future changes
+                function Invoke-QueryDBlastUsed {
+                    $server.ConnectionContext.ExecuteWithResults($querylastused).Tables[0]
+                }
+                $dblastused = Invoke-QueryDBlastUsed
             }
 
-            $Readonly = switch ( $Access ) { 'Readonly' { @($true) } 'ReadWrite' { @($false) } default { @($true,$false)} }
-			$Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true,$false,$null)} }
+            if ($NoUserDb) {
+                $DBType = @($true)
+            }
+            elseif ($NoSystemDb) {
+                $DBType = @($false)
+            }
+            else {
+                $DBType = @($false, $true)
+            }
 
-			$inputobject = $server.Databases |
+            $Readonly = switch ( $Access ) { 'Readonly' { @($true) } 'ReadWrite' { @($false) } default { @($true, $false)} }
+            $Encrypt = switch ( Test-Bound $Encrypted) { $true { @($true) } default { @($true, $false, $null)} }
+
+            $inputobject = $server.Databases  |
                 Where-Object {
-                    ($_.Name -in $Database -or !$Database) -and 
-                    ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and 
-                    ($_.Owner -in $Owner -or !$Owner) -and 
-                    $_.ReadOnly -in $Readonly -and 
-                    $_.IsSystemObject -in $DBType -and 
-                    ((Compare-Object @($_.Status.tostring().split(',').trim()) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
-                    $_.RecoveryModel -in $RecoveryModel -and 
-                    $_.EncryptionEnabled -in $Encrypt
+                ($_.Name -in $Database -or !$Database)  -and 
+               ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase)  -and 
+                ($_.Owner -in $Owner -or !$Owner) -and 
+               $_.ReadOnly -in $Readonly  -and 
+                $_.IsSystemObject -in $DBType -and 
+                ((Compare-Object @($_.Status.tostring().split(',').trim()) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
+                $_.RecoveryModel -in $RecoveryModel  -and 
+               $_.EncryptionEnabled -in $Encrypt
+            }
+
+            if ($NoFullBackup -or $NoFullBackupSince) {
+                $dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)
+                if ($null -ne $NoFullBackupSince) {
+                    $dabsWithinScope = ($dabs | Where-Object End -lt $NoFullBackupSince)
+					
+                    $inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' }
                 }
-
-			if ($NoFullBackup -or $NoFullBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)
-				if ($null -ne $NoFullBackupSince) {
-					$dabsWithinScope = ($dabs | Where-Object End -lt $NoFullBackupSince)
-					
-					$inputobject = $inputobject | Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' }
-				} else {
-					$inputObject = $inputObject | Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
-				}
+                else {
+                    $inputObject = $inputObject | Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' }
+                }
 				
-			}
-			if ($NoLogBackup -or $NoLogBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog -IgnoreCopyOnly)
-				if ($null -ne $NoLogBackupSince) {
-					$dabsWithinScope = ($dabs | Where-Object End -lt $NoLogBackupSince)
-					$inputobject = $inputobject |
+            }
+            if ($NoLogBackup -or $NoLogBackupSince) {
+                $dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog -IgnoreCopyOnly)
+                if ($null -ne $NoLogBackupSince) {
+                    $dabsWithinScope = ($dabs | Where-Object End -lt $NoLogBackupSince)
+                    $inputobject = $inputobject |
                         Where-Object { $_.Name -in $dabsWithinScope.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
-				} else {
-					$inputobject = $inputObject |
+                }
+                else {
+                    $inputobject = $inputObject |
                         Where-Object { $_.Name -notin $dabs.Database -and $_.Name -ne 'tempdb' -and $_.RecoveryModel -ne 'Simple' }
-				}
-			}
+                }
+            }
 
-			$defaults =  'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel',
-                         'LogReuseWaitStatus','Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner',
-                         'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup',
-                         'LastLogBackupDate as LastLogBackup'
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Status', 'IsAccessible', 'RecoveryModel',
+            'LogReuseWaitStatus', 'Size as SizeMB', 'CompatibilityLevel as Compatibility', 'Collation', 'Owner',
+            'LastBackupDate as LastFullBackup', 'LastDifferentialBackupDate as LastDiffBackup',
+            'LastLogBackupDate as LastLogBackup'
 
-			if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
-				$defaults += ('Notes')
-			}
-			if($LastUsed)
-			{
+            if ($NoFullBackup -or $NoFullBackupSince -or $NoLogBackup -or $NoLogBackupSince) {
+                $defaults += ('Notes')
+            }
+            if ($LastUsed) {
                 # Add Last Used to the default view
-				$defaults += ('LastRead as Last Index Read', 'LastWrite as Last Index Write')
-			}
+                $defaults += ('LastRead as Last Index Read', 'LastWrite as Last Index Write')
+            }
 			
-			try {
-				foreach ($db in $inputobject) {
+            try {
+                foreach ($db in $inputobject) {
 					
-					$Notes = $null
-					if ($NoFullBackup -or $NoFullBackupSince) {
-						if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
-							$Notes = "Only CopyOnly backups"
-						}
-					}
+                    $Notes = $null
+                    if ($NoFullBackup -or $NoFullBackupSince) {
+                        if (@($db.EnumBackupSets()).count -eq @($db.EnumBackupSets() | Where-Object { $_.IsCopyOnly }).count -and (@($db.EnumBackupSets()).count -gt 0)) {
+                            $Notes = "Only CopyOnly backups"
+                        }
+                    }
                     if ($LastUsed) {
                         ## Add last used information to the input object
                         $lastusedinfo = $dblastused | Where-Object { $_.dbname -eq $db.name }
                         Add-Member -Force -InputObject $db -MemberType NoteProperty -Name LastRead -value $lastusedinfo.last_read
                         Add-Member -Force -InputObject $db -MemberType NoteProperty -Name LastWrite -value $lastusedinfo.last_write
                     }
-					Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
 					
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-					Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-					Select-DefaultView -InputObject $db -Property $defaults
-				}
-			}
-			catch {
-				Stop-Message -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified. If so, please use parens (Get-DbaDatabase ....) | when working with commands that modify the collection such as Remove-DbaDatabase" -Continue
-			}
-		}
-	}
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+                    Select-DefaultView -InputObject $db -Property $defaults
+                }
+            }
+            catch {
+                Stop-Message -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified. If so, please use parens (Get-DbaDatabase ....) | when working with commands that modify the collection such as Remove-DbaDatabase" -Continue
+            }
+        }
+    }
 }

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -163,8 +163,7 @@
 		[datetime]$NoFullBackupSince,
 		[switch]$NoLogBackup,
 		[datetime]$NoLogBackupSince,
-		[switch]$Silent,
-		[switch]$LastUsed
+		[switch]$Silent
 	)
 	
 	begin {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -244,14 +244,14 @@
 
             $inputobject = $server.Databases  |
                 Where-Object {
-                ($_.Name -in $Database -or !$Database)  -and 
-               ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase)  -and 
+                ($_.Name -in $Database -or !$Database) -and 
+                ($_.Name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and 
                 ($_.Owner -in $Owner -or !$Owner) -and 
-               $_.ReadOnly -in $Readonly  -and 
+                $_.ReadOnly -in $Readonly -and 
                 $_.IsSystemObject -in $DBType -and 
                 ((Compare-Object @($_.Status.tostring().split(',').trim()) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and 
-                $_.RecoveryModel -in $RecoveryModel  -and 
-               $_.EncryptionEnabled -in $Encrypt
+                $_.RecoveryModel -in $RecoveryModel -and 
+                $_.EncryptionEnabled -in $Encrypt
             }
 
             if ($NoFullBackup -or $NoFullBackupSince) {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -23,13 +23,13 @@
 		.PARAMETER ExcludeDatabase
 			The database(s) to exclude.
 
-		.PARAMETER ExcludeUserDb
+		.PARAMETER ExcludeAllUserDb
 			Returns only databases that are not User Databases.
-            This parameter cannot be used together with -ExcludeSystemDb.
+            This parameter cannot be used together with -ExcludeAllSystemDb.
 
-		.PARAMETER ExcludeSystemDb
+		.PARAMETER ExcludeAllSystemDb
 			Returns only databases that are not System Databases.
-            This parameter cannot be used together with -ExcludeUserDb.
+            This parameter cannot be used together with -ExcludeAllUserDb.
 
 		.PARAMETER Status
 			Returns SQL Server databases in the status(es) listed.
@@ -88,12 +88,12 @@
 			Returns all databases on the local default SQL Server instance
 
 		.EXAMPLE
-			Get-DbaDatabase -SqlInstance localhost -ExcludeUserDb
+			Get-DbaDatabase -SqlInstance localhost -ExcludeAllUserDb
 
 			Returns only the system databases on the local default SQL Server instance
 
 		.EXAMPLE
-			Get-DbaDatabase -SqlInstance localhost -ExcludeSystemDb
+			Get-DbaDatabase -SqlInstance localhost -ExcludeAllSystemDb
 
 			Returns only the user databases on the local default SQL Server instance
 
@@ -148,9 +148,9 @@
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
 		[Alias("SystemDbOnly", "NoUserDb")]
-		[switch]$ExcludeUserDb,
+		[switch]$ExcludeAllUserDb,
 		[Alias("UserDbOnly", "NoSystemDb")]
-		[switch]$ExcludeSystemDb,
+		[switch]$ExcludeAllSystemDb,
 		[string[]]$Owner,
 		[switch]$Encrypted,
 		[ValidateSet('EmergencyMode', 'Normal', 'Offline', 'Recovering', 'Restoring', 'Standby', 'Suspect')]
@@ -168,8 +168,8 @@
 	
 	begin {
 		
-		if ($ExcludeUserDb -and $ExcludeSystemDb) {
-			Stop-Function -Message "You cannot specify both ExcludeUserDb and ExcludeSystemDb" -Continue -Silent $Silent
+		if ($ExcludeAllUserDb -and $ExcludeAllSystemDb) {
+			Stop-Function -Message "You cannot specify both ExcludeAllUserDb and ExcludeAllSystemDb" -Continue -Silent $Silent
 		}
 		
 	}
@@ -228,10 +228,10 @@
 			}
 			$dblastused = Invoke-QueryDBlastUsed
 			
-			if ($ExcludeUserDb) {
+			if ($ExcludeAllUserDb) {
 				$DBType = @($true)
 			}
-			elseif ($ExcludeSystemDb) {
+			elseif ($ExcludeAllSystemDb) {
 				$DBType = @($false)
 			}
 			else {

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -1,27 +1,66 @@
-﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
-	Context "Count system databases on localhost" {
-		$results = Get-DbaDatabase -SqlInstance $script:instance1 -NoUserDb 
-		It "Should report the right number of databases" {
-			$results.Count | Should Be 4
-		}
-	}
-
-	Context "Check that master database is in Simple recovery mode" {
-		$results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
-		It "Should say the recovery mode of master is Simple" {
-			$results.RecoveryModel | Should Be "Simple"
-		}
-	}
+    Context "Count system databases on localhost" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -NoUserDb 
+        It "Should report the right number of databases" {
+            $results.Count | Should Be 4
+        }
+    }
+ 
+    Context "Check that master database is in Simple recovery mode" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
+        It "Should say the recovery mode of master is Simple" {
+            $results.RecoveryModel | Should Be "Simple"
+        }
+    }
 	
-	Context "Check that master database is accessible" {
-		$results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
-		It "Should return true that master is accessible" {
-			$results.IsAccessible | Should Be $true
-		}
-	}
+    Context "Check that master database is accessible" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
+        It "Should return true that master is accessible" {
+            $results.IsAccessible | Should Be $true
+        }
+    }
+}
+
+
+
+Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
+    BeforeAll {
+        ## Ensure it is the module that is being coded that is in the session
+        # Remove-Module dbatools -Force -ErrorAction SilentlyContinue
+        # $Base = Split-Path -parent $PSCommandPath
+        # Import-Module $Base\..\dbatools.psd1
+    }
+    Context "Input validation" {
+        BeforeAll {
+            Mock Stop-Function {} -ModuleName dbatools
+            Mock Test-FunctionInterrupt {} -ModuleName dbatools
+        }
+        It "Should Call Stop-Function if NoUserDbs and NoSystemDbs are specified" {
+            Get-DbaDatabase -SqlInstance Dummy -NoSystemDb -NoUserDb | Should Be 
+        }
+        It "Validates that Stop Function Mock has been called" {
+            ## Nope I have no idea why it's two either - RMS
+            $assertMockParams = @{
+                'CommandName' = 'Stop-Function'
+                'Times'       = 2 
+                'Exactly'     = $true
+                'Module'      = 'dbatools'
+            }
+            Assert-MockCalled @assertMockParams 
+        }
+        It "Validates that Test-FunctionInterrupt Mock has been called" {
+            $assertMockParams = @{
+                'CommandName' = 'Test-FunctionInterrupt'
+                'Times'       = 1 
+                'Exactly'     = $true
+                'Module'      = 'dbatools'
+            }
+            Assert-MockCalled @assertMockParams 
+        }
+    }
 }

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -86,8 +86,8 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
                     last_write = (Get-Date).AddHours(-1)
                 }
             } -ModuleName dbatools 
-            (Get-DbaDatabase -SqlInstance SQLServerName -LastUsed).LastRead -ne $null | Should Be $true
-            (Get-DbaDatabase -SqlInstance SQLServerName -LastUsed).LastWrite -ne $null | Should Be $true
+            (Get-DbaDatabase -SqlInstance SQLServerName).LastRead -ne $null | Should Be $true
+            (Get-DbaDatabase -SqlInstance SQLServerName).LastWrite -ne $null | Should Be $true
         } 
         It "Validates that Connect-SqlInstance Mock has been called" {
             $assertMockParams = @{

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -3,110 +3,111 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-
-    Context "Count system databases on localhost" {
-        $results = Get-DbaDatabase -SqlInstance $script:instance1 -NoUserDb 
-        It "Should report the right number of databases" {
-            $results.Count | Should Be 4
-        }
-    }
- 
-    Context "Check that master database is in Simple recovery mode" {
-        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
-        It "Should say the recovery mode of master is Simple" {
-            $results.RecoveryModel | Should Be "Simple"
-        }
-    }
 	
-    Context "Check that master database is accessible" {
-        $results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
-        It "Should return true that master is accessible" {
-            $results.IsAccessible | Should Be $true
-        }
-    }
+	Context "Count system databases on localhost" {
+		$results = Get-DbaDatabase -SqlInstance $script:instance1 -ExcludeAllUserDb
+		It "Should report the right number of databases" {
+			$results.Count | Should Be 4
+		}
+	}
+	
+	Context "Check that master database is in Simple recovery mode" {
+		$results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
+		It "Should say the recovery mode of master is Simple" {
+			$results.RecoveryModel | Should Be "Simple"
+		}
+	}
+	
+	Context "Check that master database is accessible" {
+		$results = Get-DbaDatabase -SqlInstance $script:instance1 -Database master
+		It "Should return true that master is accessible" {
+			$results.IsAccessible | Should Be $true
+		}
+	}
 }
 
 Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
-    BeforeAll {
-        ## Ensure it is the module that is being coded that is in the session when running just this Pester test
-        #  Remove-Module dbatools -Force -ErrorAction SilentlyContinue
-        #  $Base = Split-Path -parent $PSCommandPath
-        #  Import-Module $Base\..\dbatools.psd1
-    }
-    Context "Input validation" {
-        BeforeAll {
-            Mock Stop-Function {} -ModuleName dbatools
-            Mock Test-FunctionInterrupt {} -ModuleName dbatools
-        }
-        It "Should Call Stop-Function if NoUserDbs and NoSystemDbs are specified" {
-            Get-DbaDatabase -SqlInstance Dummy -NoSystemDb -NoUserDb -ErrorAction SilentlyContinue | Should Be 
-        }
-        It "Validates that Stop Function Mock has been called" {
-            ## Nope I have no idea why it's two either - RMS
-            $assertMockParams = @{
-                'CommandName' = 'Stop-Function'
-                'Times'       = 2 
-                'Exactly'     = $true
-                'Module'      = 'dbatools'
-            }
-            Assert-MockCalled @assertMockParams 
-        }
-        It "Validates that Test-FunctionInterrupt Mock has been called" {
-            $assertMockParams = @{
-                'CommandName' = 'Test-FunctionInterrupt'
-                'Times'       = 1 
-                'Exactly'     = $true
-                'Module'      = 'dbatools'
-            }
-            Assert-MockCalled @assertMockParams 
-        }
-    }
-    Context "Output" {
-        It "Should have Last Read and Last Write Property when LastUsed switch is added" {
-            Mock Connect-SQLInstance -MockWith {
-                [object]@{
-                    Name      = 'SQLServerName';
-                    Databases = [object]@(
-                        @{
-                            Name           = 'db1';
-                            Status         = 'Normal';
-                            ReadOnly       = 'false';
-                            IsSystemObject = 'false';
-                            RecoveryModel  = 'Full';
-                            Owner          = 'sa'
-                        }
-                    ); #databases
-                } #object
-            } -ModuleName dbatools #mock connect-sqlserver
-            function Invoke-QueryDBlastUsed {}
-            Mock Invoke-QueryDBlastUsed -MockWith { [object]
-                @{
-                    dbname     = 'db1';
-                    last_read  = (Get-Date).AddHours(-1);
-                    last_write = (Get-Date).AddHours(-1)
-                }
-            } -ModuleName dbatools 
-            (Get-DbaDatabase -SqlInstance SQLServerName).LastRead -ne $null | Should Be $true
-            (Get-DbaDatabase -SqlInstance SQLServerName).LastWrite -ne $null | Should Be $true
-        } 
-        It "Validates that Connect-SqlInstance Mock has been called" {
-            $assertMockParams = @{
-                'CommandName' = 'Connect-SqlInstance'
-                'Times'       = 2
-                'Exactly'     = $true
-                'Module'      = 'dbatools'
-            }
-            Assert-MockCalled @assertMockParams 
-        }
-        It "Validates that Invoke-QueryDBlastUsed Mock has been called" {
-            $assertMockParams = @{
-                'CommandName' = 'Invoke-QueryDBlastUsed'
-                'Times'       = 2
-                'Exactly'     = $true
-                'Module'      = 'dbatools'
-            }
-            Assert-MockCalled @assertMockParams 
-        }
-    }
+	BeforeAll {
+		## Ensure it is the module that is being coded that is in the session when running just this Pester test
+		#  Remove-Module dbatools -Force -ErrorAction SilentlyContinue
+		#  $Base = Split-Path -parent $PSCommandPath
+		#  Import-Module $Base\..\dbatools.psd1
+	}
+	Context "Input validation" {
+		BeforeAll {
+			Mock Stop-Function { } -ModuleName dbatools
+			Mock Test-FunctionInterrupt { } -ModuleName dbatools
+		}
+		It "Should Call Stop-Function if NoUserDbs and NoSystemDbs are specified" {
+			Get-DbaDatabase -SqlInstance Dummy -ExcludeAllSystemDb -ExcludeAllUserDb -ErrorAction SilentlyContinue | Should Be
+		}
+		It "Validates that Stop Function Mock has been called" {
+			## Nope I have no idea why it's two either - RMS
+			$assertMockParams = @{
+				'CommandName'  = 'Stop-Function'
+				'Times'	       = 2
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+		It "Validates that Test-FunctionInterrupt Mock has been called" {
+			$assertMockParams = @{
+				'CommandName'  = 'Test-FunctionInterrupt'
+				'Times'	       = 1
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+	}
+	Context "Output" {
+		It "Should have Last Read and Last Write Property when LastUsed switch is added" {
+			Mock Connect-SQLInstance -MockWith {
+				[object]@{
+					Name	   = 'SQLServerName';
+					Databases  = [object]@(
+						@{
+							Name		    = 'db1';
+							Status		    = 'Normal';
+							ReadOnly	    = 'false';
+							IsSystemObject  = 'false';
+							RecoveryModel   = 'Full';
+							Owner		    = 'sa'
+						}
+					); #databases
+				} #object
+			} -ModuleName dbatools #mock connect-sqlserver
+			function Invoke-QueryDBlastUsed { }
+			Mock Invoke-QueryDBlastUsed -MockWith {
+				[object]
+				@{
+					dbname	    = 'db1';
+					last_read   = (Get-Date).AddHours(-1);
+					last_write  = (Get-Date).AddHours(-1)
+				}
+			} -ModuleName dbatools
+			(Get-DbaDatabase -SqlInstance SQLServerName).LastRead -ne $null | Should Be $true
+			(Get-DbaDatabase -SqlInstance SQLServerName).LastWrite -ne $null | Should Be $true
+		}
+		It "Validates that Connect-SqlInstance Mock has been called" {
+			$assertMockParams = @{
+				'CommandName'  = 'Connect-SqlInstance'
+				'Times'	       = 2
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+		It "Validates that Invoke-QueryDBlastUsed Mock has been called" {
+			$assertMockParams = @{
+				'CommandName'  = 'Invoke-QueryDBlastUsed'
+				'Times'	       = 2
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+	}
 }
          

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -87,8 +87,8 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
 					last_write  = (Get-Date).AddHours(-1)
 				}
 			} -ModuleName dbatools
-			(Get-DbaDatabase -SqlInstance SQLServerName).LastRead -ne $null | Should Be $true
-			(Get-DbaDatabase -SqlInstance SQLServerName).LastWrite -ne $null | Should Be $true
+			(Get-DbaDatabase -SqlInstance SQLServerName -LastUsed).LastRead -ne $null | Should Be $true
+			(Get-DbaDatabase -SqlInstance SQLServerName -LastUsed).LastWrite -ne $null | Should Be $true
 		}
 		It "Validates that Connect-SqlInstance Mock has been called" {
 			$assertMockParams = @{


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
Adds -LastUsed parameter to Get-DBADatabase returning the last index usage from sys.dm_db_index_usage_stats DMV
 - [X] Bug fix (non-breaking change, fixes #547
 - [X ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
.\tests\manual.pester.ps1 -Show Summary
Tests completed in 196.88s
Tests Passed: 9897, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0

 - [X ] Pester test is included
Invoke-Pester -Script .\tests\Get-DbaDatabase.Tests.ps1 -Tag Unittests -Show Summary
Tests Passed: 6, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
Added Unit test for NoSytemDbs and NoUserDbs
Added Unit Test for -LastUsed