### PR TITLE
DbaHistory order test

### DIFF
--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -27,8 +27,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 	
 	Context "Get last history for single database" {
 		$results = Get-DbaBackupHistory -SqlInstance $script:instance1 -Database $dbname -Last
-		It "Should be more than one database" {
+		It "Should be 4 backups returned" {
 			$results.count | Should Be 4
+		}
+		It "First backup should be a Full Backup" {
+			$results[0].Type | Should be "Full"
+		}
+		It "Last Backup Should be a log backup" {
+			$results[-1].Type | Should Be "Log"
 		}
 	}
 	


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Had a report on slack of misordered Get-DbaBackupHistory order, I think it's potentially an LSN issue, but noticed we don't check the ordering. So added a simple pester test to make sure we don't introduce that error..


