### PR TITLE
Fixing SSIS service check in Copy-DbaSsisCatalog

### DIFF
--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -109,8 +109,8 @@ Deploy entire SSIS catalog to an instance without a destination catalog.  Passin
             param (
                 [Object]$Computer
             )
-	    $result = Get-DbaSqlService -ComputerName $Computer | Where-Object Servicename -like "MsDts*"
-            if ($result.Count -gt 0) {
+	    $result = Get-DbaSqlService -ComputerName $Computer -Type SSIS
+            if ($result) {
                 $running = $false
                 foreach ($service in $result) {
                     if (!$service.State -eq "Running") {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2278 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix incorrect handling of the array of objects in the code, which can sometimes be just an object

### Approach
removed .Count property

### Commands to test
Copy-DbaSsisCatalog -Source src -Destination dst

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
