### PR TITLE
Test-DbaNetworkLatency: Fixing math

### DIFF
--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -85,7 +85,7 @@ function Test-DbaNetworkLatency {
 					$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
 				}
 				catch {
-					Stop-Function -Message "Failed to connect to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+					Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 				}
 				
 				do {

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -85,7 +85,7 @@ function Test-DbaNetworkLatency {
 					$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
 				}
 				catch {
-					Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+					Stop-Function -Message "Failed to connect to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 				}
 				
 				do {
@@ -108,7 +108,7 @@ function Test-DbaNetworkLatency {
 					$averagewarm = $totalwarm
 				}
 				else {
-					$averagewarm = $totalwarm / ($count - 1)
+					$averagewarm = $totalwarm / $count
 				}
 				
 				
@@ -124,7 +124,7 @@ function Test-DbaNetworkLatency {
 				} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, 'Count as ExecutionCount', Total, 'Avg as Average', ExecuteOnlyTotal, 'ExecuteOnlyAvg as ExecuteOnlyAverage' #backwards compat
 			}
 			catch {
-				Stop-Function -Message "Error occurred: $_" -InnerErrorRecord $_ -Continue
+				Stop-Function -Message "Error occurred testing dba network latency: $_" -ErrorRecord $_ -Continue -Target $instance
 			}
 		}
 	}

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -121,6 +121,7 @@ function Test-DbaNetworkLatency {
 					Avg              = [prettytimespan]::FromMilliseconds($average)
 					ExecuteOnlyTotal = [prettytimespan]::FromMilliseconds($totalwarm)
 					ExecuteOnlyAvg   = [prettytimespan]::FromMilliseconds($averagewarm)
+					NetworkOnlyTotal = [prettytimespan]::FromMiliseconds($totaltime - $totalwarm)
 				} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, 'Count as ExecutionCount', Total, 'Avg as Average', ExecuteOnlyTotal, 'ExecuteOnlyAvg as ExecuteOnlyAverage' #backwards compat
 			}
 			catch {

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -122,7 +122,7 @@ function Test-DbaNetworkLatency {
 					ExecuteOnlyTotal = [prettytimespan]::FromMilliseconds($totalwarm)
 					ExecuteOnlyAvg   = [prettytimespan]::FromMilliseconds($averagewarm)
 					NetworkOnlyTotal = [prettytimespan]::FromMilliseconds($totaltime - $totalwarm)
-				} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, 'Count as ExecutionCount', Total, 'Avg as Average', ExecuteOnlyTotal, 'ExecuteOnlyAvg as ExecuteOnlyAverage' #backwards compat
+				} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, 'Count as ExecutionCount', Total, 'Avg as Average', ExecuteOnlyTotal, 'ExecuteOnlyAvg as ExecuteOnlyAverage', NetworkOnlyTotal #backwards compat
 			}
 			catch {
 				Stop-Function -Message "Error occurred testing dba network latency: $_" -ErrorRecord $_ -Continue -Target $instance

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -108,7 +108,7 @@ function Test-DbaNetworkLatency {
 					$averagewarm = $totalwarm
 				}
 				else {
-					$averagewarm = $totalwarm / ($count - 1)
+					$averagewarm = $totalwarm / $count
 				}
 				
 				

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -121,7 +121,7 @@ function Test-DbaNetworkLatency {
 					Avg              = [prettytimespan]::FromMilliseconds($average)
 					ExecuteOnlyTotal = [prettytimespan]::FromMilliseconds($totalwarm)
 					ExecuteOnlyAvg   = [prettytimespan]::FromMilliseconds($averagewarm)
-					NetworkOnlyTotal = [prettytimespan]::FromMiliseconds($totaltime - $totalwarm)
+					NetworkOnlyTotal = [prettytimespan]::FromMilliseconds($totaltime - $totalwarm)
 				} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, 'Count as ExecutionCount', Total, 'Avg as Average', ExecuteOnlyTotal, 'ExecuteOnlyAvg as ExecuteOnlyAverage' #backwards compat
 			}
 			catch {

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -108,7 +108,7 @@ function Test-DbaNetworkLatency {
 					$averagewarm = $totalwarm
 				}
 				else {
-					$averagewarm = $totalwarm / $count
+					$averagewarm = $totalwarm / ($count - 1)
 				}
 				
 				

--- a/tests/Test-DbaNetworkLatency.Tests.ps1
+++ b/tests/Test-DbaNetworkLatency.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		
 		It "has the correct properties" {
 			$result = $results | Select-Object -First 1
-			$ExpectedPropsDefault = 'ComputerName,InstanceName,SqlInstance,ExecutionCount,Total,Average,ExecuteOnlyTotal,ExecuteOnlyAverage'.Split(',')
+			$ExpectedPropsDefault = 'ComputerName,InstanceName,SqlInstance,ExecutionCount,Total,Average,ExecuteOnlyTotal,ExecuteOnlyAverage,NetworkOnlyTotal'.Split(',')
 			($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
 		}
 	}


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fixes math error when calculating average latency on query execution time.
Also upgraded messages a bit ...