### PR TITLE
Get-DbaBackupHistory, fix list dbs with -Last*

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -329,7 +329,7 @@ function Get-DbaBackupHistory {
 					if ($DeviceTypeFilter) {
 						$DevTypeFilterWhere = "AND mediafamily.device_type $DeviceTypeFilterRight"
 					}
-					$sql = "
+					$sql += "
 								SELECT
 									a.BackupSetRank,
 									a.Server,
@@ -412,8 +412,7 @@ function Get-DbaBackupHistory {
 								ORDER BY a.Type;
 								"
 				}
-				
-				#$sql = $sql -join "; "
+				$sql = $sql -join "; "
 			}
 			else {
 				if ($Force -eq $true) {


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes query construction for multiple dbs and -Last)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
### Purpose
Fix for -Last and multiple dbs passed down the line. It _seems_ that it has been intentionally removed by https://github.com/sqlcollaborative/dbatools/commit/91c82ce4c3bfc4da5240bb5c7d375cdf539fdbde but I'm more prone to think it's a slip.

Also fixes #2181

/cc @Stuart-Moore