### PR TITLE
new-dbadatabasesnapshot tests, speedup

### DIFF
--- a/tests/New-DbaDatabaseSnapshot.Tests.ps1
+++ b/tests/New-DbaDatabaseSnapshot.Tests.ps1
@@ -29,11 +29,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 			$server.Query("CREATE DATABASE $db1")
 			$server.Query("CREATE DATABASE $db2")
 			$server.Query("CREATE DATABASE $db3")
-			$null = Set-DbaDatabaseState -Sqlinstance $script:instance2 -Database $db3 -Offline -Force
+			$server.Query("ALTER DATABASE $db3 SET OFFLINE WITH ROLLBACK IMMEDIATE")
 		}
 		AfterAll {
-			Stop-DbaProcess -SqlInstance $script:instance2 -Database $db1, $db2, $db3
-			$null = Set-DbaDatabaseState -Sqlinstance $script:instance2 -Database $db3 -Online -Force
+			$server.Query("ALTER DATABASE $db3 SET ONLINE WITH ROLLBACK IMMEDIATE")
 			Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db1,$db2,$db3 -Force
 			Remove-DbaDatabase -SqlInstance $script:instance2 -Database $db1,$db2,$db3
 		}


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
appveyor has issues enumerating $db.useraccess. Set-DbadatabaseState takes a long time to execute there so, waiting for a fix on the enums, this speeds up the setup phase.
