### PR TITLE
Close connection in Get-DbaRegisteredServer.

### DIFF
--- a/functions/Get-DbaRegisteredServer.ps1
+++ b/functions/Get-DbaRegisteredServer.ps1
@@ -146,6 +146,9 @@ function Get-DbaRegisteredServer {
 			if ($ExcludeCmsServer) {
 				$servers = ($servers | Where-Object { $_.ServerName -ne $instance})
 			}
+
+			# Close the connection, otherwise using it with the ServersStore will keep it open
+			$cmsStore.ServerConnection.Disconnect()
 		}
 		
 		foreach ($server in $servers) {


### PR DESCRIPTION
Because the connection is passed to the RegisteredServersStore object, it does not get closed after use, and stays alive on the SQL Server.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Clean up the connection in `Get-DbaRegisteredServer`. Because we pass it to another object (`RegisteredServersStore`), this prevents the connection from auto-closing and being released back to the pool.

You can verify on the current version by running the following (or comment out [line 151](https://github.com/sqlcollaborative/dbatools/pull/2271/files#diff-ddbe25c86fa572357b14f4bcc64435e9R151) if you pull in this change) in a fresh PowerShell window:

```powershell
for ($i=0; $i -lt 50; $i++) {
	$servers = Get-DbaRegisteredServer -SqlInstance sqldbatools -Group "Group Name"
}
```

Then run this query on the instance to see the sleeping threads:

```sql
SELECT c.session_id, c.connect_time, c.num_reads, c.num_writes, 
	s.host_name, s.program_name, s.cpu_time,
	S.last_request_start_time, s.last_request_end_time
FROM sys.dm_exec_connections c
INNER JOIN sys.dm_exec_sessions s
ON s.session_id = c.session_id
WHERE program_name LIKE 'dbatools PowerShell module%'
ORDER BY last_request_start_time DESC
```

You will see roughly 50 connections (one for each loop, and possibly a few for the Tab Expansion processes).

Then, running the same test harness with the fix in place, you should only see one thread (and maybe one for TEPP).