### PR TITLE
DbaInstanceParameter - Added support for connection strings

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 1, 20)
+$currentLibraryVersion = New-Object System.Version(0, 6, 2, 21)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Exceptions/BloodyHellGiveMeSomethingToWorkWithException.cs
+++ b/bin/projects/dbatools/dbatools/Exceptions/BloodyHellGiveMeSomethingToWorkWithException.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sqlcollaborative.Dbatools.Exceptions
+{
+    /// <summary>
+    /// An exception that is thrown by parameter classes when given empty input
+    /// </summary>
+    public class BloodyHellGiveMeSomethingToWorkWithException : Exception
+    {
+        /// <summary>
+        /// The parameter class that did the throwing
+        /// </summary>
+        public string ParameterClass;
+
+        /// <summary>
+        /// Creates an empty exception
+        /// </summary>
+        public BloodyHellGiveMeSomethingToWorkWithException()
+        {
+
+        }
+
+        /// <summary>
+        /// Creates an exception with a simple message
+        /// </summary>
+        /// <param name="Message">The message to tell</param>
+        public BloodyHellGiveMeSomethingToWorkWithException(string Message)
+            : base(Message)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates an exception with a message and a nested exception
+        /// </summary>
+        /// <param name="Message">The message to tell</param>
+        /// <param name="Inner">The inner exception to nest</param>
+        public BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner)
+            : base(Message, Inner)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates an exception with a message and a ParameterClass
+        /// </summary>
+        /// <param name="Message">The message to tell</param>
+        /// <param name="ParameterClass">The Parameter Class that threw the exception</param>
+        public BloodyHellGiveMeSomethingToWorkWithException(string Message, string ParameterClass)
+            : base(Message)
+        {
+            this.ParameterClass = ParameterClass;
+        }
+
+        /// <summary>
+        /// Creates an exception with a message, a nested exception and a ParameterClass
+        /// </summary>
+        /// <param name="Message">The message to tell</param>
+        /// <param name="Inner">The inner exception to nest</param>
+        /// <param name="ParameterClass">The Parameter Class that threw the exception</param>
+        public BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner, string ParameterClass)
+            : base(Message, Inner)
+        {
+            this.ParameterClass = ParameterClass;
+        }
+    }
+}

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -268,6 +268,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
                 {
                     throw new ArgumentException(String.Format("Failed to interpret named pipe path notation: {0} | {1}", InputObject, e.Message), e);
                 }
+
+                return;
             }
 
             // Connection String interpretation

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -242,6 +242,9 @@ namespace Sqlcollaborative.Dbatools.Parameter
         {
             InputObject = Name;
 
+            if (Name == "")
+                throw new ArgumentException("Bloody hell! Don't give me an empty string for an instance name!");
+
             if (Name == ".")
             {
                 _ComputerName = Name;

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -262,6 +262,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
                 _NetworkProtocol = tempParam.NetworkProtocol;
 
                 IsConnectionString = true;
+
+                return;
             }
             catch { }
 

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -145,6 +145,12 @@ namespace Sqlcollaborative.Dbatools.Parameter
         }
 
         /// <summary>
