### PR TITLE
Library - Added build configurations

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -90,10 +90,12 @@ if ($ImportLibrary) {
 				$start = Get-Date
 				$system = [Appdomain]::CurrentDomain.GetAssemblies() | Where-Object FullName -like "System, *"
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
-				$msbuildOptions = "/p:Configuration=Release"
+				$msbuildConfiguration = "/p:Configuration=Release"
+				$msbuildOptions = ""
 				if ($env:APPVEYOR -eq 'True') {
 					# This doesn't seem to work. Keep it here for now
-					$msbuildOptions = '/p:Configuration=Debug /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
+					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
+					$msbuildConfiguration = '/p:Configuration=Debug'
 					
 					if (-not (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll")) {
 						throw "msbuild logger not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
@@ -105,7 +107,7 @@ if ($ImportLibrary) {
 				}
 				
 				Write-Verbose -Message "Building the library"
-				& $msbuild "$libraryBase\projects\dbatools\dbatools.sln" $msbuildOptions
+				& $msbuild "$libraryBase\projects\dbatools\dbatools.sln" $msbuildConfiguration $msbuildOptions
 				
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -90,16 +90,16 @@ if ($ImportLibrary) {
 				$start = Get-Date
 				$system = [Appdomain]::CurrentDomain.GetAssemblies() | Where-Object FullName -like "System, *"
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
-				$msbuildOptions = ""
-				if($env:APPVEYOR -eq 'True') {
+				$msbuildOptions = "/p:Configuration=Release"
+				if ($env:APPVEYOR -eq 'True') {
 					# This doesn't seem to work. Keep it here for now
-					$msbuildOptions = '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
+					$msbuildOptions = '/p:Configuration=Debug /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"'
 					
 					if (-not (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll")) {
 						throw "msbuild logger not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
 					}
 				}
-
+				
 				if (-not (Test-Path $msbuild)) {
 					throw "msbuild not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
 				}
@@ -174,7 +174,7 @@ aka "The guy who made most of The Library that Failed to import"
 }
 
 #region Version Warning
-if ($currentLibraryVersion -ne ([version](([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object ManifestModule -like "dbatools.dll").CustomAttributes | Where-Object AttributeType -like "System.Reflection.AssemblyFileVersionAttribute" ).ConstructorArguments.Value)) {
+if ($currentLibraryVersion -ne ([version](([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object ManifestModule -like "dbatools.dll").CustomAttributes | Where-Object AttributeType -like "System.Reflection.AssemblyFileVersionAttribute").ConstructorArguments.Value)) {
 	Write-Warning @"
 A version missmatch between the dbatools library loaded and the one expected by
 this module. This usually happens when you update the dbatools module and use

--- a/bin/projects/dbatools/dbatools.sln
+++ b/bin/projects/dbatools/dbatools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dbatools", "dbatools\dbatools.csproj", "{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}"
 EndProject
@@ -20,7 +20,6 @@ Global
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose & Change
Updated the way the library is being built-on-demand, as configuration specific issues have kept coming up:
 - Only appveyor will build the tests library (A dependency would cause issues)
 - Users will build the release configuration instead, which only contains the dbatools library itself
 - Users are specifically pointed at the configuration to build

Should fix: https://github.com/sqlcollaborative/dbatools/issues/2378#issuecomment-334176115