### PR TITLE
Get-DbaCmObject - Fixed enum addition error

### DIFF
--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -133,11 +133,14 @@
 				Stop-Function -Message $message -ErrorRecord $_ -Target $connection -Continue -OverrideExceptionMessage
 			}
 			
-			[Sqlcollaborative.Dbatools.Connection.ManagementConnectionType]$enabledProtocols = "None"
-			if ($connection.CimRM -notlike "Disabled") { $enabledProtocols += "CimRM" }
-			if ($connection.CimDCOM -notlike "Disabled") { $enabledProtocols += "CimDCOM" }
-			if ($connection.Wmi -notlike "Disabled") { $enabledProtocols += "Wmi" }
-			if ($connection.PowerShellRemoting -notlike "Disabled") { $enabledProtocols += "PowerShellRemoting" }
+			# Flags-Enumerations cannot be added in PowerShell 4 or older.
+			# Thus we create a string and convert it afterwards.
+			$enabledProtocols = "None"
+			if ($connection.CimRM -notlike "Disabled") { $enabledProtocols += ", CimRM" }
+			if ($connection.CimDCOM -notlike "Disabled") { $enabledProtocols += ", CimDCOM" }
+			if ($connection.Wmi -notlike "Disabled") { $enabledProtocols += ", Wmi" }
+			if ($connection.PowerShellRemoting -notlike "Disabled") { $enabledProtocols += ", PowerShellRemoting" }
+			[Sqlcollaborative.Dbatools.Connection.ManagementConnectionType]$enabledProtocols = $enabledProtocols
 			
 			# Create list of excluded connection types (Duplicates don't matter)
 			$excluded = @()


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
A recent change used addition for flags-enabled enumerations.
This is a feature introduced in PowerShell 5, causing the command to fail on older versions.

Fixes https://github.com/sqlcollaborative/dbatools/issues/2390
Where the issue was showing symptoms by claiming that no namespace was available.