### PR TITLE
Testing/db instance paramater constructors

### DIFF
--- a/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
+++ b/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
@@ -29,30 +29,6 @@ namespace Sqlcollaborative.Dbatools.Parameter
         }
 
         /// <summary>
-        /// Checks that [localhost\instancename] is treated as a localhost connection
-        /// </summary>
-        [TestMethod]
-        public void TestBracketedName()
-        {
-            var dbaInstanceParamater = new DbaInstanceParameter("[computerName]");
-
-            Assert.AreEqual("computerName", dbaInstanceParamater.FullName);
-            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
-        }
-
-        /// <summary>
-        /// Checks that [localhost\instancename] is treated as a localhost connection
-        /// </summary>
-        [TestMethod]
-        public void TestBracketedNameWithInstance()
-        {
-            var dbaInstanceParamater = new DbaInstanceParameter("[computerName\\sql2008r2sp2]");
-
-            Assert.AreEqual("computerName\\sql2008r2sp2", dbaInstanceParamater.FullName);
-            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
-        }
-
-        /// <summary>
         /// Checks that . is treated as a localhost connection
         /// </summary>
         [TestMethod]

--- a/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
+++ b/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Sqlcollaborative.Dbatools.Parameter
+{
+    [TestClass]
+    public class DbaInstanceParamaterTest
+    {
+        [TestMethod]
+        public void TestStringConstructor()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("someMachine");
+
+            Assert.AreEqual("someMachine", dbaInstanceParamater.FullName);
+            Assert.IsFalse(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that localhost\instancename is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestLocalhostNamedInstance()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("localhost\\sql2008r2sp2");
+
+            Assert.AreEqual("localhost\\sql2008r2sp2", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that [localhost\instancename] is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestBracketedName()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("[computerName]");
+
+            Assert.AreEqual("computerName", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that [localhost\instancename] is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestBracketedNameWithInstance()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("[computerName\\sql2008r2sp2]");
+
+            Assert.AreEqual("computerName\\sql2008r2sp2", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that . is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestDotHostname()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter(".");
+
+            Assert.AreEqual(".", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that 127.0.0.1 is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestLocalhostIPConstructor()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter(IPAddress.Loopback);
+
+            Assert.AreEqual("127.0.0.1", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+
+        /// <summary>
+        /// Checks that . is treated as a localhost connection
+        /// </summary>
+        [TestMethod]
+        public void TestLocalhostIPv6Constructor()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter(IPAddress.IPv6Loopback);
+
+            Assert.AreEqual("::1", dbaInstanceParamater.FullName);
+            Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
+        }
+    }
+}

--- a/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
+++ b/bin/projects/dbatools/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
@@ -53,7 +53,7 @@ namespace Sqlcollaborative.Dbatools.Parameter
         }
 
         /// <summary>
-        /// Checks that . is treated as a localhost connection
+        /// Checks that ::1 is treated as a localhost connection
         /// </summary>
         [TestMethod]
         public void TestLocalhostIPv6Constructor()

--- a/bin/projects/dbatools/dbatools.Tests/dbatools.Tests.csproj
+++ b/bin/projects/dbatools/dbatools.Tests/dbatools.Tests.csproj
@@ -54,6 +54,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Connection\ManagementConnectionTest.cs" />
+    <Compile Include="Parameter\DbaInstanceParamaterTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utility\SizeTest.cs" />
   </ItemGroup>

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -244,12 +244,12 @@ namespace Sqlcollaborative.Dbatools.Parameter
             string tempString = Name;
 
             // Handle and clear protocols. Otherwise it'd make port detection unneccessarily messy
-            if (Regex.IsMatch(tempString, "^TCP:", RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(tempString, "^TCP:", RegexOptions.IgnoreCase)) //TODO: Use case insinsitive String.BeginsWith()
             {
                 _NetworkProtocol = SqlConnectionProtocol.TCP;
                 tempString = tempString.Substring(4);
             }
-            if (Regex.IsMatch(tempString, "^NP:", RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(tempString, "^NP:", RegexOptions.IgnoreCase)) // TODO: Use case insinsitive String.BeginsWith()
             {
                 _NetworkProtocol = SqlConnectionProtocol.NP;
                 tempString = tempString.Substring(3);
@@ -342,7 +342,7 @@ namespace Sqlcollaborative.Dbatools.Parameter
 
                 else
                 {
-                    throw new PSArgumentException("Failed to parse instance name: " + Name);
+                    throw new PSArgumentException(string.Format("Failed to parse instance name: {0}. Computer Name: {1}, Instance {2}", Name, tempComputerName, tempInstanceName));
                 }
             }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
 - [X] C# unit test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add unit tests

### Approach
Its a unit test


### Notes

Two unit tests fail. I'm not sure if  var dbaInstanceParamater = new DbaInstanceParameter("[computerName\\sql2008r2sp2]"); is supposed to work or not. Please advise if it should.

On another PR my unit tests seem to break becasue AppVoyer seems to test agains `[host\instance]` instead of `host\instance`. Tests have passed in recent builds though. I'm not even sure if `[host\instance]` with the square brackets should be legit.