### PR TITLE
Get-DbaAgentJobHistory, now with OutputFiles.

### DIFF
--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -78,6 +78,13 @@
 			Get-DbaAgentJobHistory -SqlInstance sql2\Inst2K17 -Job 'Output File Cleanup'
 
 			Returns all properties for all SQl Agent Job execution results of the 'Output File Cleanup' job on sql2\Inst2K17.
+			
+
+		.EXAMPLE
+			Get-DbaAgentJobHistory -SqlInstance sql2\Inst2K17 -Job 'Output File Cleanup' -WithOutputFile
+
+			Returns all properties for all SQl Agent Job execution results of the 'Output File Cleanup' job on sql2\Inst2K17,
+			with additional properties that show the output filename path
 
 		.EXAMPLE
 			Get-DbaAgentJobHistory -SqlInstance sql2\Inst2K17 -NoJobSteps

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -269,7 +269,7 @@
 		
 		if ($JobCollection) {
 			foreach ($currentjob in $JobCollection) {
-				Get-JobHistory -Server $currentjob.Parent.Parent -Job $currentjob.Name
+				Get-JobHistory -Server $currentjob.Parent.Parent -Job $currentjob.Name -WithOutputFile:$WithOutputFile
 			}
 		}
 		

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -31,6 +31,10 @@
 
 		.PARAMETER NoJobSteps
 			Use this switch to discard all job steps, and return only the job totals
