### PR TITLE
[new command] Get-DbaComputerSystem

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -1,0 +1,109 @@
+function Get-DbaComputerSystem {
+	<#
+		.SYNOPSIS
+			Gets computer system information from the server.
+
+		.DESCRIPTION
+			Gets computer system information from the server and returns as an object.
+
+		.PARAMETER ComputerName
+			Target computer(s). If no computer name is specified, the local computer is targeted
+
+		.PARAMETER Credential
+			Alternate credential object to use for accessing the target computer(s).
+
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
+
+		.NOTES
+			Tags: ServerInfo
+			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+
+			Website: https: //dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https: //opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Get-DbaComputerSystem
+
+		.EXAMPLE
+			Get-DbaComputerSystem
+
+			Returns information about the local computer's operating system
+
+		.EXAMPLE
+			Get-DbaComputerSystem -ComputerName sql2016
+
+			Returns information about the sql2016's operating system
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(ValueFromPipeline = $true)]
+		[Alias("cn","host","Server")]
+		[DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
+		[PSCredential]$Credential,
+		[switch]$Silent
+	)
+	process {
+		foreach ($computer in $ComputerName) {
+			Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+			$server = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential
+
+			$computerResolved = $server.ComputerName
+
+			if (!$computerResolved) {
+				Write-Message -Level Warning -Message "Unable to resolve hostname of $computer. Skipping."
+				continue
+			}
+
+			if (Test-Bound "Credential") {
+				$computerSystem = Get-DbaCmObject -ClassName Win32_ComputerSystem -ComputerName $computerResolved -Credential $Credential
+			}
+			else {
+				$computerSystem = Get-DbaCmObject -ClassName Win32_ComputerSystem -ComputerName $computerResolved
+			}
+			
+			$adminPasswordStatus = 
+				switch ($computerSystem.AdminPasswordStatus) {
+					0 {"Disabled"}
+					1 {"Enabled"}
+					2 {"Not Implemented"}
+					3 {"Unknown"}
+					default {"Unknown"}
+				}
+			$domainRole = 
+				switch ($computerSystem.DomainRole) {
+					0 {"Standalone Workstation"}
+					1 {"Member Workstation"}
+					2 {"Standalone Server"}
+					3 {"Member Server"}
+					4 {"Backup Domain Controller"}
+					5 {"Primary Domain Controller"}
+				}
+				$isHyperThreading = $false
+				if ($computerSystem.NumberOfLogicalProcessors -gt $computerSystem.NumberofProcessors) {
+					$isHyperThreading = $true
+				}
+
+			[PSCustomObject]@{
+				ComputerName            = $computer.ComputerName
+				Domain                  = $computerSystem.Domain
+				DomainRole              = $domainRole
+				Manufacturer            = $computerSystem.Manufacturer
+				Model                   = $computerSystem.Model
+				SystemFamily            = $computerSystem.SystemFamily
+				SystemSkuNumber         = $computerSystem.SystemSKUNumber
+				SystemType              = $computerSystem.SystemType
+				NumberLogicalProcessors = $computerSystem.NumberOfLogicalProcessors
+				NumberProcessors        = $computerSystem.NumberOfProcessors
+				IsHyperThreading        = $isHyperThreading
+				TotalPhysicalMemory     = [DbaSize]$computerSystem.TotalPhysicalMemory
+				IsDaylightSavingsTime   = $computerSystem.EnableDaylightSavingsTime
+				DaylightInEffect        = $computerSystem.DaylightInEffect
+				DnsHostName             = $computerSystem.DNSHostName
+				IsSystemManagedPageFile   = $computerSystem.AutomaticManagedPagefile
+				AdminPasswordStatus     = $adminPasswordStatus
+			} | Select-DefaultView -ExcludeProperty SystemSkuNumber, IsDaylightSavingsTime,DaylightInEffect,DnsHostName,AdminPasswordStatus
+		}
+	}
+}

--- a/tests/Get-DbaComputerSystem.Tests.ps1
+++ b/tests/Get-DbaComputerSystem.Tests.ps1
@@ -1,0 +1,44 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+Describe "Get-DbaComputerSystem Unit Tests" -Tag "UnitTests" {
+	InModuleScope dbatools {
+		Context "Validate parameters" {
+			$params = (Get-ChildItem function:\Get-DbaComputerSystem).Parameters	
+			it "should have a parameter named ComputerName" {
+				$params.ContainsKey("ComputerName") | Should Be $true
+			}
+			it "should have a parameter named Credential" {
+				$params.ContainsKey("Credential") | Should Be $true
+			}
+			it "should have a parameter named Silent" {
+				$params.ContainsKey("Silent") | Should Be $true
+			}
+		}
+		Context "Validate input" {
+			it "Cannot resolve hostname of computer" {
+				mock Resolve-DbaNetworkName {$null}
+				{Get-DbaComputerSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
+			}
+		}
+	}
+}
+Describe "Get-DbaComputerSystem Integration Test" -Tag "IntegrationTests" {
+	$result = Get-DbaComputerSystem -ComputerName $script:instance1
+
+	$props = 'ComputerName','Domain','IsDaylightSavingsTime','Manufacturer','Model','NumberLogicalProcessors'
+	,'NumberProcessors','IsHyperThreading','SystemFamily','SystemSkuNumber','SystemType','IsSystemManagedPageFile','TotalPhysicalMemory'
+
+	Context "Validate output" {
+		foreach ($prop in $props) {
+			$p = $result.PSObject.Properties[$prop]
+			it "Should return property: $prop" {
+				$p.Name | Should Be $prop
+			}
+		}
+		it "Should return nothing if unable to connect to server" {
+			$result = Get-DbaComputerSystem -ComputerName 'Melton5312' -WarningAction SilentlyContinue
+			$result | Should Be $null
+		}
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [x] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Addressed part of the discussion from #837 
A need to pull common Computer System information, similar when doing an inventory or server review.
### Approach
<!-- How does this change solve that purpose -->
A command that will pull the most common (at least initial version) properties of the Operating System class `Win32_ComputerSystem`. I did change some of the properties to our usual format when we check if something is enabled or not (e.g. `IsProperty`). So you will see a few of those in the output.

I selected what I thought was most common as far as default view, this can be adjusted as anyone sees fit.
### Commands to test
<!-- if these are the examples in the help just not it as such -->
```powershell
# 1
Get-DbaComputerSystem -ComputerName sql2000, sql2016

# 2
Get-DbaComputerSystem -ComputerName sql2016c | select *

# 3 - Accepts piping
'sql2000','sql2008' | Get-DbaComputerSystem
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
(1)

![image](https://user-images.githubusercontent.com/11204251/28652717-0992b964-724f-11e7-8b73-eca9b2d8f0c2.png)

(2)

![image](https://user-images.githubusercontent.com/11204251/28652722-12f69b2e-724f-11e7-82f5-968efbea7e89.png)

(3)

![image](https://user-images.githubusercontent.com/11204251/28652725-17e18176-724f-11e7-8c8d-d88d19758607.png)
