### PR TITLE
DbaCredentialParameter - Making Credentials Great Again!

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 0, 19)
+$currentLibraryVersion = New-Object System.Version(0, 6, 1, 20)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sqlcollaborative.Dbatools.Parameter
+{
+    /// <summary>
+    /// Parameter class that handles the various kinds of credential input
+    /// </summary>
+    public class DbaCredentialParameter
+    {
+        #region Fields of contract
+        /// <summary>
+        /// The credential object received
+        /// </summary>
+        [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
+        public PSCredential Credential;
+        #endregion Fields of contract
+
+        #region Constructors
+        /// <summary>
+        /// Creates a credential parameter from a PSCredential object
+        /// </summary>
+        /// <param name="Credential">A PSCredential object</param>
+        public DbaCredentialParameter(PSCredential Credential)
+        {
+            this.Credential = Credential;
+        }
+
+        /// <summary>
+        /// Creates a credential parameter from a NetworkCredential object
+        /// </summary>
+        /// <param name="Credential">The credentials to use</param>
+        public DbaCredentialParameter(NetworkCredential Credential)
+        {
+            this.Credential = new PSCredential(String.Format("{0}\\{1}", Credential.Domain, Credential.UserName).Trim('\\'), Credential.SecurePassword);
+        }
+
+        /// <summary>
+        /// Creates a credential parameter from a string only. Will prompt the user for the rest of the input. Will provide an option to remember the credential under the name provided
+        /// </summary>
+        /// <param name="UserName">The username (and domain name as may be the case) to put a credential around</param>
+        public DbaCredentialParameter(string UserName)
+        {
+            if (CredentialStore.ContainsKey(UserName.ToLower()))
+            {
+                Credential = CredentialStore[UserName.ToLower()];
+            }
+            else if (dbaSystem.SystemHost.UnattendedMode)
+                throw new InvalidOperationException("Cannot prompt for credentials in unattended mode!");
+            else
+                Credential = PromptForCredential(UserName);
+        }
+        #endregion Constructors
+
+        #region Conversion
+        /// <summary>
+        /// Implicitly converts from DbaCredentialParameter to PSCredential
+        /// </summary>
+        /// <param name="Input">The DbaCredentialParameter to convert</param>
+        [ParameterContract(ParameterContractType.Operator, ParameterContractBehavior.Conversion)]
+        public static implicit operator PSCredential(DbaCredentialParameter Input)
+        {
+            return Input.Credential;
+        }
+
+        /// <summary>
+        /// Implicitly converts a PSCredential object to DbaCredenitalParameter
+        /// </summary>
+        /// <param name="Input">The PSCredential to convert</param>
+        public static implicit operator DbaCredentialParameter(PSCredential Input)
+        {
+            return new DbaCredentialParameter(Input);
+        }
+
+        /// <summary>
+        /// Implicitly converts from DbaCredentialParameter to NetworkCredential
+        /// </summary>
+        /// <param name="Input">The DbaCredentialParameter to convert</param>
+        [ParameterContract(ParameterContractType.Operator, ParameterContractBehavior.Conversion)]
+        public static implicit operator NetworkCredential(DbaCredentialParameter Input)
+        {
+            return Input.Credential.GetNetworkCredential();
+        }
+
+        /// <summary>
+        /// Implicitly converts a NetworkCredential object to DbaCredenitalParameter
+        /// </summary>
+        /// <param name="Input">The NetworkCredential to convert</param>
+        public static implicit operator DbaCredentialParameter(NetworkCredential Input)
+        {
+            return new DbaCredentialParameter(Input);
+        }
+        #endregion Conversion
+
+        #region Utility
+        /// <summary>
+        /// Legacy wrapper. While there exists implicit conversion, this allows using the object as before, avoiding errors for unknown method.
+        /// </summary>
+        /// <returns>A network credential object with the same credentials as the original object</returns>
+        [ParameterContract(ParameterContractType.Method, ParameterContractBehavior.Conversion)]
+        public NetworkCredential GetNetworkCredential()
+        {
+            return Credential.GetNetworkCredential();
+        }
+
+        /// <summary>
+        /// Prompts the user for a password to complete a credentials object
+        /// </summary>
+        /// <param name="Name">The name of the user. If specified, this will be added to the prompt.</param>
+        /// <returns>The finished PSCredential object</returns>
+        public static PSCredential PromptForCredential(string Name = "")
+        {
+            Utility.CredentialPrompt prompt = Utility.CredentialPrompt.GetCredential(Name);
+            if (prompt.Cancelled)
+                throw new ArgumentException("No credentials specified!");
+
+            PSCredential cred = new PSCredential(prompt.Username, prompt.Password);
+            if (prompt.Remember)
+                CredentialStore[cred.UserName.ToLower()] = cred;
+
+            return cred;
+        }
+
+        /// <summary>
+        /// Cached credentials, if the user stors them under a name.
+        /// </summary>
+        public static Dictionary<string, PSCredential> CredentialStore = new Dictionary<string, PSCredential>();
+        #endregion Utility
+    }
+}

--- a/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Net;
+using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -19,6 +20,24 @@ namespace Sqlcollaborative.Dbatools.Parameter
         /// </summary>
         [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
         public PSCredential Credential;
+
+        /// <summary>
+        /// The name of the credential object
+        /// </summary>
+        [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
+        public string UserName
+        {
+            get { return Credential.UserName; }
+        }
+
+        /// <summary>
+        /// The password of the credential object
+        /// </summary>
+        [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
+        public SecureString Password
+        {
+            get { return Credential.Password; }
+        }
         #endregion Fields of contract
 
         #region Constructors

--- a/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
@@ -12,7 +12,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
     /// <summary>
     /// Parameter class that handles the various kinds of credential input
     /// </summary>
-    public class DbaCredentialParameter
+    [System.ComponentModel.TypeConverter(typeof(TypeConversion.DbaCredentialParameterConverter))]
+    public class DbaCredentialParameter : IConvertible
     {
         #region Fields of contract
         /// <summary>
@@ -73,6 +74,21 @@ namespace Sqlcollaborative.Dbatools.Parameter
                 throw new InvalidOperationException("Cannot prompt for credentials in unattended mode!");
             else
                 Credential = PromptForCredential(UserName);
+        }
+
+        /// <summary>
+        /// Creates a credential parameter from anything it nows how to handle
+        /// </summary>
+        /// <param name="Credential">The object to convert</param>
+        public DbaCredentialParameter(object Credential)
+        {
+            if (Credential is NetworkCredential)
+                this.Credential = (new DbaCredentialParameter((NetworkCredential)Credential)).Credential;
+            else if (Credential is PSCredential)
+                this.Credential = (PSCredential)Credential;
+
+            else
+                throw new PSArgumentException("Invalid input type");
         }
         #endregion Constructors
 
@@ -150,5 +166,182 @@ namespace Sqlcollaborative.Dbatools.Parameter
         /// </summary>
         internal static Dictionary<string, PSCredential> CredentialStore = new Dictionary<string, PSCredential>();
         #endregion Utility
+
+        #region Interface Implementation
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TypeCode GetTypeCode()
+        {
+            return TypeCode.Object;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public bool ToBoolean(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public char ToChar(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public sbyte ToSByte(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public byte ToByte(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public short ToInt16(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public ushort ToUInt16(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public int ToInt32(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public uint ToUInt32(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public long ToInt64(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public ulong ToUInt64(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public Single ToSingle(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public double ToDouble(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public decimal ToDecimal(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public DateTime ToDateTime(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="Format"></param>
+        /// <returns></returns>
+        public string ToString(IFormatProvider Format)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Tries to convert the credential parameter to one of its supported types
+        /// </summary>
+        /// <param name="TargetType">The type to convert to</param>
+        /// <param name="Format">Irrelevant</param>
+        /// <returns></returns>
+        public object ToType(Type TargetType, IFormatProvider Format)
+        {
+            if (TargetType.FullName == "System.Management.Automation.PSCredential")
+                return Credential;
+            if (TargetType.FullName == "System.Net.NetworkCredential")
+                return GetNetworkCredential();
+
+            throw new NotSupportedException(String.Format("Converting from {0} to {1} is not supported!", GetType().FullName, TargetType.FullName));
+        }
+        #endregion Interface Implementation
     }
 }

--- a/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaCredentialParameter.cs
@@ -129,7 +129,7 @@ namespace Sqlcollaborative.Dbatools.Parameter
         /// <summary>
         /// Cached credentials, if the user stors them under a name.
         /// </summary>
-        public static Dictionary<string, PSCredential> CredentialStore = new Dictionary<string, PSCredential>();
+        internal static Dictionary<string, PSCredential> CredentialStore = new Dictionary<string, PSCredential>();
         #endregion Utility
     }
 }

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.0.19")]
-[assembly: AssemblyFileVersion("0.6.0.19")]
+[assembly: AssemblyVersion("0.6.1.20")]
+[assembly: AssemblyFileVersion("0.6.1.20")]

--- a/bin/projects/dbatools/dbatools/TypeConversion/DbaCredentialParameterConverter.cs
+++ b/bin/projects/dbatools/dbatools/TypeConversion/DbaCredentialParameterConverter.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+using Sqlcollaborative.Dbatools.Parameter;
+
+namespace Sqlcollaborative.Dbatools.TypeConversion
+{
+    /// <summary>
+    /// Converts to and from DbaCredentialparameter
+    /// </summary>
+    public class DbaCredentialParameterConverter : PSTypeConverter
+    {
+        /// <summary>
+        /// Verifies, whether a conversion for the object to the target type is possible
+        /// </summary>
+        /// <param name="SourceValue">The object to convert</param>
+        /// <param name="DestinationType">The type to convert to</param>
+        /// <returns>Whether it's possible, duh!</returns>
+        public override bool CanConvertTo(object SourceValue, Type DestinationType)
+        {
+            if (SourceValue == null)
+                return false;
+            if (!(SourceValue is DbaCredentialParameter))
+                return false;
+            return IsSupportedType(DestinationType);
+        }
+
+        /// <summary>
+        /// Converts from DbaCredentialparameter to whatever destination type is attempted
+        /// </summary>
+        /// <param name="sourceValue">The source object. Better be a DbaCredentialparameter!</param>
+        /// <param name="destinationType">Should be a supported destination type</param>
+        /// <param name="formatProvider">Irrelevant</param>
+        /// <param name="ignoreCase">Irrelevant</param>
+        /// <returns>The target content type</returns>
+        public override object ConvertTo(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
+        {
+            if (!CanConvertTo(sourceValue, destinationType))
+                throw new ArgumentException("Conversion not supported!");
+
+            switch (destinationType.FullName)
+            {
+                case "System.Net.NetworkCredential":
+                    return (System.Net.NetworkCredential)sourceValue;
+                case "System.Management.Automation.PSCredential":
+                    return (PSCredential)sourceValue;
+                default:
+                    throw new InvalidCastException(String.Format("Cannot convert from {0} to {1}!", sourceValue.GetType().FullName, destinationType.FullName));
+            }
+        }
+
+        /// <summary>
+        /// Verifies, whether a conversion for the object from the source type to DbaCredentialParameter is possible
+        /// </summary>
+        /// <param name="SourceValue">The object to convert</param>
+        /// <param name="DestinationType">The source type to convert to</param>
+        /// <returns>Whether it's possible, duh!</returns>
+        public override bool CanConvertFrom(object SourceValue, Type DestinationType)
+        {
+            if (DestinationType.FullName != "Sqlcollaborative.Dbatools.Parameter.DbaCredentialParameter")
+                return false;
+            if (SourceValue == null)
+                return false;
+
+            return IsSupportedType(SourceValue.GetType());
+        }
+
+        /// <summary>
+        /// Converts a source object to DbaCredentialparameter
+        /// </summary>
+        /// <param name="sourceValue">The source object</param>
+        /// <param name="destinationType">The destination type. Must be DbaCredentialParameter, or red stuff happens</param>
+        /// <param name="formatProvider">Irrelevant</param>
+        /// <param name="ignoreCase">Irrelevant</param>
+        /// <returns></returns>
+        public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
+        {
+            if (!CanConvertFrom(sourceValue, destinationType))
+                throw new ArgumentException("Conversion not supported!");
+
+            return new DbaCredentialParameter(sourceValue);
+        }
+
+        /// <summary>
+        /// Returns, whether a given type is supported for conversion
+        /// </summary>
+        /// <param name="type">The type to validate</param>
+        /// <returns>Whether it's a supported conversion</returns>
+        private bool IsSupportedType(Type type)
+        {
+            switch (type.FullName)
+            {
+                case "Sqlcollaborative.Dbatools.Parameter.DbaCredentialParameter":
+                    return true;
+                case "System.Net.NetworkCredential":
+                    return true;
+                case "System.Management.Automation.PSCredential":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/bin/projects/dbatools/dbatools/Utility/CredentialPrompt.cs
+++ b/bin/projects/dbatools/dbatools/Utility/CredentialPrompt.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Sqlcollaborative.Dbatools.Utility
+{
+    /// <summary>
+    /// Dedicated class to prompt for credentials
+    /// </summary>
+    public class CredentialPrompt
+    {
+        /// <summary>
+        /// The name of the user to pre-fill the username field
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        /// The window of the prompt that was shown
+        /// </summary>
+        public Window Window;
+
+        private PasswordBox password;
+
+        /// <summary>
+        /// The final, resulting username
+        /// </summary>
+        public string Username;
+
+        /// <summary>
+        /// The final, result password
+        /// </summary>
+        public SecureString Password;
+
+        /// <summary>
+        /// Whether the password should be remembered
+        /// </summary>
+        public bool Remember;
+
+        /// <summary>
+        /// Marker indicating that execution has finished
+        /// </summary>
+        public bool Finished = false;
+
+        /// <summary>
+        /// Whether the windoww was cancelled
+        /// </summary>
+        public bool Cancelled = false;
+
+        /// <summary>
+        /// Start asking away
+        /// </summary>
+        public void PromptForCredential()
+        {
+            Window window = new Window();
+            window.Name = "MainWindow";
+            window.Title = "Enter Credentials";
+            window.Height = 210;
+            window.Width = 300;
+            window.Icon = null;
+            window.Loaded += window_loaded;
+            this.Window = window;
+
+            Grid grid = new Grid();
+            window.Content = grid;
+
+            Label label_username = new Label();
+            label_username.Content = "Username";
+            label_username.Margin = new Thickness(10, 10, 0, 0);
+            label_username.VerticalAlignment = VerticalAlignment.Top;
+            label_username.HorizontalAlignment = HorizontalAlignment.Left;
+            label_username.Height = 23;
+            label_username.VerticalContentAlignment = VerticalAlignment.Bottom;
+            label_username.HorizontalContentAlignment = HorizontalAlignment.Left;
+            grid.Children.Add(label_username);
+
+            TextBox tb_username = new TextBox();
+            tb_username.Name = "tb_username";
+            tb_username.Text = Name;
+            tb_username.Margin = new Thickness(10, 33, 10, 0);
+            tb_username.Height = 30;
+            tb_username.BorderThickness = new Thickness(2);
+            tb_username.VerticalAlignment = VerticalAlignment.Top;
+            tb_username.VerticalContentAlignment = VerticalAlignment.Center;
+            tb_username.HorizontalContentAlignment = HorizontalAlignment.Center;
+            grid.Children.Add(tb_username);
+
+            Label label_password = new Label();
+            label_password.Content = "Password";
+            label_password.Margin = new Thickness(10, 68, 0, 0);
+            label_password.VerticalAlignment = VerticalAlignment.Top;
+            label_password.HorizontalAlignment = HorizontalAlignment.Left;
+            label_password.Height = 23;
+            label_password.VerticalContentAlignment = VerticalAlignment.Bottom;
+            label_password.HorizontalContentAlignment = HorizontalAlignment.Left;
+            grid.Children.Add(label_password);
+
+            PasswordBox tb_password = new PasswordBox();
+            tb_password.Name = "tb_password";
+            tb_password.Margin = new Thickness(10, 91, 10, 0);
+            tb_password.Height = 30;
+            tb_password.BorderThickness = new Thickness(2);
+            tb_password.VerticalAlignment = VerticalAlignment.Top;
+            tb_password.VerticalContentAlignment = VerticalAlignment.Center;
+            tb_password.HorizontalContentAlignment = HorizontalAlignment.Center;
+            grid.Children.Add(tb_password);
+            password = tb_password;
+
+            CheckBox cb_remember = new CheckBox();
+            cb_remember.Name = "cb_remember";
+            cb_remember.Content = "Remember Password";
+            cb_remember.HorizontalAlignment = HorizontalAlignment.Left;
+            cb_remember.Margin = new Thickness(10, 126, 0, 0);
+            cb_remember.VerticalAlignment = VerticalAlignment.Top;
+            grid.Children.Add(cb_remember);
+            
+            Button b_ok = new Button();
+            b_ok.Name = "b_ok";
+            b_ok.Content = "OK";
+            b_ok.Margin = new Thickness(10, 150, 0, 0);
+            b_ok.HorizontalAlignment = HorizontalAlignment.Left;
+            b_ok.VerticalAlignment = VerticalAlignment.Top;
+            b_ok.Width = 75;
+            b_ok.IsDefault = true;
+            b_ok.Click += button_ok_Click;
+            grid.Children.Add(b_ok);
+
+            Button b_cancel = new Button();
+            b_cancel.Name = "b_cancel";
+            b_cancel.Content = "Cancel";
+            b_cancel.Margin = new Thickness(0, 150, 10, 0);
+            b_cancel.HorizontalAlignment = HorizontalAlignment.Right;
+            b_cancel.VerticalAlignment = VerticalAlignment.Top;
+            b_cancel.Width = 75;
+            b_cancel.IsCancel = true;
+            b_cancel.Click += button_cancel_Click;
+            grid.Children.Add(b_cancel);
+
+            try
+            {
+                window.ShowDialog();
+                Username = tb_username.Text;
+                Password = tb_password.SecurePassword;
+                Remember = (bool)cb_remember.IsChecked;
+            }
+            catch { }
+            Finished = true;
+        }
+
+        #region EventHandler
+        private void button_ok_Click(object sender, RoutedEventArgs e)
+        {
+            Window.Close();
+        }
+
+        private void button_cancel_Click(object sender, RoutedEventArgs e)
+        {
+            Cancelled = true;
+        }
+        
+        private void window_loaded(object sender, EventArgs e)
+        {
+            Window.Activate();
+            password.Focus();
+        }
+        #endregion EventHandler
+
+        /// <summary>
+        /// Executes a request for credentials on a dedicated STA thread
+        /// </summary>
+        /// <param name="Name">THe name of the user to put in the prompt</param>
+        /// <returns>The result object</returns>
+        public static CredentialPrompt GetCredential(string Name)
+        {
+            CredentialPrompt temp = new CredentialPrompt();
+            temp.Name = Name;
+            Thread thread = new Thread(new ThreadStart(temp.PromptForCredential));
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            while (!thread.IsAlive)
+                Thread.Sleep(1);
+            thread.Join();
+            return temp;
+        }
+    }
+}

--- a/bin/projects/dbatools/dbatools/dbaSystem/SystemHost.cs
+++ b/bin/projects/dbatools/dbatools/dbaSystem/SystemHost.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sqlcollaborative.Dbatools.dbaSystem
+{
+    /// <summary>
+    /// Provides system-wide static resources regarding the dbatools system runtime in general
+    /// </summary>
+    public static class SystemHost
+    {
+        /// <summary>
+        /// When this is set to true, functions must assume dbatools is in unattended mode. May not ask for user input of any kind.
+        /// </summary>
+        public static bool UnattendedMode = false;
+    }
+}

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -49,6 +49,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Database\Dependency.cs" />
     <Compile Include="dbaSystem\SystemHost.cs" />
     <Compile Include="Parameter\DbaCredentialParameter.cs" />
+    <Compile Include="TypeConversion\DbaCredentialParameterConverter.cs" />
     <Compile Include="Utility\CredentialPrompt.cs" />
     <Compile Include="Validation\LinkedServerResult.cs" />
     <Compile Include="Utility\DateTimeExtension.cs" />

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -39,6 +39,8 @@
       <HintPath>C:\Windows\Microsoft.NET\assembly\GAC_MSIL\Microsoft.Management.Infrastructure\v4.0_1.0.0.0__31bf3856ad364e35\Microsoft.Management.Infrastructure.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -47,12 +49,16 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Database\BackupHistory.cs" />
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Connection\ConnectionHost.cs" />
     <Compile Include="Database\Dependency.cs" />
+    <Compile Include="dbaSystem\SystemHost.cs" />
+    <Compile Include="Parameter\DbaCredentialParameter.cs" />
+    <Compile Include="Utility\CredentialPrompt.cs" />
     <Compile Include="Validation\LinkedServerResult.cs" />
     <Compile Include="Utility\DateTimeExtension.cs" />
     <Compile Include="Utility\DbaDate.cs" />

--- a/bin/typealiases.ps1
+++ b/bin/typealiases.ps1
@@ -21,3 +21,7 @@ try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators
 catch { }
 try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("DbaMode", "Sqlcollaborative.Dbatools.General.ExecutionMode") }
 catch { }
+try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("DbaCredential", "Sqlcollaborative.Dbatools.Parameter.DbaCredentialparameter") }
+catch { }
+try { [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")::add("DbaCredentialParameter", "Sqlcollaborative.Dbatools.Parameter.DbaCredentialparameter") }
+catch { }


### PR DESCRIPTION
## Type of Change

 - [ ] Bug fix (non-breaking change, fixes
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Purpose
 - Make credential use more comfortable
 - Be more flexible about accepted credentials

### Approach
 - Created a new parameter class for the library that shall henceforth be used instead of `PSCredential` for credential parameters
 - All its magic happens during parameter binding, little effort needed internally
 - Can be used for most things asking for either PSCredentials or NetworkCredentials
 - Can accept both PSCredentials or NetworkCredentials

### Commands to test
```PowerShell
$cred = [DbaCredential]"foo\bar" # During prompt, check 'Remember Password'

$cred = [DbaCredential]"foo\bar" # Won't ask for credentials this time

Get-WmiObject -ComputerName "sql2014" -Credential $cred.Credential -Class "Win32_OperatingSystem"
# Will probably error out due to bad credentials
```

### Screenshots
![image](https://user-images.githubusercontent.com/23364253/29049127-815447b8-7bd4-11e7-9aca-a54aca809c31.png)
![image](https://user-images.githubusercontent.com/23364253/29049145-9789339a-7bd4-11e7-90e9-6004583dfc88.png)


### Learning
Implementation considerations:
 - The issue of credentials prompt can be eliminated by a combination of DbaCredential and some slight considerations as shown in the following implementation example:
```PowerShell
function Get-Test {
	[CmdletBinding()]
	Param (
		[Parameter(ValueFromPipeline = $true)]
		[DbaInstanceParameter[]]
		$ComputerName,
		
		[DbaCredential]
		$SqlCredential
	)
	begin {
		if (-not $SqlCredential) { $SqlCredential = [System.Management.Automation.PSCredential]::Empty }
	}
	
	process {
		foreach ($computer in $ComputerName) {
			Get-WmiObject -ComputerName $computer.ComputerName -Credential $SqlCredential.Credential -Class Win32_OperatingSystem
		}
	}
}
```
Note the begin block. Making sure that is set should eliminate all credential prompts on older systems unless specifying a string.