### PR TITLE
Switching Tepp default mode to synchronous updates

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 2, 21)
+$currentLibraryVersion = New-Object System.Version(0, 6, 2, 22)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.1.20")]
-[assembly: AssemblyFileVersion("0.6.2.21")]
+[assembly: AssemblyVersion("0.6.2.22")]
+[assembly: AssemblyFileVersion("0.6.2.22")]

--- a/bin/projects/dbatools/dbatools/TabExpansion/TabExpansionHost.cs
+++ b/bin/projects/dbatools/dbatools/TabExpansion/TabExpansionHost.cs
@@ -82,12 +82,12 @@ namespace Sqlcollaborative.Dbatools.TabExpansion
         /// <summary>
         /// Whether asynchronous TEPP updating should be disabled
         /// </summary>
-        public static bool TeppAsyncDisabled = false;
+        public static bool TeppAsyncDisabled = true;
 
         /// <summary>
         /// Whether synchronous TEPP updating should be disabled
         /// </summary>
-        public static bool TeppSyncDisabled = true;
+        public static bool TeppSyncDisabled = false;
 
         /// <summary>
         /// The interval in which asynchronous TEPP cache updates are performed

--- a/bin/projects/dbatools/dbatools/dbaSystem/DebugHost.cs
+++ b/bin/projects/dbatools/dbatools/dbaSystem/DebugHost.cs
@@ -74,6 +74,11 @@ namespace Sqlcollaborative.Dbatools.dbaSystem
         /// Enables the developer mode. In this additional information and logs are written, in order to make it easier to troubleshoot issues.
         /// </summary>
         public static bool DeveloperMode = false;
+
+        /// <summary>
+        /// Returns whether the module is currently in a development branch. Some warnings will only be shown in development branch, but hidden in master / public releases
+        /// </summary>
+        public static bool DevelopmentBranch = true;
         #endregion Defines
 
         #region Queues

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -35,21 +35,11 @@ function Connect-SqlInstance {
 	
 	[CmdletBinding()]
 	param (
-		[Parameter(Mandatory = $true)]
-		[object]
-		$SqlInstance,
-		
-		[object]
-		$SqlCredential,
-		
-		[switch]
-		$ParameterConnection,
-		
-		[switch]
-		$RegularUser = $true,
-		
-		[int]
-		$MinimumVersion
+		[Parameter(Mandatory = $true)][object]$SqlInstance,
+		[object]$SqlCredential,
+		[switch]$ParameterConnection,
+		[switch]$RegularUser = $true,
+		[int]$MinimumVersion
 	)
 	
 	#region Utility functions

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -70,9 +70,11 @@ function Connect-SqlInstance {
 			}
 			
 			if ($ENV:APPVEYOR_BUILD_FOLDER -or ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DeveloperMode)) { throw }
+			<#
 			elseif ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DevelopmentBranch) {
 				Write-Message -Level Warning -Message "Failed TEPP Caching: $($s | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ -Silent $false
 			}
+			#>
 			else {
 				Write-Message -Level Warning -Message "Failed TEPP Caching: $($s | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ -Silent $true
 			}

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -48,9 +48,6 @@ function Connect-SqlInstance {
 		[switch]
 		$RegularUser = $true,
 		
-		# let's see how this goes
-
-		
 		[int]
 		$MinimumVersion
 	)
@@ -72,7 +69,13 @@ function Connect-SqlInstance {
 				return
 			}
 			
-			throw
+			if ($ENV:APPVEYOR_BUILD_FOLDER -or ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DeveloperMode)) { throw }
+			elseif ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DevelopmentBranch) {
+				Write-Message -Level Warning -Message "Failed TEPP Caching: $($s | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ -Silent $false
+			}
+			else {
+				Write-Message -Level Warning -Message "Failed TEPP Caching: $($s | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ -Silent $true
+			}
 		}
 	}
 	#endregion Utility functions

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -99,7 +99,7 @@ function Connect-SqlInstance {
 		if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
 			$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
 			foreach ($scriptBlock in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast)) {
-				$ExecutionContext.InvokeCommand.InvokeScript($false, $scriptBlock, $null, $null)
+				[ScriptBlock]::Create($scriptBlock).Invoke()
 			}
 		}
 		return $server
@@ -221,7 +221,7 @@ function Connect-SqlInstance {
 	if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
 		$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
 		foreach ($scriptBlock in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppGatherScriptsFast)) {
-			$ExecutionContext.InvokeCommand.InvokeScript($false, $scriptBlock, $null, $null)
+			[ScriptBlock]::Create($scriptBlock).Invoke()
 		}
 	}
 	

--- a/internal/configurations/tabexpansion.ps1
+++ b/internal/configurations/tabexpansion.ps1
@@ -4,5 +4,5 @@ Set-DbaConfig -Name 'TabExpansion.UpdateTimeout' -Value (New-TimeSpan -Minutes 3
 
 # Disable the management cache entire
 Set-DbaConfig -Name 'TabExpansion.Disable' -Value $false -Default -DisableHandler -Description 'Globally disables all TEPP functionality by dbatools'
-Set-DbaConfig -Name 'TabExpansion.Disable.Asynchronous' -Value $false -Default -DisableHandler -Description 'Globally disables asynchronous TEPP updates in the background'
-Set-DbaConfig -Name 'TabExpansion.Disable.Synchronous' -Value $true -Default -DisableHandler -Description 'Globally disables synchronous TEPP updates, performed whenever connecting o the server. If this is not disabled, it will only perform updates that are fast to perform, in order to minimize performance impact. This may lead to some TEPP functionality loss if asynchronous updates are disabled.'
+Set-DbaConfig -Name 'TabExpansion.Disable.Asynchronous' -Value $true -Default -DisableHandler -Description 'Globally disables asynchronous TEPP updates in the background'
+Set-DbaConfig -Name 'TabExpansion.Disable.Synchronous' -Value $false -Default -DisableHandler -Description 'Globally disables synchronous TEPP updates, performed whenever connecting o the server. If this is not disabled, it will only perform updates that are fast to perform, in order to minimize performance impact. This may lead to some TEPP functionality loss if asynchronous updates are disabled.'


### PR DESCRIPTION
## Type of Change

 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included

### Purpose
Fixes complaints about persistent connections due to asynchronous update of TEPP data.
This is accomplished by making the synchronous mode the default mode.