### PR TITLE
Copy-DbaAgentJob - Set logic to Force owner to sa if login is missing on destination

### DIFF
--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -167,12 +167,14 @@
 			$missingLogin = $serverJob.OwnerLoginName | Where-Object { $destServer.Logins.Name -notcontains $_ }
 
 			if ($missingLogin.Count -gt 0) {
-				$missingLogin = ($missingLogin | Sort-Object | Get-Unique) -join ", "
-				$copyJobStatus.Status = "Skipped"
-				$copyJobStatus.Notes = "Job is dependent on login $missingLogin"
-				$copyJobStatus
-				Write-Message -Level Warning -Message "Login(s) $missingLogin doesn't exist on destination. Skipping job [$jobName]."
-				continue
+				if ($force -eq $false) {
+					$missingLogin = ($missingLogin | Sort-Object | Get-Unique) -join ", "
+					$copyJobStatus.Status = "Skipped"
+					$copyJobStatus.Notes = "Job is dependent on login $missingLogin"
+					$copyJobStatus
+					Write-Message -Level Warning -Message "Login(s) $missingLogin doesn't exist on destination. Use -Force to set owner to [sa]. Skipping job [$jobName]."
+					continue
+				}
 			}
 
 			$proxyNames = $serverJob.JobSteps.ProxyName | Where-Object { $_.Length -gt 0 }
@@ -227,8 +229,16 @@
 				try {
 					Write-Message -Message "Copying Job $jobName" -Level Verbose
 					$sql = $serverJob.Script() | Out-String
+
+					if ($missingLogin.Count -gt 0 -and $force) {
+						$saLogin = Get-SqlSaLogin -SqlInstance $destServer
+						$sql = $sql -replace [Regex]::Escape("@owner_login_name=N'$missingLogin'"), [Regex]::Escape("@owner_login_name=N'$saLogin'")
+					}
+
 					Write-Message -Message $sql -Level Debug
 					$destServer.Query($sql)
+
+					$destServer.JobServer.Jobs.Refresh()
 				}
 				catch {
 					$copyJobStatus.Status = "Failed"
@@ -241,17 +251,16 @@
 			if ($DisableOnDestination) {
 				if ($Pscmdlet.ShouldProcess($destination, "Disabling $jobName")) {
 					Write-Message -Message "Disabling $jobName on $destination" -Level Verbose
-					$destServer.JobServer.Jobs.Refresh()
-					$destServer.JobServer.Jobs[$job.name].IsEnabled = $False
-					$destServer.JobServer.Jobs[$job.name].Alter()
+					$destServer.JobServer.Jobs[$serverJob.name].IsEnabled = $False
+					$destServer.JobServer.Jobs[$serverJob.name].Alter()
 				}
 			}
 
 			if ($DisableOnSource) {
 				if ($Pscmdlet.ShouldProcess($source, "Disabling $jobName")) {
 					Write-Message -Message "Disabling $jobName on $source" -Level Verbose
-					$job.IsEnabled = $false
-					$job.Alter()
+					$serverJob.IsEnabled = $false
+					$serverJob.Alter()
 				}
 			}
 			$copyJobStatus.Status = "Successful"

--- a/internal/Get-SqlSaLogin.ps1
+++ b/internal/Get-SqlSaLogin.ps1
@@ -1,9 +1,12 @@
-Function Get-SqlSaLogin
-{
-<#
-.SYNOPSIS
-Internal function. Gets the name of the sa login in case someone changed it.
-#>
+function Get-SqlSaLogin {
+	<#
+		.SYNOPSIS
+			Internal function. Gets the name of the sa login in case someone changed it.
+		.PARAMETER SqlInstance
+			The SQL Server instance.
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted).
+	#>
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
@@ -12,8 +15,6 @@ Internal function. Gets the name of the sa login in case someone changed it.
 		[PSCredential]$SqlCredential
 	)
 	$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-	$sa = $server.Logins | Where-Object { $_.id -eq 1 }
-	
-	return $sa.name
-	
+	$sa = $server.Logins | Where-Object Id -eq 1
+	return $sa.Name
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #204 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Address issue where owner login of source job does not exist on destination instance. Previous we skipped those jobs, now it will set the job owner to "sa" of the destination server, if `-Force` is provided.

### Commands to test
<!-- if these are the examples in the help just not it as such -->
1. Create job on your source instance with owner of that job set to a login that does not exist on your destination
2. Copy the job using `Copy-DbaAgentJob`

### Screenshots
![image](https://user-images.githubusercontent.com/11204251/28750930-0e20e352-74c0-11e7-9501-2cc34aad6e9a.png)

![image](https://user-images.githubusercontent.com/11204251/28750937-363088de-74c0-11e7-8d76-cf6b5e3be3d8.png)

![image](https://user-images.githubusercontent.com/11204251/28750940-4149cee2-74c0-11e7-9724-4f68a593f5d5.png)
