### PR TITLE
Change all 'Original Author' labels in .NOTES sections to 'Author'

### DIFF
--- a/functions/Backup-DbaDatabaseCertificate.ps1
+++ b/functions/Backup-DbaDatabaseCertificate.ps1
@@ -46,7 +46,7 @@ function Backup-DbaDatabaseCertificate {
 			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
 		.NOTES
-			Original Author: Jess Pomfret (@jpomfret)
+			Author: Jess Pomfret (@jpomfret)
 			Tags: Migration, Certificate
 
 			Website: https://dbatools.io

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -49,7 +49,7 @@ function Copy-DbaBackupDevice {
 
 		.NOTES
 			Tags: Migration, DisasterRecovery, Backup
-			Original Author: Chrissy LeMaire (@cl), netnerds.net
+			Author: Chrissy LeMaire (@cl), netnerds.net
 			Requires: sysadmin access on SQL Servers
 
 			Website: https://dbatools.io

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -111,7 +111,7 @@ function Copy-DbaDatabase {
 
 		.NOTES
 			Tags: Migration, DisasterRecovery, Backup, Restore
-			Original Author: Chrissy LeMaire (@cl), netnerds.net
+			Author: Chrissy LeMaire (@cl), netnerds.net
 			Requires: sysadmin access on SQL Servers
 			Limitations: Doesn't cover what it doesn't cover (replication, certificates, etc)
 						SQL Server 2000 databases cannot be directly migrated to SQL Server 2012 and above.

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -54,7 +54,7 @@ Windows Authentication will be used if DestinationSqlCredential is not specified
 
 .NOTES
 Tags: Migration, SSIS
-Original Author: Phil Schwartz (philschwartz.me, @pschwartzzz)
+Author: Phil Schwartz (philschwartz.me, @pschwartzzz)
 	
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -28,7 +28,7 @@ function Disable-DbaAgHadr {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -28,7 +28,7 @@ function Enable-DbaAgHadr {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Expand-DbaTLogResponsibly.ps1
+++ b/functions/Expand-DbaTLogResponsibly.ps1
@@ -97,7 +97,7 @@ function Expand-DbaTLogResponsibly {
             Tags: Storage, Backup
             This script uses Get-DbaDiskSpace dbatools command to get the TLog's drive free space
             
-            Original Author: Claudio Silva (@ClaudioESSilva)
+            Author: Claudio Silva (@ClaudioESSilva)
             Requires: ALTER DATABASE permission
             Limitations: Freespace cannot be validated on the directory where the log file resides in SQL Server 2005.
 

--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -25,7 +25,7 @@ function Export-DbaDiagnosticQuery {
 
 		.NOTES
 			Tags: Query
-			Original Author: André Kamman (@AndreKamman), http://clouddba.io
+			Author: André Kamman (@AndreKamman), http://clouddba.io
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -48,7 +48,7 @@ function Export-DbaUser {
 
 		.NOTES
 			Tags: User, Export
-			Original Author: Claudio Silva (@ClaudioESSilva)
+			Author: Claudio Silva (@ClaudioESSilva)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -32,7 +32,7 @@ function Find-DbaCommand {
 
 		.NOTES
 			Tags: Find,Help,Command
-			Original Author: Simone Bizzotto
+			Author: Simone Bizzotto
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -23,7 +23,7 @@ function Find-DbaDatabaseGrowthEvent {
 
 		.NOTES
 			Tags: AutoGrow
-			Original Author: Aaron Nelson
+			Author: Aaron Nelson
 			Query Extracted from SQL Server Management Studio (SSMS) 2016.
 
 			Website: https://dbatools.io

--- a/functions/Find-DbaDuplicateIndex.ps1
+++ b/functions/Find-DbaDuplicateIndex.ps1
@@ -70,7 +70,7 @@ function Find-DbaDuplicateIndex {
 			If this switch is enabled, the internal messaging functions will be silenced.
 
 		.NOTES 
-			Original Author: Claudio Silva (@ClaudioESSilva)
+			Author: Claudio Silva (@ClaudioESSilva)
 			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 			Copyright (C) 2016 Chrissy LeMaire
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -8,8 +8,8 @@ Finds Logins in Active Directory groups that have logins on the SQL Instance.
 Outputs all the active directory groups members for a server, or limits it to find a specific AD user in the groups
 	
 .NOTES 
-Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
-Original Author: Simone Bizzotto, @niphlod
+Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+Author: Simone Bizzotto, @niphlod
 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Find-DbaSimilarTable.ps1
+++ b/functions/Find-DbaSimilarTable.ps1
@@ -46,7 +46,7 @@ The minimum percentage of column names that should match between the matching an
 Use this switch to disable any kind of verbose messages
 
 .NOTES
-Original Author: Jana Sattainathan (@SQLJana - http://sqljana.wordpress.com)
+Author: Jana Sattainathan (@SQLJana - http://sqljana.wordpress.com)
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -33,7 +33,7 @@ By default system databases are ignored but you can include them within the sear
 Use this switch to disable any kind of verbose messages
 
 .NOTES
-Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaTrigger.ps1
+++ b/functions/Find-DbaTrigger.ps1
@@ -37,7 +37,7 @@ By default system databases are ignored but you can include them within the sear
 Use this switch to disable any kind of verbose messages
 
 .NOTES
-Original Author: Cláudio Silva, @ClaudioESSilva
+Author: Cláudio Silva, @ClaudioESSilva
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaUnusedIndex.ps1
+++ b/functions/Find-DbaUnusedIndex.ps1
@@ -48,7 +48,7 @@ function Find-DbaUnusedIndex {
 
 		.NOTES
 			Tags: Indexes
-			Original Author: Aaron Nelson (@SQLvariant), SQLvariant.com
+			Author: Aaron Nelson (@SQLvariant), SQLvariant.com
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -29,7 +29,7 @@ PSCredential object to connect as. If not specified, current Windows login will 
 The regex pattern that the command will search for
 
 .NOTES 
-Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/functions/Find-DbaView.ps1
+++ b/functions/Find-DbaView.ps1
@@ -33,7 +33,7 @@ By default system databases are ignored but you can include them within the sear
 Use this switch to disable any kind of verbose messages
 
 .NOTES
-Original Author: Cláudio Silva (@ClaudioESSilva)
+Author: Cláudio Silva (@ClaudioESSilva)
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -27,7 +27,7 @@ function Get-DbaAgDatabase {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup, Replica
-			Original Author: Shawn Melton (@wsmelton)
+			Author: Shawn Melton (@wsmelton)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -17,7 +17,7 @@ function Get-DbaAgHadr {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgListener.ps1
+++ b/functions/Get-DbaAgListener.ps1
@@ -27,7 +27,7 @@ function Get-DbaAgListener {
 
         .NOTES
             Tags: DisasterRecovery, AG, AvailabilityGroup, Replica
-            Original Author: Viorel Ciucu (@viorelciucu)
+            Author: Viorel Ciucu (@viorelciucu)
 
             Website: https://dbatools.io
             Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -23,7 +23,7 @@ function Get-DbaAgReplica {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup, Replica
-			Original Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
+			Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -26,7 +26,7 @@ FUNCTION Get-DbaAgentJob {
 
 		.NOTES
 			Tags: Job, Agent
-			Original Author: Garry Bargsley (@gbargsley), http://blog.garrybargsley.com
+			Author: Garry Bargsley (@gbargsley), http://blog.garrybargsley.com
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -44,7 +44,7 @@
 
 		.NOTES
 			Tags: Job, Agent
-			Original Author: Klaas Vandenberghe ( @PowerDbaKlaas )
+			Author: Klaas Vandenberghe ( @PowerDbaKlaas )
 			Editor: niphlod
 
 			Website: https://dbatools.io

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -23,7 +23,7 @@ function Get-DbaAvailabilityGroup {
 
 		.NOTES
 			Tags: DisasterRecovery, AG, AvailabilityGroup
-			Original Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
+			Author: Shawn Melton (@wsmelton) | Chrissy LeMaire (@ctrlb)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaCmConnection.ps1
+++ b/functions/Get-DbaCmConnection.ps1
@@ -17,7 +17,7 @@
     Use this if you want the function to throw terminating errors you want to catch.
 
 	.NOTES
-	Original Author: Fred Winmann (@FredWeinmann)
+	Author: Fred Winmann (@FredWeinmann)
 	Tags: ComputerManagement
 
 	Website: https://dbatools.io

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -56,7 +56,7 @@
 		It will use the credewntials stored in $cred to connect, unless they are known to not work, in which case they will default to windows credentials (unless another default has been set).
 	
 	.NOTES
-		Original Author: Fred Winmann (@FredWeinmann)
+		Author: Fred Winmann (@FredWeinmann)
 		Tags: ComputerManagement
 		
 		Website: https://dbatools.io

--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -20,7 +20,7 @@ function Get-DbaComputerSystem {
 
 		.NOTES
 			Tags: ServerInfo
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https: //dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -76,7 +76,7 @@
 
 		.NOTES
 			Tags: Database
-			Original Author: Garry Bargsley (@gbargsley | http://blog.garrybargsley.com)
+			Author: Garry Bargsley (@gbargsley | http://blog.garrybargsley.com)
             Author: Klaas Vandenberghe ( @PowerDbaKlaas )
             Author: Simone Bizzotto ( @niphlod )
 

--- a/functions/Get-DbaDatabaseEncryption.ps1
+++ b/functions/Get-DbaDatabaseEncryption.ps1
@@ -25,7 +25,7 @@ function Get-DbaDatabaseEncryption {
 		Use this switch to disable any kind of verbose messages.
 		
 	.NOTES 
-		Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+		Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Get-DbaDatabaseSpace.ps1
+++ b/functions/Get-DbaDatabaseSpace.ps1
@@ -54,7 +54,7 @@
 		Returns database files and free space information for the db1 and db2 on localhost.
 	
 	.NOTES
-		Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+		Author: Michael Fal (@Mike_Fal), http://mikefal.net
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Get-DbaDbQueryStoreOptions.ps1
+++ b/functions/Get-DbaDbQueryStoreOptions.ps1
@@ -26,7 +26,7 @@ Use this switch to disable any kind of verbose messages
 
 .NOTES
 Tags: QueryStore
-Original Author: Enrico van de Laar ( @evdlaar )
+Author: Enrico van de Laar ( @evdlaar )
 Author: Klaas Vandenberghe ( @PowerDBAKlaas )
 
 Website: https://dbatools.io

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -55,7 +55,7 @@ function Get-DbaHelpIndex {
 
 		.NOTES
 			Tags: Indexes
-			Original Author: Nic Cain, https://sirsql.net/
+			Author: Nic Cain, https://sirsql.net/
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -31,7 +31,7 @@ function Get-DbaLogin {
 			Use this switch to disable any kind of verbose messages
 
 		.NOTES
-			Original Author: Mitchell Hamann (@SirCaptainMitch)
+			Author: Mitchell Hamann (@SirCaptainMitch)
 			Author: Klaas Vandenberghe (@powerdbaklaas)
 
 			Website: https://dbatools.io

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -17,7 +17,7 @@ function Get-DbaOperatingSystem {
 
 		.NOTES
 			Tags: ServerInfo, OperatingSystem
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https: //dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaPolicy.ps1
+++ b/functions/Get-DbaPolicy.ps1
@@ -25,7 +25,7 @@ Function Get-DbaPolicy {
 	If this switch is enabled, the internal messaging functions will be silenced. 
 
 	.NOTES
-	Original Author: Stephen Bennett (https://sqlnotesfromtheunderground.wordpress.com/)
+	Author: Stephen Bennett (https://sqlnotesfromtheunderground.wordpress.com/)
 	Tags: Policy, PoilcyBasedManagement
 
 	Website: https://dbatools.io

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -18,7 +18,7 @@ Replaces user friendly yellow warnings with bloody red exceptions of doom!
 Use this if you want the function to throw terminating errors you want to catch.
 
 .NOTES 
-Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Get-DbaServerInstallDate.ps1
+++ b/functions/Get-DbaServerInstallDate.ps1
@@ -25,7 +25,7 @@ Use this switch to disable any kind of verbose messages
 
 .NOTES
 Tags: CIM 
-Original Author: Mitchell Hamann (@SirCaptainMitch), mitchellhamann.com
+Author: Mitchell Hamann (@SirCaptainMitch), mitchellhamann.com
 	
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaSqlManagementObject.ps1
+++ b/functions/Get-DbaSqlManagementObject.ps1
@@ -22,7 +22,7 @@
 		
 		.NOTES
 			Tags: SMO
-			Original Author: Ben Miller (@DBAduck - http://dbaduck.com)
+			Author: Ben Miller (@DBAduck - http://dbaduck.com)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaTable.ps1
+++ b/functions/Get-DbaTable.ps1
@@ -33,7 +33,7 @@ Use this switch to disable any kind of verbose messages
 
 .NOTES
 Tags: Database, Tables
-Original Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
+Author: Stephen Bennett, https://sqlnotesfromtheunderground.wordpress.com/
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -20,7 +20,7 @@
 
 		.NOTES
 			Tags: Trace, Flag
-			Original Author: Kevin Bullen (@sqlpadawan)
+			Author: Kevin Bullen (@sqlpadawan)
 
 			References:  https://docs.microsoft.com/en-us/sql/t-sql/database-console-commands/dbcc-traceon-trace-flags-transact-sql
 

--- a/functions/Get-DbaWindowsLog.ps1
+++ b/functions/Get-DbaWindowsLog.ps1
@@ -36,7 +36,7 @@
 	
 	.NOTES
 		Tags: Logging
-		Original Author: Drew Furgiuele
+		Author: Drew Furgiuele
 		Editor: Friedrich "Fred" Weinmann
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Get-DbatoolsLog.ps1
+++ b/functions/Get-DbatoolsLog.ps1
@@ -10,7 +10,7 @@
     Instead of log entries, the error entries will be retrieved
 
     .NOTES
-	Original Author: Fred Weinmann (@FredWeinmann)
+	Author: Fred Weinmann (@FredWeinmann)
 	Tags: Debug
 
 	Website: https://dbatools.io

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -25,7 +25,7 @@ If SqlCredential is not specified, Windows authentication will be used.
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original author: Tara Kizer, Brent Ozar Unlimited (https://www.brentozar.com/)
+Author: Tara Kizer, Brent Ozar Unlimited (https://www.brentozar.com/)
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Invoke-DbaCycleErrorLog.ps1
+++ b/functions/Invoke-DbaCycleErrorLog.ps1
@@ -31,7 +31,7 @@ function Invoke-DbaCycleErrorLog {
 
 		.NOTES
 			Tags: Log, Cycle
-			Original Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
+			Author: Shawn Melton (@wsmelton | http://blog.wsmelton.info)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -328,7 +328,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Log shippin, disaster recovery
 	
 Website: https://dbatools.io

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -89,7 +89,7 @@ Prompts you for confirmation before executing any changing operations within the
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job, Job Step
 	
 Website: https://dbatools.io

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -95,7 +95,7 @@ Use this switch to disable any kind of verbose messages
 
 .NOTES
 Tags: Agent, Job, Job Step
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -101,7 +101,7 @@ function New-DbaAgentSchedule {
 
 		.NOTES
 			Tags: Agent, Job, Job Step
-			Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+			Author: Sander Stad (@sqlstad, sqlstad.nl)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/New-DbaCmConnection.ps1
+++ b/functions/New-DbaCmConnection.ps1
@@ -65,7 +65,7 @@
 
         .NOTES
             Tags: ComputerManagement
-            Original Author: Fred Winmann (@FredWeinmann)
+            Author: Fred Winmann (@FredWeinmann)
 
             Website: https://dbatools.io
             Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/New-DbatoolsSupportPackage.ps1
+++ b/functions/New-DbatoolsSupportPackage.ps1
@@ -28,7 +28,7 @@
     Use this if you want the function to throw terminating errors you want to catch.
 
     .NOTES
-	Original Author: Fred Weinmann (@FredWeinmann)
+	Author: Fred Weinmann (@FredWeinmann)
 	Tags: Debug
 
 	Website: https://dbatools.io

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -34,7 +34,7 @@ Prompts you for confirmation before executing any changing operations within the
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job
 	
 Website: https://dbatools.io

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -36,7 +36,7 @@ Prompts you for confirmation before executing any changing operations within the
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job, Job Step
 	
 Website: https://dbatools.io

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -32,7 +32,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job, Job Step, Schedule
 	
 Website: https://dbatools.io

--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -52,7 +52,7 @@ Prompts you for confirmation before executing any changing operations within the
 
 .NOTES
 Tags: Storage, DisasterRecovery, Backup
-Original Author: Chris Sommer, @cjsommer, www.cjsommer.com
+Author: Chris Sommer, @cjsommer, www.cjsommer.com
 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Remove-DbaCmConnection.ps1
+++ b/functions/Remove-DbaCmConnection.ps1
@@ -15,7 +15,7 @@
     Use this if you want the function to throw terminating errors you want to catch.
 	
 	.NOTES
-	Original Author: Fred Winmann (@FredWeinmann)
+	Author: Fred Winmann (@FredWeinmann)
 	Tags: ComputerManagement
 	
 	Website: https://dbatools.io

--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -36,7 +36,7 @@ Shows what would happen if the command were to run. No actions are actually perf
 
 .NOTES 
 Tags: Login
-Original Author: Mitchell Hamann (@SirCaptainMitch)
+Author: Mitchell Hamann (@SirCaptainMitch)
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -76,7 +76,7 @@ function Repair-DbaOrphanUser {
 
 		.NOTES
 			Tags: Orphan
-			Original Author: Claudio Silva (@ClaudioESSilva)
+			Author: Claudio Silva (@ClaudioESSilva)
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -51,7 +51,7 @@ function Resolve-DbaNetworkName {
 
 		.NOTES
 			Tags: Network, Resolve
-			Original Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+			Author: Klaas Vandenberghe ( @PowerDBAKlaas )
 			Editor: niphlod
 			
 			Website: https://dbatools.io

--- a/functions/Restore-DbaDatabaseCertificate.ps1
+++ b/functions/Restore-DbaDatabaseCertificate.ps1
@@ -36,7 +36,7 @@ Use this switch to disable any kind of verbose messages
 
 .NOTES
 Tags: Migration, Certificate
-Original Author: Jess Pomfret (@jpomfret)
+Author: Jess Pomfret (@jpomfret)
 
 Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -88,7 +88,7 @@ Prompts you for confirmation before executing any changing operations within the
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job
 	
 Website: https://dbatools.io

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -93,7 +93,7 @@ Use this switch to disable any kind of verbose messages
 The force parameter will ignore some errors in the parameters and assume defaults.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job, Job Step
 	
 Website: https://dbatools.io

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -87,7 +87,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Agent, Job, Job Step
 	
 Website: https://dbatools.io

--- a/functions/Set-DbaDbQueryStoreOptions.ps1
+++ b/functions/Set-DbaDbQueryStoreOptions.ps1
@@ -57,7 +57,7 @@ function Set-DbaDbQueryStoreOptions {
 
 		.NOTES
 			Tags: QueryStore
-			Original Author: Enrico van de Laar ( @evdlaar )
+			Author: Enrico van de Laar ( @evdlaar )
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Set-DbaJobOwner.ps1
+++ b/functions/Set-DbaJobOwner.ps1
@@ -14,7 +14,7 @@ function Set-DbaJobOwner {
 
 		.NOTES
 			Tags: Agent, Job
-			Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+			Author: Michael Fal (@Mike_Fal), http://mikefal.net
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Set-DbaSpConfigure.ps1
+++ b/functions/Set-DbaSpConfigure.ps1
@@ -38,7 +38,7 @@
 
 		.NOTES 
 			Tags: SpConfigure
-			Original Author: Nic Cain, https://sirsql.net/
+			Author: Nic Cain, https://sirsql.net/
 			
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Set-DbaTempDbConfiguration.ps1
+++ b/functions/Set-DbaTempDbConfiguration.ps1
@@ -9,7 +9,7 @@ function Set-DbaTempDbConfiguration {
 			Other parameters can adjust the settings as the user desires (such as different file paths, number of data files, and log file size). No functions that shrink or delete data files are performed. If you wish to do this, you will need to resize tempdb so that it is "smaller" than what the function will size it to before running the function.
 
 		.NOTES 
-			Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+			Author: Michael Fal (@Mike_Fal), http://mikefal.net
 
 			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 			Copyright (C) 2016 Chrissy LeMaire

--- a/functions/Sync-DbaSqlLoginPermission.ps1
+++ b/functions/Sync-DbaSqlLoginPermission.ps1
@@ -47,7 +47,7 @@ function Sync-DbaSqlLoginPermission {
 
 		.NOTES
 			Tags: Migration, Login
-			Original Author: Chrissy LeMaire (@cl), netnerds.net
+			Author: Chrissy LeMaire (@cl), netnerds.net
 			Requires: sysadmin access on SQL Servers
 			Limitations: Does not support Application Roles yet
 

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -36,7 +36,7 @@
 		If this switch is enabled, the internal messaging functions will be silenced.
 
 	.NOTES
-        Original Author: Fred Winmann (@FredWeinmann)
+        Author: Fred Winmann (@FredWeinmann)
         Tags: ComputerManagement
 
         Website: https://dbatools.io

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -51,7 +51,7 @@ function Test-DbaConnection {
 
 		.NOTES
 			Tags: CIM, Test, Connection
-			Original Author: Chrissy LeMaire
+			Author: Chrissy LeMaire
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -13,7 +13,7 @@ function Test-DbaDatabaseOwner {
 		Best Practice reference: http://weblogs.sqlteam.com/dang/archive/2008/01/13/Database-Owner-Troubles.aspx
 
 	.NOTES
-		Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+		Author: Michael Fal (@Mike_Fal), http://mikefal.net
 
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Test-DbaDiskAlignment.ps1
+++ b/functions/Test-DbaDiskAlignment.ps1
@@ -71,7 +71,7 @@ Function Test-DbaDiskAlignment
         Get WMI Disk Information - http://powershell.com/cs/media/p/7937.aspx
         Thanks to jbruns2010!
         
-        Original Author: Constantine Kokkinos (https://constantinekokkinos.com, @mobileck)
+        Author: Constantine Kokkinos (https://constantinekokkinos.com, @mobileck)
         
         dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com,)
         Copyright (C) 2016 Chrissy Lemaire

--- a/functions/Test-DbaJobOwner.ps1
+++ b/functions/Test-DbaJobOwner.ps1
@@ -39,7 +39,7 @@ function Test-DbaJobOwner {
 
 		.NOTES
 			Tags: Agent, Job, Owner
-			Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+			Author: Michael Fal (@Mike_Fal), http://mikefal.net
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Test-DbaSqlManagementObject.ps1
+++ b/functions/Test-DbaSqlManagementObject.ps1
@@ -20,7 +20,7 @@
 		
 		.NOTES
 			Tags: SMO
-			Original Author: Ben Miller (@DBAduck - http://dbaduck.com)
+			Author: Ben Miller (@DBAduck - http://dbaduck.com)
 
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -31,7 +31,7 @@ function Test-DbaTempDbConfiguration {
 
 		.NOTES
 			Tags: tempdb, configuration
-			Original Author: Michael Fal (@Mike_Fal), http://mikefal.net
+			Author: Michael Fal (@Mike_Fal), http://mikefal.net
 			Based off of Amit Bannerjee's (@banerjeeamit) Get-TempDB function (https://github.com/amitmsft/SqlOnAzureVM/blob/master/Get-TempdbFiles.ps1)
 
 			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)

--- a/internal/Get-JobList.ps1
+++ b/internal/Get-JobList.ps1
@@ -45,7 +45,7 @@ function Get-JobList {
 
 		Returns any Job object where job is not job_3_upload or job_3_download on sql2016
 	.NOTES
-		Original Author: Shawn Melton (@wsmelton)
+		Author: Shawn Melton (@wsmelton)
 
 		Website: https://dbatools.io
 		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com

--- a/internal/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/New-DbaLogShippingPrimaryDatabase.ps1
@@ -79,7 +79,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Log shippin, primary database
 	
 Website: https://dbatools.io

--- a/internal/New-DbaLogShippingPrimarySecondary.ps1
+++ b/internal/New-DbaLogShippingPrimarySecondary.ps1
@@ -38,7 +38,7 @@ Prompts you for confirmation before executing any changing operations within the
 Use this switch to disable any kind of verbose messages
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Log shipping, primary database, secondary database
 	
 Website: https://dbatools.io

--- a/internal/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/New-DbaLogShippingSecondaryDatabase.ps1
@@ -80,7 +80,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Log shippin, secondary database
 	
 Website: https://dbatools.io

--- a/internal/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/New-DbaLogShippingSecondaryPrimary.ps1
@@ -71,7 +71,7 @@ The force parameter will ignore some errors in the parameters and assume default
 It will also remove the any present schedules with the same name for the specific job.
 
 .NOTES 
-Original Author: Sander Stad (@sqlstad, sqlstad.nl)
+Author: Sander Stad (@sqlstad, sqlstad.nl)
 Tags: Log shippin, primary database, secondary database
 	
 Website: https://dbatools.io


### PR DESCRIPTION
Per conversation with @niphlod and @wsmelton in Slack. Revises all .NOTES fields which contain `Original Author` to instead use `Author`. `Find-DbaCommand` searches for the `Author:` label in comment-based help when indexing content and this will allow users to locate functions by author name more readily.

https://sqlcommunity.slack.com/archives/C3EJ852JD/p1505221156000450