### PR TITLE
Fix Copy-DbaSsisCatalog with Named Instances

### DIFF
--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -109,7 +109,10 @@ Deploy entire SSIS catalog to an instance without a destination catalog.  Passin
             param (
                 [Object]$Computer
             )
-            $result = Get-Service -ComputerName $Computer -Name msdts*
+            if ($Computer -like "*\*") {
+                $Computer = $Computer -split '\\' | Select-Object -First 1
+            }
+	    $result = Get-Service -ComputerName $Computer -Name msdts*
             if ($result.Count -gt 0) {
                 $running = $false
                 foreach ($service in $result) {

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -109,14 +109,11 @@ Deploy entire SSIS catalog to an instance without a destination catalog.  Passin
             param (
                 [Object]$Computer
             )
-            if ($Computer -like "*\*") {
-                $Computer = $Computer -split '\\' | Select-Object -First 1
-            }
-	    $result = Get-Service -ComputerName $Computer -Name msdts*
+	    $result = Get-DbaSqlService -ComputerName $Computer | Where-Object Servicename -like "MsDts*"
             if ($result.Count -gt 0) {
                 $running = $false
                 foreach ($service in $result) {
-                    if (!$service.Status -eq "Running") {
+                    if (!$service.State -eq "Running") {
                         Write-Warning "Service $($service.DisplayName) was found on the destination, but is currently not running."
                     }
                     else {


### PR DESCRIPTION
The get-service check is passed the raw connection string so fails if a named instance is used. Added a sanitization to grab just the servername part.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The function would fail if the destination was a named instance.

### Approach
Added a quick check for a \ and if one is found grab just the server part for the service check.
