### PR TITLE
Address issue where we connect using Windows Auth when Credential is provided

### DIFF
--- a/functions/Connect-DbaSqlServer.ps1
+++ b/functions/Connect-DbaSqlServer.ps1
@@ -210,7 +210,7 @@ function Connect-DbaSqlServer {
             return $SqlInstance
         }
 		
-        $server = New-Object Microsoft.SqlServer.Management.Smo.Server ([guid]::NewGuid())
+        $server = New-Object Microsoft.SqlServer.Management.Smo.Server ([System.Guid]::NewGuid())
 		
         if ($AppendConnectionString) {
             $connstring = $server.ConnectionContext.ConnectionString

--- a/functions/Connect-DbaSqlServer.ps1
+++ b/functions/Connect-DbaSqlServer.ps1
@@ -1,4 +1,4 @@
-Function Connect-DbaSqlServer {
+function Connect-DbaSqlServer {
     <#
     .SYNOPSIS
         Creates an efficient SMO SQL Server object.
@@ -210,7 +210,7 @@ Function Connect-DbaSqlServer {
             return $SqlInstance
         }
 		
-        $server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlInstance
+        $server = New-Object Microsoft.SqlServer.Management.Smo.Server ([guid]::NewGuid())
 		
         if ($AppendConnectionString) {
             $connstring = $server.ConnectionContext.ConnectionString
@@ -268,7 +268,7 @@ Function Connect-DbaSqlServer {
                         $server.ConnectionContext.set_SecurePassword($Credential.Password)
                     }
                 }
-				
+				$server.ConnectionContext.ServerInstance = $SqlInstance
                 $server.ConnectionContext.Connect()
             }
             catch {
@@ -282,10 +282,10 @@ Function Connect-DbaSqlServer {
 			
         }
 		
-		$loadedsmoversion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }
+		$loadedSmoVersion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }
 		
-		if ($loadedsmoversion) {
-			$loadedsmoversion = $loadedsmoversion | ForEach-Object {
+		if ($loadedSmoVersion) {
+			$loadedSmoVersion = $loadedSmoVersion | ForEach-Object {
 				if ($_.Location -match "__") {
 					((Split-Path (Split-Path $_.Location) -Leaf) -split "__")[0]
 				}
@@ -295,7 +295,7 @@ Function Connect-DbaSqlServer {
 			}
 		}
 		
-		if ($loadedsmoversion -ge 11) {
+		if ($loadedSmoVersion -ge 11) {
 			if ($server.VersionMajor -eq 8) {
 				# 2000
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Version')

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -121,7 +121,7 @@ function Connect-SqlInstance {
 		}
 	}
 	
-	$server = New-Object Microsoft.SqlServer.Management.Smo.Server ([guid]::NewGuid())
+	$server = New-Object Microsoft.SqlServer.Management.Smo.Server ([System.Guid]::NewGuid())
 	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
 	
 	try {

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -1,4 +1,4 @@
-﻿function Connect-SqlInstance {
+function Connect-SqlInstance {
     <#
         .SYNOPSIS
             Internal function to establish smo connections.
@@ -36,7 +36,7 @@
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
-		[Object]$SqlInstance,
+		[object]$SqlInstance,
 		[object]$SqlCredential,
 		[switch]$ParameterConnection,
 		[switch]$RegularUser = $true,
@@ -83,34 +83,6 @@
 	#region Input Object was a server object
 	if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 		$server = $ConvertedSqlInstance.InputObject
-		if ($ParameterConnection) {
-			$paramserver = New-Object Microsoft.SqlServer.Management.Smo.Server
-			$paramserver.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
-			$paramserver.ConnectionContext.ConnectionString = $server.ConnectionContext.ConnectionString
-			
-			if ($SqlCredential.username -ne $null) {
-				$username = ($SqlCredential.username).TrimStart("\")
-				
-				if ($username -like "*\*") {
-					$username = $username.Split("\")[1]
-					$authtype = "Windows Authentication with Credential"
-					$paramserver.ConnectionContext.LoginSecure = $true
-					$paramserver.ConnectionContext.ConnectAsUser = $true
-					$paramserver.ConnectionContext.ConnectAsUserName = $username
-					$paramserver.ConnectionContext.ConnectAsUserPassword = ($SqlCredential).GetNetworkCredential().Password
-				}
-				else {
-					$authtype = "SQL Authentication"
-					$paramserver.ConnectionContext.LoginSecure = $false
-					$paramserver.ConnectionContext.set_Login($username)
-					$paramserver.ConnectionContext.set_SecurePassword($SqlCredential.Password)
-				}
-			}
-			
-			$paramserver.ConnectionContext.Connect()
-			return $paramserver
-		}
-		
 		if ($server.ConnectionContext.IsOpen -eq $false) {
 			$server.ConnectionContext.Connect()
 		}
@@ -130,17 +102,16 @@
 				$ExecutionContext.InvokeCommand.InvokeScript($false, $scriptBlock, $null, $null)
 			}
 		}
-		
 		return $server
 	}
 	#endregion Input Object was a server object
 	
 	#region Input Object was anything else
 	# This seems a little complex but is required because some connections do TCP,SqlInstance
-	$loadedsmoversion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }
+	$loadedSmoVersion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName -like "Microsoft.SqlServer.SMO,*" }
 	
-	if ($loadedsmoversion) {
-		$loadedsmoversion = $loadedsmoversion | ForEach-Object {
+	if ($loadedSmoVersion) {
+		$loadedSmoVersion = $loadedSmoVersion | ForEach-Object {
 			if ($_.Location -match "__") {
 				((Split-Path (Split-Path $_.Location) -Leaf) -split "__")[0]
 			}
@@ -160,8 +131,8 @@
 	}
 	
 	try {
-		if ($SqlCredential.username -ne $null) {
-			$username = ($SqlCredential.username).TrimStart("\")
+		if ($SqlCredential.Username -ne $null) {
+			$username = ($SqlCredential.Username).TrimStart("\")
 			
 			if ($username -like "*\*") {
 				$username = $username.Split("\")[1]
@@ -181,11 +152,7 @@
 	}
 	catch { }
 	
-	try {
-		if ($ParameterConnection) {
-			$server.ConnectionContext.ConnectTimeout = 7
-		}
-		
+	try {		
 		$server.ConnectionContext.Connect()
 	}
 	catch {
@@ -208,9 +175,9 @@
 		}
 	}
 	
-	if ($loadedsmoversion -ge 11) {
+	if ($loadedSmoVersion -ge 11) {
 		try {
-			if (-not $ParameterConnection -or ($Server.ServerType -ne 'SqlAzureDatabase')) {
+			if ($Server.ServerType -ne 'SqlAzureDatabase') {
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Trigger], 'IsSystemObject')
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Schema], 'IsSystemObject')
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.SqlAssembly], 'IsSystemObject')
@@ -224,13 +191,11 @@
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Version')
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'CreateDate', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'Name', 'Sid', 'WindowsLoginAccessType')
 				}
-				
 				elseif ($server.VersionMajor -eq 9 -or $server.VersionMajor -eq 10) {
 					# 2005 and 2008
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'BrokerEnabled', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsMirroringEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Trustworthy', 'Version')
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'AsymmetricKey', 'Certificate', 'CreateDate', 'Credential', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'MustChangePassword', 'Name', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced', 'Sid', 'WindowsLoginAccessType')
 				}
-				
 				else {
 					# 2012 and above
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'ActiveConnections', 'AvailabilityDatabaseSynchronizationState', 'AvailabilityGroupName', 'BrokerEnabled', 'Collation', 'CompatibilityLevel', 'ContainmentType', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsMirroringEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Trustworthy', 'Version')


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix ( non-breaking change, fixes #2012 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (affects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
It was found after debugging and stepping through `Connect-SqlServer` that when a credential object is passed in, or the `-MinimumVersion` parameter was used in a command that an attempt is made to connect to the given SQL Server instance. This allows for an unknown login attempt by the account running the PowerShell session/host.

The main issue where this is found is when the account running the PowerShell host does not have access to the given SQL Server instance. The instance will log multiple login failed attempts just by executing a single command. If a credential (e.g. SQL Login) is provided it still attempts to login as the account running the PowerShell host. [See learning section below.]
### Approach
<!-- How does this change solve that purpose -->
By provided a known bogus server name then no connection will be made until the `$server.ConnectionContext.Connect()` line of either command is executed.
### Commands to test
<!-- if these are the examples in the help just not it as such -->
Appveyor test should run enough as the Pester test utilize `Connect-DbaSqlServer` and then the commands run in the integration test call `Connect-SqlInstance`.
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Will provide a blog post that details how this was identified in debugging.
### Learning
This was one of those "after I saw it I knew/recall why this happens".

The general reasoning is just executing this command in a PowerShell host will cause an attempted connection to the `localhost`:
```powershell
New-Object Microsoft.SqlServer.Management.Smo.Server
```

If the `localhost` does not have SQL Server running, then you will never notice anything. If the `localhost` has SQL Server running, but the account executing it does not have access then a login failed message will be logged, **but you will not see any error posted to the PowerShell host**.

So as we do this in our code (or close to it):
```powershell
$server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlInstance
```
This will try to immediately connect to the `$SqlInstance` as soon as that line is run. Then, as well, any subsequent line that accesses the `$server` object will cause additional login attempts to be performed.

The only workaround to this is to pass in a bogus server to the initial `New-Object` so it connects to nothing. That is the sole purpose in this `([System.Guid]::NewGuid())`. PowerShell 5 offers `New-Guid` but in order to support back to PowerShell 3 we have to use the `System.Guid` 's `NewGuid()` method.