### PR TITLE
InModule.Help.Tests, complete overhaul

### DIFF
--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -22,6 +22,7 @@ $commands = Get-Command -Module (Get-Module dbatools) -CommandType Cmdlet, Funct
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.
 
+
 foreach ($command in $commands) {
     $commandName = $command.Name
     
@@ -30,83 +31,139 @@ foreach ($command in $commands) {
     
     # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
     $Help = Get-Help $commandName -ErrorAction SilentlyContinue
-    
-    Describe "Test help for $commandName" {
-        
-        # If help is not found, synopsis in auto-generated help is the syntax diagram
-        It "should not be auto-generated" {
-            $Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
-        }
-        
-        # Should be a description for every function
-        It "gets description for $commandName" {
-            $Help.Description | Should Not BeNullOrEmpty
-        }
-        
-        # Should be at least one example
-        It "gets example code from $commandName" {
-            ($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
-        }
-        
-        # Should be at least one example description
-        It "gets example help from $commandName" {
-            ($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
-        }
-        
-        Context "Test parameter help for $commandName" {
-            
-            $Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
-            'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
-            
-            $parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
-            $parameterNames = $parameters.Name
-            $HelpParameterNames = $Help.Parameters.Parameter.Name | Sort-Object -Unique
-            
-            foreach ($parameter in $parameters) {
-                $parameterName = $parameter.Name
-                $parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
-                
-                # Should be a description for every parameter
-                It "gets help for parameter: $parameterName : in $commandName" {
-                    $parameterHelp.Description.Text | Should Not BeNullOrEmpty
-                }
-                
-                # Required value in Help should match IsMandatory property of parameter
-                It "help for $parameterName parameter in $commandName has correct Mandatory value" {
-                    $codeMandatory = $parameter.IsMandatory.toString()
-                    $parameterHelp.Required | Should Be $codeMandatory
-                }
-				
-				if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
-                
-                # Parameter type in Help should match code
-                It "help for $commandName has correct parameter type for $parameterName" {
-                    $codeType = $parameter.ParameterType.Name
-                    
-					if ($parameter.ParameterType.IsEnum) {
-                        # Enumerations often have issues with the typename not being reliably available
-                        $names = $parameter.ParameterType::GetNames($parameter.ParameterType)
-                        $parameterHelp.parameterValueGroup.parameterValue | Should be $names
-                    }
-					elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
-						# Enumerations often have issues with the typename not being reliably available
-                        $names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
-                        $parameterHelp.parameterValueGroup.parameterValue | Should be $names
+	$testhelperrors = 0
+	$testhelpall = 0
+	Describe "Test help for $commandName" {
+
+		$testhelpall += 1
+		if ($Help.Synopsis -like '*`[`<CommonParameters`>`]*') {
+			# If help is not found, synopsis in auto-generated help is the syntax diagram
+			It "should not be auto-generated" {
+				$Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
+			}
+			$testhelperrors += 1
+		}
+
+		$testhelpall += 1
+		if ([String]::IsNullOrEmpty($Help.Description.Text)) {
+			# Should be a description for every function
+			It "gets description for $commandName" {
+				$Help.Description | Should Not BeNullOrEmpty
+			}
+			$testhelperrors += 1
+		}
+
+		$testhelpall += 1
+		if ([String]::IsNullOrEmpty(($Help.Examples.Example | Select-Object -First 1).Code)) {
+			# Should be at least one example
+			It "gets example code from $commandName" {
+				($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+			}
+			$testhelperrors += 1
+		}
+
+		$testhelpall += 1
+		if ([String]::IsNullOrEmpty(($Help.Examples.Example.Remarks | Select-Object -First 1).Text)) {
+			# Should be at least one example description
+			It "gets example help from $commandName" {
+				($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+			}
+			$testhelperrors += 1
+		}
+
+		if ($testhelperrors -eq 0) {
+			It "Ran silently $testhelpall tests" {
+				$testhelperrors | Should be 0
+			}
+		}
+
+		$testparamsall = 0
+		$testparamserrors = 0
+		Context "Test parameter help for $commandName" {
+			
+			$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable',
+			'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
+			
+			$parameters = $command.ParameterSets.Parameters | Sort-Object -Property Name -Unique | Where-Object Name -notin $common
+			$parameterNames = $parameters.Name
+			$HelpParameterNames = $Help.Parameters.Parameter.Name | Sort-Object -Unique
+			foreach ($parameter in $parameters) {
+				$parameterName = $parameter.Name
+				$parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
+
+				$testparamsall += 1 
+				if ([String]::IsNullOrEmpty($parameterHelp.Description.Text)) {
+					# Should be a description for every parameter
+					It "gets help for parameter: $parameterName : in $commandName" {
+						$parameterHelp.Description.Text | Should Not BeNullOrEmpty
 					}
-                    else {
-                        # To avoid calling Trim method on a null object.
-                        $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
-                        $helpType | Should be $codeType 
-                    }
-                }
-            }
-            
-            foreach ($helpParm in $HelpParameterNames) {
-                # Shouldn't find extra parameters in help.
-                It "finds help parameter in code: $helpParm" {
-                    $helpParm -in $parameterNames | Should Be $true
-                }
-            }
-        }
-    }
+					$testparamserrors += 1
+				}
+
+				$testparamsall += 1
+				$codeMandatory = $parameter.IsMandatory.toString()
+				if ($parameterHelp.Required -ne $codeMandatory) {
+					# Required value in Help should match IsMandatory property of parameter
+					It "help for $parameterName parameter in $commandName has correct Mandatory value" {
+						$parameterHelp.Required | Should Be $codeMandatory
+					}
+					$testparamserrors += 1
+				}
+
+				if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
+
+				$codeType = $parameter.ParameterType.Name
+				
+				$testparamsall += 1
+				if ($parameter.ParameterType.IsEnum) {
+				# Enumerations often have issues with the typename not being reliably available
+				$names = $parameter.ParameterType::GetNames($parameter.ParameterType)
+				if ($parameterHelp.parameterValueGroup.parameterValue -ne $names) {
+					# Parameter type in Help should match code
+					It "help for $commandName has correct parameter type for $parameterName" {
+						$parameterHelp.parameterValueGroup.parameterValue | Should be $names
+					}
+					$testparamserrors += 1
+				}
+				}
+				elseif ($parameter.ParameterType.FullName -in $HelpTestEnumeratedArrays) {
+					# Enumerations often have issues with the typename not being reliably available
+					$names = [Enum]::GetNames($parameter.ParameterType.DeclaredMembers[0].ReturnType)
+					if ($parameterHelp.parameterValueGroup.parameterValue -ne $names) {
+						# Parameter type in Help should match code
+						It "help for $commandName has correct parameter type for $parameterName" {
+							$parameterHelp.parameterValueGroup.parameterValue | Should be $names
+						}
+						$testparamserrors += 1
+					}
+				}
+				else {
+					# To avoid calling Trim method on a null object.
+					$helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+					if ($helpType -ne $codeType ) {
+						# Parameter type in Help should match code
+						It "help for $commandName has correct parameter type for $parameterName" {
+							$helpType | Should be $codeType
+						}
+						$testparamserrors += 1
+					}
+				}
+			}
+			foreach ($helpParm in $HelpParameterNames) {
+				$testparamsall += 1
+				if ($helpParm -notin $parameterNames) {
+					# Shouldn't find extra parameters in help.
+					It "finds help parameter in code: $helpParm" {
+						$helpParm -in $parameterNames | Should Be $true
+					}
+					$testparamserrors += 1
+				}
+			}
+			if ($testparamserrors -eq 0) {
+				It "Ran silently $testparamsall tests" {
+					$testparamserrors | Should be 0
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
On my test rig, this brings a 14x speedup


## Type of Change

 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Pester test is included

### Purpose
Save CPU puppies.

### Approach
Avoid using `It` and pipes on perster tests if strictly not needed, because they kill puppies.

