### PR TITLE
Invoke-SqlCmd2 fix for UNC path and other style/grammar/spelling

### DIFF
--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -5,8 +5,8 @@ function Invoke-Sqlcmd2
         Runs a T-SQL script.
 
     .DESCRIPTION
-        Runs a T-SQL script. Invoke-Sqlcmd2 runs the whole scipt and only captures the first selected result set, such as the output of PRINT statements when -verbose parameter is specified.
-        Paramaterized queries are supported.
+        Runs a T-SQL script. Invoke-Sqlcmd2 runs the whole script and only captures the first selected result set, such as the output of PRINT statements when -verbose parameter is specified.
+        Parameterized queries are supported.
 
         Help details below borrowed from Invoke-Sqlcmd
 
@@ -292,7 +292,7 @@ function Invoke-Sqlcmd2
     {
         if ($InputFile)
         {
-            $filePath = $(Resolve-Path $InputFile).path
+            $filePath = $(Resolve-Path $InputFile).ProviderPath
             $Query =  [System.IO.File]::ReadAllText("$filePath")
         }
 

--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -1,6 +1,5 @@
-function Invoke-Sqlcmd2
-{
-    <#
+function Invoke-Sqlcmd2 {
+	<#
     .SYNOPSIS
         Runs a T-SQL script.
 
@@ -11,53 +10,58 @@ function Invoke-Sqlcmd2
         Help details below borrowed from Invoke-Sqlcmd
 
     .PARAMETER ServerInstance
-        One or more ServerInstances to query. For default instances, only specify the computer name: "MyComputer". For named instances, use the format "ComputerName\InstanceName".
+		Specifies the SQL Server instance(s) to execute the query against.
 
     .PARAMETER Database
-        A character string specifying the name of a database. Invoke-Sqlcmd2 connects to this database in the instance that is specified in -ServerInstance.
-
-        If a SQLConnection is provided, we explicitly switch to this database
+		Specifies the name of the database to execute the query against. If specified, this database will be used in the ConnectionString when establishing the connection to SQL Server.
+		
+		If a SQLConnection is provided, the default database for that connection is overridden with this database.
 
     .PARAMETER Query
-        Specifies one or more queries to be run. The queries can be Transact-SQL (? or XQuery statements, or sqlcmd commands. Multiple queries separated by a semicolon can be specified. Do not specify the sqlcmd GO separator. Escape any double quotation marks included in the string ?). Consider using bracketed identifiers such as [MyTable] instead of quoted identifiers such as "MyTable".
+		Specifies one or more queries to be run. The queries can be Transact-SQL, XQuery statements, or sqlcmd commands. Multiple queries in a single batch may be separated by a semicolon.
+		
+		Do not specify the sqlcmd GO separator. Escape any double quotation marks included in the string.
+		
+		Consider using bracketed identifiers such as [MyTable] instead of quoted identifiers such as "MyTable".
 
     .PARAMETER InputFile
-        Specifies a file to be used as the query input to Invoke-Sqlcmd2. The file can contain Transact-SQL statements, (? XQuery statements, and sqlcmd commands and scripting variables ?). Specify the full path to the file.
-
+		Specifies the full path to a file to be used as the query input to Invoke-Sqlcmd2. The file can contain Transact-SQL statements, XQuery statements, sqlcmd commands and scripting variables.
+		
     .PARAMETER Credential
-        Specifies A PSCredential for SQL Server Authentication connection to an instance of the Database Engine.
+		Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-        If -Credential is not specified, Invoke-Sqlcmd attempts a Windows Authentication connection using the Windows account running the PowerShell session.
+		$cred = Get-Credential, this pass this $cred to the param.
 
+		Windows Authentication will be used if Credential is not specified. To connect as a different Windows user, run PowerShell as that user.
+		
         SECURITY NOTE: If you use the -Debug switch, the connectionstring including plain text password will be sent to the debug stream.
 
-    .PARAMETER Encrypt
-        If specified, will request that the connection to the SQL is done over SSL. This requires that the SQL Server has been set up to accept SSL requests. For information regarding setting up SSL on SQL Server, visit this link: https://technet.microsoft.com/en-us/library/ms189067(v=sql.105).aspx
+	.PARAMETER Encrypt
+		If this switch is enabled, the connection to SQL Server will be made using SSL.
+
+        This requires that the SQL Server has been set up to accept SSL requests. For information regarding setting up SSL on SQL Server, see https://technet.microsoft.com/en-us/library/ms189067(v=sql.105).aspx
 
     .PARAMETER QueryTimeout
         Specifies the number of seconds before the queries time out.
 
     .PARAMETER ConnectionTimeout
-        Specifies the number of seconds when Invoke-Sqlcmd2 times out if it cannot successfully connect to an instance of the Database Engine. The timeout value must be an integer between 0 and 65534. If 0 is specified, connection attempts do not time out.
+        Specifies the number of seconds before Invoke-Sqlcmd2 times out if it cannot successfully connect to an instance of the Database Engine. The timeout value must be an integer between 0 and 65534. If 0 is specified, connection attempts do not time out.
 
     .PARAMETER As
-        Specifies output type - DataSet, DataTable, array of DataRow, PSObject or Single Value
+		Specifies output type. Valid options for this parameter are 'DataSet', 'DataTable', 'DataRow', 'PSObject', and 'SingleValue'
 
         PSObject output introduces overhead but adds flexibility for working with results: http://powershell.org/wp/forums/topic/dealing-with-dbnull/
 
     .PARAMETER SqlParameters
-        Hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
+        Specifies a hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
 
         Example:
-            -Query "SELECT ServerName FROM tblServerInfo WHERE ServerName LIKE @ServerName"
-            -SqlParameters @{"ServerName = "c-is-hyperv-1"}
 
-    .PARAMETER AppendServerInstance
-        If specified, append the server instance to PSObject and DataRow output
+	.PARAMETER AppendServerInstance
+		If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
 
-    .PARAMETER SQLConnection
-        If specified, use an existing SQLConnection.
-            We attempt to open this connection if it is closed
+	.PARAMETER SQLConnection
+		Specifies an existing SQLConnection object to use in connecting to SQL Server. If the connection is closed, an attempt will be made to open it.
 
     .INPUTS
         None
@@ -73,20 +77,21 @@ function Invoke-Sqlcmd2
     .EXAMPLE
         Invoke-Sqlcmd2 -ServerInstance "MyComputer\MyInstance" -Query "SELECT login_time AS 'StartTime' FROM sysprocesses WHERE spid = 1"
 
-        This example connects to a named instance of the Database Engine on a computer and runs a basic T-SQL query.
-        StartTime
+        Connects to a named instance of the Database Engine on a computer and runs a basic T-SQL query.
+		
+		StartTime
         -----------
         2010-08-12 21:21:03.593
 
     .EXAMPLE
         Invoke-Sqlcmd2 -ServerInstance "MyComputer\MyInstance" -InputFile "C:\MyFolder\tsqlscript.sql" | Out-File -filePath "C:\MyFolder\tsqlscript.rpt"
 
-        This example reads a file containing T-SQL statements, runs the file, and writes the output to another file.
+        Reads a file containing T-SQL statements, runs the file, and writes the output to another file.
 
     .EXAMPLE
         Invoke-Sqlcmd2  -ServerInstance "MyComputer\MyInstance" -Query "PRINT 'hello world'" -Verbose
 
-        This example uses the PowerShell -Verbose parameter to return the message output of the PRINT command.
+        Uses the PowerShell -Verbose parameter to return the message output of the PRINT command.
         VERBOSE: hello world
 
     .EXAMPLE
@@ -129,11 +134,16 @@ function Invoke-Sqlcmd2
     .EXAMPLE
         Invoke-Sqlcmd2 -SQLConnection $Conn -Query "SELECT login_time AS 'StartTime' FROM sysprocesses WHERE spid = 1"
 
-        This example uses an existing SQLConnection and runs a basic T-SQL query against it
+        Uses an existing SQLConnection and runs a basic T-SQL query against it
 
         StartTime
         -----------
         2010-08-12 21:21:03.593
+
+	.EXAMPLE
+		Invoke-SqlCmd -SQLConnection $Conn -Query "SELECT ServerName FROM tblServerInfo WHERE ServerName LIKE @ServerName" -SqlParameters @{"ServerName = "c-is-hyperv-1"}
+
+		Executes a parameterized query against the existing SQLConnection, with a collection of one parameter to be passed to the query when executed.
 
     .NOTES
         Changelog moved to CHANGELOG.md:
@@ -150,157 +160,155 @@ function Invoke-Sqlcmd2
         SQL
     #>
 
-    [CmdletBinding( DefaultParameterSetName='Ins-Que' )]
-    [OutputType([System.Management.Automation.PSCustomObject],[System.Data.DataRow],[System.Data.DataTable],[System.Data.DataTableCollection],[System.Data.DataSet])]
-    param(
-        [Parameter( ParameterSetName='Ins-Que',
-                    Position=0,
-                    Mandatory=$true,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false,
-                    HelpMessage='SQL Server Instance required...' )]
-        [Parameter( ParameterSetName='Ins-Fil',
-                    Position=0,
-                    Mandatory=$true,
-                    ValueFromPipeline=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false,
-                    HelpMessage='SQL Server Instance required...' )]
-        [Alias( 'Instance', 'Instances', 'ComputerName', 'Server', 'Servers' )]
-        [ValidateNotNullOrEmpty()]
-        [string[]]
-        $ServerInstance,
+	[CmdletBinding( DefaultParameterSetName = 'Ins-Que' )]
+	[OutputType([System.Management.Automation.PSCustomObject], [System.Data.DataRow], [System.Data.DataTable], [System.Data.DataTableCollection], [System.Data.DataSet])]
+	param(
+		[Parameter( ParameterSetName = 'Ins-Que',
+			Position = 0,
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false,
+			HelpMessage = 'SQL Server Instance required...' )]
+		[Parameter( ParameterSetName = 'Ins-Fil',
+			Position = 0,
+			Mandatory = $true,
+			ValueFromPipeline = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false,
+			HelpMessage = 'SQL Server Instance required...' )]
+		[Alias( 'Instance', 'Instances', 'ComputerName', 'Server', 'Servers' )]
+		[ValidateNotNullOrEmpty()]
+		[string[]]
+		$ServerInstance,
 
-        [Parameter( Position=1,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false)]
-        [string]
-        $Database,
+		[Parameter( Position = 1,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false)]
+		[string]
+		$Database,
 
-        [Parameter( ParameterSetName='Ins-Que',
-                    Position=2,
-                    Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [Parameter( ParameterSetName='Con-Que',
-                    Position=2,
-                    Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [string]
-        $Query,
+		[Parameter( ParameterSetName = 'Ins-Que',
+			Position = 2,
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[Parameter( ParameterSetName = 'Con-Que',
+			Position = 2,
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[string]
+		$Query,
 
-        [Parameter( ParameterSetName='Ins-Fil',
-                    Position=2,
-                    Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [Parameter( ParameterSetName='Con-Fil',
-                    Position=2,
-                    Mandatory=$true,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [ValidateScript({ Test-Path $_ })]
-        [string]
-        $InputFile,
+		[Parameter( ParameterSetName = 'Ins-Fil',
+			Position = 2,
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[Parameter( ParameterSetName = 'Con-Fil',
+			Position = 2,
+			Mandatory = $true,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[ValidateScript( { Test-Path $_ })]
+		[string]
+		$InputFile,
 
-        [Parameter( ParameterSetName='Ins-Que',
-                    Position=3,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false)]
-        [Parameter( ParameterSetName='Ins-Fil',
-                    Position=3,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false)]
-        [System.Management.Automation.PSCredential]
-        $Credential,
+		[Parameter( ParameterSetName = 'Ins-Que',
+			Position = 3,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false)]
+		[Parameter( ParameterSetName = 'Ins-Fil',
+			Position = 3,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false)]
+		[System.Management.Automation.PSCredential]
+		$Credential,
 
-        [Parameter( ParameterSetName='Ins-Que',
-                    Position=4,
-                    Mandatory=$false,
-                    ValueFromRemainingArguments=$false)]
-        [Parameter( ParameterSetName='Ins-Fil',
-                    Position=4,
-                    Mandatory=$false,
-                    ValueFromRemainingArguments=$false)]
-        [switch]
-        $Encrypt,
+		[Parameter( ParameterSetName = 'Ins-Que',
+			Position = 4,
+			Mandatory = $false,
+			ValueFromRemainingArguments = $false)]
+		[Parameter( ParameterSetName = 'Ins-Fil',
+			Position = 4,
+			Mandatory = $false,
+			ValueFromRemainingArguments = $false)]
+		[switch]
+		$Encrypt,
 
-        [Parameter( Position=5,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [Int32]
-        $QueryTimeout=600,
+		[Parameter( Position = 5,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[Int32]
+		$QueryTimeout = 600,
 
-        [Parameter( ParameterSetName='Ins-Fil',
-                    Position=6,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [Parameter( ParameterSetName='Ins-Que',
-                    Position=6,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [Int32]
-        $ConnectionTimeout=15,
+		[Parameter( ParameterSetName = 'Ins-Fil',
+			Position = 6,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[Parameter( ParameterSetName = 'Ins-Que',
+			Position = 6,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[Int32]
+		$ConnectionTimeout = 15,
 
-        [Parameter( Position=7,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [ValidateSet("DataSet", "DataTable", "DataRow","PSObject","SingleValue")]
-        [string]
-        $As="DataRow",
+		[Parameter( Position = 7,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "SingleValue")]
+		[string]
+		$As = "DataRow",
 
-        [Parameter( Position=8,
-                    Mandatory=$false,
-                    ValueFromPipelineByPropertyName=$true,
-                    ValueFromRemainingArguments=$false )]
-        [System.Collections.IDictionary]
-        $SqlParameters,
+		[Parameter( Position = 8,
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true,
+			ValueFromRemainingArguments = $false )]
+		[System.Collections.IDictionary]
+		$SqlParameters,
 
-        [Parameter( Position=9,
-                    Mandatory=$false )]
-        [switch]
-        $AppendServerInstance,
+		[Parameter( Position = 9,
+			Mandatory = $false )]
+		[switch]
+		$AppendServerInstance,
 
-        [Parameter( ParameterSetName = 'Con-Que',
-                    Position=10,
-                    Mandatory=$false,
-                    ValueFromPipeline=$false,
-                    ValueFromPipelineByPropertyName=$false,
-                    ValueFromRemainingArguments=$false )]
-        [Parameter( ParameterSetName = 'Con-Fil',
-                    Position=10,
-                    Mandatory=$false,
-                    ValueFromPipeline=$false,
-                    ValueFromPipelineByPropertyName=$false,
-                    ValueFromRemainingArguments=$false )]
-        [Alias( 'Connection', 'Conn' )]
-        [ValidateNotNullOrEmpty()]
-        [System.Data.SqlClient.SQLConnection]
-        $SQLConnection
-    )
+		[Parameter( ParameterSetName = 'Con-Que',
+			Position = 10,
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelineByPropertyName = $false,
+			ValueFromRemainingArguments = $false )]
+		[Parameter( ParameterSetName = 'Con-Fil',
+			Position = 10,
+			Mandatory = $false,
+			ValueFromPipeline = $false,
+			ValueFromPipelineByPropertyName = $false,
+			ValueFromRemainingArguments = $false )]
+		[Alias( 'Connection', 'Conn' )]
+		[ValidateNotNullOrEmpty()]
+		[System.Data.SqlClient.SQLConnection]
+		$SQLConnection
+	)
 
-    begin
-    {
-        if ($InputFile) {
-            $filePath = $(Resolve-Path $InputFile).ProviderPath
-            $Query =  [System.IO.File]::ReadAllText("$filePath")
-        }
+	begin {
+		if ($InputFile) {
+			$filePath = $(Resolve-Path $InputFile).ProviderPath
+			$Query = [System.IO.File]::ReadAllText("$filePath")
+		}
 
-        Write-Verbose "Running Invoke-Sqlcmd2 with ParameterSet '$($PSCmdlet.ParameterSetName)'.  Performing query '$Query'"
+		Write-Verbose "Running Invoke-Sqlcmd2 with ParameterSet '$($PSCmdlet.ParameterSetName)'.  Performing query '$Query'."
 
-        if ($As -eq "PSObject")
-        {
-            #This code scrubs DBNulls.  Props to Dave Wyatt
-            $cSharp = @'
+		if ($As -eq "PSObject") {
+			#This code scrubs DBNulls.  Props to Dave Wyatt
+			$cSharp = @'
                 using System;
                 using System.Data;
                 using System.Management.Automation;
@@ -330,117 +338,117 @@ function Invoke-Sqlcmd2
                 }
 '@
 
-            try {
-                Add-Type -TypeDefinition $cSharp -ReferencedAssemblies 'System.Data','System.Xml' -ErrorAction stop
-            }
-            catch {
-                if (-not $_.ToString() -like "*The type name 'DBNullScrubber' already exists*") {
-                    Write-Warning "Could not load DBNullScrubber.  Defaulting to DataRow output: $_."
-                    $As = "Datarow"
-                }
-            }
-        }
+			try {
+				Add-Type -TypeDefinition $cSharp -ReferencedAssemblies 'System.Data', 'System.Xml' -ErrorAction stop
+			}
+			catch {
+				if (-not $_.ToString() -like "*The type name 'DBNullScrubber' already exists*") {
+					Write-Warning "Could not load DBNullScrubber.  Defaulting to DataRow output: $_."
+					$As = "Datarow"
+				}
+			}
+		}
 
-        #Handle existing connections
-        if ($PSBoundParameters.ContainsKey('SQLConnection')) {
-            if ($SQLConnection.State -notlike "Open") {
-                try {
-                    Write-Verbose "Opening connection from '$($SQLConnection.State)' state."
-                    $SQLConnection.Open()
-                }
-                catch {
-                    throw $_
-                }
-            }
+		#Handle existing connections
+		if ($PSBoundParameters.ContainsKey('SQLConnection')) {
+			if ($SQLConnection.State -notlike "Open") {
+				try {
+					Write-Verbose "Opening connection from '$($SQLConnection.State)' state."
+					$SQLConnection.Open()
+				}
+				catch {
+					throw $_
+				}
+			}
 
-            if ($Database -and $SQLConnection.Database -notlike $Database) {
-                try {
-                    Write-Verbose "Changing SQLConnection database from '$($SQLConnection.Database)' to $Database."
-                    $SQLConnection.ChangeDatabase($Database)
-                }
-                catch {
-                    throw "Could not change Connection database '$($SQLConnection.Database)' to $Database`: $_"
-                }
-            }
+			if ($Database -and $SQLConnection.Database -notlike $Database) {
+				try {
+					Write-Verbose "Changing SQLConnection database from '$($SQLConnection.Database)' to $Database."
+					$SQLConnection.ChangeDatabase($Database)
+				}
+				catch {
+					throw "Could not change Connection database '$($SQLConnection.Database)' to $Database`: $_"
+				}
+			}
 
-            if ($SQLConnection.state -like "Open") {
-                $ServerInstance = @($SQLConnection.DataSource)
-            }
-            else {
-                throw "SQLConnection is not open"
-            }
-        }
+			if ($SQLConnection.state -like "Open") {
+				$ServerInstance = @($SQLConnection.DataSource)
+			}
+			else {
+				throw "SQLConnection is not open"
+			}
+		}
 
-    }
-    process {
-        foreach($SQLInstance in $ServerInstance) {
-            Write-Verbose "Querying ServerInstance '$SQLInstance'."
+	}
+	process {
+		foreach ($SQLInstance in $ServerInstance) {
+			Write-Verbose "Querying ServerInstance '$SQLInstance'."
 
-            if($PSBoundParameters.Keys -contains "SQLConnection") {
-                $Conn = $SQLConnection
-            }
-            else {
-                if ($Credential) {
-                    $ConnectionString = "Server={0};Database={1};User ID={2};Password=`"{3}`";Trusted_Connection=False;Connect Timeout={4};Encrypt={5}" -f $SQLInstance,$Database,$Credential.UserName,$Credential.GetNetworkCredential().Password,$ConnectionTimeout,$Encrypt
-                }
-                else {
-                    $ConnectionString = "Server={0};Database={1};Integrated Security=True;Connect Timeout={2};Encrypt={3}" -f $SQLInstance,$Database,$ConnectionTimeout,$Encrypt
-                }
+			if ($PSBoundParameters.Keys -contains "SQLConnection") {
+				$Conn = $SQLConnection
+			}
+			else {
+				if ($Credential) {
+					$ConnectionString = "Server={0};Database={1};User ID={2};Password=`"{3}`";Trusted_Connection=False;Connect Timeout={4};Encrypt={5}" -f $SQLInstance, $Database, $Credential.UserName, $Credential.GetNetworkCredential().Password, $ConnectionTimeout, $Encrypt
+				}
+				else {
+					$ConnectionString = "Server={0};Database={1};Integrated Security=True;Connect Timeout={2};Encrypt={3}" -f $SQLInstance, $Database, $ConnectionTimeout, $Encrypt
+				}
 
-                $conn = New-Object System.Data.SqlClient.SQLConnection
-                $conn.ConnectionString = $ConnectionString
-                Write-Debug "ConnectionString $ConnectionString."
+				$conn = New-Object System.Data.SqlClient.SQLConnection
+				$conn.ConnectionString = $ConnectionString
+				Write-Debug "ConnectionString $ConnectionString."
 
-                try {
-                    $conn.Open()
-                }
-                catch {
-                    Write-Error $_
-                    continue
-                }
-            }
+				try {
+					$conn.Open()
+				}
+				catch {
+					Write-Error $_
+					continue
+				}
+			}
 
-            #Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller
-            if ($PSBoundParameters.Verbose) {
-                $conn.FireInfoMessageEventOnUserErrors=$false # Shiyang, $true will change the SQL exception to information
-                $handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose "$($_)" }
-                $conn.add_InfoMessage($handler)
-            }
+			#Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller
+			if ($PSBoundParameters.Verbose) {
+				$conn.FireInfoMessageEventOnUserErrors = $false # Shiyang, $true will change the SQL exception to information
+				$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose "$($_)" }
+				$conn.add_InfoMessage($handler)
+			}
 
-            $cmd = New-Object system.Data.SqlClient.SqlCommand($Query,$conn)
-            $cmd.CommandTimeout=$QueryTimeout
+			$cmd = New-Object system.Data.SqlClient.SqlCommand($Query, $conn)
+			$cmd.CommandTimeout = $QueryTimeout
 
-            if ($SqlParameters -ne $null) {
-                $SqlParameters.GetEnumerator() |
-                    ForEach-Object {
-                        if ($_.Value -ne $null) {
-							$cmd.Parameters.AddWithValue($_.Key, $_.Value)
-						}
-                        else {
-							$cmd.Parameters.AddWithValue($_.Key, [DBNull]::Value)
-						}
-                    } > $null
-            }
+			if ($SqlParameters -ne $null) {
+				$SqlParameters.GetEnumerator() |
+					ForEach-Object {
+					if ($_.Value -ne $null) {
+						$cmd.Parameters.AddWithValue($_.Key, $_.Value)
+					}
+					else {
+						$cmd.Parameters.AddWithValue($_.Key, [DBNull]::Value)
+					}
+				} > $null
+			}
 
-            $ds = New-Object system.Data.DataSet
-            $da = New-Object system.Data.SqlClient.SqlDataAdapter($cmd)
+			$ds = New-Object system.Data.DataSet
+			$da = New-Object system.Data.SqlClient.SqlDataAdapter($cmd)
 
-            try {
-                [void]$da.fill($ds)
-            }
-            catch [System.Data.SqlClient.SqlException] { # For SQL exception
-                $Err = $_
-                Write-Verbose "Capture SQL Error."
+			try {
+				[void]$da.fill($ds)
+			}
+			catch [System.Data.SqlClient.SqlException] {
+				# For SQL exception
+				$Err = $_
+				Write-Verbose "Capture SQL Error."
 				if ($PSBoundParameters.Verbose) {
 					Write-Verbose "SQL Error:  $Err."
-			 	} #Shiyang, add the verbose output of exception
+				} #Shiyang, add the verbose output of exception
 
-                switch ($ErrorActionPreference.tostring())
-                {
-                    {'SilentlyContinue','Ignore' -contains $_} {
+				switch ($ErrorActionPreference.tostring()) {
+					{'SilentlyContinue', 'Ignore' -contains $_} {
 
 					}
-                    'Stop' {
+					'Stop' {
 						throw $Err
 					}
 					'Continue' {
@@ -449,71 +457,70 @@ function Invoke-Sqlcmd2
 					default {
 						throw $Err
 					}
-                }
-            }
-            catch { # For other exception
-                Write-Verbose "Capture Other Error." 
-                $Err = $_
+				}
+			}
+			catch {
+				# For other exception
+				Write-Verbose "Capture Other Error." 
+				$Err = $_
 
 				if ($PSBoundParameters.Verbose) {
 					Write-Verbose "Other Error:  $Err."
 				} 
 
-                switch ($ErrorActionPreference.tostring())
-                {
-                    {'SilentlyContinue','Ignore' -contains $_} {
+				switch ($ErrorActionPreference.tostring()) {
+					{'SilentlyContinue', 'Ignore' -contains $_} {
 
 					}
-                    'Stop' {
+					'Stop' {
 						throw $Err
 					}
-                    'Continue' {
+					'Continue' {
 						throw $Err
 					}
 					default {
 						throw $Err
 					}
-                }
-            }
-            finally
-            {
-                #Close the connection
-                if (-not $PSBoundParameters.ContainsKey('SQLConnection')) {
-                    $conn.Close()
-                }               
-            }
+				}
+			}
+			finally {
+				#Close the connection
+				if (-not $PSBoundParameters.ContainsKey('SQLConnection')) {
+					$conn.Close()
+				}               
+			}
 
-            if ($AppendServerInstance) {
-                #Basics from Chad Miller
-                $Column =  New-Object Data.DataColumn
-                $Column.ColumnName = "ServerInstance"
-                $ds.Tables[0].Columns.Add($Column)
-                Foreach($row in $ds.Tables[0]) {
-                    $row.ServerInstance = $SQLInstance
-                }
-            }
+			if ($AppendServerInstance) {
+				#Basics from Chad Miller
+				$Column = New-Object Data.DataColumn
+				$Column.ColumnName = "ServerInstance"
+				$ds.Tables[0].Columns.Add($Column)
+				Foreach ($row in $ds.Tables[0]) {
+					$row.ServerInstance = $SQLInstance
+				}
+			}
 
-            switch ($As) {
-                'DataSet' {
+			switch ($As) {
+				'DataSet' {
 					$ds
-                }
-                'DataTable' {
-                    $ds.Tables
-                }
-                'DataRow' {
-                    $ds.Tables[0]
-                }
-                'PSObject' {
-                    #Scrub DBNulls - Provides convenient results you can use comparisons with
-                    #Introduces overhead (e.g. ~2000 rows w/ ~80 columns went from .15 Seconds to .65 Seconds - depending on your data could be much more!)
-                    foreach ($row in $ds.Tables[0].Rows) {
-                        [DBNullScrubber]::DataRowToPSObject($row)
-                    }
-                }
-                'SingleValue' {
-                    $ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
-                }
-            }
-        }
-    }
+				}
+				'DataTable' {
+					$ds.Tables
+				}
+				'DataRow' {
+					$ds.Tables[0]
+				}
+				'PSObject' {
+					#Scrub DBNulls - Provides convenient results you can use comparisons with
+					#Introduces overhead (e.g. ~2000 rows w/ ~80 columns went from .15 Seconds to .65 Seconds - depending on your data could be much more!)
+					foreach ($row in $ds.Tables[0].Rows) {
+						[DBNullScrubber]::DataRowToPSObject($row)
+					}
+				}
+				'SingleValue' {
+					$ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+				}
+			}
+		}
+	}
 } #Invoke-Sqlcmd2


### PR DESCRIPTION
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
 - [X] Spelling, grammar & other cleanup in Help and other text content

### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
To clean up grammar, style, spelling and other issues related to comment-based help and other text in functions.

Fix #2192 to allow for successful access to UNC paths