### PR TITLE
Get-FilteredRestoreFile - changed gt to ge to include trn that was being skipped. Fixes #2167

### DIFF
--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -219,7 +219,7 @@ function Get-FilteredRestoreFile {
  
                 Write-Message -Level Verbose -Message "Got a Full/Diff backups, now find all Tlogs needed"
                 $AllTlogs = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log'} 
-                $Filteredlogs = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log' -and $_.FirstRecoveryForkID -eq $Fullbackup.FirstRecoveryForkID -and $_.LastLSN -gt $TlogStartLSN -and $_.BackupStartDate -lt $RestoreTime}
+                $Filteredlogs = $SQLBackupdetails | Where-Object {$_.BackupTypeDescription -eq 'Transaction Log' -and $_.FirstRecoveryForkID -eq $Fullbackup.FirstRecoveryForkID -and $_.LastLSN -ge $TlogStartLSN -and $_.BackupStartDate -lt $RestoreTime}
                 # -and $_.BackupStartDate -ge $LogStartDate
                 $GroupedLogs = $FilteredLogs | Group-Object -Property LastLSN, FirstLSN
                 $Tlogs = @()

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -190,8 +190,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	
     Context "Properly restores an instance using ola-style backups" {
         $results = Get-ChildItem $script:appeyorlabrepo\sql2008-backups | Restore-DbaDatabase -SqlInstance $script:instance1
-        It "Restored files count should be 30" {
-            $results.DatabaseName.Count | Should Be 15
+        It "Restored files count should be 27" {
+            $results.DatabaseName.Count | Should Be 27
         }
         It "Should return successful restore" {
             ($results.RestoreComplete -contains $false) | Should Be $false


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes issue where first TRN after full/diff was being skipped because the first LSN of the log was equal to the last LSN of the diff.

### Approach
<!-- How does this change solve that purpose -->
Changed filter from -gt to -ge to include the TRN that matched LSNs

### Commands to test
<!-- if these are the examples in the help just note it as such -->
There is a full, differential and several log backups in the path directory. This was complaining of a break in the LSN chain when the filter used -gt 
```Restore-DbaDatabase -Path \\server1\BackupTest\Database1\ -SqlInstance server1 -DatabaseName Database1 -useDestinationDefaultDirectories```


### Screenshots
<!-- pictures say a thousand words without typing any of it -->
There was a trn in the folder from 0455 that was being skipped, hence the break in the LSN chain.
![image](https://user-images.githubusercontent.com/981370/29838789-2bd06ebe-8cca-11e7-82b3-d01f72b6c659.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
