### PR TITLE
Get-DbaCmObject reliability and performance upgrade

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 0, 18)
+$currentLibraryVersion = New-Object System.Version(0, 6, 0, 19)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools.Tests/Connection/ManagementConnectionTest.cs
+++ b/bin/projects/dbatools/dbatools.Tests/Connection/ManagementConnectionTest.cs
@@ -15,7 +15,7 @@ namespace Sqlcollaborative.Dbatools.Connection
             Assert.IsFalse(mgmtCn.DisableBadCredentialCache);
             Assert.IsFalse(mgmtCn.DisableCimPersistence);
             Assert.IsFalse(mgmtCn.DisableCredentialAutoRegister);
-            Assert.AreEqual(ManagementConnectionType.None, mgmtCn.DisabledConnectionTypes);
+            Assert.AreEqual(ManagementConnectionType.Wmi | ManagementConnectionType.PowerShellRemoting, mgmtCn.DisabledConnectionTypes);
             Assert.IsFalse(mgmtCn.EnableCredentialFailover);
             Assert.IsFalse(mgmtCn.OverrideExplicitCredential);
             Assert.IsFalse(mgmtCn.UseWindowsCredentials);

--- a/bin/projects/dbatools/dbatools/Connection/ConnectionHost.cs
+++ b/bin/projects/dbatools/dbatools/Connection/ConnectionHost.cs
@@ -48,6 +48,26 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// Globally disables the persistence of Cim sessions used to connect to a target system.
         /// </summary>
         public static bool DisableCimPersistence = false;
+
+        /// <summary>
+        /// Whether the CM connection using Cim over WinRM is disabled globally
+        /// </summary>
+        public static bool DisableConnectionCimRM = false;
+
+        /// <summary>
+        /// Whether the CM connection using Cim over DCOM is disabled globally
+        /// </summary>
+        public static bool DisableConnectionCimDCOM = false;
+
+        /// <summary>
+        /// Whether the CM connection using WMI is disabled globally
+        /// </summary>
+        public static bool DisableConnectionWMI = true;
+
+        /// <summary>
+        /// Whether the CM connection using PowerShell Remoting is disabled globally
+        /// </summary>
+        public static bool DisableConnectionPowerShellRemoting = true;
         #endregion Configuration
     }
 }

--- a/bin/projects/dbatools/dbatools/Connection/ManagementConnection.cs
+++ b/bin/projects/dbatools/dbatools/Connection/ManagementConnection.cs
@@ -217,16 +217,32 @@ namespace Sqlcollaborative.Dbatools.Connection
             _overrideExplicitCredential = 0;
             _disableCimPersistence = 0;
             _enableCredentialFailover = 0;
+            OverrideConnectionPolicy = false;
         }
 
         #endregion Configuration
 
         #region Connection Stats
+        /// <summary>
+        /// Whether this connection adhers to the global connection lockdowns or not
+        /// </summary>
+        public bool OverrideConnectionPolicy = false;
 
         /// <summary>
         /// Did the last connection attempt using CimRM work?
         /// </summary>
-        public ManagementConnectionProtocolState CimRM = ManagementConnectionProtocolState.Unknown;
+        public ManagementConnectionProtocolState CimRM
+        {
+            get
+            {
+                if (!OverrideConnectionPolicy && ConnectionHost.DisableConnectionCimRM)
+                    return ManagementConnectionProtocolState.Disabled;
+                else
+                    return _CimRM;
+            }
+            set { _CimRM = value; }
+        }
+        private ManagementConnectionProtocolState _CimRM = ManagementConnectionProtocolState.Unknown;
 
         /// <summary>
         /// When was the last connection attempt using CimRM?
@@ -236,7 +252,18 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// <summary>
         /// Did the last connection attempt using CimDCOM work?
         /// </summary>
-        public ManagementConnectionProtocolState CimDCOM = ManagementConnectionProtocolState.Unknown;
+        public ManagementConnectionProtocolState CimDCOM
+        {
+            get
+            {
+                if (!OverrideConnectionPolicy && ConnectionHost.DisableConnectionCimDCOM)
+                    return ManagementConnectionProtocolState.Disabled;
+                else
+                    return _CimDCOM;
+            }
+            set { _CimDCOM = value; }
+        }
+        private ManagementConnectionProtocolState _CimDCOM = ManagementConnectionProtocolState.Unknown;
 
         /// <summary>
         /// When was the last connection attempt using CimRM?
@@ -246,7 +273,18 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// <summary>
         /// Did the last connection attempt using Wmi work?
         /// </summary>
-        public ManagementConnectionProtocolState Wmi = ManagementConnectionProtocolState.Unknown;
+        public ManagementConnectionProtocolState Wmi
+        {
+            get
+            {
+                if (!OverrideConnectionPolicy && ConnectionHost.DisableConnectionWMI)
+                    return ManagementConnectionProtocolState.Disabled;
+                else
+                    return _Wmi;
+            }
+            set { _Wmi = value; }
+        }
+        private ManagementConnectionProtocolState _Wmi = ManagementConnectionProtocolState.Unknown;
 
         /// <summary>
         /// When was the last connection attempt using CimRM?
@@ -256,7 +294,18 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// <summary>
         /// Did the last connection attempt using PowerShellRemoting work?
         /// </summary>
-        public ManagementConnectionProtocolState PowerShellRemoting = ManagementConnectionProtocolState.Unknown;
+        public ManagementConnectionProtocolState PowerShellRemoting
+        {
+            get
+            {
+                if (!OverrideConnectionPolicy && ConnectionHost.DisableConnectionPowerShellRemoting)
+                    return ManagementConnectionProtocolState.Disabled;
+                else
+                    return _PowerShellRemoting;
+            }
+            set { _PowerShellRemoting = value; }
+        }
+        private ManagementConnectionProtocolState _PowerShellRemoting = ManagementConnectionProtocolState.Unknown;
 
         /// <summary>
         /// When was the last connection attempt using CimRM?
