### PR TITLE
Fix Get-DbaRegisteredServerName Group issue

### DIFF
--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -130,6 +130,10 @@ function Get-DbaRegisteredServerName {
 			if ($Group -ne $null) {
 				foreach ($currentGroup in $Group) {
 					$cms = Find-CmsGroup -CmsGrp $cmsStore.DatabaseEngineServerGroup.ServerGroups -Stopat $currentGroup
+					if ($cms -eq $null) {
+						Write-Message -Level Output -Message "No groups found matching that name"
+						continue
+					}
 					$servers += ($cms.GetDescendantRegisteredServers()).ServerName
 				}
 			}

--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -101,7 +101,7 @@ function Get-DbaRegisteredServerName {
 				}
 				else {
 					foreach ($elg in $el.ServerGroups) {
-						$results += Find-CmsGroup -CmsGp $elg -Base $partial -Stopat $Stopat
+						$results += Find-CmsGroup -CmsGrp $elg -Base $partial -Stopat $Stopat
 					}
 				}
 			}

--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -1,13 +1,14 @@
 function Get-DbaRegisteredServerName {
 	<#
 		.SYNOPSIS
-			Gets list of SQL Server names stored in SQL Server Central Management Server.
+			Gets list of SQL Server names stored in SQL Server Central Management Server (CMS).
 
 		.DESCRIPTION
-			Returns a simple array of server names. Be aware of the dynamic parameter 'Group', which can be used to limit results to one or more groups you have created on the CMS. See get-help for examples.
+			Returns a simple array of server names found in the CMS.
 
 		.PARAMETER SqlInstance
-			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection to allow the function to be executed against multiple SQL Server instances.
+			SQL Server name or SMO object representing the SQL Server to connect to. 
+			This can be a collection to allow the function to be executed against multiple SQL Server instances.
 	
 		.PARAMETER SqlCredential
 			SqlCredential object to connect as. If not specified, current Windows login will be used.
@@ -16,7 +17,8 @@ function Get-DbaRegisteredServerName {
 			Auto-populated list of groups in SQL Server Central Management Server. You can specify one or more, comma separated.
 
 		.PARAMETER NoCmsServer
-			By default, the Central Management Server name is included in the list. Use -NoCmsServer to exclude the CMS itself.
+			If a group is not provided then by default, the Central Management Server name is included in the output.
+			If not searching by group then use -NoCmsServer to exclude the CMS itself.
 
 		.PARAMETER NetBiosName
 			Returns just the NetBios names of each server.
@@ -40,27 +42,32 @@ function Get-DbaRegisteredServerName {
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a
 
-			Gets a list of all server names from the Central Management Server on sqlserver2014a, using Windows Credentials
+			Gets a list of all server names from the CMS on sqlserver2014a, using Windows Credentials
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -SqlCredential $credential
 
-			Gets a list of all server names from the Central Management Server on sqlserver2014a, using SQL Authentication
+			Gets a list of all server names from the CMS on sqlserver2014a, using SQL Authentication
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting
 
-			Gets a list of server names in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
+			Gets a list of server names in the HR and Accounting groups from the CMS on sqlserver2014a.
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddress
 
-			Gets a list of server IP addresses in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
+			Gets a list of server IP addresses in the HR and Accounting groups from the CMS on sqlserver2014a.
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -NoCmsServer
 
-			Gets a list of server names from the Central Management Server on sqlserver2014a, but excludes the cms server name.
+			Gets a list of server names from the CMS on sqlserver2014a, but excludes the CMS server name.
+		
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR\Development
+
+			Returns a list of server names in the HR and sub-group Development from the CMS on sqlserver2014a
 
 	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]

--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -138,7 +138,7 @@ function Get-DbaRegisteredServerName {
 				$servers += ($cms.GetDescendantRegisteredServers()).ServerName
 			}
 
-			if ($NoCmsServer -eq $false) {
+			if ($NoCmsServer -eq $false -and $Group -eq $null) {
 				$servers += $SqlInstance.ComputerName
 			}
 		}

--- a/tests/Get-DbaRegisteredServerName.Tests.ps1
+++ b/tests/Get-DbaRegisteredServerName.Tests.ps1
@@ -1,0 +1,60 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "Setup" {
+		BeforeAll {
+			$server = Connect-DbaSqlServer $script:instance1
+			$regStore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($server.ConnectionContext.SqlConnectionObject)
+			$dbStore = $regStore.DatabaseEngineServerGroup
+
+			$srvName = "dbatoolsci-server1"
+			$group = "dbatoolsci-group1"
+			$regSrvName = "dbatoolsci-server12"
+			$regSrvDesc = "dbatoolsci-server123"
+
+			<# Create that first group #>
+			$newGroup = New-Object Microsoft.SqlServer.Management.RegisteredServers.ServerGroup($dbStore, $group)
+			$newGroup.Create()
+			$dbStore.Refresh()
+
+			$groupStore = $dbStore.ServerGroups[$group]
+			$newServer = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer($groupStore,$regSrvName)
+			$newServer.ServerName = $srvName
+			$newServer.Description = $regSrvDesc
+			$newServer.Create()
+
+			<# Create the sub-group #>
+			$srvName2 = "dbatoolsci-server2"
+			$group2 = "dbatoolsci-group1a"
+			$regSrvName2 = "dbatoolsci-server21"
+			$regSrvDesc2 = "dbatoolsci-server321"
+
+			$newGroup2 = New-Object Microsoft.SqlServer.Management.RegisteredServers.ServerGroup($groupStore,$group2)
+			$newGroup2.Create()
+			$dbStore.Refresh()
+
+			$groupStore2 = $dbStore.ServerGroups[$group].ServerGroups[$group2]
+			$newServer2 = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer($groupStore2,$regSrvName2)
+			$newServer2.ServerName = $srvName2
+			$newServer2.Description = $regSrvDesc2
+			$newServer2.Create()
+		}
+		AfterAll {
+			<# The top level group is all that is needed to be dropped #>
+			$newGroup.Drop()
+		}
+
+		It "Should return multiple objects" {
+			$results = Get-DbaRegisteredServerName -SqlInstance $script:instance1 -Group $group
+			$results.Count | Should Be 2
+		}
+		It "Should allow searching subgroups" {
+			$results = Get-DbaRegisteredServerName -SqlInstance $script:instance1 -Group "$group\$group2"
+			$results.Count | Should Be 1
+		}
+		
+		# Property Comparisons will come later when we have the commands
+	}
+}

--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -3,7 +3,7 @@ if (Test-Path C:\temp\constants.ps1) {
 	. C:\temp\constants.ps1
 }
 else {
-	$script:instance1 = "localhost\sql2008r2sp2"
+	$script:instance1 = "sql2016a"
 	$script:instance2 = "localhost\sql2016"
 	$script:appeyorlabrepo = "C:\github\appveyor-lab"
 	$instances = @($script:instance1, $script:instance2)

--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -3,7 +3,7 @@ if (Test-Path C:\temp\constants.ps1) {
 	. C:\temp\constants.ps1
 }
 else {
-	$script:instance1 = "sql2016a"
+	$script:instance1 = "localhost\sql2008r2sp2"
 	$script:instance2 = "localhost\sql2016"
 	$script:appeyorlabrepo = "C:\github\appveyor-lab"
 	$instances = @($script:instance1, $script:instance2)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1975 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixing a bug when passing in a group to the command. The dynamic part of the parameter is not working for me anymore but it should accept the value now.
### Approach
<!-- How does this change solve that purpose -->
Found a few issues where we were checking for an empty string/whitespace in an inaccurate method. Adjusted that to properly validate if the string was null, empty, or whitespaced.

As well added proper param block to the internal command so it is more clear parameters being passed to it, and corrected spelling error on parameter name (`$Bbase` to `$Base`).

### Commands to test
<!-- if these are the examples in the help just not it as such -->
`Get-DbaRegisteredServerName -SqlInstance Server -Group SomeGroup`

`Get-DbaRegisteredServerName -SqlInstance Server`
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Passing `-Group`

![image](https://user-images.githubusercontent.com/11204251/28876842-235edaec-7760-11e7-8ca9-bf6f47b5b67d.png)

No `-Group`

![image](https://user-images.githubusercontent.com/11204251/28877037-c001c13e-7760-11e7-8650-72c7720df66d.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
Issue was being hit at line 99 with validating two variables that contained the group being passed in. Line 93 was also wrong so updated it to validate the `$Base`.

![image](https://user-images.githubusercontent.com/11204251/28878205-3301591c-7764-11e7-8053-6a93ff62c917.png)

A bit of research and chatting with Klaas. Came across [proper way to check for empty string](https://blogs.technet.microsoft.com/heyscriptingguy/2015/10/07/dude-a-string-is-a-string-in-powershell/) and updated line 93 to be `$Base -eq $null -or [string]::IsNullOrWhiteSpace($Base)`