### PR TITLE
Get-DbaForceNetworkEncryption - make this command work on legacy

### DIFF
--- a/functions/Get-DbaForceNetworkEncryption.ps1
+++ b/functions/Get-DbaForceNetworkEncryption.ps1
@@ -108,7 +108,8 @@ function Get-DbaForceNetworkEncryption {
 				$cert = (Get-ItemProperty -Path $regpath -Name Certificate).Certificate
 				$forceencryption = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
 				
-				[pscustomobject]@{
+				# [pscustomobject] doesn't always work, unsure why. so return hashtable then turn it into  pscustomobject on client
+				@{
 					ComputerName		  = $env:COMPUTERNAME
 					InstanceName		  = $args[2]
 					SqlInstance		      = $args[1]
@@ -119,7 +120,10 @@ function Get-DbaForceNetworkEncryption {
 			
 			if ($PScmdlet.ShouldProcess("local", "Connecting to $instance")) {
 				try {
-					Invoke-Command2 -ComputerName $resolved.fqdn -Credential $Credential -ArgumentList $regroot, $vsname, $instancename -ScriptBlock $scriptblock -ErrorAction Stop | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
+					$results = Invoke-Command2 -ComputerName $resolved.fqdn -Credential $Credential -ArgumentList $regroot, $vsname, $instancename -ScriptBlock $scriptblock -ErrorAction Stop -Raw
+					foreach ($result in $results) {
+						[pscustomobject]$result	
+					}
 				}
 				catch {
 					Stop-Function -Message "Failed to connect to $($resolved.fqdn) using PowerShell remoting!" -ErrorRecord $_ -Target $instance -Continue


### PR DESCRIPTION
Returned weird on PS4/Win2012 R2

Working (works on older systems too)
![image](https://user-images.githubusercontent.com/8278033/29283363-b9ab3b6a-8126-11e7-9bf8-86ac76c24fab.png)
