### PR TITLE
Fixing only doing diffs on first piped in db

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -117,7 +117,7 @@ function Backup-DbaDatabase {
 		[string]$BackupFileName,
 		[switch]$CopyOnly,
 		[ValidateSet('Full', 'Log', 'Differential', 'Diff', 'Database')]
-		[string]$Type = "Database",
+		[string]$Type = 'Database',
 		[parameter(ParameterSetName = "NoPipe", Mandatory = $true, ValueFromPipeline = $true)]
 		[object[]]$DatabaseCollection,
 		[switch]$CreateFolder,
@@ -194,7 +194,7 @@ function Backup-DbaDatabase {
 			continue
 		}
 		
-		Write-Message -Level Verbose -Message "$($DatabaseCollection.count) database to backup"
+		Write-Message -Level Verbose -Message "$($DatabaseCollection.count) database to backup, type = $type"
 		
 		ForEach ($Database in $databasecollection) {
 			$failures = @()
@@ -265,7 +265,7 @@ function Backup-DbaDatabase {
 			
 			if ($type -in 'diff', 'differential') {
 				Write-Message -Level VeryVerbose -Message "Creating differential backup"
-				$type = "Database"
+				$SMOBackuptype = "Database"
 				$backup.Incremental = $true
 				$outputType = 'Differential'
 			}
@@ -274,16 +274,17 @@ function Backup-DbaDatabase {
 				Write-Message -Level VeryVerbose -Message "Creating log backup"
 				$Suffix = "trn"
 				$OutputType = 'Log'
+				$SMOBackupType = 'Log'
 			}
 			
 			if ($type -in 'Full', 'Database') {
 				Write-Message -Level VeryVerbose -Message "Creating full backup"
-				$type = "Database"
+				$SMOBackupType = "Database"
 				$OutputType='Full'
 			}
 			
 			$backup.CopyOnly = $copyonly
-			$backup.Action = $type
+			$backup.Action = $SMOBackupType
 			if ('' -ne $AzureBaseUrl) {
 				$backup.CredentialName = $AzureCredential
 			}

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -194,7 +194,7 @@ function Backup-DbaDatabase {
 			continue
 		}
 		
-		Write-Message -Level Verbose -Message "$($DatabaseCollection.count) database to backup, type = $type"
+		Write-Message -Level Verbose -Message "$($DatabaseCollection.count) database to backup"
 		
 		ForEach ($Database in $databasecollection) {
 			$failures = @()


### PR DESCRIPTION
Fixing #2014 

Was doing a diff on the 1st db, then resetting the type.

Now an obvious change in var name to make sure it doesn't happen

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing Issue #2014

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
Get-DbaDatabase -SqlInstance Server\Instance | Backup-DbaDatabase -Type Diff

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
Make variable names really obvious. And reassign if it's going to be used again in a loop.

Don't break things before going on holiday as the broadband in the Cairngorms is a bit slow :)
