### PR TITLE
[new command] Get-DbaOperatingSystem

### DIFF
--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -1,0 +1,71 @@
+function Get-DbaOperatingSystem {
+	<#
+		.SYNOPSIS
+			Gets operating system information from the server.
+
+		.DESCRIPTION
+			Gets operating system information from the server and returns as an object.
+
+		.PARAMETER ComputerName
+			Target computer(s). If no computer name is specified, the local computer is targeted
+
+		.PARAMETER Credential
+			Alternate credential object to use for accessing the target computer(s).
+
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
+
+		.NOTES
+			Tags: ServerInfo, OperatingSystem
+			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+
+			Website: https: //dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https: //opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Get-DbaOperatingSystem
+
+		.EXAMPLE
+			Get-DbaOperatingSystem
+
+			Returns information about the local computer's operating system
+
+		.EXAMPLE
+			Get-DbaOperatingSystem -ComputerName sql2016
+
+			Returns information about the sql2016's operating system
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(ValueFromPipeline = $true)]
+		[Alias("cn","host","Server")]
+		[DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
+		[PSCredential]$Credential,
+		[switch]$Silent
+	)
+	process {
+		foreach ($computer in $ComputerName) {
+			Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+			$server = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
+			
+			$computerResolved = $server.ComputerName
+			
+			if (!$computerResolved) {
+				Write-Message -Level Warning -Message "Unable to resolve hostname of $computer. Skipping."
+				continue
+			}
+			
+			if (Test-Bound "Credential") {
+				$os = Get-DbaCmObject -ClassName Win32_OperatingSystem -ComputerName $computerResolved -Credential $Credential
+				$tz = Get-DbaCmObject -ClassName Win32_TimeZone -ComputerName $computerResolved -Credential $Credential
+			}
+			else {
+				$os = Get-DbaCmObject -ClassName Win32_OperatingSystem -ComputerName $computerResolved
+				$tz = Get-DbaCmObject -ClassName Win32_TimeZone -ComputerName $computerResolved
+			}
+
+			Add-Member -Force -InputObject $os -MemberType NoteProperty -Name ComputerName -Value $computerResolved
+		} #end foreach instance
+	}
+}

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -48,24 +48,57 @@ function Get-DbaOperatingSystem {
 		foreach ($computer in $ComputerName) {
 			Write-Message -Level Verbose -Message "Attempting to connect to $computer"
 			$server = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
-			
+
 			$computerResolved = $server.ComputerName
-			
+
 			if (!$computerResolved) {
 				Write-Message -Level Warning -Message "Unable to resolve hostname of $computer. Skipping."
 				continue
 			}
-			
+
 			if (Test-Bound "Credential") {
 				$os = Get-DbaCmObject -ClassName Win32_OperatingSystem -ComputerName $computerResolved -Credential $Credential
 				$tz = Get-DbaCmObject -ClassName Win32_TimeZone -ComputerName $computerResolved -Credential $Credential
+				$powerPlan = Get-DbaCmObject -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" -ComputerName $computerResolved -Credential $Credential | Select-Object ElementName, InstanceId, IsActive
 			}
 			else {
 				$os = Get-DbaCmObject -ClassName Win32_OperatingSystem -ComputerName $computerResolved
 				$tz = Get-DbaCmObject -ClassName Win32_TimeZone -ComputerName $computerResolved
+				$powerPlan = Get-DbaCmObject -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" -ComputerName $computerResolved | Select-Object ElementName, InstanceId, IsActive
 			}
 
-			Add-Member -Force -InputObject $os -MemberType NoteProperty -Name ComputerName -Value $computerResolved
+			$activePowerPlan = ($powerPlan | Where-Object IsActive).ElementName -join ','
+
+			$inputObject = [PSCustomObject]@{
+				ComputerName = $computerResolved
+				InstanceName = $computer.InstanceName
+				SqlInstance = $computer.SqlInstanceName
+				Manufacturer = $os.Manufacturer
+				Organization = $os.Organization
+				Architecture = $os.OSArchitecture
+				Version = $os.Version
+				Build = $os.BuildNumber
+				InstallDate = [DbaDateTime]$os.InstallDate
+				LastBootTime = [DbaDateTime]$os.LastBootUpTime
+				LocalDateTime = [DbaDateTime]$os.LocalDateTime
+				TimeZone = $tz.Caption
+				TimeZoneStandard = $tz.StandardName
+				TimeZoneDaylight = $tz.DaylightName
+				BootDevice = $os.BootDevice
+				TotalVisibleMemory = [DbaSize]$os.TotalVisibleMemorySize
+				FreePhysicalMemory = [DbaSize]$os.FreePhysicalMemory
+				TotalVirtualMemory = [DbaSize]$os.TotalVirtualMemorySize
+				FreeVirtualMemory = [DbaSize]$os.FreeVirtualMemory
+				ActivePowerPlan = $activePowerPlan
+				Language = $os.OSLanguage
+				CodeSet = $os.CodeSet
+				CountryCode = $os.CountryCode
+				Locale = $os.Locale
+			}
+
+			$defaults = 'ComputerName','InstanceName','SqlInstance','Manufacturer','Architecture','Build','Version','InstallDate','LastBootTime','LocalDateTime'
+
+			Select-DefaultView -InputObject $inputObject -Property $defaults
 		} #end foreach instance
 	}
 }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -4,7 +4,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "Get-DbaOperatingSystem Unit Tests" -Tag "UnitTests" {
 	InModuleScope dbatools {
 		Context "Validate parameters" {
-			$params = (Get-ChildItem function:\Get-DbaServerOperatingSystem).Parameters	
+			$params = (Get-ChildItem function:\Get-DbaOperatingSystem).Parameters	
 			it "should have a parameter named ComputerName" {
 				$params.ContainsKey("ComputerName") | Should Be $true
 			}
@@ -18,13 +18,13 @@ Describe "Get-DbaOperatingSystem Unit Tests" -Tag "UnitTests" {
 		Context "Validate input" {
 			it "Cannot resolve hostname of computer" {
 				mock Resolve-DbaNetworkName {$null}
-				{Get-DbaServerOperatingSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
+				{Get-DbaOperatingSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
 			}
 		}
 	}
 }
-Describe "Get-DbaServerOperatingSystem Integration Test" -Tag "IntegrationTests" {
-	$result = Get-DbaServerOperatingSystem -ComputerName $script:instance1
+Describe "Get-DbaOperatingSystem Integration Test" -Tag "IntegrationTests" {
+	$result = Get-DbaOperatingSystem -ComputerName $script:instance1
 
 	$props = 'ComputerName','Server','SqlInstance','Manufacturer','OSArchitecture',
 		'BuildNumber','Version','InstallDate','LastBootUpTime','LocalDateTime','BootDevice',
@@ -40,11 +40,11 @@ Describe "Get-DbaServerOperatingSystem Integration Test" -Tag "IntegrationTests"
 		foreach ($prop in $props) {
 			$p = $result.PSObject.Properties[$prop]
 			it "Should return property: $prop" {
-				$p.Name | Should Not Be $prop
+				$p.Name | Should Be $prop
 			}
 		}
 		it "Should return nothing if unable to connect to server" {
-			$result = Get-DbaServerOperatingSystem -ComputerName 'Melton5312'
+			$result = Get-DbaOperatingSystem -ComputerName 'Melton5312' -WarningAction SilentlyContinue
 			$result | Should Be $null
 		}
 	}

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -26,9 +26,9 @@ Describe "Get-DbaOperatingSystem Unit Tests" -Tag "UnitTests" {
 Describe "Get-DbaOperatingSystem Integration Test" -Tag "IntegrationTests" {
 	$result = Get-DbaOperatingSystem -ComputerName $script:instance1
 
-	$props = 'ComputerName','Server','SqlInstance','Manufacturer','OSArchitecture',
-		'BuildNumber','Version','InstallDate','LastBootUpTime','LocalDateTime','BootDevice',
-		'TimeZone','TimeZoneDaylight','TimeZoneStandard','TotalVisibleMemorySize'
+	$props = 'ComputerName','InstanceName','SqlInstance','Manufacturer','Organization',
+		'Architecture','Build','Version','InstallDate','LastBootTime','LocalDateTime',
+		'BootDevice','TimeZone','TimeZoneDaylight','TimeZoneStandard','TotalVisibleMemorySize'
 	<#
 		FreePhysicalMemory: units = KB
 		FreeVirtualMemory: units = KB

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -1,0 +1,51 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+Describe "Get-DbaOperatingSystem Unit Tests" -Tag "UnitTests" {
+	InModuleScope dbatools {
+		Context "Validate parameters" {
+			$params = (Get-ChildItem function:\Get-DbaServerOperatingSystem).Parameters	
+			it "should have a parameter named ComputerName" {
+				$params.ContainsKey("ComputerName") | Should Be $true
+			}
+			it "should have a parameter named Credential" {
+				$params.ContainsKey("Credential") | Should Be $true
+			}
+			it "should have a parameter named Silent" {
+				$params.ContainsKey("Silent") | Should Be $true
+			}
+		}
+		Context "Validate input" {
+			it "Cannot resolve hostname of computer" {
+				mock Resolve-DbaNetworkName {$null}
+				{Get-DbaServerOperatingSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
+			}
+		}
+	}
+}
+Describe "Get-DbaServerOperatingSystem Integration Test" -Tag "IntegrationTests" {
+	$result = Get-DbaServerOperatingSystem -ComputerName $script:instance1
+
+	$props = 'ComputerName','Server','SqlInstance','Manufacturer','OSArchitecture',
+		'BuildNumber','Version','InstallDate','LastBootUpTime','LocalDateTime','BootDevice',
+		'TimeZone','TimeZoneDaylight','TimeZoneStandard','TotalVisibleMemorySize'
+	<#
+		FreePhysicalMemory: units = KB
+		FreeVirtualMemory: units = KB
+		TimeZoneStandard: StandardName from win32_timezone
+		TimeZoneDaylight: DaylightName from win32_timezone
+		TimeZone: Caption from win32_timezone
+	#>
+	Context "Validate output" {
+		foreach ($prop in $props) {
+			$p = $result.PSObject.Properties[$prop]
+			it "Should return property: $prop" {
+				$p.Name | Should Not Be $prop
+			}
+		}
+		it "Should return nothing if unable to connect to server" {
+			$result = Get-DbaServerOperatingSystem -ComputerName 'Melton5312'
+			$result | Should Be $null
+		}
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Addressed part of the discussion from #837 
A need to pull common Operating System information, similar when doing an inventory or server review.
### Approach
<!-- How does this change solve that purpose -->
A command that will pull the most common (at least initial version) properties of the Operating System class `Win32_OperatingSystem`. I did break the rule a bit and include the active power plan in this command, which is a different class...if that is not allowed we can remove it for a command specific to that class.
### Commands to test
<!-- if these are the examples in the help just not it as such -->
```powershell
# 1
Get-DbaOperatingSystem -ComputerName sql2016, sql2016c,sql2016a

# 2
Get-DbaOperatingSystem -ComputerName sql2016 | select *

# 3 - Accepts piping
'sql2016' | Get-DbaOperatingSystem | select *
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
(1)

![image](https://user-images.githubusercontent.com/11204251/28603078-94e70682-7187-11e7-92dd-ad5af6201e17.png)

(2)

![image](https://user-images.githubusercontent.com/11204251/28603100-be4c403c-7187-11e7-8f19-ae72d8f78f15.png)

### Learning

I tried to make the command return the full object you get from `Get-DbaCmObject` but that overwrites the use of `Select-DefaultView` within the command. The default view of `Win32_OperatingSystem` was the only thing to output when I tried. So I had to revert to building a custom object.

In the end, we can always expand this to additional properties if folks feel a need.