### PR TITLE
DbaInstanceParameter - Input updates

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 6, 2, 24)
+$currentLibraryVersion = New-Object System.Version(0, 6, 2, 25)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaInstanceParameter.cs
@@ -409,10 +409,11 @@ namespace Sqlcollaborative.Dbatools.Parameter
                     }
                 }
 
-                if (Utility.Validation.IsValidComputerTarget(tempComputerName) && Utility.Validation.IsValidInstanceName(tempInstanceName))
+                if (Utility.Validation.IsValidComputerTarget(tempComputerName) && Utility.Validation.IsValidInstanceName(tempInstanceName, true))
                 {
                     _ComputerName = tempComputerName;
-                    _InstanceName = tempInstanceName;
+                    if ((tempInstanceName.ToLower() != "default") && (tempInstanceName.ToLower() != "mssqlserver"))
+                        _InstanceName = tempInstanceName;
                 }
 
                 else

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.2.24")]
-[assembly: AssemblyFileVersion("0.6.2.24")]
+[assembly: AssemblyVersion("0.6.2.25")]
+[assembly: AssemblyFileVersion("0.6.2.25")]

--- a/bin/projects/dbatools/dbatools/Utility/RegexHelper.cs
+++ b/bin/projects/dbatools/dbatools/Utility/RegexHelper.cs
@@ -53,12 +53,12 @@
         /// <summary>
         /// Will match a mostly valid instance name.
         /// </summary>
-        public static string InstanceName = @"^[\p{L}&_#][\p{L}\d\$#_]{1,15}$";
+        public static string InstanceName = @"^[\p{L}&_#][\p{L}\d\$#_]{0,15}$";
 
         /// <summary>
         /// Will match any instance of a mostly valid instance name.
         /// </summary>
-        public static string InstanceNameEx = @"[\p{L}&_#][\p{L}\d\$#_]{1,15}";
+        public static string InstanceNameEx = @"[\p{L}&_#][\p{L}\d\$#_]{0,15}";
 
         /// <summary>
         /// Matches a word against the list of officially reserved keywords

--- a/bin/projects/dbatools/dbatools/Utility/Validation.cs
+++ b/bin/projects/dbatools/dbatools/Utility/Validation.cs
@@ -98,8 +98,9 @@ namespace Sqlcollaborative.Dbatools.Utility
         /// Tests whether a given string is a valid instance name.
         /// </summary>
         /// <param name="InstanceName">The name to test. MAY contain server name, but will NOT test the server.</param>
+        /// <param name="Lenient">Setting this to true will make the validation ignore default and mssqlserver as illegal names (as they are illegal names for named instances, but legal for targeting)</param>
         /// <returns>Whether the name is legal</returns>
-        public static bool IsValidInstanceName(string InstanceName)
+        public static bool IsValidInstanceName(string InstanceName, bool Lenient = false)
         {
             string temp;
             if (InstanceName.Split('\\').Length == 1) { temp = InstanceName; }
@@ -108,8 +109,11 @@ namespace Sqlcollaborative.Dbatools.Utility
 
             if (Regex.IsMatch(temp, RegexHelper.SqlReservedKeyword, RegexOptions.IgnoreCase)) { return false; }
 
-            if (temp.ToLower() == "default") { return false; }
-            if (temp.ToLower() == "mssqlserver") { return false; }
+            if (!Lenient)
+            {
+                if (temp.ToLower() == "default") { return false; }
+                if (temp.ToLower() == "mssqlserver") { return false; }
+            }
 
             if (!Regex.IsMatch(temp, RegexHelper.InstanceName, RegexOptions.IgnoreCase)) { return false; }
 


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Changes
 - Bugfix: Allow single-letter instance names
 - Update: Allow `MSSQLSERVER` and `default` as input names for instances, even though they are technically illegal names for instances (as they legitimately target the default instance)