### PR TITLE
Adding tests for *-DbaSqlService in a separate scenario

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
     - scenario: 2016
       main_instance: localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2016.ps1
+    - scenario: 2016_service
+      main_instance: localhost\SQL2016
+      setup_scripts: \tests\appveyor.SQL2016.ps1
     - scenario: default
       main_instance: localhost\SQL2008R2SP2,localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2008R2SP2.ps1,\tests\appveyor.SQL2016.ps1

--- a/tests/Restart-DbaSqlService.Tests.ps1
+++ b/tests/Restart-DbaSqlService.Tests.ps1
@@ -1,0 +1,29 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\internal\Connect-SqlInstance.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	
+	Context "Command actually works" {
+		
+		$instanceName = (Connect-SqlInstance -SqlInstance $script:instance2).ServiceName
+		It "restarts some services" {
+			$services = Restart-DbaSqlService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Running'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+			
+		It "restarts some services through pipeline" {
+			$services = Get-DbaSqlService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent, Engine | Restart-DbaSqlService
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Running'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+	}
+}

--- a/tests/Start-DbaSqlService.Tests.ps1
+++ b/tests/Start-DbaSqlService.Tests.ps1
@@ -1,0 +1,51 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\internal\Connect-SqlInstance.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	
+	Context "Command actually works" {
+		
+		$server = Connect-SqlInstance -SqlInstance $script:instance2
+		$instanceName = $server.ServiceName
+		$computerName = $server.NetName
+
+		
+		#Stop services using native cmdlets
+		if ($instanceName -eq 'MSSQLSERVER') {
+			$serviceName = "SQLSERVERAGENT"
+		}
+		else {
+			$serviceName = "SqlAgent`$$instanceName"
+		}
+		Get-Service -ComputerName $computerName -Name $serviceName | Stop-Service -WarningAction SilentlyContinue | Out-Null
+		
+		It "starts the services back" {
+			$services = Start-DbaSqlService -ComputerName $script:instance2 -Type Agent -InstanceName $instanceName
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Running'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+		
+		#Stop services using native cmdlets
+		if ($instanceName -eq 'MSSQLSERVER') {
+			$serviceName = "SQLSERVERAGENT", "MSSQLSERVER"
+		}
+		else {
+			$serviceName = "SqlAgent`$$instanceName", "MsSql`$$instanceName"
+		}
+		foreach ($sn in $servicename) { Get-Service -ComputerName $computerName -Name $sn | Stop-Service -WarningAction SilentlyContinue | Out-Null }
+		
+		It "starts the services back through pipeline" {
+			$services = Get-DbaSqlService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent, Engine | Start-DbaSqlService
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Running'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+	}
+}

--- a/tests/Stop-DbaSqlService.Tests.ps1
+++ b/tests/Stop-DbaSqlService.Tests.ps1
@@ -1,0 +1,51 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\internal\Connect-SqlInstance.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	
+	Context "Command actually works" {
+
+		$server = Connect-SqlInstance -SqlInstance $script:instance2
+		$instanceName = $server.ServiceName
+		$computerName = $server.NetName
+		
+		It "stops some services" {
+			$services = Stop-DbaSqlService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Stopped'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+		
+		#Start services using native cmdlets
+		if ($instanceName -eq 'MSSQLSERVER') {
+			$serviceName = "SQLSERVERAGENT"
+		}
+		else {
+			$serviceName = "SqlAgent`$$instanceName"
+		}
+		Get-Service -ComputerName $computerName -Name $serviceName | Start-Service -WarningAction SilentlyContinue | Out-Null
+		
+		It "stops specific services based on instance name through pipeline" {
+			$services = Get-DbaSqlService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent, Engine | Stop-DbaSqlService
+			$services | Should Not Be $null
+			foreach ($service in $services) {
+				$service.State | Should Be 'Stopped'
+				$service.Status | Should Be 'Successful'
+			}
+		}
+		
+		#Start services using native cmdlets
+		if ($instanceName -eq 'MSSQLSERVER') {
+			$serviceName = "MSSQLSERVER", "SQLSERVERAGENT"
+		}
+		else {
+			$serviceName = "MsSql`$$instanceName", "SqlAgent`$$instanceName"
+		}
+		foreach ($sn in $servicename) { Get-Service -ComputerName $computerName -Name $sn | Start-Service -WarningAction SilentlyContinue | Out-Null }
+		
+	}
+}

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -2,7 +2,7 @@
 
 $TestsRunGroups = @{
 	# run on scenario 2008R2
-	"2008R2" = @(
+	"2008R2"            = @(
 		'Add-DbaComputerCertificate',
 		'Connect-DbaSqlServer',
 		'Get-DbaAgentJobs',
@@ -20,7 +20,6 @@ $TestsRunGroups = @{
 		'Get-DbaSpConfigure',
 		'Get-DbaSqlLog',
 		'Get-DbaSqlModule',
-		'Get-DbaSqlService',
 		'Invoke-DbaCycleErrorLog',
 		'Invoke-DbaDiagnosticQuery',
 		'Mount-DbaDatabase',
@@ -30,7 +29,7 @@ $TestsRunGroups = @{
 		'Test-DbaIdentityUsage'
 	)
 	# run on scenario 2016
-	"2016" = @(
+	"2016"              = @(
 		'Dismount-DbaDatabase',
 		'Get-DbaAgDatabase',
 		'Get-DbaAgHadr',
@@ -52,10 +51,17 @@ $TestsRunGroups = @{
 		'Test-DbaDbCompression',
 		'Test-DbaLastBackup'
 	)
+	#run on scenario 2016_service - SQL Server service tests that might disrupt other tests
+	"2016_service" = @(
+		'Start-DbaSqlService',
+		'Stop-DbaSqlService',
+		'Restart-DbaSqlService',
+		'Get-DbaSqlService'
+	)
 	# do not run on appveyor
 	"appveyor_disabled" = @(
 		'Get-DbaDatabaseState'
 	)
 	# do not run everywhere
-	"disabled" = @()
+	"disabled"          = @()
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding tests for start/stop/restart-DbaSqlService in a separate scenario 2016_service

### Approach
Multiple start/stop tests + new appveyor scenario and pester group

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
