### PR TITLE
[new command] Get-DbaTraceFlag

### DIFF
--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -22,7 +22,7 @@
 			Tags: Trace, Flag
 			Original Author: Kevin Bullen (@sqlpadawan)
 
-            References:  https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.enumactivecurrentsessiontraceflags(v=sql.120).aspx
+			References:  https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.enumactivecurrentsessiontraceflags(v=sql.120).aspx
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -1,0 +1,96 @@
+﻿FUNCTION Get-DbaTraceFlag {
+	<#
+		.SYNOPSIS
+			Gets SQL Trace Flags information for each instance(s) of SQL Server.
+
+		.DESCRIPTION
+			The Get-DbaTraceFlag returns connected SMO object for SQL Trace Flags information for each instance(s) of SQL Server.
+
+		.PARAMETER SqlInstance
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+		.PARAMETER SqlCredential
+			SqlCredential object to connect as. If not specified, current Windows login will be used.
+
+		.PARAMETER TraceFlag
+			Use this switch to filter to a specific Trace Flag.
+
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages.
+
+		.NOTES
+			Tags: Trace, Flag
+			Original Author: Kevin Bullen (@sqlpadawan)
+
+            References:  https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.enumactivecurrentsessiontraceflags(v=sql.120).aspx
+
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Get-DbaTraceFlag
+
+		.EXAMPLE
+			Get-DbaTraceFlag -SqlInstance localhost
+
+			Returns all SQL Trace Flag information on the local default SQL Server instance
+
+		.EXAMPLE
+			Get-DbaTraceFlag -SqlInstance localhost, sql2016
+
+			Returns all SQl Trace Flag for the local and sql2016 SQL Server instances
+
+		.EXAMPLE
+			Get-DbaTraceFlag -SqlInstance localhost -TraceFlag 4199,3205
+
+			Returns all SQl Trace Flag 4199 and 3205 status for local SQL Server instance
+	#>
+	[CmdletBinding()]
+	param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]
+		$SqlCredential,
+		[object[]]$TraceFlag,
+		[switch]$Silent
+	)
+
+	process {
+		foreach ($instance in $SqlInstance) {
+			Write-Verbose "Attempting to connect to $instance"
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+            $tflags = New-Object System.Data.DataTable;
+
+			$tflags = $server.EnumActiveGlobalTraceFlags();
+			
+			if ($TraceFlag) {
+				$tflags = $tflags | Where-Object TraceFlag -In $TraceFlag
+			}
+		               
+			foreach ($tflag in $tflags) {
+                
+                #otherwise rowerror, rowstate, blah blah fields added to output.
+                $tflagdata = @{'ComputerName' = $server.NetName;
+                               'InstanceName' = $server.ServiceName;
+                               'SqlInstance' = $server.DomainInstanceName;
+                               'TraceFlag' = $tflag.TraceFlag;
+                               'Global' = $tflag.Global;
+                               'Session' = $tflag.Session;
+                               'Status' = $tflag.Status};
+                               
+                $tflagrow = New-Object psobject -Property $tflagdata
+                
+                Select-DefaultView -InputObject $tflagrow -Property 'ComputerName','InstanceName','SqlInstance','TraceFlag','Global','Session','Status'
+
+            } 
+		}
+	}
+}

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -77,17 +77,17 @@
 			    $tflags = $tflags | Where-Object TraceFlag -In $TraceFlag
 		    }
 	               