@@ -795,34 +844,9 @@ namespace Sqlcollaborative.Dbatools.Connection
             CimSession tempSession;
             IEnumerable<CimInstance> result;
 
-            try
-            {
-                tempSession = GetCimWinRMSession(Credential);
-                result = tempSession.EnumerateInstances(Namespace, Class);
-                result.GetEnumerator().MoveNext();
-            }
-            catch (Exception e)
-            {
-                bool testBadCredential = false;
-                try
-                {
-                    string tempMessageId = ((CimException) e).MessageId;
-                    if (tempMessageId == "HRESULT 0x8007052e")
-                        testBadCredential = true;
-                    else if (tempMessageId == "HRESULT 0x80070005")
-                        testBadCredential = true;
-                }
-                catch
-                {
-                }
-
-                if (testBadCredential)
-                {
-                    throw new UnauthorizedAccessException("Invalid credentials!", e);
-                }
-                throw;
-            }
-
+            tempSession = GetCimWinRMSession(Credential);
+            result = tempSession.EnumerateInstances(Namespace, Class);
+            
             if (DisableCimPersistence)
             {
                 try
@@ -1028,33 +1052,8 @@ namespace Sqlcollaborative.Dbatools.Connection
             CimSession tempSession;
             IEnumerable<CimInstance> result = new List<CimInstance>();
 
-            try
-            {
-                tempSession = GetCimDComSession(Credential);
-                result = tempSession.EnumerateInstances(Namespace, Class);
-                result.GetEnumerator().MoveNext();
-            }
-            catch (Exception e)
-            {
-                bool testBadCredential = false;
-                try
-                {
-                    string tempMessageId = ((CimException) e).MessageId;
-                    if (tempMessageId == "HRESULT 0x8007052e")
-                        testBadCredential = true;
-                    else if (tempMessageId == "HRESULT 0x80070005")
-                        testBadCredential = true;
-                }
-                catch
-                {
-                }
-
-                if (testBadCredential)
-                {
-                    throw new UnauthorizedAccessException("Invalid credentials!", e);
-                }
-                throw;
-            }
+            tempSession = GetCimDComSession(Credential);
+            result = tempSession.EnumerateInstances(Namespace, Class);
 
             if (DisableCimPersistence)
             {
@@ -1089,33 +1088,9 @@ namespace Sqlcollaborative.Dbatools.Connection
             CimSession tempSession;
             IEnumerable<CimInstance> result = new List<CimInstance>();
 
-            try
-            {
-                tempSession = GetCimDComSession(Credential);
-                result = tempSession.QueryInstances(Namespace, Dialect, Query);
-                result.GetEnumerator().MoveNext();
-            }
-            catch (Exception e)
-            {
-                bool testBadCredential = false;
-                try
-                {
-                    string tempMessageId = ((CimException) e).MessageId;
-                    if (tempMessageId == "HRESULT 0x8007052e")
-                        testBadCredential = true;
-                    else if (tempMessageId == "HRESULT 0x80070005")
-                        testBadCredential = true;
-                }
-                catch
-                {
-                }
-
-                if (testBadCredential)
-                {
-                    throw new UnauthorizedAccessException("Invalid credentials!", e);
-                }
-                throw;
-            }
+            tempSession = GetCimDComSession(Credential);
+            result = tempSession.QueryInstances(Namespace, Dialect, Query);
+            result.GetEnumerator().MoveNext();
 
             if (DisableCimPersistence)
             {

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.0.18")]
-[assembly: AssemblyFileVersion("0.6.0.18")]
+[assembly: AssemblyVersion("0.6.0.19")]
+[assembly: AssemblyFileVersion("0.6.0.19")]

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -1,246 +1,272 @@
 ﻿function Get-DbaCmObject {
-    <#
-    .SYNOPSIS
-    Retrieves Wmi/Cim-Style information from computers.
-
-    .DESCRIPTION
-    This function centralizes all requests for information retrieved from Get-WmiObject or Get-CimInstance.
-    It uses different protocols as available in this order:
-        - Cim over WinRM
-        - Cim over DCOM
-        - Wmi
-        - Wmi over PowerShell Remoting
-    It remembers channels that didn't work and will henceforth avoid them. It remembers invalid credentials and will avoid reusing them.
-    Much of its behavior can be configured using Test-DbaWmConnection.
-
-    .PARAMETER ClassName
-    The name of the class to retrieve.
+<#
+	.SYNOPSIS
+		Retrieves Wmi/Cim-Style information from computers.
+	
+	.DESCRIPTION
+		This function centralizes all requests for information retrieved from Get-WmiObject or Get-CimInstance.
+		It uses different protocols as available in this order:
+		- Cim over WinRM
+		- Cim over DCOM
+		- Wmi
+		- Wmi over PowerShell Remoting
+		It remembers channels that didn't work and will henceforth avoid them. It remembers invalid credentials and will avoid reusing them.
+		Much of its behavior can be configured using Test-DbaWmConnection.
+	
+	.PARAMETER ClassName
+		The name of the class to retrieve.
 	
 	.PARAMETER Query
-	The Wmi/Cim query tu run against the server.
-
-    .PARAMETER ComputerName
-    The computer(s) to connect to. Defaults to localhost.
-
-    .PARAMETER Credential
-    Credentials to use. Invalid credentials will be stored in a credentials cache and not be reused.
-
-    .PARAMETER Namespace
-    The namespace of the class to use.
-
-    .PARAMETER DoNotUse
-    Connection Protocols that should not be used.
-
-    .PARAMETER Force
-    Overrides some checks that might otherwise halt execution as a precaution
-    - Ignores timeout on bad connections
+		The Wmi/Cim query tu run against the server.
+	
+	.PARAMETER ComputerName
+		The computer(s) to connect to. Defaults to localhost.
+	
+	.PARAMETER Credential
+		Credentials to use. Invalid credentials will be stored in a credentials cache and not be reused.
+	
+	.PARAMETER Namespace
+		The namespace of the class to use.
+	
+	.PARAMETER DoNotUse
+		Connection Protocols that should not be used.
+	
+	.PARAMETER Force
+		Overrides some checks that might otherwise halt execution as a precaution
+		- Ignores timeout on bad connections
 	
 	.PARAMETER SilentlyContinue
-	Use in conjunction with the -Silent switch.
-	By default, Get-DbaCmObject will throw a terminating exception when connecting to a target is impossible in silent mode.
-	Setting this switch will cause it write a non-terminating exception and continue with the next computer.
-
-    .PARAMETER Silent
-    Replaces user friendly yellow warnings with bloody red exceptions of doom!
-    Use this if you want the function to throw terminating errors you want to catch.
-
+		Use in conjunction with the -Silent switch.
+		By default, Get-DbaCmObject will throw a terminating exception when connecting to a target is impossible in silent mode.
+		Setting this switch will cause it write a non-terminating exception and continue with the next computer.
+	
+	.PARAMETER Silent
+		Replaces user friendly yellow warnings with bloody red exceptions of doom!
+		Use this if you want the function to throw terminating errors you want to catch.
+	
+	.EXAMPLE
+		Get-DbaCmObject win32_OperatingSystem
+		
+		Retrieves the common operating system informations from the local computer.
+	
+	.EXAMPLE
+		Get-DbaCmObject -Computername "sql2014" -ClassName Win32_OperatingSystem -Credential $cred -DoNotUse CimRM
+		
+		Retrieves the common operating system informations from the server sql2014.
+		It will use the credewntials stored in $cred to connect, unless they are known to not work, in which case they will default to windows credentials (unless another default has been set).
+	
 	.NOTES
-	Original Author: Fred Winmann (@FredWeinmann)
-	Tags: ComputerManagement
-
-	Website: https://dbatools.io
-	Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
-
+		Original Author: Fred Winmann (@FredWeinmann)
+		Tags: ComputerManagement
+		
+		Website: https://dbatools.io
+		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+	
 	.LINK
-	https://dbatools.io/Get-DbaCmObject
-
-    .EXAMPLE
-    Get-DbaCmObject win32_OperatingSystem
-
-    Retrieves the common operating system informations from the local computer.
-
-    .EXAMPLE
-    Get-DbaCmObject -Computername "sql2014" -ClassName Win32_OperatingSystem -Credential $cred -DoNotUse CimRM
-
-    Retrieves the common operating system informations from the server sql2014.
-    It will use the credewntials stored in $cred to connect, unless they are known to not work, in which case they will default to windows credentials (unless another default has been set).
-    #>
-    [CmdletBinding(DefaultParameterSetName = "Class")]
-    param (
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Class")]
-        [Alias('Class')]
-        [string]
-        $ClassName,
-
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
-        [string]
-        $Query,
-
-        [Parameter(ValueFromPipeline = $true)]
-        [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
-        $ComputerName = $env:COMPUTERNAME,
-
-        [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [string]
-        $Namespace = "root\cimv2",
-
-        [Sqlcollaborative.Dbatools.Connection.ManagementConnectionType[]]
-        $DoNotUse = "None",
-
-        [switch]
-        $Force,
-
-        [switch]
-        $SilentlyContinue,
-
-        [switch]
-        $Silent
-    )
-
-    Begin {
-        #region Configuration Values
-        $disable_cache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.All' -Fallback $false
-        $disable_badcredentialcache = Get-DbaConfigValue -Name 'ComputerManagement.Cache.Disable.BadCredentialList' -Fallback $false
-
-        $disable_CimRM = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.CimRM' -Fallback $false
-        $disable_CimDCOM = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.CimDCOM' -Fallback $false
-        $disable_WMI = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.WMI' -Fallback $false
-        $disable_PowerShellRemoting = Get-DbaConfigValue -Name 'ComputerManagement.Type.Disable.PowerShellRemoting' -Fallback $false
-
-        Write-Message -Level Verbose -Message "Configuration loaded | Cache disabled: $disable_cache | Bad Credential Cache disabled: $disable_badcredentialcache | CimRM disabled: $disable_CimRM | CimDCOM disabled: $disable_CimDCOM | Wmi disabled: $disable_WMI | PowerShellRemoting disabled: $disable_PowerShellRemoting"
-        #endregion Configuration Values
-
-        $ParSet = $PSCmdlet.ParameterSetName
-    }
-    Process {
-        :main foreach ($connectionObject in $ComputerName) {
-            if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret input: $($connectionObject.Input)" -Category InvalidArgument -Target $connectionObject.Input -Continue -SilentlyContinue:$SilentlyContinue }
-
-            # Since all connection caching runs using lower-case strings, making it lowercase here simplifies things.
-            $computer = $connectionObject.Connection.ComputerName.ToLower()
-
-            Write-Message -Message "[$computer] Retrieving Management Information" -Level VeryVerbose -Target $computer
-
-            $connection = $connectionObject.Connection
-
-            # Ensure using the right credentials
-            try { $cred = $connection.GetCredential($Credential) }
-            catch {
-                $message = "Bad credentials! "
-                if ($Credential) { $message += "The credentials for $($Credential.UserName) are known to not work. " }
-                else { $message += "The windows credentials are known to not work. " }
-                if ($connection.EnableCredentialFailover -or $connection.OverrideExplicitCredential) { $message += "The connection is configured to use credentials that are known to be good, but none have been registered yet. " }
-                elseif ($connection.Credentials) { $message += "Working credentials are known for $($connection.Credentials.UserName), however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
-                elseif ($connection.UseWindowsCredentials) { $message += "The windows credentials are known to work, however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
-                $message += $_.Exception.Message
-                Stop-Function -Message $message -InnerErrorRecord $_ -Target $connection -Continue
-            }
-
-            # Create list of excluded connection types (Duplicates don't matter)
-            $excluded = @()
-            foreach ($item in $DoNotUse) { $excluded += $item }
-            if ($disable_CimRM) { $excluded += "CimRM" }
-            if ($disable_CimDCOM) { $excluded += "CimDCOM" }
-            if ($disable_WMI) { $excluded += "Wmi" }
-            if ($disable_PowerShellRemoting) { $excluded += "PowerShellRemoting" }
-
-            :sub while ($true) {
-                try { $conType = $connection.GetConnectionType(($excluded -join ","), $Force) }
-                catch {
-                    if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                    Stop-Function -Message "[$computer] Could not find a valid connection protocol, interrupting execution now" -Target $computer -Category OpenError -Continue -ContinueLabel "main" -SilentlyContinue:$SilentlyContinue -ErrorRecord $_
-                }
-
-                switch ($conType.ToString()) {
-                    #region CimRM
-                    "CimRM" {
-                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM"
-                        try {
-                            switch ($ParSet) {
-                                "Class" { $connection.GetCimRMInstance($cred, $ClassName, $Namespace) }
-                                "Query" { $connection.QueryCimRMInstance($cred, $Query, "WQL", $Namespace) }
-                            }
-
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Success!"
-                            $connection.ReportSuccess('CimRM')
-                            $connection.AddGoodCredential($cred)
-                            if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                            continue main
-                        }
-                        catch {
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Failed!"
-                            if ($Session) { Remove-CimSession -CimSession $Session }
-
-                            if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException") {
-                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
-                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
-                                $connection.AddBadCredential($cred)
-                                if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            elseif ($_.Exception.InnerException.MessageId -eq "HRESULT 0x80338000") {
-                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            else {
-                                $connection.ReportFailure('CimRM')
-                                $excluded += "CimRM"
-                                continue sub
-                            }
-                        }
-                    }
-                    #endregion CimRM
-
-                    #region CimDCOM
-                    "CimDCOM" {
-                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM"
-                        try {
-                            switch ($ParSet) {
-                                "Class" { $connection.GetCimDCOMInstance($cred, $ClassName, $Namespace) }
-                                "Query" { $connection.QueryCimDCOMInstance($cred, $Query, "WQL", $Namespace) }
-                            }
-
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Success!"
-                            $connection.ReportSuccess('CimDCOM')
-                            $connection.AddGoodCredential($cred)
-                            if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                            continue main
-                        }
-                        catch {
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Failed!"
-                            if ($Session) { Remove-CimSession -CimSession $Session }
-
-                            if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException") {
-                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
-                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
-                                $connection.AddBadCredential($cred)
-                                if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            elseif ($_.Exception.InnerException.MessageId -eq "HRESULT 0x80338000") {
-                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -InnerErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            else {
-                                $connection.ReportFailure('CimDCOM')
-                                $excluded += "CimDCOM"
-                                continue sub
-                            }
-                        }
-                    }
-                    #endregion CimDCOM
-
-                    #region Wmi
-                    "Wmi" {
-                        Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI"
+		https://dbatools.io/Get-DbaCmObject
+#>
+	[CmdletBinding(DefaultParameterSetName = "Class")]
+	param (
+		[Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Class")]
+		[Alias('Class')]
+		[string]
+		$ClassName,
+		
+		[Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+		[string]
+		$Query,
+		
+		[Parameter(ValueFromPipeline = $true)]
+		[Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
+		$ComputerName = $env:COMPUTERNAME,
+		
+		[System.Management.Automation.PSCredential]
+		$Credential,
+		
+		[string]
+		$Namespace = "root\cimv2",
+		
+		[Sqlcollaborative.Dbatools.Connection.ManagementConnectionType[]]
+		$DoNotUse = "None",
+		
+		[switch]
+		$Force,
+		
+		[switch]
+		$SilentlyContinue,
+		
+		[switch]
+		$Silent
+	)
+	
+	Begin {
+		#region Configuration Values
+		$disable_cache = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::DisableCache
+		
+		Write-Message -Level Verbose -Message "Configuration loaded | Cache disabled: $disable_cache"
+		#endregion Configuration Values
+		
+		$ParSet = $PSCmdlet.ParameterSetName
+	}
+	Process {
+		:main foreach ($connectionObject in $ComputerName) {
+			if (-not $connectionObject.Success) { Stop-Function -Message "Failed to interpret input: $($connectionObject.Input)" -Category InvalidArgument -Target $connectionObject.Input -Continue -SilentlyContinue:$SilentlyContinue }
+			
+			# Since all connection caching runs using lower-case strings, making it lowercase here simplifies things.
+			$computer = $connectionObject.Connection.ComputerName.ToLower()
+			
+			Write-Message -Message "[$computer] Retrieving Management Information" -Level VeryVerbose -Target $computer
+			
+			$connection = $connectionObject.Connection
+			
+			# Ensure using the right credentials
+			try { $cred = $connection.GetCredential($Credential) }
+			catch {
+				$message = "Bad credentials! "
+				if ($Credential) { $message += "The credentials for $($Credential.UserName) are known to not work. " }
+				else { $message += "The windows credentials are known to not work. " }
+				if ($connection.EnableCredentialFailover -or $connection.OverrideExplicitCredential) { $message += "The connection is configured to use credentials that are known to be good, but none have been registered yet. " }
+				elseif ($connection.Credentials) { $message += "Working credentials are known for $($connection.Credentials.UserName), however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
+				elseif ($connection.UseWindowsCredentials) { $message += "The windows credentials are known to work, however the connection is not configured to automatically use them. This can be done using 'Set-DbaCmConnection -ComputerName $connection -OverrideExplicitCredential' " }
+				$message += $_.Exception.Message
+				Stop-Function -Message $message -ErrorRecord $_ -Target $connection -Continue
+			}
+			
+			# Create list of excluded connection types (Duplicates don't matter)
+			$excluded = @()
+			foreach ($item in $DoNotUse) { $excluded += $item }
+			
+			:sub while ($true) {
+				try { $conType = $connection.GetConnectionType(($excluded -join ","), $Force) }
+				catch {
+					if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+					Stop-Function -Message "[$computer] Could not find a valid connection protocol, interrupting execution now" -Target $computer -Category OpenError -Continue -ContinueLabel "main" -SilentlyContinue:$SilentlyContinue -ErrorRecord $_
+				}
+				
+				switch ($conType.ToString()) {
+					#region CimRM
+					"CimRM" {
+						Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM"
+						try {
+							if ($ParSet-eq "Class") { $connection.GetCimRMInstance($cred, $ClassName, $Namespace) }
+							else { $connection.QueryCimRMInstance($cred, $Query, "WQL", $Namespace) }
+							
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Success!"
+							$connection.ReportSuccess('CimRM')
+							$connection.AddGoodCredential($cred)
+							if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+							continue main
+						}
+						catch {
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over WinRM - Failed!"
+							
+							# 1 = Generic runtime error
+							if ($_.Exception.InnerException.StatusCode -eq 1) {
+								# 0x8007052e, 0x80070005 : Authentication error, bad credential
+								if (($_.Exception.InnerException -eq 0x8007052e) -or ($_.Exception.InnerException -eq 0x80070005)) {
+									# Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+									# This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+									$connection.AddBadCredential($cred)
+									if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+									Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+								}
+								else {
+									$connection.ReportFailure('CimRM')
+									$excluded += "CimRM"
+									continue sub
+								}
+							}
+							
+							# 2 = Access to specific resource denied
+							elseif ($_.Exception.InnerException.StatusCode -eq 2) {
+								Stop-Function -Message "[$computer] Access to computer granted, but access to $Namespace\$ClassName denied!" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							
+							# 3 = Invalid Namespace
+							elseif ($_.Exception.InnerException.StatusCode -eq 3) {
+								Stop-Function -Message "[$computer] Invalid namespace: $Namespace" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							# 5 = Invalid Class
+							# See here for code reference: https://msdn.microsoft.com/en-us/library/cc150671(v=vs.85).aspx
+							elseif ($_.Exception.InnerException.StatusCode -eq 5) {
+								Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							else {
+								$connection.ReportFailure('CimRM')
+								$excluded += "CimRM"
+								continue sub
+							}
+						}
+					}
+					#endregion CimRM
+					
+					#region CimDCOM
+					"CimDCOM" {
+						Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM"
+						try {
+							if ($ParSet -eq "Class") { $connection.GetCimDCOMInstance($cred, $ClassName, $Namespace) }
+							else { $connection.QueryCimDCOMInstance($cred, $Query, "WQL", $Namespace) }
+							
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Success!"
+							$connection.ReportSuccess('CimDCOM')
+							$connection.AddGoodCredential($cred)
+							if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+							continue main
+						}
+						catch {
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using Cim over DCOM - Failed!"
+							
+							# 1 = Generic runtime error
+							if ($_.Exception.InnerException.StatusCode -eq 1) {
+								# 0x8007052e, 0x80070005 : Authentication error, bad credential
+								if (($_.Exception.InnerException -eq 0x8007052e) -or ($_.Exception.InnerException -eq 0x80070005)) {
+									# Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+									# This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+									$connection.AddBadCredential($cred)
+									if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+									Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+								}
+								else {
+									$connection.ReportFailure('CimDCOM')
+									$excluded += "CimDCOM"
+									continue sub
+								}
+							}
+							
+							# 2 = Access to specific resource denied
+							elseif ($_.Exception.InnerException.StatusCode -eq 2) {
+								Stop-Function -Message "[$computer] Access to computer granted, but access to $Namespace\$ClassName denied!" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							
+							# 3 = Invalid Namespace
+							elseif ($_.Exception.InnerException.StatusCode -eq 3) {
+								Stop-Function -Message "[$computer] Invalid namespace: $Namespace" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							# 5 = Invalid Class
+							# See here for code reference: https://msdn.microsoft.com/en-us/library/cc150671(v=vs.85).aspx
+							elseif ($_.Exception.InnerException.StatusCode -eq 5) {
+								Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage
+							}
+							else {
+								$connection.ReportFailure('CimDCOM')
+								$excluded += "CimDCOM"
+								continue sub
+							}
+						}
+					}
+					#endregion CimDCOM
+					
+					#region Wmi
+					"Wmi" {
+						Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI"
 						try {
 							switch ($ParSet) {
 								"Class" {
 									$parameters = @{
-										ComputerName = $computer
-										ClassName = $ClassName
-										ErrorAction = 'Stop'
+										ComputerName  = $computer
+										ClassName	  = $ClassName
+										ErrorAction   = 'Stop'
 									}
 									if ($cred) { $parameters["Credential"] = $cred }
 									if (Test-Bound "Namespace") { $parameters["Namespace"] = $Namespace }
@@ -248,9 +274,9 @@
 								}
 								"Query" {
 									$parameters = @{
-										ComputerName = $computer
-										Query = $Query
-										ErrorAction = 'Stop'
+										ComputerName  = $computer
+										Query		  = $Query
+										ErrorAction   = 'Stop'
 									}
 									if ($cred) { $parameters["Credential"] = $cred }
 									if (Test-Bound "Namespace") { $parameters["Namespace"] = $Namespace }
@@ -258,70 +284,70 @@
 							}
 							
 							Get-WmiObject @parameters
-
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Success!"
-                            $connection.ReportSuccess('Wmi')
-                            $connection.AddGoodCredential($cred)
-                            if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                            continue main
-                        }
-                        catch {
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Failed!" -ErrorRecord $_
-
-                            if ($_.CategoryInfo.Reason -eq "UnauthorizedAccessException") {
-                                # Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
-                                # This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
-                                $connection.AddBadCredential($cred)
-                                if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                                Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            elseif ($_.CategoryInfo.Category -eq "InvalidType") {
-                                Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue
-                            }
-                            else {
-                                $connection.ReportFailure('Wmi')
-                                $excluded += "Wmi"
-                                continue sub
-                            }
-                        }
-                    }
-                    #endregion Wmi
-
-                    #region PowerShell Remoting
-                    "PowerShellRemoting" {
-                        try {
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting"
-                            $scp_string = "Get-WmiObject -Class $ClassName -ErrorAction Stop"
-                            if ($PSBoundParameters.ContainsKey("Namespace")) { $scp_string += " -Namespace $Namespace" }
-
-                            $parameters = @{
-                                ScriptBlock  = ([System.Management.Automation.ScriptBlock]::Create($scp_string))
-                                ComputerName = $ComputerName
-                                ErrorAction  = 'Stop'
-                            }
-                            if ($Credential) { $parameters["Credential"] = $Credential }
-                            Invoke-Command @parameters
-
-                            Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting - Success!"
-                            $connection.ReportSuccess('PowerShellRemoting')
-                            $connection.AddGoodCredential($cred)
-                            if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
-                            continue main
-                        }
-                        catch {
-                            # Will always consider authenticated, since any call with credentials to a server that doesn't exist will also carry invalid credentials error.
-                            # There simply is no way to differentiate between actual authentication errors and server not reached
-                            $connection.ReportFailure('PowerShellRemoting')
-                            $excluded += "PowerShellRemoting"
-                            continue sub
-                        }
-                    }
-                    #endregion PowerShell Remoting
-                }
-            }
-        }
-    }
-    End {
-
-    }
+							
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Success!"
+							$connection.ReportSuccess('Wmi')
+							$connection.AddGoodCredential($cred)
+							if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+							continue main
+						}
+						catch {
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using WMI - Failed!" -ErrorRecord $_
+							
+							if ($_.CategoryInfo.Reason -eq "UnauthorizedAccessException") {
+								# Ignore the global setting for bad credential cache disabling, since the connection object is aware of that state and will ignore input if it should.
+								# This is due to the ability to locally override the global setting, thus it must be done on the object and can then be done in code
+								$connection.AddBadCredential($cred)
+								if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+								Stop-Function -Message "[$computer] Invalid connection credentials" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+							}
+							elseif ($_.CategoryInfo.Category -eq "InvalidType") {
+								Stop-Function -Message "[$computer] Invalid class name ($ClassName), not found in current namespace ($Namespace)" -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $_ -SilentlyContinue:$SilentlyContinue
+							}
+							else {
+								$connection.ReportFailure('Wmi')
+								$excluded += "Wmi"
+								continue sub
+							}
+						}
+					}
+					#endregion Wmi
+					
+					#region PowerShell Remoting
+					"PowerShellRemoting" {
+						try {
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting"
+							$scp_string = "Get-WmiObject -Class $ClassName -ErrorAction Stop"
+							if ($PSBoundParameters.ContainsKey("Namespace")) { $scp_string += " -Namespace $Namespace" }
+							
+							$parameters = @{
+								ScriptBlock   = ([System.Management.Automation.ScriptBlock]::Create($scp_string))
+								ComputerName  = $ComputerName
+								ErrorAction   = 'Stop'
+							}
+							if ($Credential) { $parameters["Credential"] = $Credential }
+							Invoke-Command @parameters
+							
+							Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting - Success!"
+							$connection.ReportSuccess('PowerShellRemoting')
+							$connection.AddGoodCredential($cred)
+							if (-not $disable_cache) { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$computer] = $connection }
+							continue main
+						}
+						catch {
+							# Will always consider authenticated, since any call with credentials to a server that doesn't exist will also carry invalid credentials error.
+							# There simply is no way to differentiate between actual authentication errors and server not reached
+							$connection.ReportFailure('PowerShellRemoting')
+							$excluded += "PowerShellRemoting"
+							continue sub
+						}
+					}
+					#endregion PowerShell Remoting
+				}
+			}
+		}
+	}
+	End {
+		
+	}
 }

--- a/functions/Set-DbaCmConnection.ps1
+++ b/functions/Set-DbaCmConnection.ps1
@@ -1,115 +1,117 @@
 ﻿function Set-DbaCmConnection {
-    <#
-    .SYNOPSIS
-    Configures a connection object for use in remote computer management.
-
-    .DESCRIPTION
-    Configures a connection object for use in remote computer management.
-    This function will either create new records for computers that have no connection registered so far, or it will configure existing connections if already present.
-
-    As such it can be handy in making bulk-edits on connections or manually adjusting some settings.
-
-    .PARAMETER ComputerName
-    The computer to build the connection object for.
-
-    .PARAMETER Credential
-    The credential to register.
-
-    .PARAMETER UseWindowsCredentials
-    Whether using the default windows credentials is legit.
-    Not setting this will not exclude using windows credentials, but only not pre-confirm them as working.
-
-    .PARAMETER OverrideExplicitCredential
-    Setting this will enable the credential override.
-    The override will cause the system to ignore explicitly specified credentials, so long as known, good credentials are available.
-
-    .PARAMETER DisabledConnectionTypes
-    Exlicitly disable connection types.
-    These types will then not be used for connecting to the computer.
-
-    .PARAMETER DisableBadCredentialCache
-    Will prevent the caching of credentials if set to true.
-
-    .PARAMETER DisableCimPersistence
-    Will prevent Cim-Sessions to be reused.
-
-    .PARAMETER DisableCredentialAutoRegister
-    Will prevent working credentials from being automatically cached
-
-    .PARAMETER EnableCredentialFailover
-    Will enable automatic failing over to known to work credentials, when using bad credentials.
-    By default, passing bad credentials will cause the Computer Management functions to interrupt with a warning (Or exception if in silent mode).
-
-    .PARAMETER WindowsCredentialsAreBad
-    Will prevent the windows credentials of the currently logged on user from being used for the remote connection.
-
-    .PARAMETER CimWinRMOptions
-    Specify a set of options to use when connecting to the target computer using CIM over WinRM.
-    Use 'New-CimSessionOption' to create such an object.
-
-    .PARAMETER CimDCOMOptions
-    Specify a set of options to use when connecting to the target computer using CIM over DCOM.
-    Use 'New-CimSessionOption' to create such an object.
-
-    .PARAMETER AddBadCredential
-    Adds credentials to the bad credential cache.
-    These credentials will not be used when connecting to the target remote computer.
-
-    .PARAMETER RemoveBadCredential
-    Removes credentials from the bad credential cache.
-
-    .PARAMETER ClearBadCredential
-    Clears the cache of credentials that didn't worked.
-    Will be applied before adding entries to the credential cache.
-
-    .PARAMETER ClearCredential
-    Clears the cache of credentials that worked.
-    Will be applied before adding entries to the credential cache.
-
-    .PARAMETER ResetCredential
-    Resets all credential-related caches:
-    - Clears bad credential cache
-    - Removes last working credential
-    - Un-Confirms the windows credentials as working
-    - Un-Confirms the windows credentials as not working
-
-    Automatically implies the parameters -ClearCredential and -ClearBadCredential. Using them together is redundant.
-    Will be applied before adding entries to the credential cache.
-
-    .PARAMETER ResetConnectionStatus
-    Restores all connection stati to default, as if no connection protocol had ever been tested.
-
-    .PARAMETER ResetConfiguration
-    Restores the configuration back to system default.
-    Configuration elements are the basic behavior controlling settings, such as whether to cache bad credentials, etc.
-    These can be configured globally using the dbatools configuration system and overridden locally on a per-connection basis.
-    For a list of all available settings, use "Get-DbaConfig -Module ComputerManagement".
-
-    Note: Does not apply to globally overridden protocols to connect over.
-
-    .PARAMETER Silent
-    Replaces user friendly yellow warnings with bloody red exceptions of doom!
-    Use this if you want the function to throw terminating errors you want to catch.
-
-    .EXAMPLE
-    Get-DbaCmConnection sql2014 | Set-DbaCmConnection -ClearBadCredential -UseWindowsCredentials
-
-    Retrieves the already existing connection to sql2014, removes the list of not working credentials and configures it to default to the credentials of the logged on user.
-
-    .EXAMPLE
-    Get-DbaCmConnection | Set-DbaCmConnection -RemoveBadCredential $cred
-    Removes the credentials stored in $cred from all connections' list of "known to not work" credentials.
-    Handy to update changes in privilege.
-
-    .EXAMPLE
-    Get-DbaCmConnection | Export-Clixml .\connections.xml
-    Import-Clixml .\connections.xml | Set-DbaCmConnection -ResetConfiguration
-
-    At first, the current cached connections are stored in an xml file. At a later time - possibly in the profile when starting the console again - those connections are imported again and applied again to the connection cache.
-
-    In this example, the configuration settings will also be reset, since after reimport those will be set to explicit, rather than deriving them from the global settings.
-    In many cases, using the default settings is desirable. For specific settings, use New-DbaCmConnection as part of the profile in order to explicitly configure a connection.
-    #>
+<#
+	.SYNOPSIS
+		Configures a connection object for use in remote computer management.
+	
+	.DESCRIPTION
+		Configures a connection object for use in remote computer management.
+		This function will either create new records for computers that have no connection registered so far, or it will configure existing connections if already present.
+		
+		As such it can be handy in making bulk-edits on connections or manually adjusting some settings.
+	
+	.PARAMETER ComputerName
+		The computer to build the connection object for.
+	
+	.PARAMETER Credential
+		The credential to register.
+	
+	.PARAMETER UseWindowsCredentials
+		Whether using the default windows credentials is legit.
+		Not setting this will not exclude using windows credentials, but only not pre-confirm them as working.
+	
+	.PARAMETER OverrideExplicitCredential
+		Setting this will enable the credential override.
+		The override will cause the system to ignore explicitly specified credentials, so long as known, good credentials are available.
+	
+	.PARAMETER OverrideConnectionPolicy
+		Setting this will configure the connection policy override.
+		By default, global configurations enforce, which connection type is available at all and which is disabled.
+	
+	.PARAMETER DisabledConnectionTypes
+		Exlicitly disable connection types.
+		These types will then not be used for connecting to the computer.
+	
+	.PARAMETER DisableBadCredentialCache
+		Will prevent the caching of credentials if set to true.
+	
+	.PARAMETER DisableCimPersistence
+		Will prevent Cim-Sessions to be reused.
+	
+	.PARAMETER DisableCredentialAutoRegister
+		Will prevent working credentials from being automatically cached
+	
+	.PARAMETER EnableCredentialFailover
+		Will enable automatic failing over to known to work credentials, when using bad credentials.
+		By default, passing bad credentials will cause the Computer Management functions to interrupt with a warning (Or exception if in silent mode).
+	
+	.PARAMETER WindowsCredentialsAreBad
+		Will prevent the windows credentials of the currently logged on user from being used for the remote connection.
+	
+	.PARAMETER CimWinRMOptions
+		Specify a set of options to use when connecting to the target computer using CIM over WinRM.
+		Use 'New-CimSessionOption' to create such an object.
+	
+	.PARAMETER CimDCOMOptions
+		Specify a set of options to use when connecting to the target computer using CIM over DCOM.
+		Use 'New-CimSessionOption' to create such an object.
+	
+	.PARAMETER AddBadCredential
+		Adds credentials to the bad credential cache.
+		These credentials will not be used when connecting to the target remote computer.
+	
+	.PARAMETER RemoveBadCredential
+		Removes credentials from the bad credential cache.
+	
+	.PARAMETER ClearBadCredential
+		Clears the cache of credentials that didn't worked.
+		Will be applied before adding entries to the credential cache.
+	
+	.PARAMETER ClearCredential
+		Clears the cache of credentials that worked.
+		Will be applied before adding entries to the credential cache.
+	
+	.PARAMETER ResetCredential
+		Resets all credential-related caches:
+		- Clears bad credential cache
+		- Removes last working credential
+		- Un-Confirms the windows credentials as working
+		- Un-Confirms the windows credentials as not working
+		
+		Automatically implies the parameters -ClearCredential and -ClearBadCredential. Using them together is redundant.
+		Will be applied before adding entries to the credential cache.
+	
+	.PARAMETER ResetConnectionStatus
+		Restores all connection stati to default, as if no connection protocol had ever been tested.
+	
+	.PARAMETER ResetConfiguration
+		Restores the configuration back to system default.
+		Configuration elements are the basic behavior controlling settings, such as whether to cache bad credentials, etc.
+		These can be configured globally using the dbatools configuration system and overridden locally on a per-connection basis.
+		For a list of all available settings, use "Get-DbaConfig -Module ComputerManagement".
+	
+	.PARAMETER Silent
+		Replaces user friendly yellow warnings with bloody red exceptions of doom!
+		Use this if you want the function to throw terminating errors you want to catch.
+	
+	.EXAMPLE
+		Get-DbaCmConnection sql2014 | Set-DbaCmConnection -ClearBadCredential -UseWindowsCredentials
+		
+		Retrieves the already existing connection to sql2014, removes the list of not working credentials and configures it to default to the credentials of the logged on user.
+	
+	.EXAMPLE
+		Get-DbaCmConnection | Set-DbaCmConnection -RemoveBadCredential $cred
+		Removes the credentials stored in $cred from all connections' list of "known to not work" credentials.
+		Handy to update changes in privilege.
+	
+	.EXAMPLE
+		Get-DbaCmConnection | Export-Clixml .\connections.xml
+		Import-Clixml .\connections.xml | Set-DbaCmConnection -ResetConfiguration
+		
+		At first, the current cached connections are stored in an xml file. At a later time - possibly in the profile when starting the console again - those connections are imported again and applied again to the connection cache.
+		
+		In this example, the configuration settings will also be reset, since after reimport those will be set to explicit, rather than deriving them from the global settings.
+		In many cases, using the default settings is desirable. For specific settings, use New-DbaCmConnection as part of the profile in order to explicitly configure a connection.
+#>
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param (
         [Parameter(ValueFromPipeline = $true)]
@@ -125,7 +127,10 @@
         $UseWindowsCredentials,
 
         [switch]
-        $OverrideExplicitCredential,
+		$OverrideExplicitCredential,
+		
+		[switch]
+		$OverrideConnectionPolicy,
 
         [Sqlcollaborative.Dbatools.Connection.ManagementConnectionType]
         $DisabledConnectionTypes = 'None',
@@ -255,9 +260,10 @@
             if (Test-Bound "EnableCredentialFailover") { $connection.DisableCredentialAutoRegister = $EnableCredentialFailover }
             if (Test-Bound "WindowsCredentialsAreBad") { $connection.WindowsCredentialsAreBad = $WindowsCredentialsAreBad }
             if (Test-Bound "CimWinRMOptions") { $connection.CimWinRMOptions = $CimWinRMOptions }
-            if (Test-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
-
-            if (-not $disable_cache) {
+			if (Test-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
+			if (Test-Bound "OverrideConnectionPolicy") { $connection.OverrideConnectionPolicy = $OverrideConnectionPolicy }
+			
+			if (-not $disable_cache) {
                 Write-Message -Level Verbose -Message "Writing connection to cache"
                 [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::Connections[$connectionObject.Connection.ComputerName] = $connection
             }

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -106,7 +106,7 @@
                 }
             }
             catch {
-                if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException") {
+                if (($_.Exception.InnerException -eq 0x8007052e) -or ($_.Exception.InnerException -eq 0x80070005)) {
                     New-Object PSObject -Property @{
                         Success       = "Error"
                         Timestamp     = Get-Date
@@ -143,7 +143,7 @@
                 }
             }
             catch {
-                if ($_.FullyQualifiedErrorId -eq "UnauthorizedAccessException") {
+                if (($_.Exception.InnerException -eq 0x8007052e) -or ($_.Exception.InnerException -eq 0x80070005)) {
                     New-Object PSObject -Property @{
                         Success       = "Error"
                         Timestamp     = Get-Date

--- a/internal/configurations/computermanagement.handler.ps1
+++ b/internal/configurations/computermanagement.handler.ps1
@@ -172,3 +172,99 @@ $ScriptBlock = {
 }
 Register-DbaConfigHandler -Name 'ComputerManagement.Cache.Enable.CredentialFailover' -ScriptBlock $ScriptBlock
 #endregion ComputerManagement.Cache.Enable.CredentialFailover
+
+#region ComputerManagement.Type.Disable.CimRM
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success  = $True
+		Message  = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollaborative.Dbatools.Connection.ConnectionHost]::DisableConnectionCimRM = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Type.Disable.CimRM' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Type.Disable.CimRM
+
+#region ComputerManagement.Type.Disable.CimDCOM
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success  = $True
+		Message  = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollaborative.Dbatools.Connection.ConnectionHost]::DisableConnectionCimDCOM = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Type.Disable.CimDCOM' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Type.Disable.CimDCOM
+
+#region ComputerManagement.Type.Disable.WMI
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success  = $True
+		Message  = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollaborative.Dbatools.Connection.ConnectionHost]::DisableConnectionWMI = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Type.Disable.WMI' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Type.Disable.WMI
+
+#region ComputerManagement.Type.Disable.PowerShellRemoting
+$ScriptBlock = {
+	Param (
+		$Value
+	)
+	
+	$Result = New-Object PSOBject -Property @{
+		Success  = $True
+		Message  = ""
+	}
+	
+	if ($Value.GetType().FullName -ne "System.Boolean") {
+		$Result.Message = "Not a Boolean: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	[Sqlcollaborative.Dbatools.Connection.ConnectionHost]::DisableConnectionPowerShellRemoting = $Value
+	
+	return $Result
+}
+Register-DbaConfigHandler -Name 'ComputerManagement.Type.Disable.PowerShellRemoting' -ScriptBlock $ScriptBlock
+#endregion ComputerManagement.Type.Disable.PowerShellRemoting


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
### Purpose
 - Performance improvement of `Get-DbaCmObject`
 - Reliability improvement of `Get-DbaCmObject`
### Notes
 - Run something else first to remove the initial cost of Write-Message before running performance comparisons