### PR TITLE
Quick fix on compare replica name to server name

### DIFF
--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -90,7 +90,7 @@ function Get-DbaAvailabilityGroup {
 				if ($IsPrimary) {
 					$defaults = 'ComputerName','InstanceName','SqlInstance','Name as AvailabilityGroup','IsPrimary'
 					$value = $false
-					if ($ag.PrimaryReplicaServerName -eq $serverName) {
+					if ($ag.PrimaryReplicaServerName -eq $server.Name) {
 						$value = $true
 					}
 					Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name IsPrimary -Value $value


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (affects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Correct the comparison to identify the `IsPrimary`. Originally it compared the replica name to the Instance name passed into the command. There is a potential the name passed in could be a DNS alias which would not match the replica name.
### Approach
<!-- How does this change solve that purpose -->
Ensures that we are matching the actual server name to the replica name.