### PR TITLE
Stop Function when function Test-PSRemoting Fails

### DIFF
--- a/internal/Test-PSRemoting.ps1
+++ b/internal/Test-PSRemoting.ps1
@@ -15,25 +15,24 @@ https://www.petri.com/test-network-connectivity-powershell-test-connection-cmdle
   )
  
   Begin {
-    Write-Verbose -Message "Starting $($MyInvocation.Mycommand)"  
+    Write-Message -Level Verbose -Message "Starting $($MyInvocation.Mycommand)"
   } #begin
  
   Process {
-    Write-Verbose -Message "Testing $computername"
+    Write-Message -Level Verbose -Message "Testing $computername"
     Try {
       $r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
       $True 
     }
     Catch {
-      Write-Verbose $_.Exception.Message
-      $False
- 
+      Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_ -Continue
+      return $false
     }
- 
+    
   } #Process
  
   End {
-    Write-Verbose -Message "Ending $($MyInvocation.Mycommand)"
+    Write-Message -Level Verbose -Message "Ending $($MyInvocation.Mycommand)"
   } #end
  
 } #close function


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2048)
 
### Purpose
Write a more accurate error message when the internal function Test-PSRemoting fails, so the user is not missleaded by the generic error message that the command throws when the WinRM service is stopped.

Also add standard messaging system to function Test-PSRemoting instead of Write-Verbose messages.

This is a clean PR that replaces PR #2114 

### Approach
Add standard messaging system

### Commands to test
Details on issue #2048 


