### PR TITLE
Adjust Watch-DbaDbLogin

### DIFF
--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -78,12 +78,14 @@ function Watch-DbaDbLogin {
 		[string]$SqlCms,
 		# File with one server per line
 
-		[string]$ServersFromFile
+		[string]$ServersFromFile,
+		[switch]$Silent
 	)
 
 	process {
-		if ([string]::IsNullOrEmpty($SqlCms) -and [string]::IsNullOrEmpty($ServersFromFile)) {
-			throw "You must specify a server list source using -SqlCms or -ServersFromFile"
+		if (Test-Bound 'SqlCms','ServersFromFile' -Not) {
+			Stop-Function -Message "You must specify a server list source using -SqlCms or -ServersFromFile"
+			return
 		}
 
 		<#
@@ -120,7 +122,7 @@ function Watch-DbaDbLogin {
 				$servers = Get-DbaRegisteredServerName -SqlInstance $SqlCms -SqlCredential $SqlCredential -Silent
 			}
 			catch {
-				Write-Warning "The CMS server, $SqlCms, was not accessible."
+				Stop-Function -Message "The CMS server, $SqlCms, was not accessible." -Target $SqlCms -ErrorRecord $_
 				return
 			}
 		}
@@ -129,7 +131,7 @@ function Watch-DbaDbLogin {
 				$servers = Get-Content $ServersFromFile
 			}
 			else {
-				Write-Warning "$ServersFromFile was not found."
+				Stop-Function -Message "$ServersFromFile was not found." -Target $ServersFromFile
 				return
 			}
 		}

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -158,7 +158,8 @@ function Watch-DbaDbLogin {
 			$procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program }
 
 			if ($procs.Count -gt 0) {
-				$procs | Select-Object LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | Out-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
+				$procs | Select-Object @{Label="ComputerName"; Expression= {$server.NetName}}, @{Label="InstanceName"; Expression= {$server.ServiceName}}, @{Label="SqlInstance"; Expression= {$server.DomainInstanceName}}, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | Out-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
+
 				Write-Output "Added process information for $instance to datatable."
 			}
 			else {

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -115,13 +115,23 @@ function Watch-DbaDbLogin {
 		<#
 			Get servers to query from Central Management Server or File
 		#>
-		$servers = @()
 		if ($SqlCms) {
-			$servers = Get-DbaRegisteredServerName -SqlInstance $SqlCms -SqlCredential $SqlCredential
+			try {
+				$servers = Get-DbaRegisteredServerName -SqlInstance $SqlCms -SqlCredential $SqlCredential -Silent
+			}
+			catch {
+				Write-Warning "The CMS server, $SqlCms, was not accessible."
+				return
+			}
 		}
-
-		if ($ServersFromFile) {
-			$servers = Get-Content $ServersFromFile
+		if (Test-Bound 'ServersFromFile') {
+			if (Test-Path $ServersFromFile) {
+				$servers = Get-Content $ServersFromFile
+			}
+			else {
+				Write-Warning "$ServersFromFile was not found."
+				return
+			}
 		}
 
 		<#
@@ -172,7 +182,6 @@ function Watch-DbaDbLogin {
 	}
 
 	end {
-		Write-Output "Script completed"
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Watch-SqlDbLogin
 	}
 	<#

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -33,6 +33,9 @@ function Watch-DbaDbLogin {
 
 			To connect as a different Windows user, run PowerShell as that user.
 
+        .PARAMETER Silent
+            If this switch is enabled, the internal messaging functions will be silenced.
+
 		.NOTES
 			Tags: Login
 			Author: Chrissy LeMaire (@cl), netnerds.net

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -1,34 +1,34 @@
 function Watch-DbaDbLogin {
-    <#
-        .SYNOPSIS
-            Tracks SQL Server logins: which host they came from, what database they're using, and what program is being used to log in.
+	<#
+		.SYNOPSIS
+			Tracks SQL Server logins: which host they came from, what database they're using, and what program is being used to log in.
 
-        .DESCRIPTION
-            Watch-DbaDbLogin uses SQL Server process enumeration to track logins in a SQL Server table. This is helpful when you need to migrate a SQL Server and update connection strings, but have inadequate documentation on which servers/applications are logging into your SQL instance.
+		.DESCRIPTION
+			Watch-DbaDbLogin uses SQL Server process enumeration to track logins in a SQL Server table. This is helpful when you need to migrate a SQL Server and update connection strings, but have inadequate documentation on which servers/applications are logging into your SQL instance.
 
-            Running this script every 5 minutes for a week should give you a sufficient idea about database and login usage.
+			Running this script every 5 minutes for a week should give you a sufficient idea about database and login usage.
 
-        .PARAMETER SqlInstance
-            The SQL Server that stores the Watch database.
+		.PARAMETER SqlInstance
+			The SQL Server that stores the Watch database.
 
-        .PARAMETER SqlCms
-            Specifies a Central Management Server to query for a list of servers to watch.
+		.PARAMETER SqlCms
+			Specifies a Central Management Server to query for a list of servers to watch.
 
-        .PARAMETER SqlCmsGroups
-            This is an auto-populated array that contains your Central Management Server top-level groups. You can use one or many groups.
+		.PARAMETER SqlCmsGroups
+			This is an auto-populated array that contains your Central Management Server top-level groups. You can use one or many groups.
 
-            If -SqlCmsGroups is not specified, the Watch-DbaDbLogin script will run against all servers in your Central Management Server.
+			If -SqlCmsGroups is not specified, the Watch-DbaDbLogin script will run against all servers in your Central Management Server.
 
-        .PARAMETER ServersFromFile
-            Specifies a file containing a list of servers to watch. This file must contain one server name per line.
+		.PARAMETER ServersFromFile
+			Specifies a file containing a list of servers to watch. This file must contain one server name per line.
 
-        .PARAMETER Database
-            The name of the Watch database. By default, this is DatabaseLogins.
+		.PARAMETER Database
+			The name of the Watch database. By default, this is DatabaseLogins.
 
-        .PARAMETER Table
-            The name of the Watch table. By default, this is DbLogins.
+		.PARAMETER Table
+			The name of the Watch table. By default, this is DbLogins.
 
-        .PARAMETER SqlCredential
+		.PARAMETER SqlCredential
 			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
 			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
@@ -37,153 +37,145 @@ function Watch-DbaDbLogin {
 
 			To connect as a different Windows user, run PowerShell as that user.
 
-        .NOTES
-            Tags: Logins
-            Author: Chrissy LeMaire (@cl), netnerds.net
-            Requires: sysadmin access on all SQL Servers for the most accurate results
+		.NOTES
+			Tags: Login
+			Author: Chrissy LeMaire (@cl), netnerds.net
+			Requires: sysadmin access on all SQL Servers for the most accurate results
 
-            Website: https://dbatools.io
-            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-            License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-        .LINK
-            https://dbatools.io/Watch-DbaDbLogin
+		.LINK
+			https://dbatools.io/Watch-DbaDbLogin
 
-        .EXAMPLE
-            Watch-DbaDbLogin -SqlInstance sqlserver -SqlCms SqlCms1
+		.EXAMPLE
+			Watch-DbaDbLogin -SqlInstance sqlserver -SqlCms SqlCms1
 
-            A list of all database instances within the Central Management Server SqlCms1 is generated. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the DatabaseLogins database on SQL Server sqlserver.
+			A list of all database instances within the Central Management Server SqlCms1 is generated. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the DatabaseLogins database on SQL Server sqlserver.
 
-        .EXAMPLE
-            Watch-DbaDbLogin -SqlInstance sqlcluster -Database CentralAudit -ServersFromFile .\sqlservers.txt
+		.EXAMPLE
+			Watch-DbaDbLogin -SqlInstance sqlcluster -Database CentralAudit -ServersFromFile .\sqlservers.txt
 
-            A list of servers is gathered from the file sqlservers.txt in the current directory. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the CentralAudit database on SQL Server sqlcluster.
+			A list of servers is gathered from the file sqlservers.txt in the current directory. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the CentralAudit database on SQL Server sqlcluster.
 
-        .EXAMPLE
-            Watch-DbaDbLogin -SqlInstance sqlserver -SqlCms SqlCms1 -SqlCmsGroups SQL2014Clusters -SqlCredential $cred
+		.EXAMPLE
+			Watch-DbaDbLogin -SqlInstance sqlserver -SqlCms SqlCms1 -SqlCmsGroups SQL2014Clusters -SqlCredential $cred
 
-            A list of servers is generated using database instance names within the SQL2014Clusters group on the Central Management Server SqlCms1. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the DatabaseLogins database on sqlserver.
+			A list of servers is generated using database instance names within the SQL2014Clusters group on the Central Management Server SqlCms1. Using this list, the script enumerates all the processes and gathers login information and saves it to the table Dblogins in the DatabaseLogins database on sqlserver.
 
-    #>
-    [CmdletBinding(DefaultParameterSetName = "Default")]
-    Param (
-        [parameter(Mandatory = $true)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter]$SqlInstance,
-        [string]$Database = "DatabaseLogins",
-        [string]$Table = "DbLogins",
-        [PSCredential]$SqlCredential,
-        # Central Management Server
+	#>
+	[CmdletBinding(DefaultParameterSetName = "Default")]
+	param (
+		[parameter(Mandatory = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstance]$SqlInstance,
+		[object[]]$Database = "DatabaseLogins",
+		[string]$Table = "DbLogins",
+		[PSCredential]$SqlCredential,
+		# Central Management Server
 
-        [string]$SqlCms,
-        # File with one server per line
+		[string]$SqlCms,
+		# File with one server per line
 
 		[string]$ServersFromFile
-    )
+	)
 
-    process {
-        if ([string]::IsNullOrEmpty($SqlCms) -and [string]::IsNullOrEmpty($ServersFromFile)) {
-            throw "You must specify a server list source using -SqlCms or -ServersFromFile"
-        }
+	process {
+		if ([string]::IsNullOrEmpty($SqlCms) -and [string]::IsNullOrEmpty($ServersFromFile)) {
+			throw "You must specify a server list source using -SqlCms or -ServersFromFile"
+		}
 
-        <#
+		<#
 			Setup datatable & bulk copy
 		#>
 
-        if ($sqlcredential.UserName) {
-            $username = $sqlcredential.Username
-            $password = $SqlCredential.GetNetworkCredential().Password
-            $connectionstring = "Data Source=$SqlInstance;Initial Catalog=$Database;User Id=$username;Password=$password;"
-        }
-        else { $connectionstring = "Data Source=$SqlInstance;Integrated Security=true;Initial Catalog=$Database;" }
+		if ($SqlCredential.UserName) {
+			$username = $SqlCredential.Username
+			$password = $SqlCredential.GetNetworkCredential().Password
+			$connectionstring = "Data Source=$SqlInstance;Initial Catalog=$Database;User Id=$username;Password=$password;"
+		}
+		else {
+			$connectionstring = "Data Source=$SqlInstance;Integrated Security=true;Initial Catalog=$Database;"
+		}
 
+		$bulkcopy = New-Object ("Data.SqlClient.SqlBulkCopy") $connectionstring
+		$bulkcopy.DestinationTableName = $Table
 
-        $bulkcopy = New-Object ("Data.SqlClient.Sqlbulkcopy") $connectionstring
-        $bulkcopy.DestinationTableName = $Table
+		$datatable = New-Object "System.Data.DataTable"
+		$null = $datatable.Columns.Add("SQLServer")
+		$null = $datatable.Columns.Add("LoginName")
+		$null = $datatable.Columns.Add("Host")
+		$null = $datatable.Columns.Add("DbName")
+		$null = $datatable.Columns.Add("Program")
 
-        $datatable = New-Object "System.Data.DataTable"
-        $null = $datatable.Columns.Add("SQLServer")
-        $null = $datatable.Columns.Add("Loginname")
-        $null = $datatable.Columns.Add("Host")
-        $null = $datatable.Columns.Add("Dbname")
-        $null = $datatable.Columns.Add("Program")
+		$systemdbs = "master", "msdb", "model", "tempdb"
+		$excludedPrograms = "Microsoft SQL Server Management Studio - Query", "SQL Management"
 
-        $systemdbs = "master", "msdb", "model", "tempdb"
-        $excludedPrograms = "Microsoft SQL Server Management Studio - Query", "SQL Management"
-
-        <#
+		<#
 			Get servers to query from Central Management Server or File
 		#>
-        $servers = @()
-        if ($SqlCms) {
-            $server = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlCms
-            $sqlconnection = $server.ConnectionContext.SqlConnectionObject
+		$servers = @()
+		if ($SqlCms) {
+			$servers = Get-DbaRegisteredServerName -SqlInstance $SqlCms -SqlCredential $SqlCredential
+		}
 
-            try { $cmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sqlconnection) }
-            catch { throw "Cannot access Central Management Server" }
+		if ($ServersFromFile) {
+			$servers = Get-Content $ServersFromFile
+		}
 
-            if ($SqlCmsGroups) {
-                foreach ($groupname in $SqlCmsGroups) {
-                    $CMS = $cmstore.ServerGroups["DatabaseEngineServerGroup"].ServerGroups[$groupname]
-                    $servers += ($cms.GetDescendantRegisteredServers()).servername
-                }
-            }
-            else {
-                $CMS = $cmstore.ServerGroups["DatabaseEngineServerGroup"]
-                $servers = ($cms.GetDescendantRegisteredServers()).servername
-                if ($servers -notcontains $SqlCms) { $servers += $SqlCms }
-            }
-        }
-
-        If ($ServersFromFile) {
-            $servers = Get-Content $ServersFromFile
-        }
-
-        <#
+		<#
 			Process each server
 		#>
 
-        foreach ($servername in $servers) {
-            Write-Output "Attempting to connect to $servername."
-            try { $server = Connect-SqlInstance -SqlInstance $servername -SqlCredential $SqlCredential }
-            catch { Write-Error "Can't connect to $servername. Skipping."; continue }
+		foreach ($instance in $servers) {
+			Write-Output "Attempting to connect to $instance."
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Write-Error "Can't connect to $instance. Skipping.";
+				continue
+			}
 
-            if (!(Test-SqlSa $server)) { Write-Warning "Not a sysadmin on $servername, resultset would be underwhelming. Skipping."; continue }
+			if (!(Test-SqlSa $server)) {
+				Write-Warning "Not a sysadmin on $instance, resultset would be underwhelming. Skipping.";
+				continue
+			}
 
+			$procs = $server.EnumProcesses() | Where-Object { $_.Host -ne $sourceserver.ComputerNamePhysicalNetBIOS -and ![string]::IsNullOrEmpty($_.Host) }
+			$procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program } | Select-Object Login, Host, Database, Program
 
-            $procs = $server.EnumProcesses() | Where-Object { $_.Host -ne $sourceserver.ComputerNamePhysicalNetBIOS -and ![string]::IsNullOrEmpty($_.Host) }
-            $procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program } | Select-Object Login, Host, Database, Program
+			foreach ($p in $procs) {
+				$row = $datatable.NewRow()
+				$row.itemarray = $server.name, $p.Login, $p.Host, $p.Database, $p.Program
+				$datatable.Rows.Add($row)
+			}
+			$server.ConnectionContext.Disconnect()
+			Write-Output "Added process information for $instance to datatable."
+		}
 
-            foreach ($p in $procs) {
-                $row = $datatable.NewRow()
-                $row.itemarray = $server.name, $p.Login, $p.Host, $p.Database, $p.Program
-                $datatable.Rows.Add($row)
-            }
-            $server.ConnectionContext.Disconnect()
-            Write-Output "Added process information for $servername to datatable."
-        }
-
-        <#
+		<#
 			Write to $Table in $Database on $SqlInstance
 		#>
 
-        try {
-            $bulkcopy.WriteToServer($datatable)
-            if ($datatable.rows.count -eq 0) {
-                Write-Warning "Nothing done."
-            }
-            $bulkcopy.Close()
-            Write-Output "Updated $Table in $Database on $SqlInstance with $($datatable.rows.count) rows."
-        }
-        catch { Write-Error "Could not update $Table in $Database on $SqlInstance. Do the database and table exist and do you have access?" }
+		try {
+			$bulkcopy.WriteToServer($datatable)
+			if ($datatable.rows.count -eq 0) {
+				Write-Warning "Nothing done."
+			}
+			$bulkcopy.Close()
+			Write-Output "Updated $Table in $Database on $SqlInstance with $($datatable.rows.count) rows."
+		}
+		catch { Write-Error "Could not update $Table in $Database on $SqlInstance. Do the database and table exist and do you have access?" }
 
-    }
+	}
 
-    end {
-        Write-Output "Script completed"
-        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Watch-SqlDbLogin
-    }
-    <#
+	end {
+		Write-Output "Script completed"
+		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Watch-SqlDbLogin
+	}
+	<#
 	---- SQL database and table ----
 
 		CREATE DATABASE DatabaseLogins

--- a/tests/Watch-DbaDbLogin.Tests.ps1
+++ b/tests/Watch-DbaDbLogin.Tests.ps1
@@ -1,0 +1,61 @@
+<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		<#
+			The $paramCount is adjusted based on the parameters your command will have.
+
+			The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+		#>
+		$paramCount = 7
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Watch-DbaDbLogin).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Silent', 'Database', 'Table', 'SqlCms','ServersFromFile'
+		it "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		it "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+<#
+	Integration test are custom to the command you are writing it for,
+		but something similar to below should be included if applicable.
+
+	The below examples are by no means set in stone and there are already
+		a number of test that you can pull examples from in how they are done.
+#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		$testFile = 'C:\temp\Servers.txt'
+		if (Test-Path $testFile) {
+			Remove-Item $testFile -Force
+		}
+		$script:instance1 | Out-File -Path C:\temp\Servers.txt
+	}
+
+	Context "Command actually works" {
+		$tableName = 'dbatoolsci-watchdblogin'
+		$databaseName = 'tempdb'
+		Watch-DbaDbLogin -SqlInstance $script:instance1 -Database $databaseName -Table $tableName -ServersFromFile $testFile -Silent
+		$result = Get-DbaTable -SqlInstance $script:instance1 -Database $databaseName -Table $tableName
+		It "Should have created table $tableName in database $databaseName" {
+			$result.Name | Should Be $tableName
+		}
+		It "Should have data in table $tableName in database $databaseName" {
+			$result.Count | Should BeGreaterThan 0
+		}
+	}
+}

