### PR TITLE
Updating Get-DbaSqlService verbosity and fixing Get-DbaCmObject

### DIFF
--- a/bin/projects/dbatools/dbatools/Connection/ManagementConnectionProtocolState.cs
+++ b/bin/projects/dbatools/dbatools/Connection/ManagementConnectionProtocolState.cs
@@ -18,11 +18,11 @@
         /// <summary>
         /// Connecting using the relevant protocol failed last it was tried
         /// </summary>
-        Error = 3,
+        Error = 4,
 
         /// <summary>
         /// The relevant protocol has been disabled and should not be used
         /// </summary>
-        Disabled = 4
+        Disabled = 8
     }
 }

--- a/functions/Get-DbaSqlService.ps1
+++ b/functions/Get-DbaSqlService.ps1
@@ -110,13 +110,13 @@ Function Get-DbaSqlService {
 			$Server = Resolve-DbaNetworkName -ComputerName $Computer -Credential $credential
 			if ($Server.ComputerName) {
 				$Computer = $server.ComputerName
-				Write-Message -Level Verbose -Message "Getting SQL Server namespace on $Computer"
-				$namespaces = Get-DbaCmObject -ComputerName $Computer -NameSpace root\Microsoft\SQLServer -Query "Select Name FROM __NAMESPACE WHERE Name Like 'ComputerManagement%'" -ErrorAction SilentlyContinue -Credential $credential | Sort-Object Name -Descending
+				Write-Message -Level VeryVerbose -Message "Getting SQL Server namespace on $Computer" -Target $Computer
+				$namespaces = Get-DbaCmObject -ComputerName $Computer -NameSpace root\Microsoft\SQLServer -Query "Select Name FROM __NAMESPACE WHERE Name Like 'ComputerManagement%'" -ErrorAction Ignore -Silent -Credential $credential | Sort-Object Name -Descending
 				if ($namespaces) {
 					ForEach ($namespace in $namespaces) {
 						try {
-							Write-Message -Level Verbose -Message "Getting Cim class SqlService in Namespace $($namespace.Name) on $Computer."
-							$services = Get-DbaCmObject -ComputerName $Computer -Namespace $("root\Microsoft\SQLServer\" + $namespace.Name) -Query "SELECT * FROM SqlService WHERE $TypeClause" -ErrorAction SilentlyContinue -Credential $credential
+							Write-Message -Level Verbose -Message "Getting Cim class SqlService in Namespace $($namespace.Name) on $Computer." -Target $Computer
+							$services = Get-DbaCmObject -ComputerName $Computer -Namespace $("root\Microsoft\SQLServer\" + $namespace.Name) -Query "SELECT * FROM SqlService WHERE $TypeClause" -Silent -Credential $credential
 						}
 						catch {
 							Write-Message -Level Verbose -Silent $Silent -Message "Failed to acquire services from namespace $($namespace.Name)."


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Fixes
 - Corrects Get-DbaCmObject usage in Get-DbaSqlService (Was not using the silent switch when it should have)
 - Updated Error handling of Get-DbaCmObject: Detects server-side provider corruption and will no longer flag the system as unreachable
 - Updated connection handling of Get-DbaCmObject : Will now correctly respect the timeout on non-reachable computers. Used to try all connections each time, even when known to be bad.