### PR TITLE
Fixing Invoke() methods in DB and Server objects

### DIFF
--- a/internal/type-extensions.ps1
+++ b/internal/type-extensions.ps1
@@ -19,7 +19,7 @@ Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Server -MemberName 
 		$Database = "master"
 	)
 	
-	else { $this.Databases[$Database].ExecuteNonQuery($Command) }
+	$this.Databases[$Database].ExecuteNonQuery($Command)
 } -ErrorAction Ignore
 
 Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Database -MemberName Query -MemberType ScriptMethod -Value {
@@ -38,5 +38,5 @@ Update-TypeData -TypeName Microsoft.SqlServer.Management.Smo.Database -MemberNam
 		$Command
 	)
 	
-	else { $this.ExecuteNonQuery($Command) }
+	$this.ExecuteNonQuery($Command)
 } -ErrorAction Ignore


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2174)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issue with the Invoke method

### Approach
Remove unneeded else from the code

### Commands to test
```powershell
$server = Connect-DbaSqlServer -SqlInstance 'myinstance'
$server.invoke('select 1')
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
