### PR TITLE
Get-FilteredRestoreFile - fixed time comparison issue

### DIFF
--- a/internal/Get-FilteredRestoreFile.ps1
+++ b/internal/Get-FilteredRestoreFile.ps1
@@ -173,7 +173,7 @@ function Get-FilteredRestoreFile {
             #If we're continuing a restore, then we aren't going to be needing a full backup....
             $TlogStartlsn = 0
             if (!($continue)) {
-                $Fullbackup = $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq 'Database' -and $_.BackupStartDate -lt $RestoreTime} | Sort-Object -Property LastLSN -descending | Select-Object -First 1
+                $Fullbackup = $SQLBackupdetails | where-object {$_.BackupTypeDescription -eq 'Database' -and $RestoreTime -ge $_.BackupStartDate} | Sort-Object -Property LastLSN -descending | Select-Object -First 1
                 $TlogStartlsn = $Fullbackup.LastLsn
                 if ($Fullbackup -eq $null) {
                     Stop-Function -Message "No Full backup found to anchor the restore" -Continue -Target $database


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fixes a time comparison that was breaking Restore-DbaDatabase when receiving input from Get-DbaBackupHistory.