### PR TITLE
Get-DbaDiskSpace 1.0.0

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 7, 0, 26)
+$currentLibraryVersion = New-Object System.Version(0, 7, 0, 27)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Computer/DiskSpace.cs
+++ b/bin/projects/dbatools/dbatools/Computer/DiskSpace.cs
@@ -1,0 +1,237 @@
+﻿using Sqlcollaborative.Dbatools.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sqlcollaborative.Dbatools.Computer
+{
+    /// <summary>
+    /// Data Container for the output of Get-DbaDiskSpace
+    /// </summary>
+    public class DiskSpace
+    {
+        /// <summary>
+        /// The computer that was scanned
+        /// </summary>
+        public string ComputerName { get; set; }
+
+        /// <summary>
+        /// Name of the disk
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Label of the disk
+        /// </summary>
+        public string Label { get; set; }
+
+        /// <summary>
+        /// What's the total capacity of the disk?
+        /// </summary>
+        public Size Capacity { get; set; }
+
+        /// <summary>
+        /// How much is still free?
+        /// </summary>
+        public Size Free { get; set; }
+
+        /// <summary>
+        /// How much is still free
+        /// </summary>
+        public double PercentFree
+        {
+            get
+            {
+                return Math.Round((double)((double)Free.Byte / (double)Capacity.Byte * 100), 2);
+            }
+        }
+
+        /// <summary>
+        /// What blocksize is the object set to
+        /// </summary>
+        public int BlockSize { get; set; }
+
+        /// <summary>
+        /// What filesystem is installed on the system
+        /// </summary>
+        public string FileSystem { get; set; }
+
+        /// <summary>
+        /// What kind of drive is it?
+        /// </summary>
+        public DriveType Type { get; set; }
+
+        #region Legacy Properties
+        /// <summary>
+        /// The computer that was scanned. Legacy-Name
+        /// </summary>
+        public string Server
+        {
+            get { return ComputerName; }
+        }
+
+        /// <summary>
+        /// The type of drive this is in the legacy string notation
+        /// </summary>
+        public string DriveType
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case Computer.DriveType.Unknown:
+                        return "Unknown";
+                    case Computer.DriveType.NoRootDirectory:
+                        return "No Root Directory";
+                    case Computer.DriveType.RemovableDisk:
+                        return "Removable Disk";
+                    case Computer.DriveType.LocalDisk:
+                        return "Local Disk";
+                    case Computer.DriveType.NetworkDrive:
+                        return "Network Drive";
+                    case Computer.DriveType.CompactDisk:
+                        return "Compact Disk";
+                    case Computer.DriveType.RAMDisk:
+                        return "RAM Disk";
+                    default:
+                        return "Unknown";
+                }
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in Bytes
+        /// </summary>
+        public double SizeInBytes
+        {
+            get
+            {
+                return Capacity.Byte;
+            }
+        }
+
+        /// <summary>
+        /// The free space in Bytes
+        /// </summary>
+        public double FreeInBytes
+        {
+            get
+            {
+                return Free.Byte;
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in KB
+        /// </summary>
+        public double SizeInKB
+        {
+            get
+            {
+                return Math.Round(Capacity.Kilobyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The free space in KB
+        /// </summary>
+        public double FreeInKB
+        {
+            get
+            {
+                return Math.Round(Free.Kilobyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in MB
+        /// </summary>
+        public double SizeInMB
+        {
+            get
+            {
+                return Math.Round(Capacity.Megabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The free space in MB
+        /// </summary>
+        public double FreeInMB
+        {
+            get
+            {
+                return Math.Round(Free.Megabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in GB
+        /// </summary>
+        public double SizeInGB
+        {
+            get
+            {
+                return Math.Round(Capacity.Gigabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The free space in GB
+        /// </summary>
+        public double FreeInGB
+        {
+            get
+            {
+                return Math.Round(Free.Gigabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in TB
+        /// </summary>
+        public double SizeInTB
+        {
+            get
+            {
+                return Math.Round(Capacity.Terabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The free space in TB
+        /// </summary>
+        public double FreeInTB
+        {
+            get
+            {
+                return Math.Round(Free.Terabyte, 2);
+            }
+        }
+
+        /// <summary>
+        /// The total capacity in PB
+        /// </summary>
+        public double SizeInPB
+        {
+            get
+            {
+                return Math.Round(Capacity.Terabyte / 1024, 2);
+            }
+        }
+
+        /// <summary>
+        /// The free space in PB
+        /// </summary>
+        public double FreeInPB
+        {
+            get
+            {
+                return Math.Round(Free.Terabyte / 1024, 2);
+            }
+        }
+        #endregion Legacy Properties
+    }
+}

--- a/bin/projects/dbatools/dbatools/Computer/DriveType.cs
+++ b/bin/projects/dbatools/dbatools/Computer/DriveType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sqlcollaborative.Dbatools.Computer
+{
+    /// <summary>
+    /// What kind of drive are you?
+    /// </summary>
+    public enum DriveType
+    {
+        /// <summary>
+        /// The drive type is not actually known
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The drive has no root directory
+        /// </summary>
+        NoRootDirectory = 1,
+
+        /// <summary>
+        /// The drive is a removable disk
+        /// </summary>
+        RemovableDisk = 2,
+
+        /// <summary>
+        /// The drive is a local disk
+        /// </summary>
+        LocalDisk = 3,
+
+        /// <summary>
+        /// The drive is a network drive
+        /// </summary>
+        NetworkDrive = 4,
+
+        /// <summary>
+        /// The drive is a compact disk
+        /// </summary>
+        CompactDisk = 5,
+
+        /// <summary>
+        /// The drive is a RAM disk
+        /// </summary>
+        RAMDisk = 6,
+    }
+}

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.26")]
-[assembly: AssemblyFileVersion("0.7.0.26")]
+[assembly: AssemblyVersion("0.7.0.27")]
+[assembly: AssemblyFileVersion("0.7.0.27")]

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -54,6 +54,8 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Computer\DiskSpace.cs" />
+    <Compile Include="Computer\DriveType.cs" />
     <Compile Include="Database\BackupHistory.cs" />
     <Compile Include="Configuration\Config.cs" />
     <Compile Include="Connection\ConnectionHost.cs" />

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -1,102 +1,89 @@
 function Get-DbaDiskSpace {
 	<#
 		.SYNOPSIS
-			Displays disk information for all local drives on a server.
-
+			Displays disk information for all local disk on a server.
+		
 		.DESCRIPTION
 			Returns a custom object with server name, name of disk, label of disk, total size, free size, percent free, block size and filesystem.
-
+			
 			By default, this function only shows drives of types 2 and 3 (removable disk and local disk).
-
+			
 			Requires Windows administrator access on SQL Servers
-
+		
 		.PARAMETER ComputerName
-			The server that you're connecting to.
-
+			The target computer. Defaults to localhost.
+		
 		.PARAMETER Unit
-			Specifies the units to use in displaying the disk space information. Valid options for this parameter are 'Bytes', 'KB', 'MB', 'GB', 'TB', and 'PB'. Default is GB.
-
+			This parameter has been deprecated and will be removed in 1.0.0
+			All properties previously generated through this command are present at the same time, but hidden by default.
+		
 		.PARAMETER CheckForSql
 			If this switch is enabled, disks will be checked for SQL Server data and log files. Windows Authentication is always used for this.
-
+		
 		.PARAMETER SqlCredential
- 			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
-
-			$cred = Get-Credential, then pass $cred object to the -SqlCredential parameter.
-
-			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
-
-			To connect as a different Windows user, run PowerShell as that user.
-
+			SqlCredential object to connect as. If not specified, current Windows login will be used.
+			Only relevant in combination with the -CheckForSql parameter.
+		
+		.PARAMETER Credential
+			The credentials to use to connect via CIM/WMI/PowerShell remoting
+		
+		.PARAMETER Force
+			Enabling this switch will cause the command to include ALL drives.
+			By default, only local disks and removable disks are shown, and hidden volumes are excluded.
+		
 		.PARAMETER CheckFragmentation
 			If this switch is enabled, fragmentation of all filesystems will be checked.
-
+			
 			This will increase the runtime of the function by seconds or even minutes per volume.
-
-		.PARAMETER AllDrives
-			If this switch is enabled, all drives visible on the server will be checked. By default, only drives of type 2 (removable) and 3 (local) are checked.
-
-			For a list of all drive types, see https://msdn.microsoft.com/en-us/library/aa394515.aspx
-
-		.PARAMETER Detailed
-			If this switch is enabled, additional information about each drive is returned. This includes the filesystem (FAT32, NTFS, etc.) and the information provided by -CheckForSql and -AllDrives and volumes that would otherwise be excluded such as \\?\Volume* volumes.
-
+		
+		.PARAMETER Silent
+			A description of the Silent parameter.
+		
 		.PARAMETER WhatIf
 			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
-
+		
 		.PARAMETER Confirm
 			If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
-
-		.NOTES
-			Tags: Storage
-			Author: Chrissy LeMaire (clemaire@gmail.com) & Jakob Bindslet (jakob@bindslet.dk)
-
-			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-			Copyright (C) 2016 Chrissy LeMaire
-			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
-
-		.LINK
-			https://dbatools.io/Get-DbaDiskSpace
-
+		
 		.EXAMPLE
 			Get-DbaDiskSpace -ComputerName srv0042 | Format-Table -AutoSize
-
+			
 			Get disk space for the server srv0042.
-
+			
 			Server  Name Label  SizeInGB FreeInGB PercentFree BlockSize
 			------  ---- -----  -------- -------- ----------- ---------
 			srv0042 C:\  System   126,45   114,12       90,25      4096
 			srv0042 E:\  Data1     97,62    96,33       98,67      4096
 			srv0042 F:\  DATA2      29,2     29,2         100     16384
-
+		
 		.EXAMPLE
 			Get-DbaDiskSpace -ComputerName srv0042 -Unit MB | Format-Table -AutoSize
-
+			
 			Get disk space for the server srv0042 and displays in megabytes (MB).
-
+			
 			Server  Name Label  SizeInMB  FreeInMB PercentFree BlockSize
 			------  ---- -----  --------  -------- ----------- ---------
 			srv0042 C:\  System   129481 116856,11       90,25      4096
 			srv0042 E:\  Data1     99968  98637,56       98,67      4096
 			srv0042 F:\  DATA2     29901  29900,92         100     16384
-
+		
 		.EXAMPLE
 			Get-DbaDiskSpace -ComputerName srv0042, srv0007 -Unit TB | Format-Table -AutoSize
-
+			
 			Get disk space from two servers and displays in terabytes (TB).
-
+			
 			Server  Name Label  SizeInTB FreeInTB PercentFree BlockSize
 			------  ---- -----  -------- -------- ----------- ---------
 			srv0042 C:\  System     0,12     0,11       90,25      4096
 			srv0042 E:\  Data1       0,1     0,09       98,67      4096
 			srv0042 F:\  DATA2      0,03     0,03         100     16384
 			srv0007 C:\  System     0,07     0,01       11,92      4096
-
+		
 		.EXAMPLE
 			Get-DbaDiskSpace -ComputerName srv0042 -Detailed | Format-Table -AutoSize
-
+			
 			Get detailed disk space information.
-
+			
 			Server  Name                                              Label    SizeInGB FreeInGB PercentFree BlockSize IsSqlDisk FileSystem DriveType
 			------  ----                                              -----    -------- -------- ----------- --------- --------- ---------- ---------
 			srv0042 C:\                                               System     126,45   114,12       90,25      4096     False NTFS       Local Disk
@@ -104,202 +91,92 @@ function Get-DbaDiskSpace {
 			srv0042 F:\                                               DATA2        29,2     29,2         100     16384     False FAT32      Local Disk
 			srv0042 \\?\Volume{7a31be94-b842-42f5-af71-e0464a1a9803}\ Recovery     0,44     0,13       30,01      4096     False NTFS       Local Disk
 			srv0042 D:\                                                               0        0           0               False            Compact Disk
-
+		
+		.NOTES
+			Tags: Storage
+			Author: Chrissy LeMaire (clemaire@gmail.com) & Jakob Bindslet (jakob@bindslet.dk)
+			
+			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+			Copyright (C) 2016 Chrissy LeMaire
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+		
+		.LINK
+			https://dbatools.io/Get-DbaDiskSpace
 	#>
 	[CmdletBinding()]
 	Param (
-		[Parameter(Mandatory, ValueFromPipeline)]
-		[Alias('ServerInstance', 'SqlInstance', 'SqlServer')]
-		[String[]]$ComputerName,
-		[ValidateSet('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB')]
-		[String]$Unit = 'GB',
+		[Parameter(ValueFromPipeline = $true)][Alias('ServerInstance', 'SqlInstance', 'SqlServer')][DbaInstance[]]$ComputerName = $env:COMPUTERNAME,
+		[ValidateSet('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB')][String]$Unit = 'GB',
 		[Switch]$CheckForSql,
 		[PSCredential]$SqlCredential,
-		[Switch]$Detailed,
+		[PSCredential]$Credential,
+		[Alias('Detailed', 'AllDrives')][Switch]$Force,
 		[Switch]$CheckFragmentation,
-		[Switch]$AllDrives
+		[Switch]$Silent
 	)
 	
 	begin {
-		$FunctionName = (Get-PSCallstack)[0].Command
-		function Get-AllDiskSpace {
-			$alldisks = @()
-			$driveTypeName = @{
-				'0' = 'Unknown';
-				'1' = 'No Root Directory';
-				'2' = 'Removable Disk';
-				'3' = 'Local Disk';
-				'4' = 'Network Drive';
-				'5' = 'Compact Disk';
-				'6' = 'RAM Disk'
-			}
-			
-			if ($Detailed -or $AllDrives) {
-				$driveTypes = 0 .. 6
-			}
-			else {
-				$driveTypes = 2, 3
-			}
-			
-			if ($Unit -eq 'Bytes') {
-				$measure = '1'
-			}
-			else {
-				$measure = "1$unit"
-			}
-			
-			try {
-				$disks = Get-WmiObject -Class Win32_Volume -Namespace 'root\CIMV2' -ComputerName $ipaddr | Where-Object DriveType -in ($driveTypes)
-					if ($CheckFragmentation) {
-						$disks = $disks | Select-Object SystemName, Name, DriveType, FileSystem, FreeSpace, Capacity, Label, BlockSize, @{ Name = 'FilePercentFragmentation'; Expression = { "$($_.defraganalysis().defraganalysis.FilePercentFragmentation)" }
-					}
-				}
-				else {
-					$disks = $disks | Select-Object SystemName, Name, DriveType, FileSystem, FreeSpace, Capacity, Label, BlockSize
-				}
-			}
-			catch {
-				Write-Warning "$FunctionName - Cannot connect to WMI on $server."
-				return
-			}
-			
-			if ($CheckForSql -or $Detailed) {
-				$SqlInstances = @()
-				$FailedToGetServiceInformation = $false
-				$IsSqlEngineService = {
-					$_.DisplayName -like 'SQL Server (*' -or $_.Name -eq 'MSSQLSERVER' -or $_.DisplayName -like 'MSSQL$*'
-				}
-				try {
-					$sqlservices = Get-Service -ComputerName $ipaddr | Where-Object $IsSqlEngineService
-				}
-				catch {
-					Write-Verbose "$FunctionName - Cannot retrieve service information from $server using Get-Service. Trying WMI."
-					try {
-						$sqlservices = Get-WmiObject Win32_Service -ComputerName $ipaddr | Where-Object $IsSqlEngineService
-					}
-					catch {
-						Write-Warning "$FunctionName - Cannot retrieve service information from $server using Get-Service or WMI."
-						$FailedToGetServiceInformation = $true
-					}
-				}
-				
-				foreach ($service in $sqlservices) {
-					$instance = $service.DisplayName.Replace('SQL Server (', '')
-					$instance = $instance.TrimEnd(')')
-					$instance = $instance.Replace('MSSQL$', '')
-					
-					if ($instance -eq 'MSSQLSERVER') {
-						$SqlInstances += $server
-						Write-Verbose "$FunctionName - Instance resolved as $server."
-					}
-					else {
-						$SqlInstances += "$server\$instance"
-						Write-Verbose "$FunctionName - Instance resolved as $server\$instance."
-					}
-				}
-			}
-			
-			foreach ($disk in $disks) {
-				$diskname = $disk.Name
-				if ($CheckForSql -or $Detailed) {
-					$sqldisk = $false
-					if ($FailedToGetServiceInformation) {
-						$sqldisk = 'unknown'
-					}
-					else {
-						foreach ($SqlInstance in $SqlInstances) {
-							try {
-								Write-Verbose "$FunctionName - Checking disk $diskname on $SqlInstance."
-								$smoserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-								$sql = "Select count(*) as Count from sys.master_files where physical_name like '$diskname%'"
-								$sqlcount = $smoserver.Databases['master'].ExecuteWithResults($sql).Tables[0].Count
-								if ($sqlcount -gt 0) {
-									$sqldisk = $true
-									break
-								}
-							}
-							catch {
-								Write-Warning "$FunctionName - Can't connect to $server ($SqlInstance)."
-								continue
-							}
-						}
-					}
-				}
-				
-				if (!$diskname.StartsWith('\\') -or $Detailed) {
-					if ($disk.capacity -eq 0 -or [string]::IsNullOrEmpty($disk.capacity)) {
-						$total = 0
-						$free = 0
-						$percentfree = 0
-					}
-					else {
-						$total = [math]::round($disk.Capacity / $measure, 2)
-						$free = [math]::round($disk.Freespace / $measure, 2)
-						$percentfree = [math]::round(($disk.Freespace / $disk.Capacity) * 100, 2)
-					}
-					
-					$diskinfo = [PSCustomObject]@{
-						Server        = $server
-						Name          = $diskname
-						Label         = $disk.Label
-						"SizeIn$unit" = $total
-						"FreeIn$unit" = $free
-						PercentFree   = $percentfree
-						BlockSize     = $disk.BlockSize
-					}
-					
-					if ($CheckForSql -or $Detailed) {
-						Add-Member -Force -InputObject $diskinfo -MemberType Noteproperty IsSqlDisk -value $sqldisk
-					}
-					
-					if ($Detailed) {
-						Add-Member -Force -InputObject $diskinfo -MemberType Noteproperty FileSystem -value $disk.FileSystem
-						Add-Member -Force -InputObject $diskinfo -MemberType Noteproperty DriveType -value $driveTypeName["$($disk.DriveType)"]
-					}
-					
-					if ($CheckFragmentation) {
-						Add-Member -Force -InputObject $diskinfo -MemberType Noteproperty PercentFragmented -value $disk.FilePercentFragmentation
-					}
-					$alldisks += $diskinfo
-				}
-			}
-			return $alldisks
-		}
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter AllDrives
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Unit
 		
+		$condition = " WHERE DriveType = 2 OR DriveType = 3"
+		if ($Force) { $condition = "" }
 		
+		# Keep track of what computer was already processed to avoid duplicates
 		$processed = New-Object System.Collections.ArrayList
 	}
 	
 	process {
-		foreach ($server in $ComputerName) {
-			if ($server -match '\\') {
-				$server = $server.Split('\')[0]
-			}
-			
-			if ($server -notin $processed) {
-				$null = $processed.Add($server)
-				Write-Verbose "$FunctionName - Connecting to $server."
+		foreach ($computer in $ComputerName) {
+			if ($computer.ComputerName -notin $processed) {
+				$null = $processed.Add($computer.ComputerName)
+				Write-Message -Level VeryVerbose -Message "Connecting to $computer." -Target $computer.ComputerName
 			}
 			else {
 				continue
 			}
 			
-			Write-Verbose "$FunctionName - Resolving computername."
-			try {
-				$ipaddr = ((Test-Connection -ComputerName $server -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
-			}
-			catch {
-				Write-Warning "$FunctionName - Can't resolve $server address."
-				return
+			try { $disks = Get-DbaCmObject -ComputerName $computer.ComputerName -Query "SELECT * FROM Win32_Volume$condition" -Credential $Credential -Namespace root\CIMv2 -ErrorAction Stop -WarningAction SilentlyContinue -Silent }
+			catch { Stop-Function -Message "Failed to connect to $computer." -Silent $Silent -ErrorRecord $_ -Target $computer.ComputerName -Continue }
+			
+			if ($CheckForSql) {
+				try {
+					$server = Connect-SqlInstance -SqlInstance $computer -SqlCredential $SqlCredential
+					$sqlSuccess = $true
+				}
+				catch {
+					Write-Message -Level Warning -Message "Failed to connect to $computer, will not be reporting SQL Stats!" -ErrorRecord $_ -OverrideExceptionMessage -Target $computer.ComputerName
+					$sqlSuccess = $false
+				}
 			}
 			
-			$data = Get-AllDiskSpace $server
-			
-			if ($data.Count -gt 1) {
-				$data.GetEnumerator() | ForEach-Object { $_ }
-			}
-			else {
-				$data
+			foreach ($disk in $disks) {
+				if ($disk.Name.StartsWith('\\') -and (-not $Force)) {
+					Write-Message -Level Verbose -Message "Skipping disk: $($disk.Name)" -Target $computer.ComputerName
+					continue
+				}
+				
+				Write-Message -Level Verbose -Message "Processing disk: $($disk.Name)" -Target $computer.ComputerName
+				
+				$info = New-Object Sqlcollaborative.Dbatools.Computer.DiskSpace
+				$info.ComputerName = $computer.ComputerName
+				$info.Name = $disk.Name
+				$info.Label = $disk.Label
+				$info.Capacity = $disk.Capacity
+				$info.Free = $disk.Freespace
+				$info.BlockSize = $disk.BlockSize
+				$info.FileSystem = $disk.FileSystem
+				$info.Type = $disk.DriveType
+				
+				if ($CheckForSql -and $sqlSuccess) {
+					$countSqlDisks = -1
+					try { $countSqlDisks = $server.Query("Select count(*) as Count from sys.master_files where physical_name like '$($disk.Name)%'").Count }
+					catch { Write-Message -Level Warning -Message "Failed to query for master_files on $computer" -ErrorRecord $_ }
+					Add-Member -Force -InputObject $info -MemberType Noteproperty IsSqlDisk -value ($countSqlDisks -gt 0)
+				}
+				
+				$info
 			}
 		}
 	}

--- a/xml/dbatools.Format.ps1xml
+++ b/xml/dbatools.Format.ps1xml
@@ -1,6 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-16"?>
 <Configuration>
 	<ViewDefinitions>
+		<!-- Sqlcollaborative.Dbatools.Computer.DiskSpace -->
+		<View>
+			<Name>Sqlcollaborative.Dbatools.Computer.DiskSpace</Name>
+			<ViewSelectedBy>
+				<TypeName>Sqlcollaborative.Dbatools.Computer.DiskSpace</TypeName>
+			</ViewSelectedBy>
+			<TableControl>
+				<AutoSize/>
+				<TableHeaders>
+					<TableColumnHeader>
+						<Alignment>Right</Alignment>
+					</TableColumnHeader>
+					<TableColumnHeader/>
+					<TableColumnHeader/>
+					<TableColumnHeader/>
+					<TableColumnHeader/>
+					<TableColumnHeader/>
+					<TableColumnHeader/>
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>ComputerName</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Name</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Label</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Capacity</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>Free</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>PercentFree</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>BlockSize</PropertyName>
+							</TableColumnItem>
+						</TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
 		<!-- Sqlcollaborative.Dbatools.Configuration.Config -->
 		<View>
 			<Name>Sqlcollaborative.Dbatools.Configuration.Config</Name>


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes
Complete redesign of the command
 - Implement parameter class
 - Implement messaging
 - Code cleanup
 - Added strongly-typed output type
 - Added format xml
 - Deprecated legacy parameters

Breaking change:
 - Parameter `-Force` (formerly `-Detailed`) used to enable sql lookup. This has been intentionally removed, it is now solely responsible for including the less likely to be of interest volumes.