### PR TITLE
Get-DbaDatabaseEncryption.Tests fixed wording of Context

### DIFF
--- a/tests/Get-DbaDatabaseEncryption.Tests.ps1
+++ b/tests/Get-DbaDatabaseEncryption.Tests.ps1
@@ -3,7 +3,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-    Context "testing pester" {
+    Context "Test Retriving Certificate" {
         BeforeAll {
 			$random = Get-Random
             $cert = "dbatoolsci_getcert$random"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Context was 'testing pester' from when I created it and was testing... pester :) Changed to match the actual purpose of the test.

### Approach
<!-- How does this change solve that purpose -->
`Context "Test Retriving Certificate" `