### PR TITLE
Test-FunctionINterrupt - Removed silent errors from $error

### DIFF
--- a/internal/Test-FunctionInterrupt.ps1
+++ b/internal/Test-FunctionInterrupt.ps1
@@ -1,4 +1,6 @@
-﻿function Test-FunctionInterrupt
+﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
+function Test-FunctionInterrupt
 {
     <#
         .SYNOPSIS

--- a/internal/Test-FunctionInterrupt.ps1
+++ b/internal/Test-FunctionInterrupt.ps1
@@ -25,14 +25,8 @@
         
     )
     
-    try
-    {
-        $var = Get-Variable -Name "__dbatools_interrupt_function_78Q9VPrM6999g6zo24Qn83m09XF56InEn4hFrA8Fwhu5xJrs6r" -Scope 1 -ErrorAction Stop
-        if ($var.Value) { return $true }
-    }
-    catch
-    {
-        
-    }
-    return $false
+    $var = Get-Variable -Name "__dbatools_interrupt_function_78Q9VPrM6999g6zo24Qn83m09XF56InEn4hFrA8Fwhu5xJrs6r" -Scope 1 -ErrorAction Ignore
+    if ($var.Value) { return $true }
+	
+	return $false
 }


### PR DESCRIPTION

## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Purpose
 - Removes the many silent errors in the automatic `$error` variable for when `Test-FunctionInterrupt` tests whether it should kill the function