### PR TITLE
Fix Remove-DbaDatabase - RESTORING databases

### DIFF
--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -115,7 +115,7 @@ Does not prompt and swiftly removes containeddb on SQL Server sql2016
 			catch {
 				try {
 					if ($Pscmdlet.ShouldProcess("$db on $server", "alter db set single_user with rollback immediate then drop")) {
-						$null = $server.Query("alter database $db set single_user with rollback immediate; drop database $db")
+						$null = $server.Query("if exists (select * from sys.databases where name = '$($db.name)' and state = 0) alter database $db set single_user with rollback immediate; drop database $db")
 
 						[pscustomobject]@{
 							ComputerName = $server.NetName

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -41,7 +41,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 			Remove-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore
 			Get-DbaProcess -SqlInstance $script:instance1 -Database singlerestore | Stop-DbaProcess
 			Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak -WithReplace -NoRecovery
-            (Get-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore).IsAccessible | Should Be $false
+            (Connect-DbaSqlServer -SqlInstance $script:instance1).Databases['singlerestore'].IsAccessible | Should Be $false
             Remove-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore
             Get-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore | Should Be $null
     }

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -36,4 +36,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             Get-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore | Should Be $null
         }
 	}
+    Context "Should remove restoring database and return useful errors if it cannot." {
+		It "Should remove a non system database." {
+			Remove-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore
+			Get-DbaProcess -SqlInstance $script:instance1 -Database singlerestore | Stop-DbaProcess
+			Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak -WithReplace -NoRecovery
+            (Get-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore).IsAccessible | Should Be $false
+            Remove-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore
+            Get-DbaDatabase -SqlInstance $script:instance1 -Database singlerestore | Should Be $null
+    }
+    }
 }


### PR DESCRIPTION
Added a verification that the database is ONLINE before running ALTER DB SET SINGLE_USER

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2035)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing #2035

### Approach
Adding `if exists (select * from sys.databases where name = 'db' and status = 0)` to check if the database is online and thus should be put into a single_user mode.

### Commands to test
Included in pester test

### Screenshots
![image](https://user-images.githubusercontent.com/30303784/29128704-36c13d84-7cea-11e7-8af1-036ea47fea79.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
