### PR TITLE
Get-DbaRegisteredServerName - changed SqlInstance to accept collection

### DIFF
--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -1,5 +1,5 @@
 function Get-DbaRegisteredServerName {
-	<#
+    <#
 		.SYNOPSIS
 			Gets list of SQL Server names stored in SQL Server Central Management Server.
 
@@ -7,15 +7,10 @@ function Get-DbaRegisteredServerName {
 			Returns a simple array of server names. Be aware of the dynamic parameter 'Group', which can be used to limit results to one or more groups you have created on the CMS. See get-help for examples.
 
 		.PARAMETER SqlInstance
-			The SQL Server instance.
-
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection to allow the function to be executed against multiple SQL Server instances.
+	
 		.PARAMETER SqlCredential
-			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
-
-			To use:
-			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
-
-			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials. To connect as a different Windows user, run PowerShell as that user.
+			SqlCredential object to connect as. If not specified, current Windows login will be used.
 
 		.PARAMETER Group
 			Auto-populated list of groups in SQL Server Central Management Server. You can specify one or more, comma separated.
@@ -26,14 +21,15 @@ function Get-DbaRegisteredServerName {
 		.PARAMETER NetBiosName
 			Returns just the NetBios names of each server.
 
-		.PARAMETER IpAddr
-			Returns just the ip addresses of each server.
+		.PARAMETER IpAddress
+			Returns just the IP addresses of each server.
 
 		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
 			Tags: RegisteredServer,CMS
+			
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
@@ -57,144 +53,148 @@ function Get-DbaRegisteredServerName {
 			Gets a list of server names in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
 
 		.EXAMPLE
-			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddr
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddress
 
 			Gets a list of server IP addresses in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
+
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -NoCmsServer
+
+			Gets a list of server names from the Central Management Server on sqlserver2014a, but excludes the cms server name.
+
 	#>
-	[CmdletBinding(DefaultParameterSetName = "Default")]
-	param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter]$SqlInstance,
-		[PSCredential]$SqlCredential,
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential][System.Management.Automation.Credential()]$SqlCredential = [System.Management.Automation.PSCredential]::Empty,
 		[Alias("Groups")]
-		[object[]]$Group,
-		[switch]$NoCmsServer,
-		[parameter(ParameterSetName = "NetBios")]
-		[switch]$NetBiosName,
-		[parameter(ParameterSetName = "IP")]
-		[switch]$IpAddr,
-		[switch]$Silent
-	)
+        [object[]]$Group,
+        [switch]$NoCmsServer,
+        [parameter(ParameterSetName = "NetBios")]
+        [switch]$NetBiosName,
+        [parameter(ParameterSetName = "IP")]
+        [switch]$IpAddress,
+        [switch]$Silent
+    )
+    process {
 
-	begin {
-		try {
-			$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-		}
-		catch {
-			Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-		}
+        # see notes at Get-ParamSqlCmsGroups
+        function Find-CmsGroup($CmsGrp, $Bbase = '', $Stopat) {
+            $results = @()
+            foreach ($el in $CmsGrp) {
+                if ($Base -eq '') {
+                    $partial = $el.name
+                }
+                else {
+                    $partial = "$Base\$($el.name)"
+                }
+                if ($partial -eq $Stopat) {
+                    return $el
+                }
+                else {
+                    foreach ($group in $el.ServerGroups) {
+                        $results += Find-CmsGroup $group $partial $Stopat
+                    }
+                }
+            }
+            return $results
+        }
+		
+        $servers = @()
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $sqlConnection = $server.ConnectionContext.SqlConnectionObject
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-		$sqlconnection = $server.ConnectionContext.SqlConnectionObject
+            try {
+                $cmsStore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlConnection)
+            }
+            catch {
+                Stop-Function -Message "Cannot access Central Management Server" -ErrorRecord $_ -Continue
+                return
+            }
 
-		try {
-			$cmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection)
-		}
-		catch {
-			Stop-Function -Message "Cannot access Central Management Server"
-			return
-		}
-	}
+            if ($Group -ne $null) {
+                foreach ($currentGroup in $Group) {
+                    $cms = Find-CmsGroup $cmsStore.DatabaseEngineServerGroup.ServerGroups '' $currentGroup
+                    $servers += ($cms.GetDescendantRegisteredServers()).ServerName
+                }
+            }
+            else {
+                $cms = $cmsStore.ServerGroups["DatabaseEngineServerGroup"]
+                $servers += ($cms.GetDescendantRegisteredServers()).ServerName
+            }
 
