### PR TITLE
Cache WhoisActive download to avoid repeated downloads

### DIFF
--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -79,6 +79,7 @@ function Install-DbaWhoIsActive {
 	)
 	
 	begin {
+        $DbatoolsData = Get-DbaConfigValue -Name "Path.DbatoolsData"
 		$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
 		$zipfile = "$temp\spwhoisactive.zip"
 
@@ -99,7 +100,7 @@ function Install-DbaWhoIsActive {
 						$url = $baseUrl + "/" + $latest
 						try {
 							Invoke-WebRequest $url -OutFile $zipfile -ErrorAction Stop
-							Copy-Item -Path $latest -Destination $LocalCachedCopy
+							Copy-Item -Path $zipfile -Destination $LocalCachedCopy
 						}
 						catch {
 							#try with default proxy and usersettings
@@ -223,7 +224,9 @@ function Install-DbaWhoIsActive {
 		}
 	}
 	end {
-        Get-Item $sqlfile | Remove-Item
+        if ($PSCmdlet.ShouldProcess($env:computername, "Post-install cleanup")) {
+            Get-Item $sqlfile | Remove-Item
+        }
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Install-SqlWhoIsActive
 	}
 }

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -89,11 +89,12 @@ function Install-DbaWhoIsActive {
 			$LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath $latest;
 
 			if (Test-Path -Path $LocalCachedCopy -PathType Leaf) {
-				Write-Message -Level Verbose -Message "Locally-cached copy exists, not downloading."
+				Write-Message -Level Verbose -Message "Locally-cached copy exists, skipping download."
 				if ($PSCmdlet.ShouldProcess($env:computername, "Copying sp_WhoisActive from local cache for installation")) {
 					Copy-Item -Path $LocalCachedCopy -Destination $zipfile;
 				}
-			} else {
+			}
+			else {
 				if ($PSCmdlet.ShouldProcess($env:computername, "Downloading sp_WhoisActive")) {
 					try {
 						Write-Message -Level Verbose -Message "Downloading sp_WhoisActive zip file, unzipping and installing."
@@ -107,13 +108,15 @@ function Install-DbaWhoIsActive {
 							(New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 							Invoke-WebRequest $url -OutFile $zipfile -ErrorAction Stop
 						}
-					} catch {
+					}
+					catch {
 						Stop-Function -Message "Couldn't download sp_WhoisActive. Please download and install manually from $url." -ErrorRecord $_
 						return
 					}
 				}
 			}
-		} else {
+		}
+		else {
 			# Look local
 			if ($PSCmdlet.ShouldProcess($env:computername, "Copying local file to temp directory")) {
 
@@ -133,7 +136,8 @@ function Install-DbaWhoIsActive {
 					
 			    if (Get-Command -ErrorAction SilentlyContinue -Name "Expand-Archive") {
 		    		Expand-Archive -Path $zipfile -DestinationPath $temp -Force
-	    		} else {
+				}
+				else {
 			    # Keep it backwards compatible
 				    $shell = New-Object -ComObject Shell.Application
 				    $zipPackage = $shell.NameSpace($zipfile)
@@ -144,7 +148,8 @@ function Install-DbaWhoIsActive {
 			    Remove-Item -Path $zipfile
             }
 			$sqlfile = (Get-ChildItem "$temp\who*active*.sql" -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
-		} else {
+		}
+		else {
 			$sqlfile = $LocalFile
 		}
 

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -36,6 +36,9 @@ function Install-DbaWhoIsActive {
 
 		.PARAMETER Silent
 			If this switch is enabled, the internal messaging functions will be silenced.
+		
+		.PARAMETER Force
+			If this switch is enabled, the sp_WhoisActive will be downloaded from the internet even if previously cached.
 
 		.EXAMPLE
 			Install-DbaWhoIsActive -SqlInstance sqlserver2014a -Database master
@@ -75,7 +78,8 @@ function Install-DbaWhoIsActive {
 		[ValidateScript({Test-Path -Path $_ -PathType Leaf})]
 		[string]$LocalFile,
 		[object]$Database,
-		[switch]$Silent
+		[switch]$Silent,
+		[switch]$Force
 	)
 	
 	begin {
@@ -88,7 +92,7 @@ function Install-DbaWhoIsActive {
 			$latest = ((Invoke-WebRequest -uri http://whoisactive.com/downloads).Links | where-object {$PSItem.href -match "who_is_active"} | Select-Object href -First 1).href	
 			$LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath $latest;
 
-			if (Test-Path -Path $LocalCachedCopy -PathType Leaf) {
+			if ((Test-Path -Path $LocalCachedCopy -PathType Leaf) -and (-not $Force)) {
 				Write-Message -Level Verbose -Message "Locally-cached copy exists, skipping download."
 				if ($PSCmdlet.ShouldProcess($env:computername, "Copying sp_WhoisActive from local cache for installation")) {
 					Copy-Item -Path $LocalCachedCopy -Destination $zipfile;


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Purpose
Caches the `sp_WhoisActive` zipfile in the local dbatools data directory so that it isn't re-downloaded repeatedly from the internet.

Per conversation in [PR 2041](https://github.com/sqlcollaborative/dbatools/pull/2041)

### Approach
1. Goes to the website & gets the name of the latest version
1. Looks for a file by the same name in `Path.DbatoolsData`
1. If found, uses that local file for the installation
1. If not found, downloads the file from the internet and saves it to `Path.DbatoolsData` for future use

### Commands to test
See help
