### PR TITLE
fix for snapshot functions, plus tests

### DIFF
--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -234,17 +234,16 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
 						}
 						foreach ($file in $fg.Files) {
 							$counter += 1
-							# fixed extension is hardcoded as "ss", which seems a "de-facto" standard
-							$fname = [IO.Path]::ChangeExtension($file.Filename, "ss")
-							$fname = [IO.Path]::Combine((Split-Path $fname -Parent), ("{0}_{1}" -f $DefaultSuffix, (Split-Path $fname -Leaf)))
-							
+							$basename = [IO.Path]::GetFileNameWithoutExtension($file.FileName)
+							$basepath = Split-Path $file.FileName -Parent
 							# change path if specified
 							if ($Path.Length -gt 0) {
-								$basename = Split-Path $fname -Leaf
-								# we need to avoid cases where basename is the same for multiple FG
-								$basename = '{0:0000}_{1}' -f $counter, $basename
-								$fname = [IO.Path]::Combine($Path, $basename)
+								$basepath = $Path
 							}
+							# we need to avoid cases where basename is the same for multiple FG
+							$fname = [IO.Path]::Combine($basepath, ("{0}_{1}_{2:0000}_{3:000}" -f $basename, $DefaultSuffix, (Get-Date).MilliSecond, $counter))
+							# fixed extension is hardcoded as "ss", which seems a "de-facto" standard
+							$fname = [IO.Path]::ChangeExtension($fname, "ss")
 							$CustomFileStructure[$fg.Name] += @{ 'name' = $file.name; 'filename' = $fname }
 						}
 					}