-	process {
-		if (Test-FunctionInterrupt) { return }
+            if ($NoCmsServer -eq $false) {
+                $servers += $SqlInstance.ComputerName
+            }
+        }
+    }
+    end {
+        if ($NetBiosName -or $IpAddress) {
+            $ipCollection = @()
+            $netBiosCollection = @()
+            $processed = @()
 
-		# see notes at Get-ParamSqlCmsGroups
-		function Find-CmsGroup($CmsGrp, $base = '', $stopat) {
-			$results = @()
-			foreach ($el in $CmsGrp) {
-				if ($base -eq '') {
-					$partial = $el.name
-				}
-				else {
-					$partial = "$base\$($el.name)"
-				}
-				if ($partial -eq $stopat) {
-					return $el
-				}
-				else {
-					foreach ($group in $el.ServerGroups) {
-						$results += Find-CmsGroup $group $partial $stopat
-					}
-				}
-			}
-			return $results
-		}
+            foreach ($server in $servers) {
+                if ($server -match '\\') {
+                    $server = $server.Split('\')[0]
+                }
 
-		$servers = @()
-		if ($Group -ne $null) {
-			foreach ($currentGroup in $Group) {
-				$cms = Find-CmsGroup $cmstore.DatabaseEngineServerGroup.ServerGroups '' $currentGroup
-				$servers += ($cms.GetDescendantRegisteredServers()).ServerName
-			}
-		}
-		else {
-			$cms = $cmstore.ServerGroups["DatabaseEngineServerGroup"]
-			$servers = ($cms.GetDescendantRegisteredServers()).ServerName
-		}
+                if ($processed -contains $server) { continue }
+                $processed += $server
 
-		if ($NoCmsServer -eq $false) {
-			$servers += $SqlInstance.ComputerName
-		}
-	}
-	end {
-		if ($NetBiosName -or $IpAddr) {
-			$ipcollection = @()
-			$netbioscollection = @()
-			$processed = @()
+                try {
+                    Write-Message -Level Verbose -Message "Testing connection to $server and resolving IP address"
+                    $ip = ((Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1).IPAddressToString
+                }
+                catch {
+                    Stop-Function -Message "Could not resolve IP address for $server" -ErrorRecord $_ -Continue
+                }
 
-			foreach ($server in $servers) {
-				if ($server -match '\\') {
-					$server = $server.Split('\')[0]
-				}
+                if ($ipCollection -notcontains $ip) {
+                    $ipCollection += $ip
+                }
 
-				if ($processed -contains $server) { continue }
-				$processed += $server
+                if ($NetBiosName) {
+                    try {
+                        $hostName = (Get-DbaCmObject -ClassName Win32_NetworkAdapterConfiguration -ComputerName $server -SilentlyContinue | Where-Object IPEnabled -eq $true).PSComputerName
 
-				try {
-					Write-Message -Level Verbose -Message "Testing connection to $server and resolving IP address"
-					$ipaddress = ((Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1).IPAddressToString
-				}
-				catch {
-					Stop-Function -Message "Could not resolve IP address for $server" -ErrorRecord $_ -Continue
-				}
+                        if ($hostname -is [array]) {
+                            $hostname = $hostname[0]
+                        }
+                        Write-Message -Level Verbose -Message "Hostname resolved to $hostname"
+                        if ($hostname -eq $null) {
+                            $hostname = (nbtstat -A $ipAddress | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim()
+                        }
+                    }
+                    catch {
+                        Stop-Function -Message "Could not resolve NetBios name for $server" -ErrorRecord $_ -Continue
+                    }
 
-				if ($ipcollection -notcontains $ipaddress) {
-					$ipcollection += $ipaddress
-				}
+                    if ($netBiosCollection -notcontains $hostname) {
+                        $netBiosCollection += $hostname
+                    }
+                }
+            }
 
-				if ($NetBiosName) {
-					try {
-						$hostName = (Get-DbaCmObject -ClassName Win32_NetworkAdapterConfiguration -ComputerName $ipaddress -SilentlyContinue | Where-Object IPEnabled -eq $true).PSComputerName
-
-						if ($hostname -is [array]) {
-							$hostname = $hostname[0]
-						}
-						Write-Message -Level Verbose -Message "Hostname resolved to $hostname"
-						if ($hostname -eq $null) {
-							$hostname = (nbtstat -A $ipaddress | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim()
-						}
-					}
-					catch {
-						Stop-Function -Message "Could not resolve NetBios name for $server" -ErrorRecord $_ -Continue
-					}
-
-					if ($netbioscollection -notcontains $hostname) {
-						$netbioscollection += $hostname
-					}
-				}
-			}
-
-			if ($NetBiosName) {
-				return $netbioscollection
-			}
-			else {
-				return $ipcollection
-			}
-		}
-		else {
-			return $servers
-		}
-		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName
-	}
+            if ($NetBiosName) {
+                return $netBiosCollection
+            }
+            else {
+                return $ipCollection
+            }
+        }
+        else {
+            return $servers
+        }
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName
+    }
 }


### PR DESCRIPTION

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
- Allows multiple SqlInstance to be passed in.
- Added examples to help
- cleaned up case of variables/params throughout

### Approach
<!-- How does this change solve that purpose -->
Added foreach to loop through SqlInstances that are passed in

### Commands to test
<!-- if these are the examples in the help just not it as such -->
`Get-DbaRegisteredServerName -SqlInstance server1,server2 ` 
Returns the servers registered to both server1 and server2 in one list
