### PR TITLE
Switching Update-ServiceStatus to use Runspaces + minor fixes

### DIFF
--- a/functions/Start-DbaSqlService.ps1
+++ b/functions/Start-DbaSqlService.ps1
@@ -87,7 +87,12 @@ Function Start-DbaSqlService {
 	begin {
 		$processArray = @()
 		if ($PsCmdlet.ParameterSetName -eq "Server") {
-			$serviceCollection = Get-DbaSqlService @PSBoundParameters
+			$serviceParams = @{ ComputerName = $ComputerName }
+			if ($InstanceName) { $serviceParams.InstanceName = $InstanceName }
+			if ($Type) { $serviceParams.Type = $Type }
+			if ($Credential) { $serviceParams.Credential = $Credential }
+			if ($Silent) { $serviceParams.Silent = $Silent }
+			$serviceCollection = Get-DbaSqlService @serviceParams
 		}
 	}
 	process {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Remove the usage of Start-Job cmdlet, which was slow and didn't work without having dbatools in $env:psmodulepath variable

### Approach
Using runspaces instead

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
