### PR TITLE
Write-Message - Fixed bug parsing error messages

### DIFF
--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -173,7 +173,7 @@
 		$newMessage = "[$FunctionName][$($timestamp.ToString("HH:mm:ss"))] $baseMessage"
 		$newColoredMessage = "[$FunctionName][$($timestamp.ToString("HH:mm:ss"))] $baseMessage"
 	}
-	if ($ErrorRecord -and ($Message -notlike "*$($ErrorRecord[0].Exception.Message)*")) {
+	if ($ErrorRecord -and ($Message -notmatch ([regex]::Escape("$($ErrorRecord[0].Exception.Message)")))) {
 		$baseMessage += " | $($ErrorRecord[0].Exception.Message)"
 		$newMessage += " | $($ErrorRecord[0].Exception.Message)"
 		$newColoredMessage += " | $($ErrorRecord[0].Exception.Message)"


### PR DESCRIPTION
Fixes a bug where Write-Message would generate an exception due to inability to use the `-NotLike` operator.
Basically it'd choke on all exception texts that included a `[`-bracket without closing it. A `-` inbetween the brackets would also prevent this detection (e.g.: `[a-b]`).