### PR TITLE
Get-DbaUptime output & parameter updates

### DIFF
--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -50,11 +50,6 @@ function Get-DbaUptime {
 			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
 			
 		.EXAMPLE   
-			Get-DbaUptime -SqlInstance sqlserver2014a, sql2016 -SqlOnly
-
-			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
-
-		.EXAMPLE   
 			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaUptime 
 
 			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for every server listed in the Central Management Server on sql2014
@@ -76,7 +71,7 @@ function Get-DbaUptime {
 	}
 	process {
 		foreach ($instance in $SqlInstance) {
-            $SqlOnly = $false;
+			$SqlOnly = $false;
 			if ($instance.Gettype().FullName -eq [System.Management.Automation.PSCustomObject] ) {
 				$servername = $instance.SqlInstance
 			}
@@ -136,7 +131,7 @@ function Get-DbaUptime {
 			}
 
 			if ($SqlOnly) {
-				Select-DefaultView -InputObject $rtn -ExcludeProperty WindowsBootTime,WindowsUptime,SinceWindowsBoot
+				Select-DefaultView -InputObject $rtn -ExcludeProperty WindowsBootTime, WindowsUptime, SinceWindowsBoot
 			}
 			else {
 				Select-DefaultView -InputObject $rtn -Property ($rtn|get-member -MemberType NoteProperty|select-object -ExpandProperty name)

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -23,7 +23,7 @@ function Get-DbaUptime {
 		.PARAMETER WindowsCredential
 			Allows you to authenticate to Windows servers using alternate credentials.
 
-			$wincred = Get-Credential, then pass $scred object to the -WindowsCredential parameter.
+			$wincred = Get-Credential, then pass $wincred object to the -WindowsCredential parameter.
 			
 		.PARAMETER SqlOnly
 			Excludes the Windows server information

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -113,12 +113,11 @@ function Get-DbaUptime {
 					$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 				}
 				catch {
-					$SqlOnly = $true;
 					Stop-Function -Message "Failure getting WinBootTime" -ErrorRecord $_ -Target $instance -Continue
 				}
 			}
 				
-			$rtn = [PSCustomObject]@{
+			[PSCustomObject]@{
 				ComputerName     = $WindowsServerName
 				InstanceName     = $server.ServiceName
 				SqlServer        = $server.Name
@@ -128,13 +127,6 @@ function Get-DbaUptime {
 				WindowsBootTime  = $WinBootTime
 				SinceSqlStart    = $SQLUptimeString
 				SinceWindowsBoot = $WindowsUptimeString
-			}
-
-			if ($SqlOnly) {
-				Select-DefaultView -InputObject $rtn -ExcludeProperty WindowsBootTime, WindowsUptime, SinceWindowsBoot
-			}
-			else {
-				Select-DefaultView -InputObject $rtn -Property ($rtn | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)
 			}
 		}
 	}

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -1,66 +1,71 @@
-function Get-DbaUptime
-{
-<#
-.SYNOPSIS
-Returns the uptime of the SQL Server instance, and if required the hosting windows server
-	
-.DESCRIPTION
-By default, this command returns for each SQL Server instance passed in:
-SQL Instance last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
-Hosting Windows server last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
-	
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+function Get-DbaUptime {
+	<#
+		.SYNOPSIS
+			Returns the uptime of the SQL Server instance, and if required the hosting windows server
+			
+		.DESCRIPTION
+			By default, this command returns for each SQL Server instance passed in:
+			SQL Instance last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
+			Hosting Windows server last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
+			
+		.PARAMETER SqlInstance
+			The SQL Server instance that you're connecting to.
 
-.PARAMETER SqlCredential
-Credential object used to connect to the SQL Server as a different user
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
-.PARAMETER WindowsCredential
-Credential object used to connect to the SQL Server as a different user
+			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+			
+			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			
+			To connect to SQL Server as a different Windows user, run PowerShell as that user.
 
-.PARAMETER SqlOnly
-Excludes the Windows server information
+		.PARAMETER WindowsCredential
+			Allows you to authenticate to Windows servers using alternate credentials.
 
-.PARAMETER WindowsOnly
-Excludes the SQL server information
+			$wincred = Get-Credential, then pass $scred object to the -WindowsCredential parameter.
+			
+		.PARAMETER SqlOnly
+			Excludes the Windows server information
 
-.PARAMETER Silent
-Use this switch to disable any kind of verbose messages
+		.PARAMETER WindowsOnly
+			Excludes the SQL server information
 
-.NOTES
-Tags: CIM
-Original Author: Stuart Moore (@napalmgram), stuart-moore.com
-	
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>
+		.PARAMETER Silent
+			If this switch is enabled, the internal messaging functions will be silenced.
 
-.LINK
-https://dbatools.io/Get-DbaUptime
+		.NOTES
+			Tags: CIM
+			Original Author: Stuart Moore (@napalmgram), stuart-moore.com
+			
+			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+			Copyright (C) 2016 Chrissy LeMaire
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.EXAMPLE
-Get-DbaUptime -SqlInstance SqlBox1\Instance2
+		.LINK
+			https://dbatools.io/Get-DbaUptime
 
-Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on winserver
+		.EXAMPLE
+			Get-DbaUptime -SqlInstance SqlBox1\Instance2
 
-.EXAMPLE
-Get-DbaUptime -SqlInstance winserver\sqlexpress, sql2016
+			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on winserver
 
-Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
-	
-.EXAMPLE   
-Get-DbaUptime -SqlInstance sqlserver2014a, sql2016 -SqlOnly
+		.EXAMPLE
+			Get-DbaUptime -SqlInstance winserver\sqlexpress, sql2016
 
-Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
+			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
+			
+		.EXAMPLE   
+			Get-DbaUptime -SqlInstance sqlserver2014a, sql2016 -SqlOnly
 
-.EXAMPLE   
-Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaUptime 
+			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
 
-Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for every server listed in the Central Management Server on sql2014
-	
-#>
+		.EXAMPLE   
+			Get-DbaRegisteredServerName -SqlInstance sql2014 | Get-DbaUptime 
+
+			Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for every server listed in the Central Management Server on sql2014
+			
+	#>
 	[CmdletBinding(DefaultParameterSetName = "Default")]
 	Param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -79,25 +84,19 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 	begin {
 		$nowutc = (Get-Date).ToUniversalTime()
 	}
-	process
-	{
-		foreach ($instance in $SqlInstance)
-		{
-			if ($instance.Gettype().FullName -eq [System.Management.Automation.PSCustomObject] )
-			{
+	process {
+		foreach ($instance in $SqlInstance) {
+			if ($instance.Gettype().FullName -eq [System.Management.Automation.PSCustomObject] ) {
 				$servername = $instance.SqlInstance
 			}
-			elseif ($instance.Gettype().FullName -eq [Microsoft.SqlServer.Management.Smo.Server])
-			{
+			elseif ($instance.Gettype().FullName -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 				$servername = $instance.NetName
 			}
-			else
-			{
+			else {
 				$servername = $instance
 			}
 
-			if ($WindowsOnly -ne $true)
-			{
+			if ($WindowsOnly -ne $true) {
 				try {
 					Write-Message -Level Verbose -Message "Connecting to $instance"
 					$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
@@ -112,21 +111,17 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 				$SQLUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($SQLUptime.Days), $($SQLUptime.Hours), $($SQLUptime.Minutes), $($SQLUptime.Seconds)
 			}
 			
-			if ($SqlOnly -ne $true)
-			{
+			if ($SqlOnly -ne $true) {
 				$WindowsServerName = (Resolve-DbaNetworkName $servername -Credential $WindowsCredential).FullComputerName
 
-				try
-				{
+				try {
 					Write-Message -Level Verbose -Message "Getting WinBootTime via CimInstance for $servername"
 					$WinBootTime = (Get-DbaOperatingSystem -ComputerName $windowsServerName -Credential $WindowsCredential -ErrorAction SilentlyContinue).LastBootUpTime
 					$WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end $nowutc
 					$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 				}
-				catch
-				{
-					try
-					{
+				catch {
+					try {
 						Write-Message -Level Verbose -Message "Getting WinBootTime via CimInstance DCOM"
 						$CimOption = New-CimSessionOption -Protocol DCOM
 						$CimSession = New-CimSession -Credential:$WindowsCredential -ComputerName $WindowsServerName -SessionOption $CimOption
@@ -134,50 +129,45 @@ Returns an object with SQL Server start time, uptime as TimeSpan object, uptime 
 						$WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end $nowutc
 						$WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
 					}
-					catch
-					{
+					catch {
 						Stop-Function -Message "Failure getting WinBootTime" -ErrorRecord $_ -Target $instance -Continue
 					}
 				}
 				
-				if ($null -eq $WinBootTime)
-				{
+				if ($null -eq $WinBootTime) {
 					#Skip the windows results as they'll either be garbage or not there.
 					$SqlOnly = $true
 				}
 			}
 			
-			if ($SqlOnly -eq $true)
-			{
+			if ($SqlOnly -eq $true) {
 				[PSCustomObject]@{
-					ComputerName = $server.NetName
-					InstanceName = $server.ServiceName
-					SqlServer = $server.Name
-					SqlUptime = $SQLUptime
-					SqlStartTime = $SQLStartTime
+					ComputerName  = $server.NetName
+					InstanceName  = $server.ServiceName
+					SqlServer     = $server.Name
+					SqlUptime     = $SQLUptime
+					SqlStartTime  = $SQLStartTime
 					SinceSqlStart = $SQLUptimeString
 				}
 			}
-			elseif ($WindowsOnly -eq $true)
-			{
+			elseif ($WindowsOnly -eq $true) {
 				[PSCustomObject]@{
-					ComputerName = $WindowsServerName
-					WindowsUptime = $WindowsUptime
-					WindowsBootTime = $WinBootTime
+					ComputerName     = $WindowsServerName
+					WindowsUptime    = $WindowsUptime
+					WindowsBootTime  = $WinBootTime
 					SinceWindowsBoot = $WindowsUptimeString
 				}
 			}
-			else
-			{
+			else {
 				[PSCustomObject]@{
-					ComputerName = $WindowsServerName
-					InstanceName = $server.ServiceName
-					SqlServer = $server.Name
-					SqlUptime = $SQLUptime
-					WindowsUptime = $WindowsUptime
-					SqlStartTime = $SQLStartTime
-					WindowsBootTime = $WinBootTime
-					SinceSqlStart  = $SQLUptimeString
+					ComputerName     = $WindowsServerName
+					InstanceName     = $server.ServiceName
+					SqlServer        = $server.Name
+					SqlUptime        = $SQLUptime
+					WindowsUptime    = $WindowsUptime
+					SqlStartTime     = $SQLStartTime
+					WindowsBootTime  = $WinBootTime
+					SinceSqlStart    = $SQLUptimeString
 					SinceWindowsBoot = $WindowsUptimeString
 				}
 			}

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -134,7 +134,7 @@ function Get-DbaUptime {
 				Select-DefaultView -InputObject $rtn -ExcludeProperty WindowsBootTime, WindowsUptime, SinceWindowsBoot
 			}
 			else {
-				Select-DefaultView -InputObject $rtn -Property ($rtn|get-member -MemberType NoteProperty|select-object -ExpandProperty name)
+				Select-DefaultView -InputObject $rtn -Property ($rtn | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
- [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
- [ ] New feature (non-breaking change, adds functionality)
- [X] Breaking change (effects multiple commands or functionality)
- [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
- [ ] Pester test is included
- [X] Spelling, grammar & other cleanup in Help and other text content

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes #2152. Eliminates the `-WindowsOnly` and `-SqlOnly` switches and always returns both Windows and SQL uptime, _unless_ Windows uptime cannot be obtained (in which case it's eliminated from the output). Uses `Set-DefaultView` for output.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See help