### PR TITLE
Touchup Test-DbaTempdbConfiguration

### DIFF
--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -87,10 +87,10 @@ function Test-DbaTempDbConfiguration {
 			}
 			else {
 				$sql = "DBCC TRACEON (3604);DBCC TRACESTATUS(-1)"
-				$tfcheck = $server.Databases['tempdb'].Query($sql)
+				$tfCheck = $server.Databases['tempdb'].Query($sql)
 				$notes = 'KB328551 describes how TF 1118 can benefit performance.'
 
-				if (($tfcheck.TraceFlag -join ',').Contains('1118')) {
+				if (($tfCheck.TraceFlag -join ',').Contains('1118')) {
 					$value = [PSCustomObject]@{
 						ComputerName   = $server.NetName
 						InstanceName   = $server.ServiceName
@@ -119,15 +119,15 @@ function Test-DbaTempDbConfiguration {
 				$isBestPractice = $true
 			}
 
-			$value | Add-Member -Force -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			$value | Add-Member -Force -MemberType NoteProperty -Name Notes -Value $notes
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value $notes
 			$result += $value
 			Write-Message -Level Verbose -Message "TF 1118 evaluated"
 
 			#get files and log files
 			$tempdbFiles = Get-DbaDatabaseFile -SqlInstance $server -Database tempdb
-			$datafiles = $tempdbFiles | Where-Object Type -ne 1
-			$logfiles = $tempdbFiles | Where-Object Type -eq 1
+			$dataFiles = $tempdbFiles | Where-Object Type -ne 1
+			$logFiles = $tempdbFiles | Where-Object Type -eq 1
 			Write-Message -Level Verbose -Message "TempDB file objects gathered"
 
 			$cores = $server.Processors
@@ -141,7 +141,7 @@ function Test-DbaTempDbConfiguration {
 				SqlInstance    = $server.DomainInstanceName
 				Rule           = 'File Count'
 				Recommended    = $cores
-				CurrentSetting = $datafiles.Count
+				CurrentSetting = $dataFiles.Count
 			}
 
 			if ($value.Recommended -ne $value.CurrentSetting -and $null -ne $value.Recommended) {
@@ -151,22 +151,22 @@ function Test-DbaTempDbConfiguration {
 				$isBestPractice = $true
 			}
 
-			$value | Add-Member -Force -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			$value | Add-Member -Force -MemberType NoteProperty -Name Notes -Value 'Microsoft recommends that the number of tempdb data files is equal to the number of logical cores up to 8.'
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value 'Microsoft recommends that the number of tempdb data files is equal to the number of logical cores up to 8.'
 			$result += $value
 
 			Write-Message -Level Verbose -Message "File counts evaluated."
 
 			#test file growth
-			$percdata = $datafiles | Where-Object GrowthType -ne 'KB' | Measure-Object
-			$perclog = $logfiles  | Where-Object GrowthType -ne 'KB' | Measure-Object
+			$percData = $dataFiles | Where-Object GrowthType -ne 'KB' | Measure-Object
+			$percLog = $logFiles  | Where-Object GrowthType -ne 'KB' | Measure-Object
 
-			$totalcount = $percdata.count + $perclog.count
-			if ($totalcount -gt 0) {
-				$totalcount = $true
+			$totalCount = $percData.Count + $percLog.Count
+			if ($totalCount -gt 0) {
+				$totalCount = $true
 			}
 			else {
-				$totalcount = $false
+				$totalCount = $false
 			}
 
 			$value = [PSCustomObject]@{
@@ -175,7 +175,7 @@ function Test-DbaTempDbConfiguration {
 				SqlInstance    = $server.DomainInstanceName
 				Rule           = 'File Growth in Percent'
 				Recommended    = $false
-				CurrentSetting = $totalcount
+				CurrentSetting = $totalCount
 			}
 
 			if ($value.Recommended -ne $value.CurrentSetting -and $null -ne $value.Recommended) {
@@ -185,14 +185,14 @@ function Test-DbaTempDbConfiguration {
 				$isBestPractice = $true
 			}
 
-			$value | Add-Member -Force -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			$value | Add-Member -Force -MemberType NoteProperty -Name Notes -Value 'Set grow with explicit values, not by percent.'
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value 'Set grow with explicit values, not by percent.'
 			$result += $value
 
 			Write-Message -Level Verbose -Message "File growth settings evaluated."
 			#test file Location
 
-			$cdata = ($datafiles | Where-Object PhysicalName -like 'C:*' | Measure-Object).Count + ($logfiles | Where-Object PhysicalName -like 'C:*' | Measure-Object).Count
+			$cdata = ($dataFiles | Where-Object PhysicalName -like 'C:*' | Measure-Object).Count + ($logFiles | Where-Object PhysicalName -like 'C:*' | Measure-Object).Count
 			if ($cdata -gt 0) {
 				$cdata = $true
 			}
@@ -216,19 +216,19 @@ function Test-DbaTempDbConfiguration {
 				$isBestPractice = $true
 			}
 
-			$value | Add-Member -Force -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			$value | Add-Member -Force -MemberType NoteProperty -Name Notes -Value "Do not place your tempdb files on C:\."
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value "Do not place your tempdb files on C:\."
 			$result += $value
 
 			Write-Message -Level Verbose -Message "File locations evaluated."
 
 			#Test growth limits
-			$growthlimits = ($datafiles | Where-Object MaxSize -gt 0 | Measure-Object).Count + ($logfiles | Where-Object MaxSize -gt 0 | Measure-Object).Count
-			if ($growthlimits -gt 0) {
-				$growthlimits = $true
+			$growthLimits = ($dataFiles | Where-Object MaxSize -gt 0 | Measure-Object).Count + ($logFiles | Where-Object MaxSize -gt 0 | Measure-Object).Count
+			if ($growthLimits -gt 0) {
+				$growthLimits = $true
 			}
 			else {
-				$growthlimits = $false
+				$growthLimits = $false
 			}
 
 			$value = [PSCustomObject]@{
@@ -237,7 +237,7 @@ function Test-DbaTempDbConfiguration {
 				SqlInstance    = $server.DomainInstanceName
 				Rule           = 'File MaxSize Set'
 				Recommended    = $false
-				CurrentSetting = $growthlimits
+				CurrentSetting = $growthLimits
 			}
 
 			if ($value.Recommended -ne $value.CurrentSetting -and $null -ne $value.Recommended) {
@@ -247,8 +247,8 @@ function Test-DbaTempDbConfiguration {
 				$isBestPractice = $true
 			}
 
-			$value | Add-Member -Force -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			$value | Add-Member -Force -MemberType NoteProperty -Name Notes -Value "Consider setting your tempdb files to unlimited growth."
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value "Consider setting your tempdb files to unlimited growth."
 			$result += $value
 
 			Write-Message -Level Verbose -Message "MaxSize values evaluated."
@@ -256,7 +256,6 @@ function Test-DbaTempDbConfiguration {
 			Select-DefaultView -InputObject $result -Property ComputerName, InstanceName, SqlInstance, Rule, Recommended, IsBestPractice
 		}
 	}
-
 	end {
 		Test-DbaDeprecation -DeprecatedOn "1.0.0" -Silent:$false -Alias Test-SqlTempDbConfiguration
 	}

--- a/tests/Test-DbaTempDbConfiguration.Tests.ps1
+++ b/tests/Test-DbaTempDbConfiguration.Tests.ps1
@@ -1,11 +1,53 @@
-﻿. "$PSScriptRoot\constants.ps1"
+﻿<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
 
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-	Context "Testing if tempdb misconfiguration is reported" {
-		$results = Test-DbaTempDbConfiguration -SqlInstance $script:instance1
-		
-		It "reports back issue for files on C drive" {
-			$results.Rule -match 'File Location' | Should Be $true
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		<#
+			The $paramCount is adjusted based on the parameters your command will have.
+
+			The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+		#>
+		$paramCount = 3
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Test-DbaTempDbConfiguration).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Silent'
+		It "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "Command actually works" {
+		$results = Test-DbaTempDbConfiguration -SqlInstance $script:instance2
+		It "Should have correct properties" {
+			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Rule,Recommended,CurrentSetting,IsBestPractice,Notes'.Split(',')
+			($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+		}
+
+		$rule = 'File Location'
+		It "Should return false for IsBestPractice with rule: $rule" {
+			($results | Where-Object Rule -match $rule).IsBestPractice | Should Be $false
+		}
+		It "Should return false for Recommended with rule: $rule" {
+			($results | Where-Object Rule -match $rule).Recommended | Should Be $false
+		}
+		$rule = 'TF 1118 Enabled'
+		It "Should return true for IsBestPractice with rule: $rule" {
+			($results | Where-Object Rule -match $rule).Recommended | Should Be $true
 		}
 	}
 }

--- a/tests/Test-DbaVirtualLogFile.Tests.ps1
+++ b/tests/Test-DbaVirtualLogFile.Tests.ps1
@@ -21,10 +21,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 		$defaultParamCount = 11
 		[object[]]$params = (Get-ChildItem function:\Test-DbaVirtualLogFile).Parameters.Keys
 		$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeSystemDbs', 'Silent'
-		it "Should contain our specific parameters" {
+		It "Should contain our specific parameters" {
 			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
 		}
-		it "Should only contain $paramCount parameters" {
+		It "Should only contain $paramCount parameters" {
 			$params.Count - $defaultParamCount | Should Be $paramCount
 		}
 	}


### PR DESCRIPTION
Touchup to standard.

Also changed piping the `$value` object to `Add-Member` to utilize the `-InputObject`, less overhead using that method.

Adjusted the test for this command as well to include more items and code coverage:
![image](https://user-images.githubusercontent.com/11204251/31327324-27baa710-ac94-11e7-8c60-81db09ba6a62.png)
