### PR TITLE
New-DbaDatabaseSnapshot tests fixes

### DIFF
--- a/tests/New-DbaDatabaseSnapshot.Tests.ps1
+++ b/tests/New-DbaDatabaseSnapshot.Tests.ps1
@@ -1,19 +1,9 @@
-﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".ps1","")
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 # Targets only instance2 because it's the only one where Snapshots can happen
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-	BeforeAll {
-		if ($env:appveyor) {
-			Get-Service | Where-Object { $_.DisplayName -match 'SQL Server (SQL2016)' } | Restart-Service -Force
-			do {
-				Start-Sleep 1
-				$null = (& sqlcmd -S $script:instance2 -b -Q "select 1" -d master)
-			}
-			while ($lastexitcode -ne 0 -and $s++ -lt 10)
-		}
-	}
 	Context "Parameter validation" {
 		It "Stops if no Database or AllDatabases" {
 			{ New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent } | Should Throw "You must specify"
@@ -93,14 +83,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 				$ExpectedProps = 'ComputerName,Database,DatabaseCreated,InstanceName,Notes,PrimaryFilePath,SizeMB,SnapshotDb,SnapshotOf,SqlInstance,Status'.Split(',')
 				($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 			}
-			
-			if (-not $env:appveyor) {
-				It "Has the correct default properties" {
-					$null = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
-					$result = New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent -Database $db2
-					$ExpectedPropsDefault = 'ComputerName,Database,DatabaseCreated,InstanceName,Notes,PrimaryFilePath,SizeMB,SnapshotOf,SqlInstance,Status'.Split(',')
-					($result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedPropsDefault | Sort-Object)
-				}
+			It "Has the correct default properties" {
+				$null = Remove-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Database $db2 -Force
+				$result = New-DbaDatabaseSnapshot -SqlInstance $script:instance2 -Silent -Database $db2
+				$ExpectedPropsDefault = 'ComputerName,Database,DatabaseCreated,InstanceName,PrimaryFilePath,SizeMB,SnapshotOf,SqlInstance,Status'.Split(',')
+				$DefaultProps = $result.PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames
+				@($DefaultProps | Where-Object {$ExpectedPropsDefault -notcontains $_}) -Join '' | Should Be ''
 			}
 		}
 	}


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Notes are hidden if no exception occurs. Until latest SMO, it was always the case. 
It seems that with the latest SMO no weird workarounds are needed (someone in MS is listening in dbatools channel, apparently :-P ). The check for default props has been adjusted to look for the common denominator of default properties.


tl;dr: my faith in computer systems is restored ^_^