### PR TITLE
Get-DbaAvailabilityGroup Change IsPrimary comparison order

### DIFF
--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -90,7 +90,7 @@ function Get-DbaAvailabilityGroup {
 				if ($IsPrimary) {
 					$defaults = 'ComputerName','InstanceName','SqlInstance','Name as AvailabilityGroup','IsPrimary'
 					$value = $false
-					if ($serverName -eq $ag.PrimaryReplicaServerName) {
+					if ($ag.PrimaryReplicaServerName -eq $serverName) {
 						$value = $true
 					}
 					Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name IsPrimary -Value $value


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1932)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
IsPrimary comparison was not working (always returning false). Switched order to force PowerShell to use implicit comparison function in DbaInstanceParameter class.

### Commands to test
<!-- if these are the examples in the help just not it as such -->
`Get-DbaAvailabilityGroup -sqlinstance SERVERNAME -AvailabilityGroup AGNAME -IsPrimary | select IsPrimary`