### PR TITLE
Fixed error on building TEPP cache

### DIFF
--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -66,7 +66,7 @@ function Connect-SqlInstance {
 			}
 			#>
 			else {
-				Write-Message -Level Warning -Message "Failed TEPP Caching: $($s | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ -Silent $true
+				Write-Message -Level Warning -Message "Failed TEPP Caching: $($scriptBlock.ToString() | Select-String '"(.*?)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })" -ErrorRecord $_ 3>$null
 			}
 		}
 	}

--- a/internal/configurations/tabexpansion.handler.ps1
+++ b/internal/configurations/tabexpansion.handler.ps1
@@ -19,10 +19,13 @@ $ScriptBlock = {
 	
 	# Disable Async TEPP runspace if not needed
 	if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled -or [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled) {
-		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Stop()
+		try { [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Stop() }
+		catch { }
 	}
-	else {
-		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Start()
+	else
+	{
+		try { [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Start() }
+		catch { }
 	}
 	
 	return $Result
@@ -51,10 +54,13 @@ $ScriptBlock = {
 	
 	# Disable Async TEPP runspace if not needed
 	if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppAsyncDisabled -or [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppDisabled) {
-		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Stop()
+		try { [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Stop() }
+		catch { }
 	}
-	else {
-		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Start()
+	else
+	{
+		try { [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Start() }
+		catch { }
 	}
 	
 	return $Result


### PR DESCRIPTION

## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
This fixes an issue where erroneously errors would be produced when failing to update TEPP cache (for example due to lacking permissions to do so)