### PR TITLE
Get-DbaDatabaseSpace: improve [UnusableSpaceMB] for unlimited maxfilesize

### DIFF
--- a/functions/Get-DbaDatabaseSpace.ps1
+++ b/functions/Get-DbaDatabaseSpace.ps1
@@ -124,26 +124,15 @@
 													ELSE (0)
 													END
 									END AS [PossibleAutoGrowthMB]
-					, CASE f.growth	WHEN 0 THEN	CASE f.max_size
-												WHEN (-1)
-												THEN CAST(((2147483648.) - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
-												ELSE CAST((f.max_size - CAST(FILEPROPERTY(f.name, 'SpaceUsed') AS int))/128.0 AS FLOAT)
+					, CASE f.max_size	WHEN -1 THEN 0
+										ELSE CASE f.growth
+												WHEN 0 THEN (f.max_size - f.size)/128
+												ELSE	CASE f.is_percent_growth
+														WHEN 0
+														THEN CAST((f.max_size - f.size - (	CONVERT(FLOAT,FLOOR((f.max_size-f.Size)/f.Growth)*f.Growth)))/128.0 AS FLOAT)
+														ELSE CAST((f.max_size - f.size - (	CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],f.Max_Size)/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))))/128.0 AS FLOAT)
+														END
 												END
-									ELSE CAST((f.max_size - f.size - (	CASE f.is_percent_growth
-												WHEN 0
-												THEN	CASE f.max_size
-														WHEN (-1)
-														THEN CONVERT(FLOAT,((((2147483648.)-f.Size)/f.Growth)*f.Growth))
-														ELSE CONVERT(FLOAT,(((f.max_size-f.Size)/f.Growth)*f.Growth))
-														END
-												WHEN 1
-												THEN	CASE f.max_size
-														WHEN (-1)
-														THEN CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],(2147483648.))/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))
-														ELSE CONVERT([int],f.Size*power((1)+CONVERT([float],f.Growth)/(100),CONVERT([int],log10(CONVERT([float],f.Max_Size)/CONVERT([float],f.Size))/log10((1)+CONVERT([float],f.Growth)/(100)))))
-														END
-														ELSE (0)
-														END ))/128.0 AS FLOAT)
 									END AS [UnusableSpaceMB]
  
 				FROM sys.database_files AS f WITH (NOLOCK) 


### PR DESCRIPTION

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
### Purpose
Calculations return 0 instead of negative numbers of UnusableSpaceMB when MaxSize is unlimited (-1).

### Approach
Improved tSQL statement.