### PR TITLE
Fixing IgnoreCopyOnly in Get-DbaDatabase #2194

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -263,7 +263,7 @@
 			}
 			
 			if ($NoFullBackup -or $NoFullBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull -IgnoreCopyOnly)
+				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull )
 				if ($null -ne $NoFullBackupSince) {
 					$dabsWithinScope = ($dabs | Where-Object End -lt $NoFullBackupSince)
 					
@@ -275,7 +275,7 @@
 				
 			}
 			if ($NoLogBackup -or $NoLogBackupSince) {
-				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog -IgnoreCopyOnly)
+				$dabs = (Get-DbaBackupHistory -SqlInstance $server -LastLog )
 				if ($null -ne $NoLogBackupSince) {
 					$dabsWithinScope = ($dabs | Where-Object End -lt $NoLogBackupSince)
 					$inputobject = $inputobject |


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2194 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes an issue that's existed since we switcthed the default behavious on CopyOnly backups

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
Get-DbaDatabase -SqlInstance localhost\sqlexpress2016 -NoFullBackup
Get-DbaDatabase -SqlInstance localhost\sqlexpress2016 -NoFullBackupSince (Get-Date).AddDays(-1)


### Learning
Remember that functions call each other.....
