### PR TITLE
Messaging system v2.2

### DIFF
--- a/internal/Stop-Function.ps1
+++ b/internal/Stop-Function.ps1
@@ -1,4 +1,6 @@
-﻿function Stop-Function
+﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
+function Stop-Function
 {
 	<#
 		.SYNOPSIS

--- a/internal/Stop-Function.ps1
+++ b/internal/Stop-Function.ps1
@@ -1,78 +1,86 @@
 ﻿function Stop-Function
 {
-    <#
-        .SYNOPSIS
-            Function that interrupts a function.
-        
-        .DESCRIPTION
-            Function that interrupts a function.
-            
-            This function is a utility function used by other functions to reduce error catching overhead.
-            It is designed to allow gracefully terminating a function with a warning by default and also allow opt-in into terminating errors.
-            It also allows simple integration into loops.
-    
-            Note:
-            When calling this function with the intent to terminate the calling function in non-silent mode too, you need to add a return below the call.
-        
-        .PARAMETER Message
-            A message to pass along, explaining just what the error was.
-        
-        .PARAMETER Silent
-            Whether the silent switch was set in the calling function.
-            If true, it will throw an error.
-            If false, it will print a warning.
-        
-        .PARAMETER Category
-            What category does this termination belong to?
-            Mandatory so long as no inner exception is passed.
-        
-        .PARAMETER InnerErrorRecord
-            An option to include an inner exception in the error record (and in the exception thrown, if one is thrown).
-            Use this, whenever you call Stop-Function in a catch block.
-    
-            Note:
-            Pass the full error record, not just the exception.
-        
-        .PARAMETER FunctionName
-            The name of the function to crash.
-            This parameter is very optional, since it automatically selects the name of the calling function.
-            The function name is used as part of the errorid.
-            That in turn allows easily figuring out, which exception belonged to which function when checking out the $error variable.
-        
-        .PARAMETER Target
-            The object that was processed when the error was thrown.
-            For example, if you were trying to process a Database Server object when the processing failed, add the object here.
-            This object will be in the error record (which will be written, even in non-silent mode, just won't show it).
-            If you specify such an object, it becomes simple to actually figure out, just where things failed at.
-        
-        .PARAMETER Continue
-            This will cause the function to call continue while not running silently.
-            Useful when mass-processing items where an error shouldn't break the loop.
-        
-        .PARAMETER SilentlyContinue
-            This will cause the function to call continue while running silently.
-            Useful when mass-processing items where an error shouldn't break the loop.
-        
-        .PARAMETER ContinueLabel
-            When specifying a label in combination with "-Continue" or "-SilentlyContinue", this function will call continue with this specified label.
-            Helpful when trying to continue on an upper level named loop.
-        
-        .EXAMPLE
-            Stop-Function -Message "Foo failed bar! $($_.Exception.Message)" -Silent $Silent -InnerErrorRecord $_
-            return
-
-            Depending on whether $silent is true or false it will:
-            - Throw a bloody terminating error. Game over.
-            - Write a nice warning about how Foo failed bar, then terminate the function. The return on the next line will then end the calling function.
-
-        .EXAMPLE
-            Stop-Function -Message "Foo failed bar!" -Silent $Silent -Category InvalidOperation -Target $foo -Continue
-
-            Depending on whether $silent is true or false it will:
-            - Throw a bloody terminating error. Game over.
-            - Write a nice warning about how Foo failed bar, then call continue to process the next item in the loop.
-            In both cases, the error record added to $error will have the content of $foo added, the better to figure out what went wrong.
-    #>
+	<#
+		.SYNOPSIS
+			Function that interrupts a function.
+		
+		.DESCRIPTION
+			Function that interrupts a function.
+			
+			This function is a utility function used by other functions to reduce error catching overhead.
+			It is designed to allow gracefully terminating a function with a warning by default and also allow opt-in into terminating errors.
+			It also allows simple integration into loops.
+			
+			Note:
+			When calling this function with the intent to terminate the calling function in non-silent mode too, you need to add a return below the call.
+		
+		.PARAMETER Message
+			A message to pass along, explaining just what the error was.
+		
+		.PARAMETER Silent
+			Whether the silent switch was set in the calling function.
+			If true, it will throw an error.
+			If false, it will print a warning.
+		
+		.PARAMETER Category
+			What category does this termination belong to?
+			Mandatory so long as no inner exception is passed.
+		
+		.PARAMETER ErrorRecord
+			An option to include an inner exception in the error record (and in the exception thrown, if one is thrown).
+			Use this, whenever you call Stop-Function in a catch block.
+			
+			Note:
+			Pass the full error record, not just the exception.
+		
+		.PARAMETER FunctionName
+			The name of the function to crash.
+			This parameter is very optional, since it automatically selects the name of the calling function.
+			The function name is used as part of the errorid.
+			That in turn allows easily figuring out, which exception belonged to which function when checking out the $error variable.
+		
+		.PARAMETER Target
+			The object that was processed when the error was thrown.
+			For example, if you were trying to process a Database Server object when the processing failed, add the object here.
+			This object will be in the error record (which will be written, even in non-silent mode, just won't show it).
+			If you specify such an object, it becomes simple to actually figure out, just where things failed at.
+		
+		.PARAMETER Exception
+			Allows specifying an inner exception as input object. This will be passed on to the logging and used for messages.
+			When specifying both ErrorRecord AND Exception, Exception wins, but ErrorRecord is still used for record metadata.
+		
+		.PARAMETER OverrideExceptionMessage
+			Disables automatic appending of exception messages.
+			Use in cases where you already have a speaking message interpretation and do not need the original message.
+		
+		.PARAMETER Continue
+			This will cause the function to call continue while not running silently.
+			Useful when mass-processing items where an error shouldn't break the loop.
+		
+		.PARAMETER SilentlyContinue
+			This will cause the function to call continue while running silently.
+			Useful when mass-processing items where an error shouldn't break the loop.
+		
+		.PARAMETER ContinueLabel
+			When specifying a label in combination with "-Continue" or "-SilentlyContinue", this function will call continue with this specified label.
+			Helpful when trying to continue on an upper level named loop.
+		
+		.EXAMPLE
+			Stop-Function -Message "Foo failed bar!" -Silent $Silent -ErrorRecord $_
+			return
+			
+			Depending on whether $silent is true or false it will:
+			- Throw a bloody terminating error. Game over.
+			- Write a nice warning about how Foo failed bar, then terminate the function. The return on the next line will then end the calling function.
+		
+		.EXAMPLE
+			Stop-Function -Message "Foo failed bar!" -Silent $Silent -Category InvalidOperation -Target $foo -Continue
+			
+			Depending on whether $silent is true or false it will:
+			- Throw a bloody terminating error. Game over.
+			- Write a nice warning about how Foo failed bar, then call continue to process the next item in the loop.
+			In both cases, the error record added to $error will have the content of $foo added, the better to figure out what went wrong.
+	#>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding(DefaultParameterSetName = 'Plain')]
     Param (
@@ -97,7 +105,13 @@
         $FunctionName = ((Get-PSCallStack)[0].Command),
         
         [object]
-        $Target,
+		$Target,
+		
+		[System.Exception]
+		$Exception,
+		
+		[switch]
+		$OverrideExceptionMessage,
         
         [switch]
         $Continue,
@@ -124,24 +138,31 @@
 	
 	$records = @()
     
-    if ($ErrorRecord)
-    {
-        foreach ($record in $ErrorRecord)
-        {
-            $exception = New-Object System.Exception($record.Exception.Message, $record.Exception)
-            if ($record.CategoryInfo.Category) { $Category = $record.CategoryInfo.Category }
-            $records += New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools_$FunctionName", $Category, $targetToAdd)
-        }
-    }
-    else
-    {
-        $exception = New-Object System.Exception($Message)
-        $records += New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools_$FunctionName", $Category, $targetToAdd)
-    }
-    
-    # Manage Debugging
-	Write-Message -Level Warning -Message $Message -Silent $Silent -FunctionName $FunctionName -Target $targetToAdd -ErrorRecord $records
-    #[Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::WriteErrorEntry($records, $FunctionName, $timestamp, $Message, $Host.InstanceId)
+    if ($ErrorRecord -or $Exception) {
+		if ($ErrorRecord) {
+			foreach ($record in $ErrorRecord) {
+				if (-not $Exception) { $newException = New-Object System.Exception($record.Exception.Message, $record.Exception) }
+				else { $newException = $Exception }
+				if ($record.CategoryInfo.Category) { $Category = $record.CategoryInfo.Category }
+				$records += New-Object System.Management.Automation.ErrorRecord($newException, "dbatools_$FunctionName", $Category, $targetToAdd)
+			}
+		}
+		else {
+			$records += New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools_$FunctionName", $Category, $targetToAdd)
+		}
+		
+		# Manage Debugging
+		Write-Message -Level Warning -Message $Message -Silent $Silent -FunctionName $FunctionName -Target $targetToAdd -ErrorRecord $records -OverrideExceptionMessage:$OverrideExceptionMessage
+	}
+	else {
+		$exception = New-Object System.Exception($Message)
+		$records += New-Object System.Management.Automation.ErrorRecord($Exception, "dbatools_$FunctionName", $Category, $targetToAdd)
+		
+		# Manage Debugging
+		Write-Message -Level Warning -Message $Message -Silent $Silent -FunctionName $FunctionName -Target $targetToAdd -ErrorRecord $records -OverrideExceptionMessage:$true
+	}
+	
+	
     
     #region Silent Mode
     if ($Silent)

--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -1,4 +1,6 @@
-﻿function Write-Message {
+﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
+function Write-Message {
 	<#
 		.SYNOPSIS
 			This function acts as central information node for dbatools.

--- a/internal/Write-Message.ps1
+++ b/internal/Write-Message.ps1
@@ -1,104 +1,108 @@
 ﻿function Write-Message {
-    <#
-        .SYNOPSIS
-            This function acts as central information node for dbatools.
-        
-        .DESCRIPTION
-            This function acts as central information node for dbatools.
-            Other functions hand off all their information output for processing to this function.
-            
-            This function will then handle:
-            - Warning output
-            - Error management for non-terminating errors (For errors that terminate execution or continue on with the next object use "Stop-Function")
-            - Logging
-            - Verbose output
-            - Message output to users
-            
-            At what complexity what path for the information is chosen is determined by the configuration settings:
-            message.maximuminfo
-            message.maximumverbose
-            message.maximumdebug
-            message.minimuminfo
-            message.minimumverbose
-            message.minimumdebug
-            Which can be set to any level from 1 through 9
-            Depending on the configuration it is very possible to have multiple paths chosen simultaneously
-        
-        .PARAMETER Message
-            The message to write/log. The function name and timestamp will automatically be prepended.
-        
-        .PARAMETER Level
-            This parameter represents the verbosity of the message. The lower the number, the more important it is for a human user to read the message.
-            By default, the levels are distributed like this:
-            - 1-3 Direct verbose output to the user (using Write-Host)
-            - 4-6 Output only visible when requesting extra verbosity (using Write-Verbose)
-            - 1-9 Debugging information, written using Write-Debug
-            The specific level of verbosity preference can be configured using the settings of the message.maximum and message.minimum namespace.
-    
-            In addition, it is possible to select the level "Warning" which moves the message out of the configurable range:
-            The user will always be shown this message, unless he silences the entire thing with -Silent
-            
-            Possible levels:
-            Critical (1), Important / Output (2), Significant (3), VeryVerbose (4), Verbose (5), SomewhatVerbose (6), System (7), Debug (8), InternalComment (9), Warning (666)
-            Either one of the strings or its respective number will do as input.
-        
-        .PARAMETER Silent
-            Whether the silent switch was set in the calling function.
-            If true, it will write errors, if any, but not write to the screen without explicit override using -Debug or -Verbose.
-            If false, it will print a warning if in wrning mode. It will also be willing to write a message to the screen, if the level is within the range configured for that.
-        
-        .PARAMETER FunctionName
-            The name of the calling function.
-            Will be automatically set, but can be overridden when necessary.
-        
-        .PARAMETER ErrorRecord
-            If an error record should be noted with the message, add the full record here.
-            Especially designed for use with Warning-mode, it can legally be used in either mode.
-            The error will be added to the $Error variable and enqued in the dbatools debugging system.
-        
-        .PARAMETER Warning
-            Deprecated, do not use anymore
-        
-        .PARAMETER Once
-            Setting this parameter will cause this function to write the message only once per session.
-            The string passed here and the calling function's name are used to create a unique ID, which is then used to register the action in the configuration system.
-            Thus will the lockout only be written if called once and not burden the system unduly.
-            This lockout will be written as a hidden value, to see it use Get-DbaConfig -Force.
-        
-        .PARAMETER Target
-            If an ErrorRecord was passed, it is possible to add the object on which the error eccoured, in order to simplify debugging / troubleshooting.
-        
-        .EXAMPLE
-            PS C:\> Write-Message -Message 'Connecting to Database1' -Level 4 -Silent $Silent
-            
-            Writes the message 'Connecting to Database1'. By default, this will be
-            - Written to the in-memory message log
-            - Written to the logfile
-            - Written to the Verbose stream (Write-Verbose)
-            - Written to the Debug stream (Write-Debug)
-        
-        .EXAMPLE
-            PS C:\> Write-Message -Message "Connecting to Database 2 failed: $($_.Exception.Message)" -Silent $silent -Warning -ErrorRecord $_ -Target $Database
-            
-            Writes the message "Connecting to Database 2 failed: $($_.Exception.Message)". By default, this will be
-            - Written to the in-memory message log
-            - Written to the in-memory error queue
-            - Written to the $error variable
-            - Written to the logfile
-            - Written to the error log files
-            - Written to the Warning stream (Write-Warning, not if silent)
-            - Written to the Debug stream (Write-Debug)
-        
-        .NOTES
-            Author: Friedrich Weinmann
-            Tags: debug
-        
-        .NOTES
-            For Implementers transitioning from previously used cmdlets, rule of thumb:
-            - Write-Host:    Level 2
-            - Write-Verbose: Level 5
-            - Write-Debug:   Level 8
-    #>
+	<#
+		.SYNOPSIS
+			This function acts as central information node for dbatools.
+		
+		.DESCRIPTION
+			This function acts as central information node for dbatools.
+			Other functions hand off all their information output for processing to this function.
+			
+			This function will then handle:
+			- Warning output
+			- Error management for non-terminating errors (For errors that terminate execution or continue on with the next object use "Stop-Function")
+			- Logging
+			- Verbose output
+			- Message output to users
+			
+			At what complexity what path for the information is chosen is determined by the configuration settings:
+			message.maximuminfo
+			message.maximumverbose
+			message.maximumdebug
+			message.minimuminfo
+			message.minimumverbose
+			message.minimumdebug
+			Which can be set to any level from 1 through 9
+			Depending on the configuration it is very possible to have multiple paths chosen simultaneously
+		
+		.PARAMETER Message
+			The message to write/log. The function name and timestamp will automatically be prepended.
+		
+		.PARAMETER Level
+			This parameter represents the verbosity of the message. The lower the number, the more important it is for a human user to read the message.
+			By default, the levels are distributed like this:
+			- 1-3 Direct verbose output to the user (using Write-Host)
+			- 4-6 Output only visible when requesting extra verbosity (using Write-Verbose)
+			- 1-9 Debugging information, written using Write-Debug
+			The specific level of verbosity preference can be configured using the settings of the message.maximum and message.minimum namespace.
+			
+			In addition, it is possible to select the level "Warning" which moves the message out of the configurable range:
+			The user will always be shown this message, unless he silences the entire thing with -Silent
+			
+			Possible levels:
+			Critical (1), Important / Output (2), Significant (3), VeryVerbose (4), Verbose (5), SomewhatVerbose (6), System (7), Debug (8), InternalComment (9), Warning (666)
+			Either one of the strings or its respective number will do as input.
+		
+		.PARAMETER Silent
+			Whether the silent switch was set in the calling function.
+			If true, it will write errors, if any, but not write to the screen without explicit override using -Debug or -Verbose.
+			If false, it will print a warning if in wrning mode. It will also be willing to write a message to the screen, if the level is within the range configured for that.
+		
+		.PARAMETER FunctionName
+			The name of the calling function.
+			Will be automatically set, but can be overridden when necessary.
+		
+		.PARAMETER ErrorRecord
+			If an error record should be noted with the message, add the full record here.
+			Especially designed for use with Warning-mode, it can legally be used in either mode.
+			The error will be added to the $Error variable and enqued in the dbatools debugging system.
+		
+		.PARAMETER Warning
+			Deprecated, do not use anymore
+		
+		.PARAMETER Once
+			Setting this parameter will cause this function to write the message only once per session.
+			The string passed here and the calling function's name are used to create a unique ID, which is then used to register the action in the configuration system.
+			Thus will the lockout only be written if called once and not burden the system unduly.
+			This lockout will be written as a hidden value, to see it use Get-DbaConfig -Force.
+		
+		.PARAMETER OverrideExceptionMessage
+			Disables automatic appending of exception messages.
+			Use in cases where you already have a speaking message interpretation and do not need the original message.
+		
+		.PARAMETER Target
+			If an ErrorRecord was passed, it is possible to add the object on which the error eccoured, in order to simplify debugging / troubleshooting.
+		
+		.EXAMPLE
+			PS C:\> Write-Message -Message 'Connecting to Database1' -Level 4 -Silent $Silent
+			
+			Writes the message 'Connecting to Database1'. By default, this will be
+			- Written to the in-memory message log
+			- Written to the logfile
+			- Written to the Verbose stream (Write-Verbose)
+			- Written to the Debug stream (Write-Debug)
+		
+		.EXAMPLE
+			PS C:\> Write-Message -Message "Connecting to Database 2 failed" -Silent $silent -Warning -ErrorRecord $_ -Target $Database
+			
+			Writes the message "Connecting to Database 2 failed". By default, this will be
+			- Written to the in-memory message log
+			- Written to the in-memory error queue
+			- Written to the $error variable
+			- Written to the logfile
+			- Written to the error log files
+			- Written to the Warning stream (Write-Warning, not if silent)
+			- Written to the Debug stream (Write-Debug)
+		
+		.NOTES
+			Author: Friedrich Weinmann
+			Tags: debug
+		
+		.NOTES
+			For Implementers transitioning from previously used cmdlets, rule of thumb:
+			- Write-Host:    Level 2
+			- Write-Verbose: Level 5
+			- Write-Debug:   Level 8
+	#>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
 	[CmdletBinding(DefaultParameterSetName = 'Level')]
 	Param (
@@ -125,6 +129,9 @@
 		
 		[string]
 		$Once,
+		
+		[switch]
+		$OverrideExceptionMessage,
 		
 		[object]
 		$Target
@@ -173,7 +180,7 @@
 		$newMessage = "[$FunctionName][$($timestamp.ToString("HH:mm:ss"))] $baseMessage"
 		$newColoredMessage = "[$FunctionName][$($timestamp.ToString("HH:mm:ss"))] $baseMessage"
 	}
-	if ($ErrorRecord -and ($Message -notmatch ([regex]::Escape("$($ErrorRecord[0].Exception.Message)")))) {
+	if ($ErrorRecord -and ($Message -notmatch ([regex]::Escape("$($ErrorRecord[0].Exception.Message)"))) -and (-not $OverrideExceptionMessage)) {
 		$baseMessage += " | $($ErrorRecord[0].Exception.Message)"
 		$newMessage += " | $($ErrorRecord[0].Exception.Message)"
 		$newColoredMessage += " | $($ErrorRecord[0].Exception.Message)"


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Features / Changes
 - Removes specifying the message multiple times when calling `Stop-Function` and not specifying an error record
 - Added parameter `-Exception` to Stop-Function to specify an Exception, which supplements the error record. That way it is now possible to pass an inner exception and discard unwanted wrappers
 - Added parameter `-OverrideExceptionMessage` to disable automatic appending of exception messages