### PR TITLE
Resolve-DbaNetworkName, revamp and improvements

### DIFF
--- a/functions/Get-DbaClientProtocol.ps1
+++ b/functions/Get-DbaClientProtocol.ps1
@@ -62,9 +62,8 @@ function Get-DbaClientProtocol {
 	process {
 		foreach ( $computer in $ComputerName.ComputerName ) {
 			$server = Resolve-DbaNetworkName -ComputerName $computer -Credential $credential
-			if ( $server.ComputerName ) {
-				$computer = $server.ComputerName
-				
+			if ( $server.FullComputerName ) {
+				$computer = $server.FullComputerName
 				Write-Message -Level Verbose -Message "Getting SQL Server namespace on $computer" -Silent $Silent
                 $namespace = Get-DbaCmObject -ComputerName $computer -Namespace root\Microsoft\SQLServer -Query "Select * FROM __NAMESPACE WHERE Name LIke 'ComputerManagement%'" -ErrorAction SilentlyContinue |
 					Where-Object {(Get-DbaCmObject -ComputerName $computer -Namespace $("root\Microsoft\SQLServer\" + $_.Name) -ClassName ClientNetworkProtocol -ErrorAction SilentlyContinue).count -gt 0} |

--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -58,7 +58,7 @@ function Get-DbaComputerSystem {
 			Write-Message -Level Verbose -Message "Attempting to connect to $computer"
 			$server = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential
 
-			$computerResolved = $server.ComputerName
+			$computerResolved = $server.FullComputerName
 
 			if (!$computerResolved) {
 				Write-Message -Level Warning -Message "Unable to resolve hostname of $computer. Skipping."

--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -117,7 +117,7 @@ function Get-DbaComputerSystem {
 				}
 			}
 			$inputObject = [PSCustomObject]@{
-				ComputerName            = $computer.ComputerName
+				ComputerName            = $computerResolved
 				Domain                  = $computerSystem.Domain
 				DomainRole              = $domainRole
 				Manufacturer            = $computerSystem.Manufacturer

--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -201,9 +201,9 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 	process {
 		foreach ($Computer in $ComputerName.ComputerName) {
 			$reply = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential -ErrorAction SilentlyContinue
-			if ($reply.ComputerName) {
-				$Computer = $reply.ComputerName
-				Write-Verbose "Connecting to $Computer"
+			if ($reply.FullComputerName) {
+				$Computer = $reply.FullComputerName
+				Write-Message -Level Verbose -Message "Connecting to $Computer"
 				Invoke-Command2 -ComputerName $Computer -Credential $Credential -ScriptBlock $scriptblock
 			}
 			else {

--- a/functions/Get-DbaNetworkActivity.ps1
+++ b/functions/Get-DbaNetworkActivity.ps1
@@ -16,6 +16,9 @@
       .PARAMETER Credential
       Credential object used to connect to the computer as a different user.
 
+      .PARAMETER Silent
+      Use this switch to disable any kind of verbose messages and allow exceptions
+
       .NOTES
       Author: Klaas Vandenberghe ( @PowerDBAKlaas )
       Tags: Network
@@ -49,12 +52,12 @@
     [parameter(ValueFromPipeline)]
     [Alias("cn","host","Server")]
     [string[]]$ComputerName = $env:COMPUTERNAME,
-    [PSCredential] $Credential
+    [PSCredential] $Credential,
+    [switch]$Silent
   )
 
   BEGIN
   {
-    $FunctionName = (Get-PSCallstack)[0].Command
     $ComputerName = $ComputerName | ForEach-Object {$_.split("\")[0]} | Select-Object -Unique
     $sessionoption = New-CimSessionOption -Protocol DCom
   }
@@ -62,21 +65,20 @@
   {
     foreach ($computer in $ComputerName)
     {
-      $props = @{ "ComputerName" = $computer }
       $Server = Resolve-DbaNetworkName -ComputerName $Computer -Credential $credential
-      if ( $Server.ComputerName )
+      if ( $Server.FullComputerName )
       {
-        $Computer = $server.ComputerName
-        Write-Verbose "$FunctionName - Creating CIMSession on $computer over WSMan"
+        $Computer = $server.FullComputerName
+        Write-Message -Level Verbose -Message "Creating CIMSession on $computer over WSMan"
         $CIMsession = New-CimSession -ComputerName $Computer -ErrorAction SilentlyContinue -Credential $Credential
         if ( -not $CIMSession )
         {
-          Write-Verbose "$FunctionName - Creating CIMSession on $computer over WSMan failed. Creating CIMSession on $computer over DCom"
+          Write-Message -Level Verbose -Message "Creating CIMSession on $computer over WSMan failed. Creating CIMSession on $computer over DCom"
           $CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
         }
         if ( $CIMSession )
         {
-          Write-Verbose "$FunctionName - Getting properties for Network Interfaces on $computer"
+          Write-Message -Level Verbose -Message "Getting properties for Network Interfaces on $computer"
           $NICs = Get-CimInstance -CimSession $CIMSession -ClassName Win32_PerfFormattedData_Tcpip_NetworkInterface
         $NICs | Add-Member -Force -MemberType ScriptProperty -Name ComputerName -Value { $computer }
           $NICs | Add-Member -Force -MemberType ScriptProperty -Name Bandwith -Value { switch  ( $this.CurrentBandWidth ) { 10000000000 { '10Gb' } 1000000000 { '1Gb' } 100000000 { '100Mb' } 10000000 { '10Mb' } 1000000 { '1Mb' } 100000 { '100Kb' } default { 'Low' } } }
@@ -84,12 +86,12 @@
         } #if CIMSession
         else
         {
-          Write-Warning "$FunctionName - Can't create CIMSession on $computer"
+          Write-Message -Level Warning -Message "Can't create CIMSession on $computer"
         }
       } #if computername
       else
       {
-        Write-Warning "$FunctionName - can't connect to $computer"
+        Write-Message -Level Warning -Message "can't connect to $computer"
       }
     } #foreach computer
   } #PROCESS

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -49,7 +49,7 @@ function Get-DbaOperatingSystem {
 			Write-Message -Level Verbose -Message "Attempting to connect to $computer"
 			$server = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential
 
-			$computerResolved = $server.ComputerName
+			$computerResolved = $server.FullComputerName
 
 			if (!$computerResolved) {
 				Write-Message -Level Warning -Message "Unable to resolve hostname of $computer. Skipping."
@@ -71,7 +71,7 @@ function Get-DbaOperatingSystem {
 			$language = Get-Language $os.OSLanguage
 			
 			[PSCustomObject]@{
-				ComputerName             = $computer.ComputerName
+				ComputerName             = $computerResolved
 				Manufacturer             = $os.Manufacturer
 				Organization             = $os.Organization
 				Architecture             = $os.OSArchitecture

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -18,6 +18,9 @@ This can be the name of a computer, a SMO object, an IP address or a SQL Instanc
 .PARAMETER Credential
 Credential object used to connect to the Computer as a different user
 
+.PARAMETER Silent
+Use this switch to disable any kind of verbose messages and allow exceptions
+
 .NOTES
 Tags: CIM
 Author: Klaas Vandenberghe ( @PowerDBAKlaas )
@@ -46,7 +49,8 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 		[Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
 		[Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
 		[object]$ComputerName,
-		[PSCredential] $Credential
+		[PSCredential] $Credential,
+		[switch]$Silent
 	)
 	PROCESS
 	{
@@ -54,22 +58,22 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 		{
 			$reply = Resolve-DbaNetworkName -ComputerName $Computer -Credential $Credential -ErrorAction silentlycontinue
 			
-			if ( !$reply.ComputerName ) # we can reach $computer
+			if ( !$reply.FullComputerName ) # we can reach $computer
 			{
-				Write-Warning "$Computer is not available."
+				Write-Message -Level Warning -Message "$Computer is not available."
 				continue
 			}
 			
-			$computer = $reply.ComputerName
-			Write-Verbose "Getting computer information from $Computer via CIM (WSMan)"
+			$computer = $reply.FullComputerName
+			Write-Message -Level Verbose -Message "Getting computer information from $Computer via CIM (WSMan)"
 			$CompSys = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_computersystem" -ErrorAction SilentlyContinue
 			
 			if ( $CompSys ) # we have computersystem class via WSMan
 			{
-				Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via CIM (WSMan)"
+				Write-Message -Level Verbose -Message "Successfully retrieved ComputerSystem information on $Computer via CIM (WSMan)"
 				if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
 				{
-					Write-Verbose "Successfully retrieved PageFile information on $Computer via CIM (WSMan)"
+					Write-Message -Level Verbose -Message "Successfully retrieved PageFile information on $Computer via CIM (WSMan)"
 					if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via WSMan
 					{
 						$PF = Get-CimInstance -ComputerName $Computer -Query "SELECT * FROM win32_pagefile" # deprecated !
@@ -79,14 +83,14 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 				}
 				else # pagefile does not exist on $computer, warn and try next computer
 				{
-					Write-Warning "$computer Operating System too old. No Pagefile information available."
+					Write-Message -Level Verbose -Message "$computer Operating System too old. No Pagefile information available."
 					continue
 				}
 			}
 			else # we do not get computersystem class via WSMan, try via DCom
 			{
-				Write-Verbose "No WSMan connection to $Computer"
-				Write-Verbose "Getting computer information from $Computer via CIM (DCOM)"
+				Write-Message -Level Verbose -Message "No WSMan connection to $Computer"
+				Write-Message -Level Verbose -Message "Getting computer information from $Computer via CIM (DCOM)"
 				
 				$sessionoption = New-CimSessionOption -Protocol DCOM
 				$CIMsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -Credential $Credential -ErrorAction SilentlyContinue
@@ -94,10 +98,10 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 				
 				if ( $CompSys ) # we have computersystem class via DCom
 				{
-					Write-Verbose "Successfully retrieved ComputerSystem information on $Computer via CIM (DCOM)"
+					Write-Message -Level Verbose -Message "Successfully retrieved ComputerSystem information on $Computer via CIM (DCOM)"
 					if ( $CompSys.PSobject.Properties.Name -contains "automaticmanagedpagefile" ) # pagefile exists on $computer
 					{
-						Write-Verbose "Successfully retrieved PageFile information on $Computer via CIM (DCOM)"
+						Write-Message -Level Verbose -Message "Successfully retrieved PageFile information on $Computer via CIM (DCOM)"
 						if ( $CompSys.automaticmanagedpagefile -eq $False ) # pagefile is not automatically managed, so get settings via DCom CimSession
 						{
 							$PF = Get-CimInstance -CimSession $CIMsession -Query "SELECT * FROM win32_pagefile" # deprecated !
@@ -107,13 +111,13 @@ Returns a custom object displaying ComputerName, AutoPageFile, FileName, Status,
 					}
 					else # pagefile does not exist on $computer, warn and try next computer
 					{
-						Write-Warning "$computer Operating System too old. No Pagefile information available."
+						Write-Message -Level Warning -Message "$computer Operating System too old. No Pagefile information available."
 						continue
 					}
 				}
 				else # we don't get computersystem, not wia WSMan nor via DCom, warn and try next computer
 				{
-					Write-Warning "No WSMan nor DCom connection to $Computer. If you're not local admin on $Computer, you need to run this command as a different user."
+					Write-Message -Level Warning -Message "No WSMan nor DCom connection to $Computer. If you're not local admin on $Computer, you need to run this command as a different user."
 					continue
 				}
 			}

--- a/functions/Get-DbaServerProtocol.ps1
+++ b/functions/Get-DbaServerProtocol.ps1
@@ -15,8 +15,8 @@ Function Get-DbaServerProtocol {
     .PARAMETER Credential
     Credential object used to connect to the computer as a different user.
 
-	.PARAMETER Silent
-		Use this switch to disable any kind of verbose messages
+   .PARAMETER Silent
+   Use this switch to disable any kind of verbose messages
 
     .NOTES
     Author: Klaas Vandenberghe ( @PowerDBAKlaas )

--- a/functions/Get-DbaServerProtocol.ps1
+++ b/functions/Get-DbaServerProtocol.ps1
@@ -64,8 +64,8 @@ Function Get-DbaServerProtocol {
 	process {
 		foreach ($Computer in $ComputerName.ComputerName) {
 			$Server = Resolve-DbaNetworkName -ComputerName $Computer -Credential $credential
-			if ($Server.ComputerName) {
-				$Computer = $server.ComputerName
+			if ($Server.FullComputerName) {
+				$Computer = $server.FullComputerName
 				Write-Message -Level Verbose -Message "Getting SQL Server namespace on $computer"
 				$namespace = Get-DbaCmObject -ComputerName $Computer -NameSpace root\Microsoft\SQLServer -Query "Select * FROM __NAMESPACE WHERE Name Like 'ComputerManagement%'" -ErrorAction SilentlyContinue |
 				Where-Object { (Get-DbaCmObject -ComputerName $Computer -Namespace $("root\Microsoft\SQLServer\" + $_.Name) -ClassName ServerNetworkProtocol -ErrorAction SilentlyContinue).count -gt 0 } |

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -69,7 +69,7 @@ Function Get-DbaStartupParameter {
                 $instanceName = $instance.InstanceName
                 $ogInstance = $instance.FullSmoName
                 
-                $computerName = (Resolve-DbaNetworkName -ComputerName $computerName).ComputerName
+                $computerName = (Resolve-DbaNetworkName -ComputerName $computerName).FullComputerName
                 
                 Write-Message -Level Verbose -message "Attempting to connect to $computerName"
                 

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -144,15 +144,15 @@ function Get-DbaTcpPort {
 					
 					$computer = $instance.ComputerName
 					$resolved = Resolve-DbaNetworkName -ComputerName $instance -Verbose:$false
-					$fqdn = $resolved.FQDN
+					$computername = $resolved.FullComputerName
 					
 					try {
 						Write-Message -Level Verbose -Message "Trying with ComputerName ($computer)"
 						$someIps = Invoke-ManagedComputerCommand -ComputerName $computer -ArgumentList $computer -ScriptBlock $scriptblock
 					}
 					catch {
-						Write-Message -Level Verbose -Message "Trying with FQDN because ComputerName failed"
-						$someIps = Invoke-ManagedComputerCommand -ComputerName $fqdn -ArgumentList $fqdn -ScriptBlock $scriptblock
+						Write-Message -Level Verbose -Message "Trying with FullComputerName because ComputerName failed"
+						$someIps = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $fqdn -ScriptBlock $scriptblock
 					}
 				}
 				catch {

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -102,11 +102,10 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 				catch {
 					Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 				}
-								
 				Write-Message -Level Verbose -Message "Getting Start times for $servername"
 				#Get tempdb creation date
-				$SQLStartTime = $server.Databases["tempdb"].CreateDate
-				$SQLUptime = New-TimeSpan -Start $SQLStartTime -End (Get-Date)
+				$SQLStartTime = $server.Databases["tempdb"].CreateDate.ToUniversalTime()
+				$SQLUptime = New-TimeSpan -Start $SQLStartTime -End (Get-Date).ToUniversalTime()
 				$SQLUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($SQLUptime.Days), $($SQLUptime.Hours), $($SQLUptime.Minutes), $($SQLUptime.Seconds)
 			}
 			
@@ -117,8 +116,8 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 				try
 				{
 					Write-Message -Level Verbose -Message "Getting WinBootTime via CimInstance for $servername"
-					$WinBootTime = (Get-CimInstance -ClassName win32_operatingsystem -ComputerName $windowsServerName -ErrorAction SilentlyContinue).lastbootuptime
-					$WindowsUptime = New-TimeSpan -start $WinBootTime -end (get-date)
+					$WinBootTime = (Get-CimInstance -ClassName win32_operatingsystem -ComputerName $windowsServerName -ErrorAction SilentlyContinue).LastBootUpTime
+					$WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end (Get-Date).ToUniversalTime()
 					$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 				}
 				catch
@@ -129,7 +128,7 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 						$CimOption = New-CimSessionOption -Protocol DCOM
 						$CimSession = New-CimSession -Credential:$WindowsCredential -ComputerName $WindowsServerName -SessionOption $CimOption
 						$WinBootTime = ($CimSession | Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime
-						$WindowsUptime = New-TimeSpan -start $WinBootTime -end (get-date)
+						$WindowsUptime = New-TimeSpan -start $WinBootTimeToUniversalTime() -end (Get-Date).ToUniversalTime()
 						$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 					}
 					catch

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -128,7 +128,7 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 						$CimOption = New-CimSessionOption -Protocol DCOM
 						$CimSession = New-CimSession -Credential:$WindowsCredential -ComputerName $WindowsServerName -SessionOption $CimOption
 						$WinBootTime = ($CimSession | Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime
-						$WindowsUptime = New-TimeSpan -start $WinBootTimeToUniversalTime() -end (Get-Date).ToUniversalTime()
+						$WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end (Get-Date).ToUniversalTime()
 						$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 					}
 					catch

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -231,7 +231,11 @@ function Resolve-DbaNetworkName {
 						}
 					}
 				}
-				$FullComputerName = $conn.DNSHostname + "." + $DNSSuffix.DNSDomain
+				if ($DNSSuffix.DNSDomain.Length -eq 0) {
+					$FullComputerName = $conn.DNSHostname
+				} else {
+					$FullComputerName = $conn.DNSHostname + "." + $DNSSuffix.DNSDomain
+				}
 				try {
 					Write-Message -Level VeryVerbose -Message "Resolving $FullComputerName using .NET.Dns GetHostEntry"
 					$hostentry = ([System.Net.Dns]::GetHostEntry($FullComputerName)).HostName
@@ -247,7 +251,7 @@ function Resolve-DbaNetworkName {
 				}
 				if ($FullComputerName -eq ".") {
 					Write-Message -Level VeryVerbose -Message "No DNS FQDN found. Setting to null"
-					$fqdn = $FullComputerName
+					$FullComputerName = $null
 				}
 
 				[PSCustomObject]@{

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -185,12 +185,12 @@ function Resolve-DbaNetworkName {
 					try {
 						try {
 							# if an alias (CNAME) is passed we should try to connect to the A name via CIM or WinRM
-							$ComputerNameIP = ([System.Net.Dns]::GetHostEntry($ComputerName)).AddressList[0].IPAddressToString
+							$ComputerNameIP = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
 							$RemoteComputer = [System.Net.Dns]::GetHostByAddress($ComputerNameIP).HostName
 						} catch {
-							$RemoteComputer = $ComputerName
+							$RemoteComputer = $Computer
 						}
-						Write-Message -Level VeryVerbose -Message "Getting computer information from $Computer"
+						Write-Message -Level VeryVerbose -Message "Getting computer information from $RemoteComputer"
 						$ScBlock = {
 							$reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, [Microsoft.Win32.RegistryView]::Default)
 							$key = $reg.OpenSubKey("SYSTEM\CurrentControlSet\services\Tcpip\Parameters")
@@ -216,14 +216,17 @@ function Resolve-DbaNetworkName {
 						try {
 							$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
 							$hostname = $fqdn.Split(".")[0]
-
+							$suffix = $fqdn.Replace("$hostname.", "")
+							if ($hostname -eq $fqdn) {
+								$suffix = ""
+							}
 							$conn = [PSCustomObject]@{
 								Name        = $Computer
 								DNSHostname = $hostname
-								Domain      = $fqdn.Replace("$hostname.", "")
+								Domain      = $suffix
 							}
 							$DNSSuffix = [PSCustomObject]@{
-								DNSDomain   = $fqdn.Replace("$hostname.", "")
+								DNSDomain   = $suffix
 							}
 						}
 						catch {

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -10,6 +10,29 @@ function Resolve-DbaNetworkName {
 			First ICMP is used to test the connection, and get the connected IPAddress.
 
 			Multiple protocols (e.g. WMI, CIM, etc) are attempted before giving up.
+			
+			Important: Remember that FQDN doesn't always match "ComputerName dot Domain" as AD intends.
+				There are network setup (google "disjoint domain") where AD and DNS do not match.
+				"Full computer name" (as reported by sysdm.cpl) is the only match between the two,
+				and it matches the "DNSHostName"  property of the computer object stored in AD.
+				This means that the notation of FQDN that matches "ComputerName dot Domain" is incorrect
+				in those scenarios.
+				In other words, the "suffix" of the FQDN CAN be different from the AD Domain.
+				
+				This cmdlet has been providing good results since its inception but for lack of useful
+				names some doubts may arise.
+				Let this clear the doubts:
+				- InputName: whatever has been passed in
+				- ComputerName: hostname only
+				- IPAddress: IP Address
+				- DNSHostName: hostname only, coming strictly from DNS (as reported from the calling computer)
+				- DNSDomain: domain only, coming strictly from DNS (as reported from the calling computer)
+				- Domain: domain only, coming strictly from AD (i.e. the domain the ComputerName is joined to)
+				- DNSHostEntry: Fully name as returned by DNS [System.Net.Dns]::GetHostEntry
+				- FQDN: "legacy" notation of ComputerName "dot" Domain (coming from AD)
+				- FullComputerName: Full name as configured from within the Computer (i.e. the only secure match between AD and DNS)
+			
+			So, if you need to use something, go with FullComputerName, always, as it is the most correct in every scenario.
 
 		.PARAMETER ComputerName
 			The Server that you're connecting to.
@@ -19,7 +42,9 @@ function Resolve-DbaNetworkName {
 			Credential object used to connect to the SQL Server as a different user
 
 		.PARAMETER Turbo
-			Resolves without accessing the serer itself. Faster but may be less accurate.
+			Resolves without accessing the server itself. Faster but may be less accurate because it relies on DNS only,
+			so it may fail spectacularly for disjoin-domain setups. Also, everyone has its own DNS (i.e. results may vary
+			changing the computer where the function runs)
 
 		.PARAMETER Silent
 			Use this switch to disable any kind of verbose messages.
@@ -27,7 +52,8 @@ function Resolve-DbaNetworkName {
 		.NOTES
 			Tags: Network, Resolve
 			Original Author: Klaas Vandenberghe ( @PowerDBAKlaas )
-
+			Editor: niphlod
+			
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
@@ -38,17 +64,17 @@ function Resolve-DbaNetworkName {
 		.EXAMPLE
 			Resolve-DbaNetworkName -ComputerName ServerA
 
-			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for ServerA
+			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, DNSDomain, Domain, DNSHostEntry, FQDN, DNSHostEntry for ServerA
 
 		.EXAMPLE
 			Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress
 
-			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress
+			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, DNSDomain, Domain, DNSHostEntry, FQDN, DNSHostEntry  for the SQL instance sql2016\sqlexpress
 
 		.EXAMPLE
 			Resolve-DbaNetworkName -SqlInstance sql2016\sqlexpress, sql2014
 
-			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for the SQL instance sql2016\sqlexpress and sql2014
+			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, DNSDomain, Domain, DNSHostEntry, FQDN, DNSHostEntry  for the SQL instance sql2016\sqlexpress and sql2014
 
 			Get-DbaRegisteredServerName -SqlInstance sql2014 | Resolve-DbaNetworkName
 
@@ -80,14 +106,14 @@ function Resolve-DbaNetworkName {
 			
 			if ($Turbo) {
 				try {
-					Write-Message -Level Verbose -Message "Resolving $Computer using .NET.Dns GetHostEntry"
+					Write-Message -Level VeryVerbose -Message "Resolving $Computer using .NET.Dns GetHostEntry"
 					$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-					Write-Message -Level Verbose -Message "Resolving $ipaddress using .NET.Dns GetHostByAddress"
+					Write-Message -Level VeryVerbose -Message "Resolving $ipaddress using .NET.Dns GetHostByAddress"
 					$fqdn = [System.Net.Dns]::GetHostByAddress($ipaddress).HostName
 				}
 				catch {
 					try {
-						Write-Message -Level Verbose -Message "Resolving $Computer and IP using .NET.Dns GetHostEntry"
+						Write-Message -Level VeryVerbose -Message "Resolving $Computer and IP using .NET.Dns GetHostEntry"
 						$resolved = [System.Net.Dns]::GetHostEntry($Computer)
 						$ipaddress = $resolved.AddressList[0].IPAddressToString
 						$fqdn = $resolved.HostName
@@ -117,95 +143,124 @@ function Resolve-DbaNetworkName {
 					ComputerName = $hostname.ToUpper()
 					IPAddress    = $ipaddress
 					DNSHostname  = $hostname
+					DNSDomain    = $fqdn.Replace("$hostname.", "")
 					Domain       = $fqdn.Replace("$hostname.", "")
 					DNSHostEntry = $fqdn
 					FQDN         = $fqdn
+					FullComputerName = $fqdn
 				}
-				return
-			}
 
-			Write-Message -Level Verbose -Message "Connecting to $Computer"
-
-			try {
-				$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
-			}
-			catch {
-								try {
-										if ($env:USERDNSDOMAIN) {
-												$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
-												$Computer = "$Computer.$env:USERDNSDOMAIN"
-										}
-								}
-								catch {
-										$Computer = $OGComputer
-										$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
-								}
-			}
-
-			if ($ipaddress) {
-				Write-Message -Level Verbose -Message "IP Address from $Computer is $ipaddress"
 			}
 			else {
-				Write-Message -Level Verbose -Message "No IP Address returned from $Computer"
-				Write-Message -Level Verbose -Message "Using .NET.Dns to resolve IP Address"
-				return (Resolve-DbaNetworkName -ComputerName $Computer -Turbo)
-			}
 
-			if ($PSVersionTable.PSVersion.Major -gt 2) {
-                Write-Message -Level Verbose -Message "Your PowerShell Version is $($PSVersionTable.PSVersion.Major)"
+				Write-Message -Level Verbose -Message "Connecting to $Computer"
+
 				try {
-					Write-Message -Level Verbose -Message "Getting computer information from $Computer"
-					if (Test-Bound "Credential") {
-						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Credential $Credential -Silent
-					}
-					else {
-						$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $Computer -Silent
-					}
+					$ipaddress = ((Test-Connection -ComputerName $Computer -Count 1 -ErrorAction Stop).Ipv4Address).IPAddressToString
 				}
 				catch {
-					Write-Message -Level Verbose -Message "Unable to get computer information from $Computer"
+						try {
+								if ($env:USERDNSDOMAIN) {
+										$ipaddress = ((Test-Connection -ComputerName "$Computer.$env:USERDNSDOMAIN" -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+										$Computer = "$Computer.$env:USERDNSDOMAIN"
+								}
+						}
+						catch {
+								$Computer = $OGComputer
+								$ipaddress = ([System.Net.Dns]::GetHostEntry($Computer)).AddressList[0].IPAddressToString
+						}
 				}
 
-				if (!$conn) {
-					Write-Message -Level Verbose -Message "No WMI/CIM from $Computer. Getting HostName via .NET.Dns"
-					try {
-						$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
-						$hostname = $fqdn.Split(".")[0]
+				if ($ipaddress) {
+					Write-Message -Level VeryVerbose -Message "IP Address from $Computer is $ipaddress"
+				}
+				else {
+					Write-Message -Level VeryVerbose -Message "No IP Address returned from $Computer"
+					Write-Message -Level VeryVerbose -Message "Using .NET.Dns to resolve IP Address"
+					return (Resolve-DbaNetworkName -ComputerName $Computer -Turbo)
+				}
 
-						$conn = [PSCustomObject]@{
-							Name        = $Computer
-							DNSHostname = $hostname
-							Domain      = $fqdn.Replace("$hostname.", "")
+				if ($PSVersionTable.PSVersion.Major -gt 2) {
+					Write-Message -Level System -Message "Your PowerShell Version is $($PSVersionTable.PSVersion.Major)"
+					try {
+						try {
+							# if an alias (CNAME) is passed we should try to connect to the A name via CIM or WinRM
+							$ComputerNameIP = ([System.Net.Dns]::GetHostEntry($ComputerName)).AddressList[0].IPAddressToString
+							$RemoteComputer = [System.Net.Dns]::GetHostByAddress($ComputerNameIP).HostName
+						} catch {
+							$RemoteComputer = $ComputerName
+						}
+						Write-Message -Level VeryVerbose -Message "Getting computer information from $Computer"
+						$ScBlock = {
+							$reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, [Microsoft.Win32.RegistryView]::Default)
+							$key = $reg.OpenSubKey("SYSTEM\CurrentControlSet\services\Tcpip\Parameters")
+							return [pscustomobject]@{
+								'DNSDomain' = $key.GetValue("Domain")
+							}
+						}
+						if (Test-Bound "Credential") {
+							$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $RemoteComputer -Credential $Credential -Silent
+							$DNSSuffix = Invoke-Command2 -Computer $RemoteComputer -ScriptBlock $ScBlock -Credential $Credential -ErrorAction Stop
+						}
+						else {
+							$conn = Get-DbaCmObject -ClassName win32_ComputerSystem -Computer $RemoteComputer -Silent
+							$DNSSuffix = Invoke-Command2 -Computer $RemoteComputer -ScriptBlock $ScBlock -ErrorAction Stop
 						}
 					}
 					catch {
-						Stop-Function -Message "No .NET.Dns information from $Computer" -InnerErrorRecord $_ -Continue
+						Write-Message -Level Verbose -Message "Unable to get computer information from $Computer"
+					}
+
+					if (!$conn) {
+						Write-Message -Level Verbose -Message "No WMI/CIM from $Computer. Getting HostName via .NET.Dns"
+						try {
+							$fqdn = ([System.Net.Dns]::GetHostEntry($Computer)).HostName
+							$hostname = $fqdn.Split(".")[0]
+
+							$conn = [PSCustomObject]@{
+								Name        = $Computer
+								DNSHostname = $hostname
+								Domain      = $fqdn.Replace("$hostname.", "")
+							}
+							$DNSSuffix = [PSCustomObject]@{
+								DNSDomain   = $fqdn.Replace("$hostname.", "")
+							}
+						}
+						catch {
+							Stop-Function -Message "No .NET.Dns information from $Computer" -InnerErrorRecord $_ -Continue
+						}
 					}
 				}
-			}
+				$FullComputerName = $conn.DNSHostname + "." + $DNSSuffix.DNSDomain
+				try {
+					Write-Message -Level VeryVerbose -Message "Resolving $FullComputerName using .NET.Dns GetHostEntry"
+					$hostentry = ([System.Net.Dns]::GetHostEntry($FullComputerName)).HostName
+				}
+				catch {
+					Stop-Function -Message ".NET.Dns GetHostEntry failed for $FullComputerName" -InnerErrorRecord $_
+				}
 
-			try {
-				Write-Message -Level Verbose -Message "Resolving $($conn.DNSHostname) using .NET.Dns GetHostEntry"
-				$hostentry = ([System.Net.Dns]::GetHostEntry($conn.DNSHostname)).HostName
-			}
-			catch {
-				Stop-Function -Message ".NET.Dns GetHostEntry failed for $($conn.DNSHostname)" -InnerErrorRecord $_
-			}
+				$fqdn = "$($conn.DNSHostname).$($conn.Domain)"
+				if ($fqdn -eq ".") {
+					Write-Message -Level VeryVerbose -Message "No full FQDN found. Setting to null"
+					$fqdn = $null
+				}
+				if ($FullComputerName -eq ".") {
+					Write-Message -Level VeryVerbose -Message "No DNS FQDN found. Setting to null"
+					$fqdn = $FullComputerName
+				}
 
-			$fqdn = "$($conn.DNSHostname).$($conn.Domain)"
-			if ($fqdn -eq ".") {
-				Write-Message -Level Verbose -Message "No full FQDN found. Setting to null"
-				$fqdn = $null
-			}
-
-			[PSCustomObject]@{
-				InputName    = $OGComputer
-				ComputerName = $conn.Name
-				IPAddress    = $ipaddress
-				DNSHostName  = $conn.DNSHostname
-				Domain       = $conn.Domain
-				DNSHostEntry = $hostentry
-				FQDN         = $fqdn
+				[PSCustomObject]@{
+					InputName        = $OGComputer
+					ComputerName     = $conn.Name
+					IPAddress        = $ipaddress
+					DNSHostName      = $conn.DNSHostname
+					DNSDomain        = $DNSSuffix.DNSDomain
+					Domain           = $conn.Domain
+					DNSHostEntry     = $hostentry
+					FQDN             = $fqdn
+					FullComputerName = $FullComputerName
+				}
 			}
 		}
 	}

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -32,6 +32,7 @@ Use this switch to disable any kind of verbose messages
 .NOTES
 Tags: SQLWMI, SPN
 Author: Drew Furgiuele (@pittfurg), http://www.port1433.com
+Editor: niphlod
 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 
@@ -91,9 +92,9 @@ have be a valid login with appropriate rights on the domain
 			}
 			
 			$ipaddr = $resolved.IPAddress
-			$hostentry = $resolved.DNSHostEntry
+			$hostentry = $resolved.FullComputerName
 			
-			Write-Message -Message "Resolved ComputerName to FQDN: $computer" -Level Verbose
+			Write-Message -Message "Resolved ComputerName to FQDN: $hostentry" -Level Verbose
 			
 			$Scriptblock = {
 				
@@ -144,7 +145,7 @@ have be a valid login with appropriate rights on the domain
 						Credential = $Credential # for piping
 					}
 					
-					$spn.InstanceName = $instance.name
+					$spn.InstanceName = $instance.Name
 					$InstanceName = $spn.InstanceName
 					
 					Write-Verbose "Parsing $InstanceName"
@@ -240,10 +241,10 @@ have be a valid login with appropriate rights on the domain
 				$spns
 			}
 			
-			Write-Message -Message "Attempting to connect to SQL WMI on remote computer" -Level Verbose
+			Write-Message -Message "Attempting to connect to SQL WMI on remote computer " -Level Verbose
 			
 			try {
-				$spns = Invoke-ManagedComputerCommand -ComputerName $ipaddr -ScriptBlock $Scriptblock -ArgumentList $computer.ComputerName, $hostentry, $computer.InstanceName -Credential $Credential -ErrorAction Stop
+				$spns = Invoke-ManagedComputerCommand -ComputerName $hostentry -ScriptBlock $Scriptblock -ArgumentList $computer.FullComputerName, $hostentry, $computer.InstanceName -Credential $Credential -ErrorAction Stop
 			}
 			catch {
 				Stop-Function -Message "Couldn't connect to $computer" -ErrorRecord $_ -Continue

--- a/internal/Invoke-ManagedComputerCommand.ps1
+++ b/internal/Invoke-ManagedComputerCommand.ps1
@@ -60,7 +60,6 @@ Function Invoke-ManagedComputerCommand {
 		
 		# Just in case we go remote, ensure the assembly is loaded
 		[void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SqlWmiManagement')
-		
 		$wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $ipaddr
 		$null = $wmi.Initialize()
 	}
@@ -77,8 +76,8 @@ Function Invoke-ManagedComputerCommand {
 		try {
 			Write-Message -Level Verbose -Message "Local connection attempt to $computer failed. Connecting remotely."
 			
-			# For surely resolve stuff
-			$hostname = $resolved.fqdn
+			# For surely resolve stuff, and going by default with kerberos, this needs to match FullComputerName
+			$hostname = $resolved.FullComputerName
 			
 			Invoke-Command2 -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -ComputerName $hostname -ErrorAction Stop
 		}


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Functions in the need of valid data for name resolution use Resolve-DbaNetworkName.
Resolve-DbaNetworkName reported properties as "seen" by setups where AD and DNS match, but for disjoint domain setups there was no clear indication whether the info came from DNS, the server itself, AD or the calling computer. Now it does.
Also, it didn't work with -Turbo and multiple servers passed in

<tl;dr> for lazy: use FullComputerName instead of FQDN. For curious: read the help

Test-DbaSpn and Invoke-ManagedComputerCommands now work for disjoint-domain setups, too.

### Approach
Instead of blindly composing "FQDN", take an extra step to ask the target what is it's real name. Labelled here and forever as "Full computer name", that is the one seen from system properties.

### Commands to test
Please, test everything you can with Resolve-DbaNetworkName AND functions that use it: hopefully places where everything worked fine before won't be broken.
