### PR TITLE
Tepp configuration updates

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 2, 23)
+$currentLibraryVersion = New-Object System.Version(0, 6, 2, 24)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.2.23")]
-[assembly: AssemblyFileVersion("0.6.2.23")]
+[assembly: AssemblyVersion("0.6.2.24")]
+[assembly: AssemblyFileVersion("0.6.2.24")]

--- a/bin/projects/dbatools/dbatools/TabExpansion/TabExpansionHost.cs
+++ b/bin/projects/dbatools/dbatools/TabExpansion/TabExpansionHost.cs
@@ -82,12 +82,12 @@ namespace Sqlcollaborative.Dbatools.TabExpansion
         /// <summary>
         /// Whether asynchronous TEPP updating should be disabled
         /// </summary>
-        public static bool TeppAsyncDisabled = true;
+        public static bool TeppAsyncDisabled = false;
 
         /// <summary>
         /// Whether synchronous TEPP updating should be disabled
         /// </summary>
-        public static bool TeppSyncDisabled = false;
+        public static bool TeppSyncDisabled = true;
 
         /// <summary>
         /// The interval in which asynchronous TEPP cache updates are performed
@@ -97,7 +97,7 @@ namespace Sqlcollaborative.Dbatools.TabExpansion
         /// <summary>
         /// After this timespan of no requests to a server, the updates to its cache are disabled.
         /// </summary>
-        public static TimeSpan TeppUpdateTimeout = new TimeSpan(0, 30, 0);
+        public static TimeSpan TeppUpdateTimeout = new TimeSpan(0, 0, 30);
         #endregion Configuration
 
         #region Updater

--- a/internal/configurations/tabexpansion.ps1
+++ b/internal/configurations/tabexpansion.ps1
@@ -1,6 +1,6 @@
 ﻿# Sets the default interval and timeout for TEPP updates
 Set-DbaConfig -Name 'TabExpansion.UpdateInterval' -Value (New-TimeSpan -Minutes 3) -Default -DisableHandler -Description 'The frequency in which TEPP tries to update each cache for autocompletion'
-Set-DbaConfig -Name 'TabExpansion.UpdateTimeout' -Value (New-TimeSpan -Minutes 30) -Default -DisableHandler -Description 'After this timespan has passed without connections to a server, the TEPP updater will no longer update the cache.'
+Set-DbaConfig -Name 'TabExpansion.UpdateTimeout' -Value (New-TimeSpan -Seconds 30) -Default -DisableHandler -Description 'After this timespan has passed without connections to a server, the TEPP updater will no longer update the cache.'
 
 # Disable the management cache entire
 Set-DbaConfig -Name 'TabExpansion.Disable' -Value $false -Default -DisableHandler -Description 'Globally disables all TEPP functionality by dbatools'

--- a/internal/configurations/tabexpansion.ps1
+++ b/internal/configurations/tabexpansion.ps1
@@ -4,5 +4,5 @@ Set-DbaConfig -Name 'TabExpansion.UpdateTimeout' -Value (New-TimeSpan -Seconds 3
 
 # Disable the management cache entire
 Set-DbaConfig -Name 'TabExpansion.Disable' -Value $false -Default -DisableHandler -Description 'Globally disables all TEPP functionality by dbatools'
-Set-DbaConfig -Name 'TabExpansion.Disable.Asynchronous' -Value $true -Default -DisableHandler -Description 'Globally disables asynchronous TEPP updates in the background'
-Set-DbaConfig -Name 'TabExpansion.Disable.Synchronous' -Value $false -Default -DisableHandler -Description 'Globally disables synchronous TEPP updates, performed whenever connecting o the server. If this is not disabled, it will only perform updates that are fast to perform, in order to minimize performance impact. This may lead to some TEPP functionality loss if asynchronous updates are disabled.'
+Set-DbaConfig -Name 'TabExpansion.Disable.Asynchronous' -Value $false -Default -DisableHandler -Description 'Globally disables asynchronous TEPP updates in the background'
+Set-DbaConfig -Name 'TabExpansion.Disable.Synchronous' -Value $true -Default -DisableHandler -Description 'Globally disables synchronous TEPP updates, performed whenever connecting o the server. If this is not disabled, it will only perform updates that are fast to perform, in order to minimize performance impact. This may lead to some TEPP functionality loss if asynchronous updates are disabled.'

--- a/internal/scripts/updateTeppAsync.ps1
+++ b/internal/scripts/updateTeppAsync.ps1
@@ -1,15 +1,11 @@
 ﻿$scriptBlock = {
 	#region Utility Functions
 	function Get-PriorityServer {
-		$res = [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT (New-Object System.DateTime(1, 1, 1, 1, 1, 1))
-		$res | Export-Csv "C:\temp\debug-priority.csv"
-		$res
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT (New-Object System.DateTime(1, 1, 1, 1, 1, 1))
 	}
 	
 	function Get-ActionableServer {
-		$res = [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT ((Get-Date) - ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateInterval)) | Where-Object -Property LastUpdate -GT ((Get-Date) - ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateTimeout))
-		$res | Export-Csv "C:\temp\debug-regular.csv"
-		$res
+		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::InstanceAccess.Values | Where-Object -Property LastUpdate -LT ((Get-Date) - ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateInterval)) | Where-Object -Property LastUpdate -GT ((Get-Date) - ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppUpdateTimeout))
 	}
 	
 	function Update-TeppCache {
@@ -32,7 +28,6 @@
 					$server.ConnectionContext.Connect()
 				}
 				catch {
-					Write-Message -Level Warning -Message "Failed to connect in order to update the Tepp Cache" -ErrorRecord $_ -Silent $true
 					continue
 				}
 				
@@ -47,6 +42,8 @@
 					# Workaround to avoid stupid issue with scriptblock from different runspace
 					[ScriptBlock]::Create($scriptBlock).Invoke()
 				}
+				
+				$server.ConnectionContext.Disconnect()
 				
 				$instance.LastUpdate = Get-Date
 			}


### PR DESCRIPTION
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Changes the default settings of the TEPP cache update:

 - Disables synchronous TEPP cache to avoid performance impact
 - Enables asynchronous TEPP cache to retain TEPP functionality
 - Reduced cache timeout from 30 minutes to 30 seconds

In result this will cause a single update per connection to a server. It will also do it no more often than once every 3 minutes.
This is a configuration change and does not affect any existing customizations to TEPP behavior.