+
+		.PARAMETER WithOutputFile
+			Use this switch to retrieve the output file (only if you want step details). Bonus points, we handle the quirks
+			of SQL Agent tokens to the best of our knowledge (https://technet.microsoft.com/it-it/library/ms175575(v=sql.110).aspx)
 	
 		.PARAMETER JobCollection
 			An array of SMO jobs
@@ -41,6 +45,7 @@
 		.NOTES
 			Tags: Job, Agent
 			Original Author: Klaas Vandenberghe ( @PowerDbaKlaas )
+			Editor: niphlod
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
@@ -101,7 +106,8 @@
 		[object[]]$ExcludeJob,
 		[DateTime]$StartDate = "1900-01-01",
 		[DateTime]$EndDate = $(Get-Date),
-		[Switch]$NoJobSteps,
+		[switch]$NoJobSteps,
+		[switch]$WithOutputFile,
 		[parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Collection")]
 		[Microsoft.SqlServer.Management.Smo.Agent.Job]$JobCollection,
 		[switch]$Silent
@@ -112,17 +118,90 @@
 		$filter.StartRunDate = $StartDate
 		$filter.EndRunDate = $EndDate
 		
+		
+		if($NoJobSteps -and $WithOutputFile) {
+			Stop-Function -Message "You can't use -NoJobSteps and -WithOutputFile together"
+		}
+		
 		function Get-JobHistory {
 			[CmdletBinding()]
 			param (
 				$Server,
-				$Job
+				$Job,
+				[switch]$WithOutputFile
 			)
 			
+			$tokenrex = [regex]'\$\((?<method>[^()]+)\((?<tok>[^)]+)\)\)|\$\((?<tok>[^)]+)\)'
+			$propmap = @{
+				'INST' = $Server.ServiceName
+				'MACH'  = $Server.NetName
+				'SQLDIR' = $Server.InstallDataDirectory
+				'SQLLOGDIR' = $Server.ErrorLogPath
+				#'STEPCT' loop number ?
+				'SRVR' = $Server.DomainInstanceName
+				# WMI( property ) impossible
+			}
+			
+			
+			$squote_rex = [regex]"(?<!')'(?!')"
+			$dquote_rex = [regex]'(?<!")"(?!")'
+			$rbrack_rex = [regex]'(?<!])](?!])'
+			
+			function Resolve-TokenEscape($method, $value) {
+				if (!$method) {
+					return $value
+				}
+				$value = switch ($method) 
+					{ 
+						'ESCAPE_SQUOTE' { $squote_rex.Replace($value, "''") }
+						'ESCAPE_DQUOTE' { $dquote_rex.Replace($value, '""') }
+						'ESCAPE_RBRACKET' { $rbrack_rex.Replace($value, ']]') }
+						'ESCAPE_NONE' { $value }
+						default { $value }
+					}
+				return $value
+			}
+			
+			
+			#'STEPID' =  stepid
+			#'STRTTM' job begin time
+			#'STRTDT' job begin date
+			#'JOBID' = JobId
+			function Resolve-JobToken($exec, $outfile, $outcome) {
+				$n = $tokenrex.Matches($outfile)
+				foreach($x in $n) {
+					$tok = $x.Groups['tok'].Value
+					$EscMethod = $x.Groups['method'].Value
+					if ($propmap.containskey($tok)) {
+						$repl = Resolve-TokenEscape -method $EscMethod -value $propmap[$tok]
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'STEPID') {
+						$repl = Resolve-TokenEscape -method $EscMethod -value $exec.StepID
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'JOBID') { # convert(binary(16), ?)
+						$repl = @('0x') +@($exec.JobID.ToByteArray() | foreach { $_.ToString('X2') }) -join ''
+						$repl = Resolve-TokenEscape -method $EscMethod -value $repl
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'STRTDT') {
+						$repl = Resolve-TokenEscape -method $EscMethod -value $outcome.RunDate.toString('yyyyMMdd')
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'STRTTM') {
+						$repl = Resolve-TokenEscape -method $EscMethod -value ([int]$outcome.RunDate.toString('HHmmss')).toString()
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'DATE') {
+						$repl = Resolve-TokenEscape -method $EscMethod -value $exec.RunDate.toString('yyyyMMdd')
+						$outfile = $outfile.Replace($x.Value, $repl)
+					} elseif ($tok -eq 'TIME') {
+						$repl = Resolve-TokenEscape -method $EscMethod -value ([int]$exec.RunDate.toString('HHmmss')).toString()
+						$outfile = $outfile.Replace($x.Value, $repl)
+					}
+				}
+				return $outfile
+			}
 			try {
 				Write-Message -Message "Attempting to get job history from $instance" -Level Verbose
 				if ($Job) {
-					foreach ($currentjob in $job) {
+					foreach ($currentjob in $Job) {
 						$filter.JobName = $currentjob
 						$executions += $server.JobServer.EnumJobHistory($filter)
 					}
@@ -135,12 +214,40 @@
 					$executions = $executions | Where-Object { $_.StepID -eq 0 }
 				}
 				
+				if ($WithOutputFile) {
+					$outmap = @{}
+					$outfiles = Get-DbaAgentJobOutPutFile -SqlInstance $Server -SqlCredential $SqlCredential -Job $Job
+					foreach($out in $outfiles) {
+						if (!$outmap.ContainsKey($out.Job)) {
+							$outmap[$out.Job] = @{}
+						}
+						$outmap[$out.Job][$out.StepId] = $out.OutputFileName
+					}
+				}
+				$outcome = [pscustomobject]@{}
 				foreach ($execution in $executions) {
 					Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name ComputerName -value $server.NetName
 					Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
 					Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+					if ($WithOutputFile) {
+						if ($execution.StepID -eq 0) {
+							$outcome = $execution
+						}
+						try {
+							$outname = $outmap[$execution.JobName][$execution.StepID]
+							$outname = Resolve-JobToken -exec $execution -outcome $outcome -outfile $outname
+							$outremote = Join-AdminUNC $Server.ComputerNamePhysicalNetBIOS $outname
+						} catch {
+							$outname = ''
+							$outremote = ''
+						}
+						Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name OutputFileName -value $outname
+						Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name RemoteOutputFileName -value $outremote
+						Select-DefaultView -InputObject $execution -Property ComputerName, InstanceName, SqlInstance, 'JobName as Job', StepName, RunDate, RunDuration, RunStatus, OutputFileName, RemoteOutputFileName
+					} else {
+						Select-DefaultView -InputObject $execution -Property ComputerName, InstanceName, SqlInstance, 'JobName as Job', StepName, RunDate, RunDuration, RunStatus
+					}
 					
-					Select-DefaultView -InputObject $execution -Property ComputerName, InstanceName, SqlInstance, 'JobName as Job', StepName, RunDate, RunDuration, RunStatus
 				}
 			}
 			catch {
@@ -150,6 +257,8 @@
 	}
 	
 	process {
+		
+		if (Test-FunctionInterrupt) { return }
 		
 		if ($JobCollection) {
 			foreach ($currentjob in $JobCollection) {
@@ -166,15 +275,16 @@
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 			
+			
 			if ($ExcludeJob) {
 				$jobs = $server.JobServer.Jobs.Name | Where-Object { $_ -notin $ExcludeJob }
 
 				foreach ($currentjob in $jobs) {
-					Get-JobHistory -Server $server -Job $currentjob
+					Get-JobHistory -Server $server -Job $currentjob -WithOutputFile:$WithOutputFile
 				}
 			}
 			else {
-				Get-JobHistory -Server $server -Job $Job
+				Get-JobHistory -Server $server -Job $Job -WithOutputFile:$WithOutputFile
 			}
 		}
 	}


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
A beautiful collaboration ( thanks @SQLDBAWithABeard and @PowerDBAKlaas ) between two cmdlets now enables people with outputfiles containing SQL Agent Tokens to actually have the "history" linked to the real output file.

### Approach
I needed to add a property in Get-DbaAgentOutputFile to have all the needed matching algorithm.
Get-DbaAgentHistory has been rewrited to use Get-DbaAgentOutputFile and to handle SQL Agent Job Tokens (BTW, see line 189...I couldn't find a better way). 
We do our best to do the replacement or we leave the token there.

### Commands to test
See the added example 

