### PR TITLE
Typo fix for $proxNames variable. Fixes #2163

### DIFF
--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -183,7 +183,7 @@
 			if ($missingProxy.Count -gt 0 -and $proxyNames.Count -gt 0) {
 				$missingProxy = ($missingProxy | Sort-Object | Get-Unique) -join ", "
 				$copyJobStatus.Status = "Skipped"
-				$copyJobStatus.Notes = "Job is dependent on proxy $($proxNames[0])"
+				$copyJobStatus.Notes = "Job is dependent on proxy $($proxyNames[0])"
 				$copyJobStatus
 				Write-Message -Level Warning -Message "Proxy Account(s) $($proxyNames[0]) doesn't exist on destination. Skipping job [$jobName]."
 				continue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #2163 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Purpose
Fix typo in variable name

### Commands to test

Copy-DbaAgentJob. Proxy account(s) must be associated with the job(s).