### PR TITLE
Change Get-DbaRegisteredServerName to take a -FullObject parameter.

### DIFF
--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -202,20 +202,20 @@ function Get-DbaRegisteredServerName {
 		}
 
 		if ($IpAddress) {
-			$ret = ($servers | Select-Object IPAddress)
+			$ret = @($servers | Select-Object IPAddress)
 
 			if (!$NoCmsServer) {
-				$ret += ($cmsServers | Select-Object IPAddress)
+				$ret += @($cmsServers | Select-Object IPAddress)
 			}
 
 			$ret | Select-Object -Unique -ExpandProperty IPAddress
 		}
 
 		elseif ($NetBiosName) {
-			$ret = ($servers | Select-Object ComputerName)
+			$ret = @($servers | Select-Object ComputerName)
 
 			if (!$NoCmsServer) {
-				$ret += ($cmsServers | Select-Object ComputerName)
+				$ret += @($cmsServers | Select-Object ComputerName)
 			}
 
 			$ret | Select-Object -Unique -ExpandProperty ComputerName
@@ -228,14 +228,13 @@ function Get-DbaRegisteredServerName {
 
 		#By default, return only the server name for backwards compatibility
 		else {
-			$ret = ($servers | Select-Object ServerName)
+			$ret = @($servers | Select-Object ServerName)
 
 			if (!$NoCmsServer) {
-				$ret += ($cmsServers | Select-Object ServerName)
+				$ret += @($cmsServers | Select-Object ServerName)
 			}
 
 			$ret | Select-Object -Unique -ExpandProperty ServerName
-
 		}
 
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName

--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -1,24 +1,28 @@
 function Get-DbaRegisteredServerName {
 	<#
 		.SYNOPSIS
-			Gets list of SQL Server names stored in SQL Server Central Management Server (CMS).
+			Gets list of SQL Server objects stored in SQL Server Central Management Server (CMS).
 
 		.DESCRIPTION
-			Returns a simple array of server names found in the CMS.
+			Returns an array of servers found in the CMS. By default, the command returns the ServerName property
+			of the servers. You can specify -FullObject to return the full SMO object, -IpAddress for only the
+			IPv4 Addresses of the server, and -NetBiosName for only the ComputerName.
 
 		.PARAMETER SqlInstance
-			SQL Server name or SMO object representing the SQL Server to connect to. 
+			SQL Server name or SMO object representing the SQL Server to connect to.
 			This can be a collection to allow the function to be executed against multiple SQL Server instances.
-	
+
 		.PARAMETER SqlCredential
 			SqlCredential object to connect as. If not specified, current Windows login will be used.
 
 		.PARAMETER Group
-			Auto-populated list of groups in SQL Server Central Management Server. You can specify one or more, comma separated.
+			List of groups to filter to in SQL Server Central Management Server. You can specify one or more, comma separated.
 
 		.PARAMETER NoCmsServer
-			If a group is not provided then by default, the Central Management Server name is included in the output.
-			If not searching by group then use -NoCmsServer to exclude the CMS itself.
+			Excludes the CMS itself from returning in the output, if pulling NetBiosName, IpAddress, or ServerName.
+
+		.PARAMETER FullObject
+			Returns the full SMO RegisteredServer object for each server. This will not return an object for the CMS Server.
 
 		.PARAMETER NetBiosName
 			Returns just the NetBios names of each server.
@@ -31,7 +35,7 @@ function Get-DbaRegisteredServerName {
 
 		.NOTES
 			Tags: RegisteredServer,CMS
-			
+
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
@@ -42,33 +46,42 @@ function Get-DbaRegisteredServerName {
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a
 
-			Gets a list of all server names from the CMS on sqlserver2014a, using Windows Credentials
+			Gets a list of server names from the CMS on sqlserver2014a, using Windows Credentials
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -SqlCredential $credential
 
-			Gets a list of all server names from the CMS on sqlserver2014a, using SQL Authentication
+			Gets a list of server names from the CMS on sqlserver2014a, using SQL Authentication
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting
 
-			Gets a list of server names in the HR and Accounting groups from the CMS on sqlserver2014a.
-
-		.EXAMPLE
-			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR, Accounting -IpAddress
-
-			Gets a list of server IP addresses in the HR and Accounting groups from the CMS on sqlserver2014a.
+			Gets a list of servers in the HR and Accounting groups from the CMS on sqlserver2014a.
 
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -NoCmsServer
 
 			Gets a list of server names from the CMS on sqlserver2014a, but excludes the CMS server name.
-		
+
 		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -Group HR\Development
 
 			Returns a list of server names in the HR and sub-group Development from the CMS on sqlserver2014a
 
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -IpAddress
+
+			Gets a list of the IP Addresses for servers in the CMS on sqlserver2014a, using Windows Credentials
+
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -NetBiosName
+
+			Gets a list of the NetBIOS names of the servers in the CMS on sqlserver2014a, using Windows Credentials
+
+		.EXAMPLE
+			Get-DbaRegisteredServerName -SqlInstance sqlserver2014a -FullObject
+
+			Returns the full SMO RegisteredServer object for servers in the CMS on sqlserver2014a, using Windows Credentials
 	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]
 	param (
@@ -83,10 +96,18 @@ function Get-DbaRegisteredServerName {
 		[switch]$NetBiosName,
 		[parameter(ParameterSetName = "IP")]
 		[switch]$IpAddress,
+		[parameter(ParameterSetName = "FullObject")]
+		[switch]$FullObject,
 		[switch]$Silent
 	)
 	process {
+		if ($NoCmsServer -and $FullObject) {
+			Write-Message -Level Verbose -Message ("-NoCmsServer is not valid in combination with -FullObject, ignoring. " + `
+					"-FullObject does not return an entry for the CMS itself.")
+		}
+
 		if (Test-FunctionInterrupt) { return }
+
 		# see notes at Get-ParamSqlCmsGroups
 		function Find-CmsGroup {
 			[cmdletbinding()]
@@ -97,7 +118,7 @@ function Get-DbaRegisteredServerName {
 			)
 			$results = @()
 			foreach ($el in $CmsGrp) {
-				if ( $Base -eq $null -or [string]::IsNullOrWhiteSpace($Base) ) {
+				if ($null -eq $Base -or [string]::IsNullOrWhiteSpace($Base) ) {
 					$partial = $el.name
 				}
 				else {
@@ -114,8 +135,9 @@ function Get-DbaRegisteredServerName {
 			}
 			return $results
 		}
-		
+
 		$servers = @()
+		$cmsServers = @()
 		foreach ($instance in $SqlInstance) {
 			try {
 				Write-Message -Level Verbose -Message "Connecting to $instance"
@@ -134,85 +156,88 @@ function Get-DbaRegisteredServerName {
 				return
 			}
 
-			if ($Group -ne $null) {
+			if ($null -ne $Group) {
 				foreach ($currentGroup in $Group) {
 					$cms = Find-CmsGroup -CmsGrp $cmsStore.DatabaseEngineServerGroup.ServerGroups -Stopat $currentGroup
-					if ($cms -eq $null) {
+					if ($null -eq $cms) {
 						Write-Message -Level Output -Message "No groups found matching that name"
 						continue
 					}
-					$servers += ($cms.GetDescendantRegisteredServers()).ServerName
+					$servers += ($cms.GetDescendantRegisteredServers())
 				}
 			}
 			else {
 				$cms = $cmsStore.ServerGroups["DatabaseEngineServerGroup"]
-				$servers += ($cms.GetDescendantRegisteredServers()).ServerName
+				$servers += ($cms.GetDescendantRegisteredServers())
 			}
 
-			if ($NoCmsServer -eq $false -and $Group -eq $null) {
-				$servers += $SqlInstance.ComputerName
+			#Store some information about the CMS's for later use
+			try {
+				$ip = (Resolve-DbaNetworkName $server.Name -Turbo -Silent).IpAddress
 			}
+			catch {
+				$ip = $null
+			}
+			$fakeCms = [PSCustomObject]@{
+				ComputerName = $server.ComputerNamePhysicalNetBIOS
+				ServerName   = $server.Name
+				IPAddress    = $ip
+			}
+			$cmsServers += $fakeCms
 		}
 	}
+
 	end {
-		if (Test-FunctionInterrupt) { return }
-		if ($NetBiosName -or $IpAddress) {
-			$ipCollection = @()
-			$netBiosCollection = @()
-			$processed = @()
-
-			foreach ($server in $servers) {
-				if ($server -match '\\') {
-					$server = $server.Split('\')[0]
-				}
-
-				if ($processed -contains $server) { continue }
-				$processed += $server
-
-				try {
-					Write-Message -Level Verbose -Message "Testing connection to $server and resolving IP address"
-					$ip = ((Test-Connection $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address | Select-Object -First 1).IPAddressToString
-				}
-				catch {
-					Stop-Function -Message "Could not resolve IP address for $server" -ErrorRecord $_ -Continue
-				}
-
-				if ($ipCollection -notcontains $ip) {
-					$ipCollection += $ip
-				}
-
-				if ($NetBiosName) {
-					try {
-						$hostName = (Get-DbaCmObject -ClassName Win32_NetworkAdapterConfiguration -ComputerName $server -SilentlyContinue | Where-Object IPEnabled -eq $true).PSComputerName
-
-						if ($hostname -is [array]) {
-							$hostname = $hostname[0]
-						}
-						Write-Message -Level Verbose -Message "Hostname resolved to $hostname"
-						if ($hostname -eq $null) {
-							$hostname = (nbtstat -A $ipAddress | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim()
-						}
-					}
-					catch {
-						Stop-Function -Message "Could not resolve NetBios name for $server" -ErrorRecord $_ -Continue
-					}
-
-					if ($netBiosCollection -notcontains $hostname) {
-						$netBiosCollection += $hostname
-					}
-				}
+		# Use Resolve-DbaNetworkName to get IP / ComputerName
+		foreach ($server in $servers) {
+			try {
+				$lookup = Resolve-DbaNetworkName $server.ServerName -Turbo -Silent
+				Add-Member -Force -InputObject $server -MemberType NoteProperty -Name ComputerName -Value $lookup.ComputerName
+				Add-Member -Force -InputObject $server -MemberType NoteProperty -Name IPAddress -Value $lookup.IPAddress
 			}
-			
-			if ($NetBiosName) {
-				$netBiosCollection | Select-Object -Unique
-			}
-			else {
-				$ipCollections | Select-Object -Unique
+			catch {
+				Add-Member -Force -InputObject $server -MemberType NoteProperty -Name ComputerName -Value $null
+				Add-Member -Force -InputObject $server -MemberType NoteProperty -Name IPAddress -Value $null
 			}
 		}
+
+		if ($IpAddress) {
+			$ret = ($servers | Select-Object IPAddress)
+
+			if (!$NoCmsServer) {
+				$ret += ($cmsServers | Select-Object IPAddress)
+			}
+
+			$ret | Select-Object -Unique -ExpandProperty IPAddress
+		}
+
+		elseif ($NetBiosName) {
+			$ret = ($servers | Select-Object ComputerName)
+
+			if (!$NoCmsServer) {
+				$ret += ($cmsServers | Select-Object ComputerName)
+			}
+
+			$ret | Select-Object -Unique -ExpandProperty ComputerName
+		}
+
+		# #If -FullObject is specified, return everything, no distinct
+		elseif ($FullObject) {
+			return $servers
+		}
+
+		#By default, return only the server name for backwards compatibility
 		else {
-			$servers | Select-Object -Unique
+			$ret = ($servers | Select-Object ServerName)
+
+			if (!$NoCmsServer) {
+				$ret += ($cmsServers | Select-Object ServerName)
+			}
+
+			$ret | Select-Object -Unique -ExpandProperty ServerName
+
 		}
+
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Get-SqlRegisteredServerName
 	}
 }

--- a/functions/Get-DbaRegisteredServerName.ps1
+++ b/functions/Get-DbaRegisteredServerName.ps1
@@ -20,6 +20,7 @@ function Get-DbaRegisteredServerName {
 
 		.PARAMETER NoCmsServer
 			Excludes the CMS itself from returning in the output, if pulling NetBiosName, IpAddress, or ServerName.
+			Without this parameter, the CMS will only be included if you do not specify a group.
 
 		.PARAMETER FullObject
 			Returns the full SMO RegisteredServer object for each server. This will not return an object for the CMS Server.
@@ -201,10 +202,12 @@ function Get-DbaRegisteredServerName {
 			}
 		}
 
+		$IncludeCmsServer = ($NoCmsServer -eq $false -and $null -eq $Group)
+
 		if ($IpAddress) {
 			$ret = @($servers | Select-Object IPAddress)
 
-			if (!$NoCmsServer) {
+			if ($IncludeCmsServer) {
 				$ret += @($cmsServers | Select-Object IPAddress)
 			}
 
@@ -214,7 +217,7 @@ function Get-DbaRegisteredServerName {
 		elseif ($NetBiosName) {
 			$ret = @($servers | Select-Object ComputerName)
 
-			if (!$NoCmsServer) {
+			if ($IncludeCmsServer) {
 				$ret += @($cmsServers | Select-Object ComputerName)
 			}
 
@@ -230,7 +233,7 @@ function Get-DbaRegisteredServerName {
 		else {
 			$ret = @($servers | Select-Object ServerName)
 
-			if (!$NoCmsServer) {
+			if ($IncludeCmsServer) {
 				$ret += @($cmsServers | Select-Object ServerName)
 			}
 

--- a/functions/Get-DbaServerInstallDate.ps1
+++ b/functions/Get-DbaServerInstallDate.ps1
@@ -32,30 +32,30 @@ Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
 .LINK
-https://dbatools.io/Get-DbaInstallDate
+https://dbatools.io/Get-DbaServerInstallDate
 
 .EXAMPLE
-Get-DbaInstallDate -SqlInstance SqlBox1\Instance2
+Get-DbaServerInstallDate -SqlInstance SqlBox1\Instance2
 
 Returns an object with SQL Instance Install date as a string and the Windows install date as string. 
 
 .EXAMPLE
-Get-DbaInstallDate -SqlInstance winserver\sqlexpress, sql2016
+Get-DbaServerInstallDate -SqlInstance winserver\sqlexpress, sql2016
 
 Returns an object with SQL Instance Install date as a string and the Windows install date as a string for both SQLInstances that are passed to the cmdlet.  
 	
 .EXAMPLE   
-Get-DbaInstallDate -SqlInstance sqlserver2014a, sql2016 
+Get-DbaServerInstallDate -SqlInstance sqlserver2014a, sql2016 
 
 Returns an object with only the SQL Server Install date as a string. 
 
 .EXAMPLE   
-Get-DbaInstallDate -SqlInstance sqlserver2014a, sql2016 -IncludeWindows
+Get-DbaServerInstallDate -SqlInstance sqlserver2014a, sql2016 -IncludeWindows
 
 Returns an object with the Windows Install date and the SQL install date as a string. 
 
 .EXAMPLE   
-Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaInstallDate
+Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaServerInstallDate
 
 Returns an object with SQL Instance install date as a string for every server listed in the Central Management Server on sql2014
 	

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -53,7 +53,7 @@ function Get-DbaTcpPort {
 			Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
 		.EXAMPLE
-			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -NoIpV6 -Detailed -Verbose
+			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -Detailed -Verbose
 
 			Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014
 	#>

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -76,6 +76,7 @@ function Resolve-DbaNetworkName {
 
 			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, DNSDomain, Domain, DNSHostEntry, FQDN, DNSHostEntry  for the SQL instance sql2016\sqlexpress and sql2014
 
+		.EXAMPLE
 			Get-DbaRegisteredServerName -SqlInstance sql2014 | Resolve-DbaNetworkName
 
 			Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, Domain, FQDN for all SQL Servers returned by Get-DbaRegisteredServerName


### PR DESCRIPTION
 * `-FullObject` returns the actual SMO object
 * Changed to use `Resolve-DbaNetworkName` to get the NetBIOS name / IP address for the Registered Servers
 * Various documentation updates.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Allows the function to return the full RegisteredServer object from SMO, but keeps output to ServerName by default for backwards compatibility.

Also, while testing, I found several unrelated issues with Example documentation, so I updated that, too! :)

Everything I tested worked in my environment, but I am open to feedback / suggestions!

### Approach
<!-- How does this change solve that purpose -->
Previously, the function would get the RegisteredServer objects from SMO, but immediately extract the ServerName field. Now, I'm keeping the full SMO object, and filtering at the end.

I also changed to use `Resolve-DbaNetworkName` to handle NetBIOS / IP Address lookups, instead of the roll-your-own version in the function.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
There are several example commands in the documentation.  I also searched for `Get-DbaRegisteredServerName`, and found other functions that use it within their documentation, to make sure the changes didn't break those. Examples from the docs:

`Get-DbaRegisteredServerName -SqlInstance sql2016 | Get-DbaBackupHistory`
`Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaServerInstallDate` 
`Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -Detailed -Verbose` 
`Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaUptime`
`Get-DbaRegisteredServerName -SqlInstance sql2014 | Resolve-DbaNetworkName`
