### PR TITLE
Trying to adjust the test for Copy-DbaCredential

### DIFF
--- a/tests/Copy-DbaCredential.Tests.ps1
+++ b/tests/Copy-DbaCredential.Tests.ps1
@@ -1,84 +1,100 @@
-﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-if ($env:appveyor) {
-	try {
-		$connstring = "Server=ADMIN:$script:instance1;Trusted_Connection=True"
-		$server = New-Object Microsoft.SqlServer.Management.Smo.Server $script:instance1
-		$server.ConnectionContext.ConnectionString = $connstring
-		$server.ConnectionContext.Connect()
-		$server.ConnectionContext.Disconnect()
-		Clear-DbaSqlConnectionPool
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		if ($env:appveyor) {
+			try {
+				$connstring = "Server=ADMIN:$script:instance1;Trusted_Connection=True"
+				$server = New-Object Microsoft.SqlServer.Management.Smo.Server $script:instance1
+				$server.ConnectionContext.ConnectionString = $connstring
+				$server.ConnectionContext.Connect()
+				$server.ConnectionContext.Disconnect()
+				Clear-DbaSqlConnectionPool -ComputerName localhost
+			}
+			catch {
+				Write-Host "DAC not working this round, likely due to Appveyor resources"
+				return
+			}
+		}
 	}
-	catch {
-		Write-Host "DAC not working this round, likely due to Appveyor resources"
-		return
+	BeforeEach {
+		# One more for the road - clearing the connection pool is important for DAC since only one is allowed
+		if ($env:appveyor) {
+			Clear-DbaSqlConnectionPool -ComputerName localhost
+		}
+		else {
+			foreach ($instance in $instances) {
+				Clear-DbaSqlConnectionPool -ComputerName ([DbaInstance]$instance).ComputerName
+			}
+		}
 	}
-}
+	AfterAll {
+		if ($env:appveyor) {
+			Clear-DbaSqlConnectionPool -ComputerName localhost
+		}
+		else {
+			foreach ($instance in $instances) {
+				Clear-DbaSqlConnectionPool -ComputerName ([DbaInstance]$instance).ComputerName
+			}
+		}		# Finish up
+		$credentials = $script:Instances | Get-DbaCredential
+		foreach ($credential in $credentials) {
+			$credential.Drop()
+		}
 
-# One more for the road - clearing the connection pool is important for DAC since only one is allowed
-Clear-DbaSqlConnectionPool
-
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+		foreach ($login in $logins) {
+			$null = net user $login /delete *>&1
+		}
+	}
 	Context "Create new credential" {
 		$credentials = $script:Instances | Get-DbaCredential
 		foreach ($Credential in $credentials) {
 			$Credential.Drop()
 		}
-		
+
 		$logins = "thor", "thorsmomma"
 		$plaintext = "BigOlPassword!"
 		$password = ConvertTo-SecureString $plaintext -AsPlainText -Force
-		
+
 		# Add user
 		foreach ($login in $logins) {
 			$null = net user $login $plaintext /add *>&1
 		}
-		
+
 		It "Should create new credentials with the proper properties" {
 			$results = New-DbaCredential -SqlInstance $script:instance1 -Name thorcred -CredentialIdentity thor -Password $password
 			$results.Name | Should Be "thorcred"
 			$results.Identity | Should Be "thor"
-			
+
 			$results = New-DbaCredential -SqlInstance $script:instance1 -CredentialIdentity thorsmomma -Password $password
 			$results.Name | Should Be "thorsmomma"
 			$results.Identity | Should Be "thorsmomma"
 		}
 	}
-	Clear-DbaSqlConnectionPool
+
 	Context "Copy Credential with the same properties." {
 		It "Should copy successfully" {
 			$results = Copy-DbaCredential -Source $script:instance1 -Destination $script:instance2 -CredentialIdentity thorcred
 			$results.Status | Should Be "Successful"
 		}
-		
+
 		It "Should retain its same properties" {
-			
+
 			$Credential1 = Get-DbaCredential -SqlInstance $script:instance1 -CredentialIdentity thor
 			$Credential2 = Get-DbaCredential -SqlInstance $script:instance2 -CredentialIdentity thor
-			
+
 			# Compare its value
 			$Credential1.Name | Should Be $Credential2.Name
 			$Credential1.CredentialIdentity | Should Be $Credential2.CredentialIdentity
 		}
 	}
-	Clear-DbaSqlConnectionPool
 	Context "No overwrite and cleanup" {
-		$results = Copy-DbaCredential -Source $script:instance1 -Destination $script:instance2 -CredentialIdentity thorcred -WarningVariable warning 3>&1
+		$null = Copy-DbaCredential -Source $script:instance1 -Destination $script:instance2 -CredentialIdentity thorcred -WarningVariable warning 3>&1
 		It "Should not attempt overwrite" {
 			$warning | Should Match "exists"
-			
-		}
-		# Finish up
-		$credentials = $script:Instances | Get-DbaCredential
-		foreach ($Credential in $credentials) {
-			$Credential.Drop()
-		}
-		
-		foreach ($login in $logins) {
-			$null = net user $login /delete *>&1
+
 		}
 	}
-	Clear-DbaSqlConnectionPool
 }


### PR DESCRIPTION
- Adding BeforeEach, BeforeAll, and AfterAll
- Moved the Clear connection pool to appropriate section noted above
- Added logic to work between Appveyor or if someone wants to run in their own environment after adjusting the `contsants.ps1` file.

Adjust the `\tests\constants.ps1` file to point to two separate instances in your local environment and this test can now be run. It fails in Appveyor for the DAC issue, so wanted to adjust it where we could run it locally to ensure if it was just Appveyor or an actual issue with the test or command(s).

This test now shows successful against my 2 SQL Server 2008 R2 named instances. So we'll see if it passes in Appveyor now.

![image](https://user-images.githubusercontent.com/11204251/29491966-3a702080-8532-11e7-8637-3941a1cc4bcd.png)
