### PR TITLE
Updated buildref index

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2017-06-04T00:00:00",
+    "LastUpdated": "2017-07-27T00:00:00",
     "Data": [
     {
         "Version":  "8.0.47",


### PR DESCRIPTION
Confirmed that there are no new releases


## Type of Change

 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
 - [x] None of the above. Just a quick update

### Purpose
Confirm that we care about keeping the index updated