--- a/tests/Watch-DbaDbLogin.Tests.ps1
+++ b/tests/Watch-DbaDbLogin.Tests.ps1
@@ -36,7 +36,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 	The below examples are by no means set in stone and there are already
 		a number of test that you can pull examples from in how they are done.
 #>
-
+<#
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	$testFile = 'C:\temp\Servers.txt'
 	$tableName = 'dbatoolsciwatchdblogin'
@@ -59,3 +59,4 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		}
 	}
 }
+#>

--- a/tests/Watch-DbaDbLogin.Tests.ps1
+++ b/tests/Watch-DbaDbLogin.Tests.ps1
@@ -38,19 +38,19 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 #>
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-	BeforeAll {
-		$testFile = 'C:\temp\Servers.txt'
-		if (Test-Path $testFile) {
-			Remove-Item $testFile -Force
-		}
-		$script:instance1 | Out-File -Path C:\temp\Servers.txt
+	$testFile = 'C:\temp\Servers.txt'
+	$tableName = 'dbatoolsciwatchdblogin'
+	$databaseName = 'master'
+	if (Test-Path $testFile) {
+		Remove-Item $testFile -Force
 	}
-
+	$script:instance1, $script:instance2 | Out-File $testFile
+	AfterAll {
+		$null = (Connect-DbaSqlServer -SqlInstance $script:instance1).Query("DROP TABLE $tableName",$databaseName)
+	}
 	Context "Command actually works" {
-		$tableName = 'dbatoolsci-watchdblogin'
-		$databaseName = 'tempdb'
 		Watch-DbaDbLogin -SqlInstance $script:instance1 -Database $databaseName -Table $tableName -ServersFromFile $testFile -Silent
-		$result = Get-DbaTable -SqlInstance $script:instance1 -Database $databaseName -Table $tableName
+		$result = Get-DbaTable -SqlInstance $script:instance1 -Database $databaseName -Table $tableName -IncludeSystemDBs
 		It "Should have created table $tableName in database $databaseName" {
 			$result.Name | Should Be $tableName
 		}

--- a/tests/Watch-DbaDbLogin.Tests.ps1
+++ b/tests/Watch-DbaDbLogin.Tests.ps1
@@ -46,7 +46,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	}
 	$script:instance1, $script:instance2 | Out-File $testFile
 	AfterAll {
-		$null = (Connect-DbaSqlServer -SqlInstance $script:instance1).Query("DROP TABLE $tableName",$databaseName)
+		$null = (Connect-DbaSqlServer -SqlInstance $script:instance1).Databases[$databaseName].Query("DROP TABLE $tableName")
 	}
 	Context "Command actually works" {
 		Watch-DbaDbLogin -SqlInstance $script:instance1 -Database $databaseName -Table $tableName -ServersFromFile $testFile -Silent


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Cleanup and standardize code to use commands available in module, among other things

- removed default Database name (this needs to be specified)
- removed SqlCmsGroups from help as it didn't exist in the code
- Updated default table name to be more descriptive on it being dbatools related, updated help as well on this
- changed Database parameter to a single object
- Updated message system
- Adjusted validation of SqlCms and ServersFromFile parameter using Test-Bound
- Replaced datatabe object  and bulkcopy object with Out-DbaDatabase and Write-DbaDataTable
- Changed enumprocess() to DMV, can expand data in the future now if we need to.
- Changed code for CMS pull to Get-DbaRegisteredServer
- Removed comment block code in end block
- Cleaned up logic where it will not try to run code if CMS or file is not found.

### Approach
<!-- How does this change solve that purpose -->
Looked at adding more columns but only ended up adding a few extra to show pertinent information and prevent the need of having the table created first. So on the first run, this command will now create the table with the needed column names.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/11204251/30528850-5dd292de-9bfc-11e7-8630-6d1624ffd14f.png)

The previous version would continue running code if CMS or file didn't exist, this has been fixed

![image](https://user-images.githubusercontent.com/11204251/30528874-a4d08f92-9bfc-11e7-9c8c-8087e7050f4d.png)

![image](https://user-images.githubusercontent.com/11204251/30528878-b9fda53a-9bfc-11e7-89a3-d3e934e88606.png)

![image](https://user-images.githubusercontent.com/11204251/30528882-cbacd350-9bfc-11e7-9d81-89df85002786.png)

Captured data:

![image](https://user-images.githubusercontent.com/11204251/30528891-e297a072-9bfc-11e7-95cf-a35bc40df292.png)

### Learning
EnumProcess() runs DMVs that do not exist in 2000 so added `-MinimumVersion 9`.

One additional tidbit discovered by tracing the `EnumProcess()` method that the query uses the `is_user_process` column found in `sys.dm_exec_sessions` but actually reverses the meaning of the column. Default this will show a 1 if the session is a user session or 0 (zero) if system. The method calls it in this manner: `CAST(~s.is_user_process AS bit) AS [IsSystem]` which changes that to return 0 (zero) when it is a user session and a 1 if is not.