-               foreach ($tflag in $tflags) {
-			    [pscustomobject]@{
-				    'ComputerName' = $server.NetName;
-				    'InstanceName' = $server.ServiceName;
-				    'SqlInstance'  = $server.DomainInstanceName;
-				    'TraceFlag'    = $tflag.TraceFlag;
-				    'Global'       = $tflag.Global;
-				    'Session'      = $tflag.Session;
-				    'Status'       = $tflag.Status
-		        } | Select-DefaultView -ExcludeProperty 'Session'
+                foreach ($tflag in $tflags) {
+			        [pscustomobject]@{
+				        'ComputerName' = $server.NetName;
+				        'InstanceName' = $server.ServiceName;
+				        'SqlInstance'  = $server.DomainInstanceName;
+				        'TraceFlag'    = $tflag.TraceFlag;
+				        'Global'       = $tflag.Global;
+				        'Session'      = $tflag.Session;
+				        'Status'       = $tflag.Status
+                } | Select-DefaultView -ExcludeProperty 'Session'
             }
-	    }
-	}
+        }
+    }
 }

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -1,10 +1,10 @@
-﻿FUNCTION Get-DbaTraceFlag {
+﻿function Get-DbaTraceFlag {
 	<#
 		.SYNOPSIS
-			Gets SQL Trace Flags information for each instance(s) of SQL Server.
+			Get global Trace Flag(s) information for each instance(s) of SQL Server.
 
 		.DESCRIPTION
-			The Get-DbaTraceFlag returns connected SMO object for SQL Trace Flags information for each instance(s) of SQL Server.
+			Returns Trace Flags that are enabled globally on each instance(s) of SQL Server as an object.
 
 		.PARAMETER SqlInstance
 			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
@@ -22,7 +22,7 @@
 			Tags: Trace, Flag
 			Original Author: Kevin Bullen (@sqlpadawan)
 
-			References:  https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.server.enumactivecurrentsessiontraceflags(v=sql.120).aspx
+			References:  https://docs.microsoft.com/en-us/sql/t-sql/database-console-commands/dbcc-traceon-trace-flags-transact-sql
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
@@ -34,17 +34,17 @@
 		.EXAMPLE
 			Get-DbaTraceFlag -SqlInstance localhost
 
-			Returns all SQL Trace Flag information on the local default SQL Server instance
+			Returns all Trace Flag information on the local default SQL Server instance
 
 		.EXAMPLE
 			Get-DbaTraceFlag -SqlInstance localhost, sql2016
 
-			Returns all SQl Trace Flag for the local and sql2016 SQL Server instances
+			Returns all Trace Flag(s) for the local and sql2016 SQL Server instances
 
 		.EXAMPLE
 			Get-DbaTraceFlag -SqlInstance localhost -TraceFlag 4199,3205
 
-			Returns all SQl Trace Flag 4199 and 3205 status for local SQL Server instance
+			Returns Trace Flag status for TF 4199 and 3205 for the local SQL Server instance if they are enabled.
 	#>
 	[CmdletBinding()]
 	param (
@@ -59,7 +59,6 @@
 
 	process {
 		foreach ($instance in $SqlInstance) {
-			Write-Verbose "Attempting to connect to $instance"
 			try {
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
@@ -67,30 +66,28 @@
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 
-            $tflags = New-Object System.Data.DataTable;
-
 			$tflags = $server.EnumActiveGlobalTraceFlags();
 			
-			if ($TraceFlag) {
-				$tflags = $tflags | Where-Object TraceFlag -In $TraceFlag
+            if ($tFlags.Rows.Count -eq 0) {
+				Write-Message -Level Output -Message "No global trace flags enabled"
+				return
 			}
-		               
-			foreach ($tflag in $tflags) {
-                
-                #otherwise rowerror, rowstate, blah blah fields added to output.
-                $tflagdata = @{'ComputerName' = $server.NetName;
-                               'InstanceName' = $server.ServiceName;
-                               'SqlInstance' = $server.DomainInstanceName;
-                               'TraceFlag' = $tflag.TraceFlag;
-                               'Global' = $tflag.Global;
-                               'Session' = $tflag.Session;
-                               'Status' = $tflag.Status};
-                               
-                $tflagrow = New-Object psobject -Property $tflagdata
-                
-                Select-DefaultView -InputObject $tflagrow -Property 'ComputerName','InstanceName','SqlInstance','TraceFlag','Global','Session','Status'
 
-            } 
-		}
+		    if ($TraceFlag) {
+			    $tflags = $tflags | Where-Object TraceFlag -In $TraceFlag
+		    }
+	               
+               foreach ($tflag in $tflags) {
+			    [pscustomobject]@{
+				    'ComputerName' = $server.NetName;
+				    'InstanceName' = $server.ServiceName;
+				    'SqlInstance'  = $server.DomainInstanceName;
+				    'TraceFlag'    = $tflag.TraceFlag;
+				    'Global'       = $tflag.Global;
+				    'Session'      = $tflag.Session;
+				    'Status'       = $tflag.Status
+		        } | Select-DefaultView -ExcludeProperty 'Session'
+            }
+	    }
 	}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Poll sql instance global enabled trace flags from the startup parameters or from DBCC TRACEON(<tf>,-1)

### Approach
<!-- How does this change solve that purpose -->
SMO trace flag enumeration

### Commands to test
<!-- if these are the examples in the help just not it as such -->
examples included from the scripts:
.EXAMPLE
Get-DbaTraceFlag -SqlInstance localhost
Returns all SQL Trace Flag information on the local default SQL Server instance

.EXAMPLE
Get-DbaTraceFlag -SqlInstance localhost, sql2016
Returns all SQl Trace Flag for the local and sql2016 SQL Server instances

.EXAMPLE
Get-DbaTraceFlag -SqlInstance localhost -TraceFlag 4199,3205
Returns all SQl Trace Flag 4199 and 3205 status for local SQL Server instance

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![capture1](https://user-images.githubusercontent.com/10745602/28853572-7a17b202-76ff-11e7-8ecc-399f81be17eb.PNG)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
