### PR TITLE
Adjust Get-DbaDbStoredProcedure

### DIFF
--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -108,7 +108,7 @@
 					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name
 
-					$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ObjectId', 'CreateDate', 
+					$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ID as ObjectId', 'CreateDate', 
 						'DateLastModified', 'Name', 'ImplementationType', 'Startup'
 					Select-DefaultView -InputObject $proc -Property $defaults
                 }

--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -1,63 +1,62 @@
-﻿Function Get-DbaDbStoredProcedure {
+﻿function Get-DbaDbStoredProcedure {
 	<#
-.SYNOPSIS
-Gets database Stored Procedures
+		.SYNOPSIS
+			Gets database Stored Procedures
 
-.DESCRIPTION
-Gets database Stored Procedures
+		.DESCRIPTION
+			Gets database Stored Procedures
 
-.PARAMETER SqlInstance
-The target SQL Server instance(s)
+		.PARAMETER SqlInstance
+			The target SQL Server instance(s)
 
-.PARAMETER SqlCredential
-Allows you to login to SQL Server using alternative credentials
+		.PARAMETER SqlCredential
+			Allows you to login to SQL Server using alternative credentials
 
-.PARAMETER Database
-To get Stored Procedures from specific database(s)
+		.PARAMETER Database
+			To get Stored Procedures from specific database(s)
 
-.PARAMETER ExcludeDatabase
-The database(s) to exclude - this list is auto populated from the server
+		.PARAMETER ExcludeDatabase
+			The database(s) to exclude - this list is auto populated from the server
 
-.PARAMETER ExcludeSystemSp
-This switch removes all system objects from the Stored Procedure collection
+		.PARAMETER ExcludeSystemSp
+			This switch removes all system objects from the Stored Procedure collection
 
-.PARAMETER Silent
-Use this switch to disable any kind of verbose messages
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
 
-.NOTES
-Tags: Databases
-Author: Klaas Vandenberghe ( @PowerDbaKlaas )
+		.NOTES
+			Tags: Databases
+			Author: Klaas Vandenberghe ( @PowerDbaKlaas )
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.EXAMPLE
-Get-DbaDbStoredProcedure -SqlInstance sql2016
+		.EXAMPLE
+			Get-DbaDbStoredProcedure -SqlInstance sql2016
 
-Gets all database Stored Procedures
+			Gets all database Stored Procedures
 
-.EXAMPLE
-Get-DbaDbStoredProcedure -SqlInstance Server1 -Database db1
+		.EXAMPLE
+			Get-DbaDbStoredProcedure -SqlInstance Server1 -Database db1
 
-Gets the Stored Procedures for the db1 database
+			Gets the Stored Procedures for the db1 database
 
-.EXAMPLE
-Get-DbaDbStoredProcedure -SqlInstance Server1 -ExcludeDatabase db1
+		.EXAMPLE
+			Get-DbaDbStoredProcedure -SqlInstance Server1 -ExcludeDatabase db1
 
-Gets the Stored Procedures for all databases except db1
+			Gets the Stored Procedures for all databases except db1
 
-.EXAMPLE
-Get-DbaDbStoredProcedure -SqlInstance Server1 -ExcludeSystemSp
+		.EXAMPLE
+			Get-DbaDbStoredProcedure -SqlInstance Server1 -ExcludeSystemSp
 
-Gets the Stored Procedures for all databases that are not system objects
+			Gets the Stored Procedures for all databases that are not system objects
 
-.EXAMPLE
-'Sql1','Sql2/sqlexpress' | Get-DbaDbStoredProcedure
+		.EXAMPLE
+			'Sql1','Sql2/sqlexpress' | Get-DbaDbStoredProcedure
 
-Gets the Stored Procedures for the databases on Sql1 and Sql2/sqlexpress
-
-#>
+			Gets the Stored Procedures for the databases on Sql1 and Sql2/sqlexpress
+	#>
 	[CmdletBinding()]
 	param (
 		[parameter(Mandatory, ValueFromPipeline)]
@@ -94,25 +93,24 @@ Gets the Stored Procedures for the databases on Sql1 and Sql2/sqlexpress
 					Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
 					continue
 				}
-
-				$StoredProcedures = $db.StoredProcedures
-
-				if (!$StoredProcedures) {
-					Write-Message -Message "No Stored Procedures exist in the $db database on $instance" -Target $db -Level Verbose
-					continue
+				if ($db.StoredProcedures.Count -eq 0) {
+					Write-Message -Message "No Stored Procedures exist in the $db database on $instance" -Target $db -Level Output
+						continue
 				}
-                if (Test-Bound -ParameterName ExcludeSystemSp) {
-                    $StoredProcedures = $StoredProcedures | Where-Object { $_.IsSystemObject -eq $false }
-                }
 
-                $StoredProcedures | foreach {
+				foreach ($proc in $db.StoredProcedures) {
+					if ( (Test-Bound -ParameterName ExcludeSystemSp) -and $proc.IsSystemObject ) {
+						continue
+					}
 
-				Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
-				Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-				Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-				Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name
+					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $server.NetName
+					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+					Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name
 
-				Select-DefaultView -InputObject $_ -Property ComputerName, InstanceName, SqlInstance, Database, Schema, CreateDate, DateLastModified, Name, ImplementationType, Startup
+					$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ObjectId', 'CreateDate', 
+						'DateLastModified', 'Name', 'ImplementationType', 'Startup'
+					Select-DefaultView -InputObject $proc -Property $defaults
                 }
 			}
 		}

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -32,10 +32,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 # Get-DbaNoun
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	Context "Command actually works" {
-		$results = Get-DbaDbStoredProcedure -SqlInstance $script:instance1 -ExcludeSystemSp
-		it "Should have correct properties" {
-			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Database,Schema,ObjectId,CreateDate,DateLastModified,Name,ImplementationType,Startup'.Split(',')
-			($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+		$results = Get-DbaDbStoredProcedure -SqlInstance $script:instance1 -Database master -ExcludeSystemSp
+		it "Should have standard properties" {
+			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance'.Split(',')
+			($results[0].PsObject.Properties.Name | Where-Object {$_ -in $ExpectedProps} | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 		}
 
 		It "Should exclude system stored procedure" {

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -1,0 +1,45 @@
+<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		<#
+			The $paramCount is adjusted based on the parameters your command will have.
+
+			The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+		#>
+		$paramCount = 6
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Get-DbaDbStoredProcedure).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemSp', 'Silent'
+		it "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		it "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+# Get-DbaNoun
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "Command actually works" {
+		$results = Get-DbaDbStoredProcedure -SqlInstance $script:instance1 -ExcludeSystemSp
+		it "Should have correct properties" {
+			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Database,Schema,ObjectId,CreateDate,DateLastModified,Name,ImplementationType,Startup'.Split(',')
+			($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+		}
+
+		It "Should exclude system stored procedure" {
+			($results | Where-Object Name -eq 'sp_helpdb') | Should Be $null
+		}
+	}
+}

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -11,6 +11,7 @@ $TestsRunGroups = @{
 		'Get-DbaComputerSystem',
 		'Get-DbaDatabase',
 		'Get-DbaDatabaseEncryption',
+		'Get-DbaDbStoredProcedure',
 		'Get-DbaLogin',
 		'Get-DbaOperatingSystem',
 		'Get-DbaProcess',


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Updated format.
- Adjusted logic to have the output come just a smidge faster.
- Adjusted default output to include the object ID.

### Approach
<!-- How does this change solve that purpose -->
The original logic populated a variable first and then output the contents. Databases that have an extremely high number of stored procedure objects can take a while before you see any output. The method implemented is similar to what is done in other commands and allows the output to start sooner than later.

### Commands to test
I'll include a Pester test shortly.