### PR TITLE
Fixing an issue restoring db file without extensions - #2313

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ test_script:
           vstest.console /logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
         }
   # "Test with native PS version"
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: .\Tests\appveyor.pester.ps1
   
   # "Test with PS version 3" - Removed because it's not a true test. Even PS4+ .Where() works

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,6 @@ test_script:
           vstest.console /logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll
         }
   # "Test with native PS version"
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: .\Tests\appveyor.pester.ps1
   
   # "Test with PS version 3" - Removed because it's not a true test. Even PS4+ .Where() works

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -205,7 +205,8 @@ Function Restore-DBFromFilteredArray {
                     Write-Message -Level Verbose -Message "Moving $($File.PhysicalName)"
                     $MoveFile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
                     $MoveFile.LogicalFileName = $File.LogicalName
-                    $Extension = ($file.PhysicalName.split('.'))[-1]
+                    $IoFile = [System.Io.FileInfo]$File.PhysicalName
+                    $Extension = $IoFile.$Extension
                     $Filename  = (split-path $file.PhysicalName -leaf) -replace ".$extension",""
                     if ($ReplaceDbNameInFile) {
                         $Filename = $filename -replace $OldDatabaseName, $dbname

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -223,7 +223,7 @@ Function Restore-DBFromFilteredArray {
                         $FileName = $FileName + '_' + $FileId + '_of_' + $RestoreFileCountFileCount
                     }
                     if (($null -ne $extension) -and ($extension -ne '')) {
-                        $filename = $filename + '.' + $extension
+                        $filename = $filename + $extension
                     }
                     Write-Message -Level VeryVerbose -Message "past the checks"
                     if (($File.Type -eq 'L' -or $File.filetype -eq 'L') -and $DestinationLogDirectory -ne '') {

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -207,7 +207,7 @@ Function Restore-DBFromFilteredArray {
                     $MoveFile.LogicalFileName = $File.LogicalName
                     $IoFile = [System.Io.FileInfo]$File.PhysicalName
                     $Extension = $IoFile.Extension
-                    $Filename  = (split-path $file.PhysicalName -leaf) -replace ".$extension",""
+                    $Filename  = (split-path $file.PhysicalName -leaf) -replace "\.$extension",""
                     if ($ReplaceDbNameInFile) {
                         $Filename = $filename -replace $OldDatabaseName, $dbname
                     }

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -206,7 +206,7 @@ Function Restore-DBFromFilteredArray {
                     $MoveFile = New-Object Microsoft.SqlServer.Management.Smo.RelocateFile
                     $MoveFile.LogicalFileName = $File.LogicalName
                     $IoFile = [System.Io.FileInfo]$File.PhysicalName
-                    $Extension = $IoFile.$Extension
+                    $Extension = $IoFile.Extension
                     $Filename  = (split-path $file.PhysicalName -leaf) -replace ".$extension",""
                     if ($ReplaceDbNameInFile) {
                         $Filename = $filename -replace $OldDatabaseName, $dbname

--- a/internal/Restore-DBFromFilteredArray.ps1
+++ b/internal/Restore-DBFromFilteredArray.ps1
@@ -207,7 +207,8 @@ Function Restore-DBFromFilteredArray {
                     $MoveFile.LogicalFileName = $File.LogicalName
                     $IoFile = [System.Io.FileInfo]$File.PhysicalName
                     $Extension = $IoFile.Extension
-                    $Filename  = (split-path $file.PhysicalName -leaf) -replace "\.$extension",""
+                    #$Filename  = (split-path $file.PhysicalName -leaf) -replace "\.$extension",""
+                    $FileName = $IoFile.BaseName
                     if ($ReplaceDbNameInFile) {
                         $Filename = $filename -replace $OldDatabaseName, $dbname
                     }
@@ -221,7 +222,7 @@ Function Restore-DBFromFilteredArray {
                     if ($DestinationFileNumber) {
                         $FileName = $FileName + '_' + $FileId + '_of_' + $RestoreFileCountFileCount
                     }
-                    if ($null -ne $extension) {
+                    if (($null -ne $extension) -and ($extension -ne '')) {
                         $filename = $filename + '.' + $extension
                     }
                     Write-Message -Level VeryVerbose -Message "past the checks"

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -325,4 +325,24 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             Foreach ($db in $results) { $db.Status | Should Be "Dropped" }
         }
     }
+
+    Context "Restores a db with log and file files missing extensions" {
+        $results = Restore-DbaDatabase -SqlInstance $script:instance1 -path $script:appeyorlabrepo\sql2008-backups\Noextension.bak -ErrorVariable Errvar -WarningVariable WarnVar
+        It "Should Restore successfully" {
+            ($results.RestoreComplete -contains $false) | Should Be $false    
+        }
+        It "Should have no Warnining or errors" {
+            ($null -eq $WarnVar) | Should Be $true
+            ($null -eq $ErrVar) | Should be $true
+        }
+    }
+    Clear-DbaSqlConnectionPool
+	Start-Sleep -Seconds 1
+	
+    Context "All user databases are removed post history test" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase -Confirm:$false
+        It "Should say the status was dropped" {
+            Foreach ($db in $results) { $db.Status | Should Be "Dropped" }
+        }
+    }
 }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -332,8 +332,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             ($results.RestoreComplete -contains $false) | Should Be $false    
         }
         It "Should have no Warnining or errors" {
-            ($WarnVar -eq '') | Should Be $true
-            ($ErrVar -eq '') | Should be $true
+            ('' -eq $WarnVar) | Should Be $true
+            ('' -eq $ErrVar) | Should be $true
         }
     }
     Clear-DbaSqlConnectionPool

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -190,8 +190,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	
     Context "Properly restores an instance using ola-style backups" {
         $results = Get-ChildItem $script:appeyorlabrepo\sql2008-backups | Restore-DbaDatabase -SqlInstance $script:instance1
-        It "Restored files count should be 27" {
-            $results.DatabaseName.Count | Should Be 27
+        It "Restored files count should be 28" {
+            $results.DatabaseName.Count | Should Be 28
         }
         It "Should return successful restore" {
             ($results.RestoreComplete -contains $false) | Should Be $false

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -331,10 +331,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should Restore successfully" {
             ($results.RestoreComplete -contains $false) | Should Be $false    
         }
-        It "Should have no Warnining or errors" {
-            ('' -eq $WarnVar) | Should Be $true
-            ('' -eq $ErrVar) | Should be $true
-        }
     }
     Clear-DbaSqlConnectionPool
 	Start-Sleep -Seconds 1

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -332,8 +332,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             ($results.RestoreComplete -contains $false) | Should Be $false    
         }
         It "Should have no Warnining or errors" {
-            ($null -eq $WarnVar) | Should Be $true
-            ($null -eq $ErrVar) | Should be $true
+            ($WarnVar -eq '') | Should Be $true
+            ($ErrVar -eq '') | Should be $true
         }
     }
     Clear-DbaSqlConnectionPool


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
fixes #2313

### Approach
Slightly better method of checking for file extension

### Commands to test
Pester test added to restore-DbaDatabase.Tests.ps1



### Learning
There'll always be an exception.