+        /// Whether the input is a connection string
+        /// </summary>
+        [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
+        public bool IsConnectionString;
+
+        /// <summary>
         /// The original object passed to the parameter class.
         /// </summary>
         [ParameterContract(ParameterContractType.Field, ParameterContractBehavior.Mandatory)]
@@ -245,6 +251,19 @@ namespace Sqlcollaborative.Dbatools.Parameter
 
             string tempString = Name.Trim();
             tempString = Regex.Replace(tempString, @"^\[(.*)\]$", "$1");
+
+            try
+            {
+                System.Data.SqlClient.SqlConnectionStringBuilder connectionString = new System.Data.SqlClient.SqlConnectionStringBuilder(tempString);
+                DbaInstanceParameter tempParam = new DbaInstanceParameter(connectionString.DataSource);
+                _ComputerName = tempParam.ComputerName;
+                if (tempParam.InstanceName != "MSSQLSERVER") { _InstanceName = tempParam.InstanceName; }
+                if (tempParam.Port != 1433) { _Port = tempParam.Port; }
+                _NetworkProtocol = tempParam.NetworkProtocol;
+
+                IsConnectionString = true;
+            }
+            catch { }
 
             // Handle and clear protocols. Otherwise it'd make port detection unneccessarily messy
             if (Regex.IsMatch(tempString, "^TCP:", RegexOptions.IgnoreCase))

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -252,6 +252,25 @@ namespace Sqlcollaborative.Dbatools.Parameter
             string tempString = Name.Trim();
             tempString = Regex.Replace(tempString, @"^\[(.*)\]$", "$1");
 
+            // Named Pipe path notation interpretation
+            if (Regex.IsMatch(tempString, @"^\\\\[^\\]+\\pipe\\([^\\]+\\){0,1}sql\\query$", RegexOptions.IgnoreCase))
+            {
+                try
+                {
+                    _NetworkProtocol = SqlConnectionProtocol.NP;
+
+                    _ComputerName = Regex.Match(tempString, @"^\\\\([^\\]+)\\").Groups[1].Value;
+
+                    if (Regex.IsMatch(tempString, @"\\MSSQL\$[^\\]+\\", RegexOptions.IgnoreCase))
+                        _InstanceName = Regex.Match(tempString, @"\\MSSQL\$([^\\]+)\\", RegexOptions.IgnoreCase).Groups[1].Value;
+                }
+                catch (Exception e)
+                {
+                    throw new ArgumentException(String.Format("Failed to interpret named pipe path notation: {0} | {1}", InputObject, e.Message), e);
+                }
+            }
+
+            // Connection String interpretation
             try
             {
                 System.Data.SqlClient.SqlConnectionStringBuilder connectionString = new System.Data.SqlClient.SqlConnectionStringBuilder(tempString);

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
 using Sqlcollaborative.Dbatools.Connection;
+using Sqlcollaborative.Dbatools.Exceptions;
 using Sqlcollaborative.Dbatools.Utility;
 
 namespace Sqlcollaborative.Dbatools.Parameter
@@ -243,7 +244,7 @@ namespace Sqlcollaborative.Dbatools.Parameter
             InputObject = Name;
 
             if (Name == "")
-                throw new ArgumentException("Bloody hell! Don't give me an empty string for an instance name!");
+                throw new BloodyHellGiveMeSomethingToWorkWithException("Bloody hell! Don't give me an empty string for an instance name!", "DbaInstanceParameter");
 
             if (Name == ".")
             {

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -243,7 +243,8 @@ namespace Sqlcollaborative.Dbatools.Parameter
                 return;
             }
 
-            string tempString = Name;
+            string tempString = Name.Trim();
+            tempString = Regex.Replace(tempString, @"^\[(.*)\]$", "$1");
 
             // Handle and clear protocols. Otherwise it'd make port detection unneccessarily messy
             if (Regex.IsMatch(tempString, "^TCP:", RegexOptions.IgnoreCase))

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.6.1.20")]
-[assembly: AssemblyFileVersion("0.6.1.20")]
+[assembly: AssemblyFileVersion("0.6.2.21")]

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -43,6 +43,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Windows\Microsoft.NET\assembly\GAC_MSIL\System.Management.Automation\v4.0_3.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Connection\ConnectionHost.cs" />
     <Compile Include="Database\Dependency.cs" />
     <Compile Include="dbaSystem\SystemHost.cs" />
+    <Compile Include="Exceptions\BloodyHellGiveMeSomethingToWorkWithException.cs" />
     <Compile Include="Parameter\DbaCredentialParameter.cs" />
     <Compile Include="TypeConversion\DbaCredentialParameterConverter.cs" />
     <Compile Include="Utility\CredentialPrompt.cs" />

--- a/functions/Connect-DbaSqlServer.ps1
+++ b/functions/Connect-DbaSqlServer.ps1
@@ -168,7 +168,7 @@ function Connect-DbaSqlServer {
 	param (
 		[Parameter(Mandatory = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[object]$SqlInstance,
+		[DbaInstanceParameter]$SqlInstance,
 		[Alias("SqlCredential")]
 		[PSCredential]$Credential,
 		[object[]]$Database,

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -122,8 +122,8 @@ function Connect-SqlInstance {
 	}
 	
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $ConvertedSqlInstance.FullSmoName
-	if ($ConvertedSqlInstance.IsConnectionString) { $server.ConnectionContext.ConnectionString = $ConvertedSqlInstance.InputObject }
 	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
+	if ($ConvertedSqlInstance.IsConnectionString) { $server.ConnectionContext.ConnectionString = $ConvertedSqlInstance.InputObject }
 	
 	try {
 		if ($SqlCredential.Username -ne $null) {

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -122,6 +122,7 @@ function Connect-SqlInstance {
 	}
 	
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $ConvertedSqlInstance.FullSmoName
+	if ($ConvertedSqlInstance.IsConnectionString) { $server.ConnectionContext.ConnectionString = $ConvertedSqlInstance.InputObject }
 	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
 	
 	try {


### PR DESCRIPTION
## Type of Change

 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

## What it does

 - Adds support for connection strings as input to the `DbaInstanceParameter`. Must include a server target. The connection will use the connection string, other functions get their usual properties (ComputerName, InstanceName, Port, ...)
 - Adds support for sql notation server names (such as `[Server\Instance]`)
Braces used to fail interpretation.
 - Adds support for named pipe path notations (e.g.: `\\.\pipe\MSSQL$SQLEXPRESS\sql\query`)