--- a/functions/Remove-DbaDatabaseSnapshot.ps1
+++ b/functions/Remove-DbaDatabaseSnapshot.ps1
@@ -167,6 +167,7 @@ Removes all snapshots associated with databases that have dumpsterfire in the na
 					continue
 				}
 				if ($Pscmdlet.ShouldProcess($server.name, "Remove db snapshot $db")) {
+					$basedb = $db.DatabaseSnapshotBaseName
 					try {
 						if ($Force) {
 							# cannot drop the snapshot if someone is using it
@@ -183,7 +184,7 @@ Removes all snapshots associated with databases that have dumpsterfire in the na
 						InstanceName = $server.ServiceName
 						SqlInstance  = $server.DomainInstanceName
 						Database     = $db
-						SnapshotOf   = $db.DatabaseSnapshotBaseName
+						SnapshotOf   = $basedb
 						Status       = $status
 					}
 				}

--- a/tests/New-DbaDatabaseSnapshot.Tests.ps1
+++ b/tests/New-DbaDatabaseSnapshot.Tests.ps1
@@ -72,15 +72,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 			$ExpectedProps = 'ComputerName,Database,DatabaseCreated,InstanceName,Notes,PrimaryFilePath,SizeMB,SnapshotDb,SnapshotOf,SqlInstance,Status'.Split(',')
 			($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 		}
-		# Removed default properties since they change and fail on appveyor
-		if (-not $env:APPVEYOR_REPO_BRANCH) {
-			It "Has the correct default properties" {
-				$null = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
-				$result = New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent -Database $db2
-				$ExpectedPropsDefault = 'ComputerName,Database,DatabaseCreated,InstanceName,Notes,PrimaryFilePath,SizeMB,SnapshotOf,SqlInstance,Status'.Split(',')
-				($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
-			}
+		
+		It "Has the correct default properties" {
+			$null = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
+			$result = New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent -Database $db2
+			$ExpectedPropsDefault = 'ComputerName,Database,DatabaseCreated,InstanceName,Notes,PrimaryFilePath,SizeMB,SnapshotOf,SqlInstance,Status'.Split(',')
+			($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
 		}
+		
 	}
 }
 

--- a/tests/Remove-DbaDatabaseSnapshot.Tests.ps1
+++ b/tests/Remove-DbaDatabaseSnapshot.Tests.ps1
@@ -1,0 +1,88 @@
+﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+
+# Targets only instance2 because it's the only one where Snapshots can happen
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		$server = Connect-DbaSqlServer -SqlInstance $script:instance2
+		$db1 = "dbatoolsci_RemoveSnap"
+		$db1_snap1 = "dbatoolsci_RemoveSnap_snapshotted1"
+		$db1_snap2 = "dbatoolsci_RemoveSnap_snapshotted2"
+		$db2 = "dbatoolsci_RemoveSnap2"
+		$db2_snap1 = "dbatoolsci_RemoveSnap2_snapshotted"
+		Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1,$db2 -Force
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $db1,$db2 | Remove-DbaDatabase
+		$server.Query("CREATE DATABASE $db1")
+		$server.Query("CREATE DATABASE $db2")
+		$needed = Get-DbaDatabase -SqlInstance $script:instance2 -Database $db1,$db2
+		$setupright = $true
+		if ($needed.Count -ne 2) {
+			$setupright = $false
+			it "has failed setup" {
+				Set-TestInconclusive -message "Setup failed"
+			}
+		}
+	}
+	AfterAll {
+		Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1,$db2 -Force -ErrorAction SilentlyContinue
+		Remove-DbaDatabase -SqlInstance $script:instance2 -Database $db1,$db2 -ErrorAction SilentlyContinue
+	}
+	Context "Parameters validation" {
+		It "Stops if no Database or AllDatabases" {
+			{ Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent } | Should Throw "You must specify"
+		}
+		It "Is nice by default" {
+			{ Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 *> $null } | Should Not Throw "You must specify"
+		}
+	}
+	Context "Operations on snapshots" {
+		BeforeEach {
+			$needed = @()
+			$needed += New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1 -Name $db1_snap1 -ErrorAction SilentlyContinue
+			$needed += New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1 -Name $db1_snap2 -ErrorAction SilentlyContinue
+			$needed += New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Name $db2_snap1 -ErrorAction SilentlyContinue
+			if ($needed.Count -ne 3) {
+				Set-TestInconclusive -message "Setup failed"
+			}
+		}
+		AfterEach {
+			Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1,$db2 -Force -ErrorAction SilentlyContinue
+		}
+	
+		if ($setupright) {
+			It "Honors the Database parameter, dropping only snapshots of that database" {
+				$results = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1 -Force
+				$results.Count | Should Be 2
+				$result = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
+				$result.SnapshotOf | Should Be $db2
+			}
+			It "Honors the ExcludeDatabase parameter, returning relevant snapshots" {
+				$alldbs = (Get-DbaDatabase -SqlInstance $script:instance2 | Where-Object IsDatabaseSnapShot -eq $false | Where-Object Name -notin @($db1, $db2)).Name
+				$results = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -ExcludeDatabase $alldbs -Force
+				$results.Count | Should Be 3
+			}
+			It "Honors the Snapshot parameter" {
+				$result = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Snapshot $db1_snap1
+				$result.Database.Name | Should Be $db1_snap1
+				$result.SnapshotOf | Should Be $db1
+			}
+			It "Works with piped snapshots" {
+				$result = Get-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Snapshot $db1_snap1 | Remove-DbaDatabaseSnapshot -Force
+				$result.Database | Should Be $db1_snap1
+				$result.SnapshotOf | Should Be $db1
+				$result = Get-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Snapshot $db1_snap1
+				$result | Should Be $null
+			}
+			It "Has the correct properties" {
+				$result = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
+				$ExpectedProps = 'ComputerName,Database,InstanceName,SnapshotOf,SqlInstance,Status'.Split(',')
+				($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+			}
+			
+		}
+	}
+}
+
+


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Pester test is included

### Purpose
making new-dbadatabasesnapshot and remove-dbadatabasesnapshot more resilient.


### Approach
new-dbadatabasesnapshot failed on ultra-speedy instances (when snap creation was sub-second). Now it includes milliseconds, too. 
Also, filename and paths diverged a bit when -Path was passed or not. That logic has been streamlined.
remove-dbadatabasesnapshot relied on the $db object to be present after dropping, but it was not always the case when the snapshot removal took a few seconds. The SnapshotOf property gets now filled before the actual drop.

----
pester tests are included/updated accordingly