### PR TITLE
Invoke-DbaLogShipping update: do not set a default monitor server if not supplied

### DIFF
--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -133,7 +133,7 @@ The parameter works as a prefix where the name of the database will be added to 
 The default is "LSBackup_[databasename]"
 
 .PARAMETER CopyRetention
-The copy retention period in minutes. Default is 4320 / 72 hours
+The copy retention period in minutes. Default is 4320 / 72 hours.
 
 .PARAMETER CopySchedule
 Name of the backup schedule created for the copy job.
@@ -200,7 +200,7 @@ This setting is default.
 
 .PARAMETER PrimaryMonitorServer
 Is the name of the monitor server for the primary server.
-The default is the name of the primary sql server.
+If Monitor server is not provided then none will be configured
 
 .PARAMETER PrimaryMonitorCredential
 Allows you to login to enter a secure credential. Only needs to be used when the PrimaryMonitorServerSecurityMode is 0 or "sqlserver" 
@@ -664,7 +664,7 @@ The script will show a message that the copy destination has not been supplied a
 		}
 
 		# Check the backup network path
-		if (-not ((Test-Path $BackupNetworkPath -PathType Container -IsValid -Credential $SourceCredential) -and (Get-Item $BackupNetworkPath).PSProvider.Name -eq 'FileSystem')) {
+		if ((Test-DbaSqlPath -Path $BackupNetworkPath -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true){
 			Stop-Function -Message "Backup network path $BackupNetworkPath is not valid or can't be reached." -Target $SourceSqlInstance 
 			return
 		}
@@ -679,7 +679,8 @@ The script will show a message that the copy destination has not been supplied a
 			$CopyDestinationFolder = "$($DestinationServer.Settings.BackupDirectory)\Logshipping"
 
 			# Check to see if the path already exists
-			if (Test-Path $CopyDestinationFolder -Credential $DestinationCredential) {
+            
+			if (Test-DbaSqlPath -Path $CopyDestinationFolder -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential) {
 				Write-Message -Message "Copy destination $CopyDestinationFolder already exists" -Level Verbose
 			}
 			else {
@@ -707,7 +708,7 @@ The script will show a message that the copy destination has not been supplied a
 								}
 								# If the server is local and the credential is set
 								elseif ($DestinationCredential) {
-									Invoke-Command2 -ScriptBlock -Credential $DestinationCredential {
+									Invoke-Command2 -Credential $DestinationCredential -ScriptBlock {
 										Write-Message -Message "Creating copy destination folder $CopyDestinationFolder" -Level Verbose
 										New-Item -Path $CopyDestinationFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
 									}
@@ -744,7 +745,7 @@ The script will show a message that the copy destination has not been supplied a
 				} # else not force
 			} # if test path copy destination
 		} # if not copy destination
-		elseif (-not ((Test-Path $CopyDestinationFolder -PathType Container -IsValid -Credential $DestinationCredential) -and (Get-Item $CopyDestinationFolder).PSProvider.Name -eq 'FileSystem')) {
+		elseif ((Test-DbaSqlPath -Path $CopyDestinationFolder -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential) -ne $true) {
 			Stop-Function -Message "Copy destination folder $CopyDestinationFolder is not valid or can't be reached." -Target $DestinationSqlInstance 
 			return
 		}
@@ -1092,13 +1093,15 @@ The script will show a message that the copy destination has not been supplied a
 				}
 				Write-Message -Message "Backup network path set to $DatabaseBackupNetworkPath." -Level Verbose
 
-
 				# Checking if the database network path exists
-				if (-not (Test-Path -Path $DatabaseBackupNetworkPath -Credential $SourceCredential)) {
+				if ((Test-DbaSqlPath -Path $DatabaseBackupNetworkPath -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true) {
 					# To to create the backup directory for the database 
 					try {
 						Write-Message -Message "Backup network path not found. Trying to create it.." -Level Verbose
-						New-Item $DatabaseBackupNetworkPath -ItemType Directory -Credential $SourceCredential | Out-Null
+                        Invoke-Command2 -Credential $DestinationCredential -ScriptBlock {
+						    Write-Message -Message "Creating backup folder $DatabaseBackupNetworkPath" -Level Verbose
+							New-Item -Path $DatabaseBackupNetworkPath -ItemType Directory -Credential $SourceCredential -Force:$Force | Out-Null
+                        }
 					}
 					catch {
 						Stop-Function -Message "Something went wrong creating the directory. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
@@ -1203,11 +1206,14 @@ The script will show a message that the copy destination has not been supplied a
 						Write-Message -Message "Restore log folder set to $DatabaseRestoreLogFolder" -Level Verbose
 
 						# Check if the restore data folder exists
-						if (-not (Test-Path -Path $DatabaseRestoreDataFolder -Credential $DestinationCredential)) {
+						if ((Test-DbaSqlPath  -Path $DatabaseRestoreDataFolder -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential)-ne $true) {
 							if ($PSCmdlet.ShouldProcess($DestinationServerName, "Creating database restore data folder on $DestinationServerName")) {
 								# Try creating the data folder
 								try {
-									New-Item $DatabaseRestoreDataFolder -ItemType Directory -Credential $DestinationCredential | Out-Null
+                                    Invoke-Command2 -Credential $DestinationCredential -ScriptBlock {
+						                Write-Message -Message "Creating data folder $DatabaseRestoreDataFolder" -Level Verbose
+							            New-Item -Path $DatabaseRestoreDataFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
+                                    }
 								}
 								catch {
 									Stop-Function -Message "Something went wrong creating the restore data directory. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
@@ -1216,12 +1222,14 @@ The script will show a message that the copy destination has not been supplied a
 						}
 
 						# Check if the restore log folder exists
-						if (-not (Test-Path $DatabaseRestoreLogFolder -Credential $DestinationCredential)) {
+						if ((Test-DbaSqlPath  -Path $DatabaseRestoreLogFolder -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential)-ne $true) {
 							if ($PSCmdlet.ShouldProcess($DestinationServerName, "Creating database restore log folder on $DestinationServerName")) {
 								# Try creating the log folder
 								try {
-									Write-Message -Message "Restore log folder $DatabaseRestoreLogFolder not found. Trying to create it.." -Level Verbose
-									New-Item $DatabaseRestoreLogFolder -ItemType Directory -Credential $DestinationCredential | Out-Null
+                                    Invoke-Command2 -Credential $DestinationCredential -ScriptBlock {
+						               Write-Message -Message "Restore log folder $DatabaseRestoreLogFolder not found. Trying to create it.." -Level Verbose
+							            New-Item -Path $DatabaseRestoreLogFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
+                                    }
 								}
 								catch {
 									Stop-Function -Message "Something went wrong creating the restore log directory. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
@@ -1235,7 +1243,7 @@ The script will show a message that the copy destination has not been supplied a
 
 					# Chech if the full backup patk can be reached
 					if ($FullBackupPath) {
-						if (-not (Test-Path -Path $FullBackupPath -Credential $DestinationCredential)) {
+						if ((Test-DbaSqlPath -Path $FullBackupPath -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential) -ne $true) {
 							Stop-Function -Message ("The path to the full backup could not be reached. Check the path and/or the crdential. `n$($_.Exception.Message)") -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
 						}
 					} 
@@ -1252,7 +1260,7 @@ The script will show a message that the copy destination has not been supplied a
 								Stop-Function -Message "The last full backup is not located on shared location. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
 							}
 							# Test the path to the backup
-							elseif (-not (Test-Path $LastBackup.Path -Credential $SourceCredential)) {
+							elseif ((Test-DbaSqlPath -Path $LastBackup.Path -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true) {
 								Stop-Function -Message "The full backup could not be found on $($LastBackup.Path). Check path and/or credentials. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $SourceSqlInstance -Continue
 							}
 							else {
@@ -1294,11 +1302,13 @@ The script will show a message that the copy destination has not been supplied a
 				}
 
 				# Check if the copy destination folder exists
-				if (-not (Test-Path -Path $DatabaseCopyDestinationFolder -Credential $DestinationCredential)) {
-					Write-Message -Message "Copy destination folder $DatabaseCopyDestinationFolder not found. Trying to create it.. ." -Level Verbose
+				if ((Test-DbaSqlPath -Path $DatabaseCopyDestinationFolder -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationCredential) -ne $true) {
 					if ($PSCmdlet.ShouldProcess($DestinationServerName, "Creating copy destination folder on $DestinationServerName")) {
 						try {
-							New-Item $DatabaseCopyDestinationFolder -ItemType Directory -Credential $DestinationCredential | Out-Null
+                                Invoke-Command2 -Credential $DestinationCredential -ScriptBlock {
+						            Write-Message -Message "Copy destination folder $DatabaseCopyDestinationFolder not found. Trying to create it.. ." -Level Verbose
+							        New-Item -Path $DatabaseCopyDestinationFolder -ItemType Directory -Credential $DestinationCredential -Force:$Force | Out-Null
+                                }
 						}
 						catch {
 							Stop-Function -Message "Something went wrong creating the database copy destination folder. `n$($_.Exception.Message)" -InnerErrorRecord $_ -Target $DestinationServerName -Continue
@@ -1356,10 +1366,10 @@ The script will show a message that the copy destination has not been supplied a
 				}
 
 				# Check the primary monitor server
-				if (($PrimaryMonitorServer) -or ([string]$PrimaryMonitorServer -eq '') -or ($PrimaryMonitorServer -eq $null)) {
-					Write-Message -Message "Setting monitor server for primary server to $SourceSqlInstance." -Level Output
-					$PrimaryMonitorServer = $SourceSqlInstance
-				}
+				#if (([string]$PrimaryMonitorServer -eq '') -or ($PrimaryMonitorServer -eq $null)) {
+				#	Write-Message -Message "Setting monitor server for primary server to $SourceSqlInstance." -Level Output
+				#	$PrimaryMonitorServer = $SourceSqlInstance
+				#}
 
 				# Check the PrimaryMonitorServerSecurityMode if it's SQL Server authentication
 				if ($PrimaryMonitorServerSecurityMode -eq 0) {
@@ -1380,10 +1390,10 @@ The script will show a message that the copy destination has not been supplied a
 				}
 
 				# Check the secondary monitor server
-				if ($SecondaryMonitorServer) {
-					Write-Message -Message "Setting secondary monitor server for $DestinationSqlInstance to $SecondaryMonitorServer." -Level Verbose
-					$SecondaryMonitorServer = $DestinationSqlInstance
-				}
+				#if ($SecondaryMonitorServer) {
+				#	Write-Message -Message "Setting secondary monitor server for $DestinationSqlInstance to $SecondaryMonitorServer." -Level Verbose
+				#	$SecondaryMonitorServer = $DestinationSqlInstance
+				#}
 
 				# Check the MonitorServerSecurityMode if it's SQL Server authentication
 				if ($SecondaryMonitorServerSecurityMode -eq 0) {
@@ -1516,22 +1526,37 @@ The script will show a message that the copy destination has not been supplied a
 					try {
 
 						Write-Message -Message "Configuring logshipping for primary database" -Level Output
-
-						New-DbaLogShippingPrimaryDatabase -SqlInstance $SourceSqlInstance `
-							-SqlCredential $SourceSqlCredential `
-							-Database $db `
-							-BackupDirectory $DatabaseBackupLocalPath `
-							-BackupJob $DatabaseBackupJob `
-							-BackupRetention $BackupRetention `
-							-BackupShare $DatabaseBackupNetworkPath `
-							-BackupThreshold $BackupThreshold `
-							-CompressBackup:$CompressBackup `
-							-HistoryRetention $HistoryRetention `
-							-MonitorServer $PrimaryMonitorServer `
-							-MonitorServerSecurityMode $PrimaryMonitorServerSecurityMode `
-							-MonitorCredential $PrimaryMonitorCredential `
-							-ThresholdAlertEnabled:$PrimaryThresholdAlertEnabled `
-							-Force:$Force 
+                        if($PrimaryMonitorServer) {
+						    New-DbaLogShippingPrimaryDatabase -SqlInstance $SourceSqlInstance `
+						    	-SqlCredential $SourceSqlCredential `
+						    	-Database $db `
+						    	-BackupDirectory $DatabaseBackupLocalPath `
+						    	-BackupJob $DatabaseBackupJob `
+						    	-BackupRetention $BackupRetention `
+						    	-BackupShare $DatabaseBackupNetworkPath `
+						    	-BackupThreshold $BackupThreshold `
+						    	-CompressBackup:$CompressBackup `
+						    	-HistoryRetention $HistoryRetention `
+						    	-MonitorServer $PrimaryMonitorServer `
+						    	-MonitorServerSecurityMode $PrimaryMonitorServerSecurityMode `
+						    	-MonitorCredential $PrimaryMonitorCredential `
+						    	-ThresholdAlertEnabled:$PrimaryThresholdAlertEnabled `
+						    	-Force:$Force 
+                        }
+                        else {
+                        	New-DbaLogShippingPrimaryDatabase -SqlInstance $SourceSqlInstance `
+						    	-SqlCredential $SourceSqlCredential `
+						    	-Database $db `
+						    	-BackupDirectory $DatabaseBackupLocalPath `
+						    	-BackupJob $DatabaseBackupJob `
+						    	-BackupRetention $BackupRetention `
+						    	-BackupShare $DatabaseBackupNetworkPath `
+						    	-BackupThreshold $BackupThreshold `
+						    	-CompressBackup:$CompressBackup `
+						    	-HistoryRetention $HistoryRetention `
+						    	-ThresholdAlertEnabled:$PrimaryThresholdAlertEnabled `
+						    	-Force:$Force 
+                        }
                         
 						# Check if the backup job needs to be enabled or disabled
 						if ($BackupScheduleDisabled) {
@@ -1582,20 +1607,33 @@ The script will show a message that the copy destination has not been supplied a
 					try {
 
 						Write-Message -Message "Configuring logshipping from secondary database $SecondaryDatabase to primary database $db." -Level Output
-
-						New-DbaLogShippingSecondaryPrimary -SqlInstance $DestinationSqlInstance `
-							-SqlCredential $DestinationSqlCredential `
-							-BackupSourceDirectory $DatabaseBackupNetworkPath `
-							-BackupDestinationDirectory $DatabaseCopyDestinationFolder `
-							-CopyJob $DatabaseCopyJob `
-							-FileRetentionPeriod $BackupRetention `
-							-MonitorServer $SecondaryMonitorServer `
-							-MonitorServerSecurityMode $SecondaryMonitorServerSecurityMode `
-							-MonitorCredential $SecondaryMonitorCredential `
-							-PrimaryServer $SourceSqlInstance `
-							-PrimaryDatabase $db `
-							-RestoreJob $DatabaseRestoreJob `
-							-Force:$Force
+                        if($SecondaryMonitorServer) {
+						    New-DbaLogShippingSecondaryPrimary -SqlInstance $DestinationSqlInstance `
+							    -SqlCredential $DestinationSqlCredential `
+							    -BackupSourceDirectory $DatabaseBackupNetworkPath `
+							    -BackupDestinationDirectory $DatabaseCopyDestinationFolder `
+							    -CopyJob $DatabaseCopyJob `
+							    -FileRetentionPeriod $BackupRetention `
+							    -MonitorServer $SecondaryMonitorServer `
+							    -MonitorServerSecurityMode $SecondaryMonitorServerSecurityMode `
+							    -MonitorCredential $SecondaryMonitorCredential `
+							    -PrimaryServer $SourceSqlInstance `
+							    -PrimaryDatabase $db `
+							    -RestoreJob $DatabaseRestoreJob `
+							    -Force:$Force
+                        }
+                        else {
+                        	New-DbaLogShippingSecondaryPrimary -SqlInstance $DestinationSqlInstance `
+							    -SqlCredential $DestinationSqlCredential `
+							    -BackupSourceDirectory $DatabaseBackupNetworkPath `
+							    -BackupDestinationDirectory $DatabaseCopyDestinationFolder `
+							    -CopyJob $DatabaseCopyJob `
+							    -FileRetentionPeriod $BackupRetention `
+							    -PrimaryServer $SourceSqlInstance `
+							    -PrimaryDatabase $db `
+							    -RestoreJob $DatabaseRestoreJob `
+							    -Force:$Force
+                        }
 
 						Write-Message -Message "Create copy job schedule $DatabaseCopySchedule" -Level Output
 
@@ -1680,3 +1718,7 @@ The script will show a message that the copy destination has not been supplied a
 		Write-Message -Message "Finished setting up log shipping." -Level Output
 	}
 }
+
+
+
+

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -1365,12 +1365,6 @@ The script will show a message that the copy destination has not been supplied a
 					}
 				}
 
-				# Check the primary monitor server
-				#if (([string]$PrimaryMonitorServer -eq '') -or ($PrimaryMonitorServer -eq $null)) {
-				#	Write-Message -Message "Setting monitor server for primary server to $SourceSqlInstance." -Level Output
-				#	$PrimaryMonitorServer = $SourceSqlInstance
-				#}
-
 				# Check the PrimaryMonitorServerSecurityMode if it's SQL Server authentication
 				if ($PrimaryMonitorServerSecurityMode -eq 0) {
 					if ($PrimaryMonitorServerLogin) {
@@ -1388,12 +1382,6 @@ The script will show a message that the copy destination has not been supplied a
 						"SQLSERVER" { 0 } "WINDOWS" { 1 } default { 1 }
 					}
 				}
-
-				# Check the secondary monitor server
-				#if ($SecondaryMonitorServer) {
-				#	Write-Message -Message "Setting secondary monitor server for $DestinationSqlInstance to $SecondaryMonitorServer." -Level Verbose
-				#	$SecondaryMonitorServer = $DestinationSqlInstance
-				#}
 
 				# Check the MonitorServerSecurityMode if it's SQL Server authentication
 				if ($SecondaryMonitorServerSecurityMode -eq 0) {

--- a/internal/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/New-DbaLogShippingPrimaryDatabase.ps1
@@ -174,18 +174,6 @@ New-DbaLogShippingPrimaryDatabase -SqlInstance sql1 -Database DB1 -BackupDirecto
 		Write-Message -Message "Setting monitor server security mode to $MonitorServerSecurityMode." -Level Verbose
 	}
 
-	# Check the MonitorServer
-	#if (-not $MonitorServer) {
-	#	if ($Force) {
-	#		$MonitorServer = $SqlInstance
-	#		Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
-	#	}
-	#	else {
-	#		Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance 
-	#		return
-	#	}
-	#}
-
 	# Check the MonitorServerSecurityMode if it's SQL Server authentication
 	if ($MonitorServerSecurityMode -eq 0 -and -not $MonitorCredential) {
 		Stop-Function -Message "The MonitorServerCredential cannot be empty when using SQL Server authentication." -InnerErrorRecord $_ -Target $SqlInstance 
@@ -231,7 +219,7 @@ New-DbaLogShippingPrimaryDatabase -SqlInstance sql1 -Database DB1 -BackupDirecto
                 ,@backup_job_name = N'$BackupJob'
                 ,@backup_retention_period = $BackupRetention
                 ,@backup_compression = $BackupCompression
-                ,@monitor_server = N'$MonitorServer '
+                ,@monitor_server = N'$MonitorServer'
                 ,@monitor_server_security_mode = $MonitorServerSecurityMode
                 ,@backup_threshold = $BackupThreshold
                 ,@threshold_alert_enabled = $ThresholdAlertEnabled

--- a/internal/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/New-DbaLogShippingPrimaryDatabase.ps1
@@ -43,7 +43,7 @@ The default is 14420.
 
 .PARAMETER MonitorServer
 Is the name of the monitor server.
-The default is the name of the primary server.
+If Monitor server is not provided then none will be configured
 
 .PARAMETER MonitorCredential
 Allows you to login to enter a secure credential. 
@@ -175,16 +175,16 @@ New-DbaLogShippingPrimaryDatabase -SqlInstance sql1 -Database DB1 -BackupDirecto
 	}
 
 	# Check the MonitorServer
-	if (-not $MonitorServer) {
-		if ($Force) {
-			$MonitorServer = $SqlInstance
-			Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
-		}
-		else {
-			Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance 
-			return
-		}
-	}
+	#if (-not $MonitorServer) {
+	#	if ($Force) {
+	#		$MonitorServer = $SqlInstance
+	#		Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
+	#	}
+	#	else {
+	#		Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance 
+	#		return
+	#	}
+	#}
 
 	# Check the MonitorServerSecurityMode if it's SQL Server authentication
 	if ($MonitorServerSecurityMode -eq 0 -and -not $MonitorCredential) {
@@ -220,26 +220,45 @@ New-DbaLogShippingPrimaryDatabase -SqlInstance sql1 -Database DB1 -BackupDirecto
 	}
 
 	# Set the log shipping primary
-	$Query = "
-        DECLARE @LS_BackupJobId AS uniqueidentifier;
-        DECLARE @LS_PrimaryId AS uniqueidentifier;
-        EXEC master.dbo.sp_add_log_shipping_primary_database 
-            @database = N'$Database'
-            ,@backup_directory = N'$BackupDirectory'
-            ,@backup_share = N'$BackupShare'
-            ,@backup_job_name = N'$BackupJob'
-            ,@backup_retention_period = $BackupRetention
-            ,@backup_compression = $BackupCompression
-            ,@monitor_server = N'$MonitorServer '
-            ,@monitor_server_security_mode = $MonitorServerSecurityMode
-            ,@backup_threshold = $BackupThreshold
-            ,@threshold_alert_enabled = $ThresholdAlertEnabled
-            ,@history_retention_period = $HistoryRetention
-            ,@backup_job_id = @LS_BackupJobId OUTPUT
-            ,@primary_id = @LS_PrimaryId OUTPUT "
+    if($MonitorServer){
+	    $Query = "
+            DECLARE @LS_BackupJobId AS uniqueidentifier;
+            DECLARE @LS_PrimaryId AS uniqueidentifier;
+            EXEC master.dbo.sp_add_log_shipping_primary_database 
+                @database = N'$Database'
+                ,@backup_directory = N'$BackupDirectory'
+                ,@backup_share = N'$BackupShare'
+                ,@backup_job_name = N'$BackupJob'
+                ,@backup_retention_period = $BackupRetention
+                ,@backup_compression = $BackupCompression
+                ,@monitor_server = N'$MonitorServer '
+                ,@monitor_server_security_mode = $MonitorServerSecurityMode
+                ,@backup_threshold = $BackupThreshold
+                ,@threshold_alert_enabled = $ThresholdAlertEnabled
+                ,@history_retention_period = $HistoryRetention
+                ,@backup_job_id = @LS_BackupJobId OUTPUT
+                ,@primary_id = @LS_PrimaryId OUTPUT "
+    }
+    else {
+    	$Query = "
+            DECLARE @LS_BackupJobId AS uniqueidentifier;
+            DECLARE @LS_PrimaryId AS uniqueidentifier;
+            EXEC master.dbo.sp_add_log_shipping_primary_database 
+                @database = N'$Database'
+                ,@backup_directory = N'$BackupDirectory'
+                ,@backup_share = N'$BackupShare'
+                ,@backup_job_name = N'$BackupJob'
+                ,@backup_retention_period = $BackupRetention
+                ,@backup_compression = $BackupCompression
+                ,@backup_threshold = $BackupThreshold
+                ,@threshold_alert_enabled = $ThresholdAlertEnabled
+                ,@history_retention_period = $HistoryRetention
+                ,@backup_job_id = @LS_BackupJobId OUTPUT
+                ,@primary_id = @LS_PrimaryId OUTPUT "
+    }
 
 	# Check the MonitorServerSecurityMode if it's SQL Server authentication
-	if ($MonitorServerSecurityMode -eq 0) {
+	if ($MonitorServer -and $MonitorServerSecurityMode -eq 0) {
 		$Query += ",@monitor_server_login = N'$MonitorLogin'
             ,@monitor_server_password = N'$MonitorPassword' "
 	}

--- a/internal/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/New-DbaLogShippingSecondaryPrimary.ps1
@@ -161,17 +161,6 @@ New-DbaLogShippingSecondaryPrimary -SqlInstance sql2 -BackupSourceDirectory "\\s
 		}
 	}
 
-	# Check the MonitorServer
-	#if (-not $MonitorServer) {
-	#	if ($Force) {
-	#		$MonitorServer = $SqlInstance
-	#		Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
-	#	}
-	#	else {
-	#		Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance -Continue
-	#	}
-	#}
-
 	# Check of the MonitorServerSecurityMode value is of type string and set the integer value
 	if ($MonitorServerSecurityMode -notin 0, 1) {
 		$MonitorServerSecurityMode = switch ($MonitorServerSecurityMode) {"WINDOWS" { 1 } "SQLSERVER" { 0 } }

--- a/internal/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/New-DbaLogShippingSecondaryPrimary.ps1
@@ -33,7 +33,7 @@ The length of time, in minutes, that a backup file is retained on the secondary 
 The default is 14420.
 
 .PARAMETER MonitorServer
-Is the name of the monitor server. The default is the secondary server.
+Is the name of the monitor server. If no monitor is provided then it will not be configured.
 
 .PARAMETER MonitorServerLogin
 Is the username of the account used to access the monitor server. 
@@ -114,7 +114,6 @@ New-DbaLogShippingSecondaryPrimary -SqlInstance sql2 -BackupSourceDirectory "\\s
 		[System.Management.Automation.PSCredential]
 		$MonitorCredential,
 
-		[Parameter(Mandatory = $true)]
 		[ValidateSet(0, "sqlserver", 1, "windows")]
 		[object]$MonitorServerSecurityMode = 1,
 
@@ -163,15 +162,15 @@ New-DbaLogShippingSecondaryPrimary -SqlInstance sql2 -BackupSourceDirectory "\\s
 	}
 
 	# Check the MonitorServer
-	if (-not $MonitorServer) {
-		if ($Force) {
-			$MonitorServer = $SqlInstance
-			Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
-		}
-		else {
-			Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance -Continue
-		}
-	}
+	#if (-not $MonitorServer) {
+	#	if ($Force) {
+	#		$MonitorServer = $SqlInstance
+	#		Write-Message -Message "Setting monitor server to $MonitorServer." -Level Verbose
+	#	}
+	#	else {
+	#		Stop-Function -Message "The monitor server needs to be set. Use -Force if system name must be used." -InnerErrorRecord $_ -Target $SqlInstance -Continue
+	#	}
+	#}
 
 	# Check of the MonitorServerSecurityMode value is of type string and set the integer value
 	if ($MonitorServerSecurityMode -notin 0, 1) {
@@ -203,26 +202,45 @@ New-DbaLogShippingSecondaryPrimary -SqlInstance sql2 -BackupSourceDirectory "\\s
 	}
 
 	# Set up the query
-	$Query = "
-        DECLARE @LS_Secondary__CopyJobId AS uniqueidentifier
-        DECLARE @LS_Secondary__RestoreJobId	AS uniqueidentifier
-        DECLARE @LS_Secondary__SecondaryId AS uniqueidentifier 
-        EXEC master.dbo.sp_add_log_shipping_secondary_primary 
-                @primary_server = N'$PrimaryServer' 
-                ,@primary_database = N'$PrimaryDatabase' 
-                ,@backup_source_directory = N'$BackupSourceDirectory' 
-                ,@backup_destination_directory = N'$BackupDestinationDirectory' 
-                ,@copy_job_name = N'$CopyJob' 
-                ,@restore_job_name = N'$RestoreJob' 
-                ,@file_retention_period = $FileRetentionPeriod 
-                ,@monitor_server = N'$MonitorServer' 
-                ,@monitor_server_security_mode = $($MonitorServerSecurityMode)
-                ,@copy_job_id = @LS_Secondary__CopyJobId
-                ,@restore_job_id = @LS_Secondary__RestoreJobId
+    if($MonitorServer) {
+	    $Query = "
+            DECLARE @LS_Secondary__CopyJobId AS uniqueidentifier
+            DECLARE @LS_Secondary__RestoreJobId	AS uniqueidentifier
+            DECLARE @LS_Secondary__SecondaryId AS uniqueidentifier 
+            EXEC master.dbo.sp_add_log_shipping_secondary_primary 
+                    @primary_server = N'$PrimaryServer' 
+                    ,@primary_database = N'$PrimaryDatabase' 
+                    ,@backup_source_directory = N'$BackupSourceDirectory' 
+                    ,@backup_destination_directory = N'$BackupDestinationDirectory' 
+                    ,@copy_job_name = N'$CopyJob' 
+                    ,@restore_job_name = N'$RestoreJob' 
+                    ,@file_retention_period = $FileRetentionPeriod 
+                    ,@monitor_server = N'$MonitorServer' 
+                    ,@monitor_server_security_mode = $($MonitorServerSecurityMode)
+                    ,@copy_job_id = @LS_Secondary__CopyJobId
+                    ,@restore_job_id = @LS_Secondary__RestoreJobId
                 ,@secondary_id = @LS_Secondary__SecondaryId OUTPUT "
+    }
+    else {
+        $Query = "
+            DECLARE @LS_Secondary__CopyJobId AS uniqueidentifier
+            DECLARE @LS_Secondary__RestoreJobId	AS uniqueidentifier
+            DECLARE @LS_Secondary__SecondaryId AS uniqueidentifier 
+            EXEC master.dbo.sp_add_log_shipping_secondary_primary 
+                    @primary_server = N'$PrimaryServer' 
+                    ,@primary_database = N'$PrimaryDatabase' 
+                    ,@backup_source_directory = N'$BackupSourceDirectory' 
+                    ,@backup_destination_directory = N'$BackupDestinationDirectory' 
+                    ,@copy_job_name = N'$CopyJob' 
+                    ,@restore_job_name = N'$RestoreJob' 
+                    ,@file_retention_period = $FileRetentionPeriod 
+                    ,@copy_job_id = @LS_Secondary__CopyJobId
+                    ,@restore_job_id = @LS_Secondary__RestoreJobId
+                ,@secondary_id = @LS_Secondary__SecondaryId OUTPUT " 
+    }
     
 	# Check the MonitorServerSecurityMode if it's SQL Server authentication
-	if ($MonitorServerSecurityMode -eq 0) {
+	if ($MonitorServer -and $MonitorServerSecurityMode -eq 0) {
 		$Query += ",@monitor_server_login = N'$MonitorLogin'
             ,@monitor_server_password = N'$MonitorPassword' "
 	}


### PR DESCRIPTION
## Bug Fix, Behavior change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #2123)
 - [ ] When not supplying a monitor server the default behavior is not to configure.

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
BugFix

### Approach
The monitoring server should be an optional configuration.

### Commands to test
Omits monitor
```powershell
Invoke-DbaLogShipping -SourceSqlInstance 'WIN2016,1435' `
-DestinationSqlInstance 'WIN2016-DR,1436' ` 
-Database test ` 
-BackupNetworkPath \\WIN2016\sqlbackup\logshipping ` 
-Force -CompressBackup ` 
-CopyDestinationFolder \\WIN2016-DR\sqlbackup\logshipping ` 
-Verbose;
```
Include Monitor
```powershell
Invoke-DbaLogShipping -SourceSqlInstance 'WIN2016,1435' ` 
-DestinationSqlInstance 'WIN2016-DR,1436' ` 
-Database test ` 
-BackupNetworkPath \\WIN2016\sqlbackup\logshipping ` 
-Force -CompressBackup `
-CopyDestinationFolder \\WIN2016-DR\sqlbackup\logshipping ` 
-Verbose -PrimaryMonitorServer "WIN2016";
```
