### PR TITLE
Get-DbaAgentJobOutputFile, kill NetBios

### DIFF
--- a/functions/Get-DbaAgentJobOutputFile.ps1
+++ b/functions/Get-DbaAgentJobOutputFile.ps1
@@ -127,7 +127,7 @@
                             Job                  = $j.Name
                             JobStep              = $Step.Name
                             OutputFileName       = $Step.OutputFileName
-                            RemoteOutputFileName = Join-AdminUNC $Server.ComputerNamePhysicalNetBIOS $Step.OutputFileName
+                            RemoteOutputFileName = Join-AdminUNC $Server.NetName $Step.OutputFileName
                             StepId               = $Step.Id
                         } | Select-DefaultView -ExcludeProperty StepId
                     }

--- a/tests/Get-DbaAgentJobOutputFile.Tests.ps1
+++ b/tests/Get-DbaAgentJobOutputFile.Tests.ps1
@@ -1,18 +1,107 @@
-$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$commandname Unit Tests" -Tag 'UnitTests' {
-    Context "Input Validation" {
-		It 'SqlInstance parameter is empty' {
-            { Get-DbaAgentJobOutputFile -SqlInstance '' -WarningAction Stop 3> $null } | Should Throw
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		$paramCount = 5
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Get-DbaAgentJobOutputFile).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'Silent'
+		It "Contains our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
 		}
-		<#
-		This takes 15 seconds to timeout for not much reward
-		It 'SqlInstance parameter host cannot be found' {
-            Mock Connect-SqlInstance { throw System.Data.SqlClient.SqlException }
-            { Get-DbaAgentJobOutputFile -SqlInstance 'ABC' -WarningAction Stop 3> $null } | Should Throw
-        }
-		#>
-    }
+		It "Contains $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
 }
+
+Describe "$CommandName Unittests" -Tag 'UnitTests' {
+	InModuleScope 'dbatools' {
+		Context "Return values" {
+			Mock Connect-SQLInstance -MockWith {
+				[object]@{
+					Name = 'SQLServerName'
+					NetName = 'SQLServerName'
+					JobServer = @{
+						Jobs = @(
+							@{
+								Name = 'Job1'
+								JobSteps = @(
+									@{
+										Id = 1
+										Name = 'Job1Step1'
+										OutputFileName = 'Job1Output1'
+									},
+									@{
+										Id = 2
+										Name = 'Job1Step2'
+										OutputFileName = 'Job1Output2'
+									}
+								)
+							},
+							@{
+								Name = 'Job2'
+								JobSteps = @(
+									@{
+										Id = 1
+										Name = 'Job2Step1'
+										OutputFileName = 'Job2Output1'
+									},
+									@{
+										Id = 2
+										Name = 'Job2Step2'
+									}
+								)
+							},
+							@{
+								Name = 'Job3'
+								JobSteps = @(
+									@{
+										Id = 1
+										Name = 'Job3Step1'
+									},
+									@{
+										Id = 2
+										Name = 'Job3Step2'
+									}
+								)
+							}
+						)
+					}
+				} #object
+			} #mock connect-sqlserver
+			It "Gets only steps with output files" {
+				$Results = @()
+				$Results += Get-DbaAgentJobOutputFile -SqlInstance 'SQLServerName'
+				$Results.Length | Should Be 3
+				$Results.Job | Should Match 'Job[12]'
+				$Results.JobStep | Should Match 'Job[12]Step[12]'
+				$Results.OutputFileName | Should Match 'Job[12]Output[12]'
+				$Results.RemoteOutputFileName | Should Match '\\\\SQLServerName\\Job[12]Output[12]'
+			}
+			It "Honors the Job parameter" {
+				$Results = @()
+				$Results += Get-DbaAgentJobOutputFile -SqlInstance 'SQLServerName' -Job 'Job1'
+				$Results.Job | Should Be 'Job1'
+				$Results.JobStep | Should Match 'Job1Step[12]'
+				$Results.OutputFileName | Should Match 'Job1Output[12]'
+			}
+			It "Honors the ExcludeJob parameter" {
+				$Results = @()
+				$Results += Get-DbaAgentJobOutputFile -SqlInstance 'SQLServerName' -ExcludeJob 'Job1'
+				$Results.Length | Should Be 1
+				$Results.Job | Should Be 'Job2'
+				$Results.OutputFileName | Should Be 'Job2Output1'
+				$Results.StepId | Should Be 1
+			}
+			It "Does not return even with a specific job without outputfiles" {
+				$Results = @()
+				$Results += Get-DbaAgentJobOutputFile -SqlInstance 'SQLServerName' -Job 'Job3'
+				$Results.Length | Should Be 0
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
plus tests ^_^

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes "Every time a dba uses NetBios after 1998, there is a network admin somewhere that falls down dead")
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding tests to the function. Also, we should start addressing the fact that NO SMO properties return the FQDN of the server unless Resolve-DbaNetworkName is called. 
IMHO
- ComputerNamePhysicalNetBIOS should ALWAYS discarded
- NetName holds the machine name, which is more useful than Name if you're targeting a cluster
- all of them have no knowledge of FQDN, which, if you ask me, is a HUGE miss on SMO's side

That being said, NetName is surely more useful than ComputerNamePhysicalNetBIOS when you're trying to target the underlying server, if you don't wanna impose the "burden" of Resolve-DbaNetworkName

