### PR TITLE
More backup history fixes

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -358,7 +358,7 @@ function Get-DbaBackupHistory {
 									a.is_copy_only,
 									a.last_recovery_fork_guid
 								FROM (SELECT
-								  RANK() OVER (ORDER BY backupset.backup_start_date DESC) AS 'BackupSetRank',
+								  RANK() OVER (ORDER BY backupset.last_lsn DESC) AS 'BackupSetRank',
 								  backupset.database_name AS [Database],
 								  backupset.user_name AS Username,
 								  backupset.backup_start_date AS Start,
@@ -484,7 +484,7 @@ function Get-DbaBackupHistory {
 				
 				if ($Last -or $LastFull -or $LastLog -or $LastDiff) {
 					$tempwhere = $wherearray -join " AND "
-					$wherearray += "type = 'Full' AND mediaset.media_set_id = (select top 1 mediaset.media_set_id $from $tempwhere order by backupset.backup_finish_date DESC)"
+					$wherearray += "type = 'Full' AND mediaset.media_set_id = (select top 1 mediaset.media_set_id $from $tempwhere order by backupset.last_lsn DESC)"
 				}
 				
 				if ($Since -ne $null) {
@@ -509,7 +509,7 @@ function Get-DbaBackupHistory {
 					$where = "$where $wherearray"
 				}
 				
-				$sql = "$select $from $where ORDER BY backupset.backup_finish_date DESC"
+				$sql = "$select $from $where ORDER BY backupset.last_lsn DESC"
 			}
 
 			Write-Message -Level Debug -Message $sql

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -548,7 +548,7 @@ function Restore-DbaDatabase {
         #$BackupFiles 
         #return
         Write-Message -Level Verbose -Message "sorting uniquely"
-        $AllFilteredFiles = $backupFiles | sort-object -property fullname -unique | Get-FilteredRestoreFile -SqlInstance $SqlInstance -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory -continue:$continue -ContinuePoints:$ContinuePoints -DatabaseName $DatabaseName -AzureCredential $AzureCredential
+        $AllFilteredFiles = $backupFiles | sort-object -property fullname,position -unique | Get-FilteredRestoreFile -SqlInstance $SqlInstance -RestoreTime $RestoreTime -SqlCredential $SqlCredential -IgnoreLogBackup:$IgnoreLogBackup -TrustDbBackupHistory:$TrustDbBackupHistory -continue:$continue -ContinuePoints:$ContinuePoints -DatabaseName $DatabaseName -AzureCredential $AzureCredential
 		
         Write-Message -Level Verbose -Message "$($AllFilteredFiles.count) dbs to restore"
 		

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -1,51 +1,61 @@
-﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
+# prep
+$null = Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeAllSystemDb | Remove-DbaDatabase
+$server = Connect-DbaSqlServer -SqlInstance $script:instance2
+$random = Get-Random
+$testlastbackup = "testlastbackup$random"
+$dbs = $testlastbackup, "lildb", "testrestore", "singlerestore"
+
+foreach ($db in $dbs) {
+	$server.Query("CREATE DATABASE $db")
+	$server.Query("ALTER DATABASE $db SET RECOVERY FULL WITH NO_WAIT")
+	$server.Query("CREATE TABLE [$db].[dbo].[Example] (id int identity, name nvarchar(max))")
+	$server.Query("INSERT INTO [$db].[dbo].[Example] values ('sample')")
+}
+
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-
-    Context "Setup removes, restores and backups on the local drive for Test-DbaLastBackup" {
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase
-
-		$null = Restore-DbaDatabase -SqlInstance $script:instance1 -Path C:\github\appveyor-lab\singlerestore\testlastbackup.bak -WithReplace
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup | Backup-DbaDatabase -Type Full
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup | Backup-DbaDatabase -Type Full
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup | Backup-DbaDatabase -Type Differential
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup -RecoveryModel Full | Backup-DbaDatabase -Type Log
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup -RecoveryModel Full | Backup-DbaDatabase -Type Log
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database testlastbackup -RecoveryModel Full | Backup-DbaDatabase -Type Log
+	
+	Context "Setup restores and backups on the local drive for Test-DbaLastBackup" {
+		Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeDatabase tempdb | Backup-DbaDatabase -Type Database
+		$server.Query("INSERT INTO [$testlastbackup].[dbo].[Example] values ('sample')")
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $testlastbackup | Backup-DbaDatabase -Type Differential
+		$server.Query("INSERT INTO [$testlastbackup].[dbo].[Example] values ('sample')")
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $testlastbackup | Backup-DbaDatabase -Type Differential
+		$server.Query("INSERT INTO [$testlastbackup].[dbo].[Example] values ('sample')")
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $testlastbackup | Backup-DbaDatabase -Type Log
+		$server.Query("INSERT INTO [$testlastbackup].[dbo].[Example] values ('sample')")
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $testlastbackup | Backup-DbaDatabase -Type Log
+		$server.Query("INSERT INTO [$testlastbackup].[dbo].[Example] values ('sample')")
 	}
 	
-	<#
-    Context "Test a single database" {
-        $results = Test-DbaLastBackup -SqlInstance $script:instance1 -Database testlastbackup
+	Context "Test a single database" {
+		$results = Test-DbaLastBackup -SqlInstance $script:instance2 -Database $testlastbackup
 		
-        It "Should return success" {
+		It "Should return success" {
 			$results.RestoreResult | Should Be "Success"
 			$results.DbccResult | Should Be "Success"
-        }
+		}
 	}
 	
-	$null = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase
-	
-	
 	Context "Testing the whole instance" {
-		$results = Test-DbaLastBackup -SqlInstance $script:instance1 -ExcludeDatabase tempdb
-        It "Should be more than 3 databases" {
-            $results.count | Should BeGreaterThan 3
-        }
+		$results = Test-DbaLastBackup -SqlInstance $script:instance2 -ExcludeDatabase tempdb
+		It "Should be more than 3 databases" {
+			$results.count | Should BeGreaterThan 3
+		}
 	}
 	
 	Context "Testing that it restores to a specific path" {
-		$null = Test-DbaLastBackup -SqlInstance $script:instance1 -Database singlerestore -DataDirectory C:\temp -LogDirectory C:\temp -NoDrop
-		$results = Get-DbaDatabaseFile -SqlInstance $script:instance1 -Database dbatools-testrestore-singlerestore
+		$null = Test-DbaLastBackup -SqlInstance $script:instance2 -Database singlerestore -DataDirectory C:\temp -LogDirectory C:\temp -NoDrop
+		$results = Get-DbaDatabaseFile -SqlInstance $script:instance2 -Database dbatools-testrestore-singlerestore
 		It "Should match C:\temp" {
 			('C:\temp\dbatools-testrestore-singlerestore.mdf' -in $results.PhysicalName) | Should Be $true
 			('C:\temp\dbatools-testrestore-singlerestore_log.ldf' -in $results.PhysicalName) | Should Be $true
 		}
 		
-		$null = Get-DbaProcess -SqlInstance $script:instance1 -Database dbatools-testrestore-singlerestore | Stop-DbaProcess
-		$null = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase
+		$null = Get-DbaProcess -SqlInstance $script:instance2 -Database dbatools-testrestore-singlerestore | Stop-DbaProcess
+		$null = Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeAllSystemDb | Remove-DbaDatabase
 	}
-	#>
 }


### PR DESCRIPTION
File positions now pass through properly
All traces of use date to filter/order backups now removed!

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes issue raised by @potatoqualitee  on slack
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included  (@potatoqualitee  was writing one which threw this up)
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For test-lastbackup to be able to cope with backups taken faster that SQL Server's normal time resolution, and to properly handle postions in backup files 

### Approach
Get-DbaBackupHistory doesn't use any dates for ordering backups now!!!!! :smile:. For the love of $DEITY don't reintroduce them

### Commands to test
Try this before and after the changes:
assume db1 is a tiny new database, run all of these together

Backup-DbaDatabase -SqlInstance instance -Database db1 -Type Database
Backup-DbaDatabase -SqlInstance instance -Database db1 -Type Database
Backup-DbaDatabase -SqlInstance instance -Database db1 -Type Differential
Backup-DbaDatabase -SqlInstance instance -Database db1 -Type Log
Backup-DbaDatabase -SqlInstance instance -Database db1 -Type Log
Test-DbaLastBackup -SqlInstance instance -Database db1

Will fail before citing a missing full backup, will work afterwards

### Learning
Anything other than LSNs are a **_REALLY_** bad way of sorting backups. (I may have mentioned this before)