### PR TITLE
Resolve-DbaNetworkName, stricter resolution

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -193,10 +193,9 @@ function Resolve-DbaNetworkName {
 						}
 						Write-Message -Level VeryVerbose -Message "Getting computer information from $RemoteComputer"
 						$ScBlock = {
-							$reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, [Microsoft.Win32.RegistryView]::Default)
-							$key = $reg.OpenSubKey("SYSTEM\CurrentControlSet\services\Tcpip\Parameters")
+							$IPGProps = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()
 							return [pscustomobject]@{
-								'DNSDomain' = $key.GetValue("Domain")
+								'DNSDomain' = $IPGProps.DomainName
 							}
 						}
 						if (Test-Bound "Credential") {


### PR DESCRIPTION
This is a more stricter resolution

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes name resolution in corner-cases)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
This checks for the proper domain name for the host EVEN if it doesn't match the default resolution configured on the host itself (i.e. it's more correctly returning how to qualify the domain name for clients connecting to the host even if the host is set to resolve names using a different domain)


@potatoqualitee: we discussed this while you were full deep in audit ^_^
