### PR TITLE
Allow SMO RegisteredServer object to be passed as DbaInstanceParameter

### DIFF
--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceInputType.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceInputType.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// A live smo server object was bound
         /// </summary>
-        Server
+        Server,
+
+        /// <summary>
+        /// A Central Management Server RegisteredServer SMO object was bound
+        /// </summary>
+        RegisteredServer
     }
 }

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -175,6 +175,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
                             return DbaInstanceInputType.Server;
                         case "microsoft.sqlserver.management.smo.linkedserver":
                             return DbaInstanceInputType.Linked;
+                        case "microsoft.sqlserver.management.registeredservers.registeredserver":
+                            return DbaInstanceInputType.RegisteredServer;
                         default:
                             return DbaInstanceInputType.Default;
                     }
@@ -444,6 +446,26 @@ namespace Sqlcollaborative.Dbatools.Parameter
                             if (!String.IsNullOrEmpty((string)tempInput.Properties["DNSHostName"].Value))
                                 _ComputerName = (string)tempInput.Properties["DNSHostName"].Value;
                         }
+                    }
+                    catch (Exception e)
+                    {
+                        throw new PSArgumentException("Failed to interpret input as Instance: " + Input, e);
+                    }
+                    break;
+                case "microsoft.sqlserver.management.registeredservers.registeredserver":
+                    try
+                    {
+                        //Pass the ServerName property of the SMO object to the string constrtuctor, 
+                        //so we don't have to re-invent the wheel on instance name / port parsing
+                        DbaInstanceParameter parm =
+                            new DbaInstanceParameter((string) tempInput.Properties["ServerName"].Value);
+                        _ComputerName = parm.ComputerName;
+
+                        if (parm.InstanceName != "MSSQLSERVER")
+                            _InstanceName = parm.InstanceName;
+
+                        if (parm.Port != 1433)
+                            _Port = parm.Port;
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
First commit in splitting [PR 2109](https://github.com/sqlcollaborative/dbatools/pull/2109) into components. 

This PR is the first step, it allows the SMO object for a Registered Server to be passed into any function taking a `DbaInstanceParameter` object. For further information, please see the other PR.