### PR TITLE
Library - DbaCmConnectionParameter accepts DbaInstanceParameter directly

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 7, 0, 27)
+$currentLibraryVersion = New-Object System.Version(0, 7, 0, 28)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Parameter/DbaCmConnectionParameter.cs
+++ b/bin/projects/dbatools/dbatools/Parameter/DbaCmConnectionParameter.cs
@@ -143,5 +143,15 @@ namespace Sqlcollaborative.Dbatools.Parameter
                     break;
             }
         }
+
+        /// <summary>
+        /// Creates a new DbaCmConnectionParameter based on an instance parameter
+        /// </summary>
+        /// <param name="Instance">The instance to interpret</param>
+        public DbaCmConnectionParameter(DbaInstanceParameter Instance)
+            : this(Instance.ComputerName)
+        {
+
+        }
     }
 }

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.27")]
-[assembly: AssemblyFileVersion("0.7.0.27")]
+[assembly: AssemblyVersion("0.7.0.28")]
+[assembly: AssemblyFileVersion("0.7.0.28")]


### PR DESCRIPTION

## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes
 - Adds direct conversion from DbaInstanceParameter to DbaCmConnectionParameter
This slightly improves performance when passing an instance parameter (since it shortstops PowerShell type coercion in an early step).
It also avoids some borderline issues, where `Get-DbaCmObject` might fail when receiving just a `[DbaInstance]` type.