### PR TITLE
Get-DbaAgentJobHistory, fix NetBios + tests

### DIFF
--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -137,7 +137,6 @@
 				$Job,
 				[switch]$WithOutputFile
 			)
-			
 			$tokenrex = [regex]'\$\((?<method>[^()]+)\((?<tok>[^)]+)\)\)|\$\((?<tok>[^)]+)\)'
 			$propmap = @{
 				'INST' = $Server.ServiceName
@@ -168,7 +167,6 @@
 					}
 				return $value
 			}
-			
 			
 			#'STEPID' =  stepid
 			#'STRTTM' job begin time
@@ -216,14 +214,14 @@
 				else {
 					$executions = $server.JobServer.EnumJobHistory($filter)
 				}
-				
 				if ($NoJobSteps) {
 					$executions = $executions | Where-Object { $_.StepID -eq 0 }
 				}
 				
 				if ($WithOutputFile) {
 					$outmap = @{}
-					$outfiles = Get-DbaAgentJobOutPutFile -SqlInstance $Server -SqlCredential $SqlCredential -Job $Job
+					$outfiles = Get-DbaAgentJobOutputFile -SqlInstance $Server -SqlCredential $SqlCredential -Job $Job
+					
 					foreach($out in $outfiles) {
 						if (!$outmap.ContainsKey($out.Job)) {
 							$outmap[$out.Job] = @{}
@@ -243,7 +241,7 @@
 						try {
 							$outname = $outmap[$execution.JobName][$execution.StepID]
 							$outname = Resolve-JobToken -exec $execution -outcome $outcome -outfile $outname
-							$outremote = Join-AdminUNC $Server.ComputerNamePhysicalNetBIOS $outname
+							$outremote = Join-AdminUNC $Server.NetName $outname
 						} catch {
 							$outname = ''
 							$outremote = ''
@@ -285,7 +283,6 @@
 			
 			if ($ExcludeJob) {
 				$jobs = $server.JobServer.Jobs.Name | Where-Object { $_ -notin $ExcludeJob }
-
 				foreach ($currentjob in $jobs) {
 					Get-JobHistory -Server $server -Job $currentjob -WithOutputFile:$WithOutputFile
 				}

--- a/tests/Get-DbaAgentJobHistory.Tests.ps1
+++ b/tests/Get-DbaAgentJobHistory.Tests.ps1
@@ -1,0 +1,388 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		$paramCount = 10
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Get-DbaAgentJobHistory).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'StartDate', 'EndDate', 'NoJobSteps', 'WithOutputFile', 'JobCollection', 'Silent'
+		It "Contains our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Contains $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+
+Describe "$CommandName Unittests" -Tag 'UnitTests' {
+	InModuleScope 'dbatools' {
+		Mock Connect-SQLInstance -MockWith {
+			# Thanks @Fred
+			$obj = [PSCustomObject]@{
+				Name                 = 'BASEName'
+				NetName              = 'BASENetName'
+				InstanceName         = 'BASEInstanceName'
+				DomainInstanceName   = 'BASEDomainInstanceName'
+				InstallDataDirectory = 'BASEInstallDataDirectory'
+				ErrorLogPath         = 'BASEErrorLog_{0}_{1}_{2}_Path' -f "'", '"', ']'
+				ServiceName          = 'BASEServiceName'
+				JobServer            = New-Object PSObject
+				ConnectionContext    = New-Object PSObject
+			}
+			Add-Member -InputObject $obj.ConnectionContext -Name ConnectionString  -MemberType NoteProperty -Value 'put=an=equal=in=it'
+			Add-Member -InputObject $obj.JobServer -Name EnumJobHistory -MemberType ScriptMethod -Value {
+				param ($filter)
+				return @(
+					@{
+						JobName = 'Job1'
+						JobID = [guid]'E7718A84-8B43-46D0-8F8D-4FC4464F9FC5'
+						StepID = 0
+						StepName = '(Job outcome)'
+						RunDate = [DateTime]::Parse('2017-09-26T13:00:00')
+						RunDuration = 2
+						RunStatus = 0
+					},
+					@{
+						JobName = 'Job1'
+						JobID = [guid]'E7718A84-8B43-46D0-8F8D-4FC4464F9FC5'
+						StepID = 1
+						StepName = 'Job1Step1'
+						RunDate = [DateTime]::Parse('2017-09-26T13:00:00')
+						RunDuration = 1
+						RunStatus = 0
+					},
+					@{
+						JobName = 'Job1'
+						JobID = [guid]'E7718A84-8B43-46D0-8F8D-4FC4464F9FC5'
+						StepID = 2
+						StepName = 'Job1Step2'
+						RunDate = [DateTime]::Parse('2017-09-26T13:00:01')
+						RunDuration = 1
+						RunStatus = 0
+					},
+					@{
+						JobName = 'Job2'
+						JobID = [guid]'9C9A6819-58CE-451A-8DD7-6D17593F0DFA'
+						StepID = 0
+						StepName = '(Job outcome)'
+						RunDate = [DateTime]::Parse('2017-09-26T01:00:00')
+						RunDuration = 2
+						RunStatus = 0
+					},
+					@{
+						JobName = 'Job2'
+						JobID = [guid]'9C9A6819-58CE-451A-8DD7-6D17593F0DFA'
+						StepID = 1
+						StepName = 'Job2Step1'
+						RunDate = [DateTime]::Parse('2017-09-26T01:00:00')
+						RunDuration = 1
+						RunStatus = 0
+					},
+					@{
+						JobName = 'Job2'
+						JobID = [guid]'9C9A6819-58CE-451A-8DD7-6D17593F0DFA'
+						StepID = 2
+						StepName = 'Job2Step2'
+						RunDate = [DateTime]::Parse('2017-09-26T01:00:01')
+						RunDuration = 1
+						RunStatus = 0
+					}
+				)
+			}
+			$obj.PSObject.TypeNames.Clear()
+			$obj.PSObject.TypeNames.Add("Microsoft.SqlServer.Management.Smo.Server")
+			return $obj
+		} #mock connect-sqlserver
+		Context "Return values" {
+			
+			Mock Get-DbaAgentJobOutputFile -MockWith {
+				@(
+					@{
+						Job = 'Job1'
+						StepId = 1
+						OutputFileName = 'Job1Output1'
+					},
+					@{
+						Job = 'Job1'
+						StepId = 2
+						OutputFileName = 'Job1Output2'
+					},
+					@{
+						Job = 'Job2'
+						StepId = 2
+						OutputFileName = 'Job2Output1'
+					}
+				)
+			}
+			It "Throws when NoJobSteps and WithOutputFile" {
+				{ Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -NoJobSteps -WithOutputFile -Silent } | Should Throw
+			}
+			It "Returns full history by default" {
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName'
+				$Results.Length | Should Be 6
+			}
+			It "Returns only runs with no steps with NoJobSteps" {
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -NoJobSteps
+				$Results.Length | Should Be 2
+			}
+			It "Figures out plain outputfiles" {
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				# no output for outcomes
+				($Results | Where-Object StepID -eq 0).Length | Should Be 2
+				($Results | Where-Object StepID -eq 0).OutputFileName -Join '' | Should Be ''
+				# correct output for job1
+				($Results | Where-Object StepID -ne 0 | Where-Object JobName -eq 'Job1').OutputFileName | Should Match 'Job1Output[12]'
+				# correct output for job2
+				($Results | Where-Object StepID -eq 2 | Where-Object JobName -eq 'Job2').OutputFileName | Should Match 'Job2Output1'
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job2').OutputFileName | Should Be ''
+			}
+		}
+		Context "SQL Agent Tokens" {
+			It "Handles INST" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(INST)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEServiceName__Job1Output1'
+				
+			}
+			It "Handles MACH" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(MACH)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASENetName__Job1Output1'
+				
+			}
+			It "Handles SQLDIR" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(SQLDIR)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEInstallDataDirectory__Job1Output1'
+				
+			}
+			It "Handles SQLLOGDIR" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(SQLLOGDIR)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEErrorLog_''_"_]_Path__Job1Output1'
+				
+			}
+			It "Handles SRVR" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(SRVR)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEDomainInstanceName__Job1Output1'
+				
+			}
+			
+			It "Handles STEPID" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(STEPID)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '1__Job1Output1'
+				
+			}
+			It "Handles JOBID" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(JOBID)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '0x848A71E7438BD0468F8D4FC4464F9FC5__Job1Output1'
+				
+			}
+			
+			
+			It "Handles STRTDT" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(STRTDT)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '20170926__Job1Output1'
+			}
+			It "Handles STRTTM" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(STRTTM)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '130000__Job1Output1'
+			}
+			It "Handles DATE" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(DATE)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '20170926__Job1Output1'
+			}
+			
+			It "Handles TIME" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 2
+							OutputFileName = '$(TIME)__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				($Results | Where-Object StepID -eq 2 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be '130001__Job1Output1'
+				
+			}
+		}
+		Context "SQL Agent escape sequences" {
+			It "Handles ESCAPE_NONE" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(ESCAPE_NONE(SQLLOGDIR))__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEErrorLog_''_"_]_Path__Job1Output1'
+				
+			}
+			It "Handles ESCAPE_SQUOTE" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(ESCAPE_SQUOTE(SQLLOGDIR))__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEErrorLog_''''_"_]_Path__Job1Output1'
+				
+			}
+			It "Handles ESCAPE_DQUOTE" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(ESCAPE_DQUOTE(SQLLOGDIR))__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEErrorLog_''_""_]_Path__Job1Output1'
+				
+			}
+			It "Handles ESCAPE_RBRACKET" {
+				Mock Get-DbaAgentJobOutputFile -MockWith {
+					@(
+						@{
+							Job = 'Job1'
+							StepId = 1
+							OutputFileName = '$(ESCAPE_RBRACKET(SQLLOGDIR))__Job1Output1'
+						}
+					)
+				}
+				$Results = @()
+				$Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
+				
+				($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEErrorLog_''_"_]]_Path__Job1Output1'
+				
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes "Every time a dba uses NetBios after 1998, there is a network admin somewhere that falls down dead")
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Same deal as https://github.com/sqlcollaborative/dbatools/pull/2312 . Plus, IMHO, a good usecase for mocks. This could have spawned weeks trying to get a proper setup with all 'full on' testcases .... instead with @FriedrichWeinmann 's invaluable help a proper "mock" made most of it disappear.
