### PR TITLE
Wrong schema validation

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -273,7 +273,7 @@ Per Microsoft, KeepNulls will "Preserve null values in the destination table reg
 			}
 			else
 			{
-				if ($schema -notin $server.Databases[0].Schemas.Name)
+				if ($schema -notin $db.Schemas.Name)
 				{
 					Write-Warning "Schema does not exist"
 					break


### PR DESCRIPTION
Seems like the schema validation is against the first database on the server. Should be the current database.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
