### PR TITLE
Rename-DbaDatabase, new command

### DIFF
--- a/functions/Rename-DbaDatabase.ps1
+++ b/functions/Rename-DbaDatabase.ps1
@@ -1,0 +1,809 @@
+Function Rename-DbaDatabase {
+<#
+	.SYNOPSIS
+		Changes database name, logical file names, file group names and physical file names (optionally handling the move).
+	
+	.DESCRIPTION
+		Can change every database metadata that can be renamed. 
+		The ultimate goal is choosing to have a default template to enforce in your environment
+		so your naming convention for every bit can be put in place in no time.
+		The process is as follows (it follows the hierarchy of the entities):
+			- database name is changed (optionally, forcing users out)
+			- filegroup name(s) are changed accordingly
+			- logical name(s) are changed accordingly
+			- physical file(s) are changed accordingly
+				- if Move is specified, the database will be taken offline and the move will initiate, then it will be taken online
+				- if Move is not specified, the database remains online (unless SetOffline), and you are in charge of moving files
+		If any of the above fails, the process stops.
+		Please take a backup of your databases BEFORE using this, and remember to backup AFTER (also a FULL backup of master)
+		
+		It returns an object for each database with all the renames done, plus hidden properties showing a "human" representation of them.
+		
+		It's better you store the resulting object in a variable so you can inspect it in case of issues, e.g. "$result = Rename-DbaDatabase ....."
+		
+		To get a grasp without worrying of what would happen under the hood, use "Rename-DbaDatabase .... -Preview | Select-Object *"
+	
+	.PARAMETER SqlInstance
+		Target any number of instances, in order to return their build state.
+	
+	.PARAMETER SqlCredential
+		When connecting to an instance, use the credentials specified.
+	
+	.PARAMETER Database
+		Targets only specified databases
+	
+	.PARAMETER ExcludeDatabase
+		Excludes only specified databases
+	
+	.PARAMETER AllDatabases
+		If you want to apply the naming convention system wide, you need to pass this parameter
+	
+	.PARAMETER DatabaseName
+		Pass a template to rename the database name. Valid placeholders are:
+			- <DBN> current database name
+			- <DATE> date (yyyyMMdd)
+	
+	.PARAMETER FileGroupName
+		Pass a template to rename file group name. Valid placeholders are:
+			- <FGN> current filegroup name
+			- <DBN> current database name
+			- <DATE> date (yyyyMMdd)
+		If distinct names cannot be generated, a counter will be appended (0001, 0002, 0003, etc)
+	
+	.PARAMETER LogicalName
+		Pass a template to rename logical name. Valid placeholders are:
+			- <FT> file type (ROWS, LOG)
+			- <LGN> current logical name
+			- <FGN> current filegroup name
+			- <DBN> current database name
+			- <DATE> date (yyyyMMdd)
+		If distinct names cannot be generated, a counter will be appended (0001, 0002, 0003, etc)
+	
+	.PARAMETER FileName
+		Pass a template to rename file name. Valid placeholders are:
+			- <FNN> current file name (the basename, without directory nor extension)
+			- <FT> file type (ROWS, LOG, MMO, FS)
+			- <LGN> current logical name
+			- <FGN> current filegroup name
+			- <DBN> current database name
+			- <DATE> date (yyyyMMdd)
+		If distinct names cannot be generated, a counter will be appended (0001, 0002, 0003, etc)
+	
+	.PARAMETER ReplaceBefore
+		If you pass this switch, all upper level "current names" will be inspected and replaced BEFORE doing the
+		rename according to the template in the current level (remember the hierarchy):
+		Let's say you have a database named "dbatools_HR", composed by 3 files
+			- dbatools_HR_Data.mdf
+			- dbatools_HR_Index.ndf
+			- dbatools_HR_log.ldf
+		Rename-DbaDatabase .... -Database "dbatools_HR" -DatabaseName "dbatools_HRARCHIVE" -FileName '<DBN><FNN>'
+		would end up with this logic: 
+		- database --> no placeholders specified 
+			- dbatools_HR to dbatools_HRARCHIVE
+				- filenames placeholders specified
+					<DBN><FNN> --> current database name + current filename"
+						- dbatools_HR_Data.mdf to dbatools_HRARCHIVEdbatools_HR_Data.mdf
+						- dbatools_HR_Index.mdf to dbatools_HRARCHIVEdbatools_HR_Data.mdf
+						- dbatools_HR_log.ldf to dbatools_HRARCHIVEdbatools_HR_log.ldf
+		Passing this switch, instead, e.g.
+		Rename-DbaDatabase .... -Database "dbatools_HR" -DatabaseName "dbatools_HRARCHIVE" -FileName '<DBN><FNN>' -ReplaceBefore
+		end up with this logic instead: 
+		- database --> no placeholders specified 
+			- dbatools_HR to dbatools_HRARCHIVE
+				- filenames placeholders specified, 
+					<DBN><FNN>, plus -ReplaceBefore --> current database name + replace OLD "upper level" names inside the current filename
+					- dbatools_HR_Data.mdf to dbatools_HRARCHIVE_Data.mdf
+					- dbatools_HR_Index.mdf to dbatools_HRARCHIVE_Data.mdf
+					- dbatools_HR_log.ldf to dbatools_HRARCHIVE_log.ldf
+
+	.PARAMETER Force
+		Kills any open session to be able to do renames.
+
+	.PARAMETER SetOffline
+		Kills any open session and sets the database offline to be able to move files
+	
+	.PARAMETER Move
+		If you want this function to move files, else you're the one in charge of it. 
+		This enables the same functionality as SetOffline, killing open transactions and putting the database
+		offline, then do the actual rename and setting it online again afterwards
+	
+	.PARAMETER Preview
+		Shows the renames without performing any operation (recommended to find your way around this function parameters ;-) )
+	
+	.PARAMETER DatabaseCollection
+		Internal parameter to be able to accept piped data
+	
+	.PARAMETER Silent
+		Use this switch to disable any kind of verbose messages
+
+	.NOTES
+		Author: niphlod
+		
+		dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+		Copyright (C) 2016 Chrissy LeMaire
+		This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+		This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+		You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+	.LINK
+		https://dbatools.io/Rename-DbaDatabase
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName HR2 | select *
+
+	Shows the detailed resultset you'll get renaming the HR database to HR2 without doing anything
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName HR2
+
+	Renames the HR database to HR2
+
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>"
+
+	Renames the HR database to dbatools_HR
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>_<DATE>"
+
+	Renames the HR database to dbatools_HR_20170807 (if today is 07th Aug 2017)
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -FileGroupName "dbatools_<FGN>"
+
+	Renames every FileGroup within HR to "dbatools_[the original FileGroup name]"
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>" -FileGroupName "<DBN>_<FGN>"
+
+	Renames the HR database to "dbatools_HR", then renames every FileGroup within to "dbatools_HR_[the original FileGroup name]"
+	Note the "default recursive behaviour" here: for all intents and purposes the result of the former can be obtained with two distinct calls:
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -FileGroupName "dbatools_<DBN>_<FGN>"
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>"
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>" -FileName "<DBN>_<FGN>_<FNN>"
+	
+	Renames the HR database to "dbatools_HR" and then all filenames as "dbatools_HR_[Name of the FileGroup]_[original_filename]"
+	The db stays online (watch out!). You can then proceed manually to move/copy files by hand, set the db offline and then online again to finish the rename process
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>" -FileName "<DBN>_<FGN>_<FNN>" -SetOffline
+	
+	Renames the HR database to "dbatools_HR" and then all filenames as "dbatools_HR_[Name of the FileGroup]_[original_filename]"
+	The db is then set offline (watch out!). You can then proceed manually to move/copy files by hand and then set it online again to finish the rename process
+	
+	.EXAMPLE
+	Rename-DbaDatabase -SqlInstance sqlserver2014a -Database HR -DatabaseName "dbatools_<DBN>" -FileName "<DBN>_<FGN>_<FNN>" -Move
+	
+	Renames the HR database to "dbatools_HR" and then all filenames as "dbatools_HR_[Name of the FileGroup]_[original_filename]"
+	The db is then set offline (watch out!). The function tries to do a simple rename and then sets the db online again to finish the rename process
+	
+#>
+
+	[CmdletBinding()]
+	Param (
+		[parameter(Mandatory, ParameterSetName = "Server")]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[Alias("Credential")]
+		[PSCredential]
+		$SqlCredential,
+		[parameter(ParameterSetName = "Server")]
+		[Alias("Databases")]
+		[object[]]$Database,
+		[object[]]$ExcludeDatabase,
+		[switch]$AllDatabases,
+		[string]$DatabaseName,
+		[string]$FileGroupName,
+		[string]$LogicalName,
+		[string]$FileName,
+		[switch]$ReplaceBefore,
+		[switch]$Force,
+		[switch]$Move,
+		[switch]$SetOffline,
+		[switch]$Preview,
+		[parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Pipe")]
+		[Microsoft.SqlServer.Management.Smo.Database[]]$DatabaseCollection,
+		[switch]$Silent
+	)
+	
+	begin {
+		$CurrentDate = Get-Date -Format 'yyyyMMdd'
+		
+		function Get-DbaNameStructure($database) {
+			$obj = @()
+			# db name
+			$obj += "- Database : $database"
+			# FileGroups
+			foreach($fg in $database.FileGroups) {
+				$obj += "  - FileGroup: $($fg.Name)"
+				# LogicalNames
+				foreach($ln in $fg.Files) {
+					$obj += "    - Logical: $($ln.Name)"
+					$obj += "      - FileName: $($ln.FileName)"
+					
+				}
+			}
+			$obj += "  - Logfiles"
+			foreach($log in $database.LogFiles) {
+				$obj += "    - Logical: $($log.Name)"
+				$obj += "      - FileName: $($log.FileName)"
+			}
+			return $obj -Join "`n"
+		}
+	}
+	process {
+		if (Test-FunctionInterrupt) { return }
+		if (!$Database -and !$AllDatabases -and !$DatabaseCollection -and !$ExcludeDatabase) {
+			Stop-Function -Message "You must specify a -AllDatabases or -Database/ExcludeDatabase to continue"
+			return
+		}
+		if (!$DatabaseName -and !$FileGroupName -and !$LogicalName -and !$FileName) {
+			Stop-Function -Message "You must specify at least one of -DatabaseName,-FileGroupName,-LogicalName or -Filename to continue"
+			return
+		}
+		$dbs = @()
+		if ($DatabaseCollection) {
+			if ($DatabaseCollection.Name) {
+				# comes from Get-DbaDatabase
+				$dbs += $DatabaseCollection
+			}
+		}
+		else {
+			foreach ($instance in $SqlInstance) {
+				Write-Message -Level Verbose -Message "Connecting to $instance"
+				try {
+					$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+				}
+				catch {
+					Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+				}
+				$all_dbs = $server.Databases
+				$dbs += $all_dbs | Where-Object { @('master', 'model', 'msdb', 'tempdb', 'distribution') -notcontains $_.Name }
+				
+				if ($Database) {
+					$dbs = $dbs | Where-Object { $Database -contains $_.Name }
+				}
+				if ($ExcludeDatabase) {
+					$dbs = $dbs | Where-Object { $ExcludeDatabase -notcontains $_.Name }
+				}
+			}
+		}
+		
+		# holds all dbs per instance to avoid naming clashes
+		$InstanceDbs = @{}
+		
+		# holds all db file enumerations (used for -Move only)
+		$InstanceFiles = @{}
+		
+		foreach($db in $dbs) {
+			# used to stop futher operations on database
+			$failed = $false
+			
+			# pending renames initialized at db level
+			$Pending_Renames = @()
+			
+			$Entities_Before = @{}
+			
+			$server = $db.Parent
+			if ($db.Name -in @('master', 'model', 'msdb', 'tempdb', 'distribution')) {
+				Write-Message -Level Warning -Message "Database $($db.Name) is a system one, skipping..."
+				continue
+			}
+			if (!$db.IsAccessible) {
+				Write-Message -Level Warning -Message "Database $($db.Name) is not accessible, skipping..."
+				continue
+			}
+			if ($db.IsMirroringEnabled -eq $true -or $db.AvailabilityGroupName.Length -gt 0) {
+				Write-Message -Level Warning -Message "Database $($db.Name) is either mirrored or in an AG, skipping..."
+				continue
+			}
+			$Server_Id = $server.DomainInstanceName
+			if ( !$InstanceDbs.ContainsKey($Server_Id) ) {
+				$InstanceDbs[$Server_Id] = @{}
+				foreach ($dn in $server.Databases.Name) {
+					$InstanceDbs[$Server_Id][$dn] = 1
+				}
+			}
+
+			$Entities_Before['DBN'] = @{}
+			$Entities_Before['FGN'] = @{}
+			$Entities_Before['LGN'] = @{}
+			$Entities_Before['FNN'] = @{}
+			if ($ReplaceBefore) {
+				$Entities_Before['DBN'][$db.Name] = $db.Name
+			}
+			if (!$failed -and $DatabaseName) {
+				$Orig_DBName = $db.Name
+				# fixed replacements
+				$NewDBName = $DatabaseName.Replace('<DBN>', $Orig_DBName).Replace('<DATE>', $CurrentDate)
+				if ($Orig_DBName -eq $NewDBName) {
+					Write-Message -Level VeryVerbose -Message "Database name unchaged, skipping"
+				} else {
+					if ($InstanceDbs[$Server_Id].ContainsKey($NewDBName)) {
+						Write-Message -Level Warning -Message "Database $NewDBName exists already, skipping this rename"
+						$failed = $true
+					} else {
+						Write-Message -Level VeryVerbose -Message "Renaming Database $db to $NewDBName"
+						if ($Force) {
+							$server.KillAllProcesses($Orig_DBName)
+						}
+						try {
+							if (!$Preview) {
+								$db.Rename($NewDBName)
+							}
+							$InstanceDbs[$Server_Id].Remove($Orig_DBName)
+							$InstanceDbs[$Server_Id][$NewDBName] = 1
+							$Entities_Before['DBN'][$Orig_DBName] = $NewDBName
+							$db.Refresh()
+						} catch {
+							Stop-Function -Message "Failed to rename Database : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+							# stop any further renames
+							$failed = $true
+						}
+					}
+				}
+			}
+			$orig_filegroups = $db.FileGroups | Where-Object Name -ne 'PRIMARY'
+			if ($ReplaceBefore) {
+				#backfill PRIMARY
+				$Entities_Before['FGN']['PRIMARY'] = 'PRIMARY'
+				foreach($fg in $db.FileGroups.Name) {
+					$Entities_Before['FGN'][$fg] = $fg
+				}
+			}
+			
+			if (!$failed -and $FileGroupName) {
+				$Editable_FGs = $db.FileGroups | Where-Object Name -ne 'PRIMARY'
+				$New_FGNames = @{}
+				foreach($fg in $db.FileGroups.Name) {
+					$New_FGNames[$fg] = 1
+				}
+				$FGCounter = 0
+				foreach($fg in $Editable_FGs) {
+					$Orig_FGName = $fg.Name
+					$Orig_Placeholder = $Orig_FGName
+					if ($ReplaceBefore) {
+						# at Filegroup level, we need to worry about database name
+						$Orig_Placeholder = $Orig_Placeholder.Replace($Entities_Before['DBN'][$db.Name], '')
+					}
+					$NewFGName = $FileGroupName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', $Orig_Placeholder)
+					$FinalFGName = $NewFGName
+					while($fg.Name -ne $FinalFGName) {
+						if ($FinalFGName -in $New_FGNames.Keys) {
+							$FGCounter += 1
+							$FinalFGName = "$NewFGName$($FGCounter.ToString('000'))"
+						} else {
+							break
+						}
+					}
+					if ($fg.Name -eq $FinalFGName) {
+						Write-Message -Level VeryVerbose -Message "No rename necessary for FileGroup $($fg.Name) (on $db)"
+						continue
+					} else {
+						Write-Message -Level VeryVerbose -Message "Renaming FileGroup $($fg.Name) to $FinalFGName (on $db)"
+					}
+					try {
+						if (!$Preview) {
+							$fg.Rename($FinalFGName)
+						}
+						$New_FGNames.Remove($Orig_FGName)
+						$New_FGNames[$FinalFGName] = 1
+						$Entities_Before['FGN'][$Orig_FGName] = $FinalFGName
+					} catch {
+						Stop-Function -Message "Failed to rename FileGroup : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+						# stop any further renames
+						$failed = $true
+						break
+					}
+				}
+				$db.FileGroups.Refresh()
+			}
+			if ($ReplaceBefore) {
+				foreach($fn in $db.FileGroups.Files.Name) {
+					$Entities_Before['LGN'][$fn] = $fn
+				}
+				foreach($fn in $db.Logfiles.Name) {
+					$Entities_Before['LGN'][$fn] = $fn
+				}
+			}
+			if (!$failed -and $LogicalName) {
+				$New_LogicalNames = @{}
+				foreach($fn in $db.FileGroups.Files.Name) {
+					$New_LogicalNames[$fn] = 1
+				}
+				foreach($fn in $db.Logfiles.Name) {
+					$New_LogicalNames[$fn] = 1
+				}
+				$LNCounter = 0
+				foreach($fg in $db.FileGroups) {
+					$logicalfiles = @($fg.Files)
+					for ($i = 0; $i -lt $logicalfiles.Count; $i++) {
+						$logical = $logicalfiles[$i]
+						$FileType = switch ($fg.FileGroupType) {
+							'RowsFileGroup' { 'ROWS' }
+							'MemoryOptimizedDataFileGroup' { 'MMO' }
+							'FileStreamDataFileGroup' { 'FS' }
+							default { 'STD' }
+						}
+						$Orig_LGName = $logical.Name
+						$Orig_Placeholder = $Orig_LGName
+						if ($ReplaceBefore) {
+							# at Logical Name level, we need to worry about database name and filegroup name
+							$Orig_Placeholder = $Orig_Placeholder.Replace($Entities_Before['DBN'][$db.Name], '').Replace($Entities_Before['FGN'][$fg.Name], '')
+						}
+						$NewLGName = $LogicalName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', $fg.Name).Replace(
+							'<FT>', $FileType).Replace('<LGN>', $Orig_Placeholder)
+						$FinalLGName = $NewLGName
+						while($logical.Name -ne $FinalLGName) {
+							if ($FinalLGName -in $New_LogicalNames.Keys) {
+								$LNCounter += 1
+								$FinalLGName = "$NewLGName$($LNCounter.ToString('000'))"
+							} else {
+								break
+							}
+						}
+						if ($logical.Name -eq $FinalLGName) {
+							Write-Message -Level VeryVerbose -Message "No rename necessary for LogicalFile (on FileGroup $($fg.Name) (on $db))"
+							continue
+						}
+						Write-Message -Level VeryVerbose -Message "Renaming LogicalFile $($logical.Name) to $FinalLGName (on FileGroup $($fg.Name) (on $db))"
+						try {
+							if (!$Preview) {
+								$logical.Rename($FinalLGName)
+							}
+							$New_LogicalNames.Remove($Orig_LGName)
+							$New_LogicalNames[$FinalLGName] = 1
+							$Entities_Before['LGN'][$FinalLGName] = $Orig_LGName
+						} catch {
+							Stop-Function -Message "Failed to Rename Logical File : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+							# stop any further renames
+							$failed = $true
+							break
+						}
+					}
+				}
+				$fg.Files.Refresh()
+				if(!$failed) {
+					$logfiles = @($db.Logfiles)
+					for ($i = 0; $i -lt $logfiles.Count; $i++) {
+						$logicallog = $logfiles[$i]
+						$Orig_LGName = $logicallog.Name
+						$Orig_Placeholder = $Orig_LGName
+						if ($ReplaceBefore) {
+							# at Logical Name level, we need to worry about database name and filegroup name, but for logfiles filegroup is not there
+							$Orig_Placeholder = $Orig_Placeholder.Replace($Entities_Before['DBN'][$db.Name], '').Replace($Entities_Before['FGN'][$fg.Name], '')
+						}
+						$NewLGName = $LogicalName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', '').Replace(
+							'<FT>', 'LOG').Replace('<LGN>', $Orig_Placeholder)
+						$FinalLGName = $NewLGName
+						while($logicallog.Name -ne $FinalLGName) {
+							if ($FinalLGName -in $New_LogicalNames.Keys) {
+								$LNCounter += 1
+								$FinalLGName = "$NewLGName$($LNCounter.ToString('000'))"
+							} else {
+								break
+							}
+						}
+						if ($logicallog.Name -eq $FinalLGName) {
+							Write-Message -Level VeryVerbose -Message "No Rename necessary for LogicalFile log $($logicallog.Name) (LOG on (on $db))"
+							continue
+						} else {
+							Write-Message -Level VeryVerbose -Message "Renaming LogicalFile log $($logicallog.Name) to $FinalLGName (LOG on (on $db))"
+						}
+						try {
+							if (!$Preview) {
+								$logicallog.Rename($FinalLGName)
+							}
+							$New_LogicalNames.Remove($Orig_LGName)
+							$New_LogicalNames[$FinalLGName] = 1
+							$Entities_Before['LGN'][$FinalLGName] = $Orig_LGName
+						} catch {
+							Stop-Function -Message "Failed to Rename Logical File : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+							# stop any further renames
+							$failed = $true
+							break
+						}
+					}
+					$db.Logfiles.Refresh()
+				}
+			}
+			if ($ReplaceBefore) {
+				foreach($fn in $db.FileGroups.Files.FileName) {
+					$Entities_Before['FNN'][$fn] = $fn
+				}
+				foreach($fn in $db.Logfiles.FileName) {
+					$Entities_Before['FNN'][$fn] = $fn
+				}
+			}
+			if (!$failed -and $FileName) {
+				
+				$New_FileNames = @{}
+				foreach($fn in $db.FileGroups.Files.FileName) {
+					$New_FileNames[$fn] = 1
+				}
+				foreach($fn in $db.Logfiles.FileName) {
+					$New_FileNames[$fn] = 1
+				}
+				# we need to inspect what files are in the same directory
+				# to avoid failing the process because the move won't work
+				# here we have a dict keyed by instance and then keyed by path
+				if ( !$InstanceFiles.ContainsKey($Server_Id) ) {
+					$InstanceFiles[$Server_Id] = @{}
+				}
+				foreach($fn in $New_FileNames.Keys) {
+					$dirname = [IO.Path]::GetDirectoryName($fn)
+					if ( !$InstanceFiles[$Server_Id].ContainsKey($dirname) ) {
+						$InstanceFiles[$Server_Id][$dirname] = @{}
+						try {
+							$dirfiles = Get-DbaFile -SqlInstance $server -Path $dirname -Silent
+						} catch {
+							Write-Message -Level Warning -Message "Failed to enumerate existing files at $dirname, move could go wrong"
+						}
+						foreach($f in $dirfiles) {
+							$InstanceFiles[$Server_Id][$dirname][$f.Filename] = 1
+						}
+					}
+				}
+				$FNCounter = 0
+				foreach($fg in $db.FileGroups) {
+					$FG_Files = @($fg.Files)
+					foreach($logical in $FG_Files) {
+						$FileType = switch ($fg.FileGroupType) {
+							'RowsFileGroup' { 'ROWS' }
+							'MemoryOptimizedDataFileGroup' { 'MMO' }
+							'FileStreamDataFileGroup' { 'FS' }
+							default { 'STD' }
+						}
+						if ($FileType -in @('FS', 'MMO')) {
+							## FIXME (do we wanna handle FS and MMO "moving" ? If so, renaming the dir is enough ?? )
+							Write-Message -Level VeryVerbose -Message "FileStream/MMO moving is not supported ATM, skipping"
+							continue
+						}
+						$FNName = $logical.FileName
+						$FNNameDir = [IO.Path]::GetDirectoryName($FNName)
+						$Orig_FNNameLeaf = [IO.Path]::GetFileNameWithoutExtension($logical.FileName)
+						$Orig_Placeholder = $Orig_FNNameLeaf
+						if ($ReplaceBefore) {
+							# at Filename level, we need to worry about database name, filegroup name and logical file name
+							$Orig_Placeholder = $Orig_Placeholder.Replace($Entities_Before['DBN'][$db.Name], '').Replace(
+								$Entities_Before['FGN'][$fg.Name], '').Replace($Entities_Before['LGN'][$logical.Name], '')
+						}
+						$NewFNName = $FileName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', $fg.Name).Replace(
+							'<FT>', $FileType).Replace('<LGN>', $logical.Name).Replace('<FNN>', $Orig_Placeholder)
+						$FinalFNName = [IO.Path]::Combine($FNNameDir, "$NewFNName$([IO.Path]::GetExtension($FNName))")
+						
+						while($logical.FileName -ne $FinalFNName) {
+							if ($InstanceFiles[$Server_Id][$FNNameDir].ContainsKey($FinalFNName)) {
+								$FNCounter += 1
+								$FinalFNName = [IO.Path]::Combine($FNNameDir, "$NewFNName$($FNCounter.ToString('000'))$([IO.Path]::GetExtension($FNName))"
+								)
+							} else {
+								break
+							}
+						}
+						if ($logical.FileName -eq $FinalFNName) {
+							Write-Message -Level VeryVerbose -Message "No rename necessary (on FileGroup $($fg.Name) (on $db))"
+							continue
+						} else {
+							Write-Message -Level VeryVerbose -Message "Renaming FileName $($logical.FileName) to $FinalFNName (on FileGroup $($fg.Name) (on $db))"
+						}
+						
+						try {
+							if (!$Preview) {
+								$logical.FileName = $FinalFNName
+								$db.Alter()
+							}
+							$InstanceFiles[$Server_Id][$FNNameDir].Remove($FNName)
+							$InstanceFiles[$Server_Id][$FNNameDir][$FinalFNName] = 1
+							$Entities_Before['FNN'][$FinalFNName] = $FNName
+							$Pending_Renames += [pscustomobject]@{
+								Source      = $FNName
+								Destination = $FinalFNName
+							}
+						} catch {
+							Stop-Function -Message "Failed to Rename FileName : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+							# stop any further renames
+							$failed = $true
+							break
+						}
+					}
+					if(!$failed) {
+						$FG_Files = @($db.Logfiles)
+						foreach($logical in $FG_Files) {
+							$FNName = $logical.FileName
+							$FNNameDir = [IO.Path]::GetDirectoryName($FNName)
+							$Orig_FNNameLeaf = [IO.Path]::GetFileNameWithoutExtension($logical.FileName)
+							$Orig_Placeholder = $Orig_FNNameLeaf
+							if ($ReplaceBefore) {
+								# at Filename level, we need to worry about database name, filegroup name and logical file name
+								$Orig_Placeholder = $Orig_Placeholder.Replace($Entities_Before['DBN'][$db.Name], '').Replace(
+									$Entities_Before['FGN'][$fg.Name], '').Replace($Entities_Before['LGN'][$logical.Name], '')
+							}
+							$NewFNName = $FileName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', '').Replace(
+								'<FT>', 'LOG').Replace('<LGN>', $logical.Name).Replace('<FNN>', $Orig_Placeholder)
+							$FinalFNName = [IO.Path]::Combine($FNNameDir, "$NewFNName$([IO.Path]::GetExtension($FNName))")
+							while ($logical.FileName -ne $FinalFNName) {
+								if ($InstanceFiles[$Server_Id][$FNNameDir].ContainsKey($FinalFNName)) {
+									$FNCounter += 1
+									$FinalFNName = [IO.Path]::Combine($FNNameDir, "$NewFNName$($FNCounter.ToString('000'))$([IO.Path]::GetExtension($FNName))")
+								} else {
+									break
+								}
+							}
+							if ($logical.FileName -eq $FinalFNName) {
+								Write-Message -Level VeryVerbose -Message "No rename necessary for $($logical.FileName) (LOG on (on $db))"
+								continue
+							} else {
+								Write-Message -Level VeryVerbose -Message "Renaming FileName $($logical.FileName) to $FinalFNName (LOG on (on $db))"
+							}
+							
+							try {
+								if (!$Preview) {
+									$logical.FileName = $FinalFNName
+									$db.Alter()
+								}
+								$InstanceFiles[$Server_Id][$FNNameDir].Remove($FNName)
+								$InstanceFiles[$Server_Id][$FNNameDir][$FinalFNName] = 1
+								$Entities_Before['FNN'][$FinalFNName] = $FNName
+								$Pending_Renames += [pscustomobject]@{
+									Source      = $FNName
+									Destination = $FinalFNName
+								}
+							} catch {
+								Stop-Function -Message "Failed to Rename FileName : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+								# stop any further renames
+								$failed = $true
+								break
+							}
+						}
+					}
+					
+				}
+				$ComputerName = $null
+				$Final_Renames = New-Object System.Collections.ArrayList
+				if ([DbaValidate]::IsLocalhost($server.NetName)) {
+					# locally ran so we can just use rename-item
+					$ComputerName = $server.NetName
+				} else {
+					# let's start checking if we can access .NetName
+					$testPS = $false
+					if ($SqlCredential) {
+						# why does Test-PSRemoting require a Credential param ? this is ugly...
+						$testPS = Test-PSRemoting -ComputerName $server.NetName -Credential $SqlCredential -ErrorAction Stop
+					} else {
+						$testPS = Test-PSRemoting -ComputerName $server.NetName -ErrorAction Stop
+					}
+					if (!($testPS)) {
+						# let's try to resolve it to a more qualified name, without "cutting" knowledge about the domain (only $server.Name possibly holds the complete info)
+						$Resolved = (Resolve-DbaNetworkName -ComputerName $server.Name).FullComputerName
+						if ($SqlCredential) {
+							$testPS = Test-PSRemoting -ComputerName $Resolved -Credential $SqlCredential -ErrorAction Stop
+						} else {
+							$testPS = Test-PSRemoting -ComputerName $Resolved -ErrorAction Stop
+						}
+						if ($testPS) {
+							$ComputerName = $Resolved
+						}
+					} else {
+						$ComputerName = $server.NetName
+					}
+				}
+				foreach($op in $pending_renames) {
+					if ([DbaValidate]::IsLocalhost($server.NetName)) {
+						$null = $Final_Renames.Add([pscustomobject]@{
+									Source       = $op.Source
+									Destination  = $op.Destination
+									ComputerName = $ComputerName
+								})
+					} else {
+						if ($null -eq $ComputerName) {
+							# if we don't have remote access ($ComputerName is null) we can fallback to admin shares if they're available
+							if (Test-Path (Join-AdminUnc -ServerName $server.NetName -filepath $op.Source)) {
+								$null = $Final_Renames.Add([pscustomobject]@{
+											Source       = Join-AdminUnc -ServerName $server.NetName -filepath $op.Source
+											Destination  = Join-AdminUnc -ServerName $server.NetName -filepath $op.Destination
+											ComputerName = $server.NetName
+										})
+							} else {
+								# flag the impossible rename ($ComputerName is $null)
+								$null = $Final_Renames.Add([pscustomobject]@{
+											Source       = $op.Source
+											Destination  = $op.Destination
+											ComputerName = $ComputerName
+										})
+							}
+						} else {
+							# we can do renames in a remote pssession
+							$null = $Final_Renames.Add([pscustomobject]@{
+										Source       = $op.Source
+										Destination  = $op.Destination
+										ComputerName = $ComputerName
+									})
+						}
+					}
+				}
+				$Status = 'FULL'
+				if (!$failed -and ($SetOffline -or $Move) -and $Final_Renames) {
+					if (!$Move) {
+						Write-Message -Level VeryVerbose -Message "Setting the database offline. You are in charge of moving the files to the new location"
+						$Status = 'PARTIAL'
+					} else {
+						Write-Message -Level VeryVerbose -Message "File Rename required, setting db offline"
+						$SetState = Set-DbaDatabaseState -SqlInstance $server -Database $db.Name -Offline -Force
+						if($SetState.Status -ne 'OFFLINE') {
+							Write-Message -Level Warning -Message "Setting db offline failed, You are in charge of moving the files to the new location"
+							$Status = 'PARTIAL'
+						} else {
+							try {
+								while($Final_Renames.Count -gt 0) {
+									$op = $Final_Renames.Item(0)
+									if ($null -eq $op.ComputerName) {
+										Stop-Function -Message "No access to physical files for renames"
+									} else {
+										Write-Message -Level VeryVerbose -Message "Moving file $($op.Source) to $($op.Destination)"
+										if (!$Preview) {
+											$scriptblock = {
+												$op = $args[0]
+												Rename-Item -Path $op.Source -NewName $op.Destination
+											}
+											Invoke-Command2 -ComputerName $op.ComputerName -Credential $Credential -ScriptBlock $scriptblock -ArgumentList $op
+										}
+									}
+									$null = $Final_Renames.RemoveAt(0)
+								}
+							} catch {
+								$failed = $true
+								$Status = 'PARTIAL'
+								Stop-Function -Message "Failed to rename $($op.Source) to $($op.Destination), you are in charge of moving the files to the new location" -ErrorRecord $_ -Target $instance -Exception $_.Exception -Continue
+							}
+							if (!$failed) {
+								$SetState = Set-DbaDatabaseState -SqlInstance $server -Database $db.Name -Online -Force
+								if($SetState.Status -ne 'ONLINE') {
+									Write-Message -Level Warning -Message "Setting db online failed"
+									$Status = 'PARTIAL'
+								} else {
+									Write-Message -Level VeryVerbose -Message "Everything OK"
+									$Status = 'FULL'
+								}
+							}
+						}
+					}
+				} else {
+					$Status = 'PARTIAL'
+				}
+			} else {
+				if (!$failed) {
+					$Status = 'FULL'
+				} else {
+					$Status = 'PARTIAL'
+				}
+			}
+			# remove entities that match for the output
+			foreach($k in $Entities_Before.Keys) {
+				$ToRemove = $Entities_Before[$k].GetEnumerator() | Where-Object { $_.Name -eq $_.Value } | Select-Object -ExpandProperty Name
+				foreach($el in $ToRemove) {
+					$Entities_Before[$k].Remove($el)
+				}
+			}
+			[pscustomobject]@{
+					ComputerName = $server.NetName
+					InstanceName = $server.ServiceName
+					SqlInstance = $server.DomainInstanceName
+					Database = $db
+					DBN = $Entities_Before['DBN']
+					DatabaseRenames = ($Entities_Before['DBN'].GetEnumerator() | Foreach-Object { "$($_.Name) --> $($_.Value)" }) -Join "`n"
+					FGN = $Entities_Before['FGN']
+					FileGroupsRenames = ($Entities_Before['FGN'].GetEnumerator() | Foreach-Object { "$($_.Name) --> $($_.Value)" }) -Join "`n"
+					LGN = $Entities_Before['LGN']
+					LogicalNameRenames = ($Entities_Before['LGN'].GetEnumerator() | Foreach-Object { "$($_.Name) --> $($_.Value)"  }) -Join "`n"
+					FNN = $Entities_Before['FNN']
+					FileNameRenames = ($Entities_Before['FNN'].GetEnumerator() | Foreach-Object { "$($_.Name) --> $($_.Value)"  }) -Join "`n"
+					PendingRenames = $Final_Renames
+					Status = $Status
+				} | Select-DefaultView -ExcludeProperty DatabaseRenames, FileGroupsRenames, LogicalNameRenames, FileNameRenames
+		}
+		
+	}
+}

--- a/internal/Test-PSRemoting.ps1
+++ b/internal/Test-PSRemoting.ps1
@@ -5,34 +5,34 @@ Function Test-PSRemoting {
 Jeff Hicks
 https://www.petri.com/test-network-connectivity-powershell-test-connection-cmdlet
 #>
-  [cmdletbinding()]
- 
-  Param(
-    [Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
-    [ValidateNotNullorEmpty()]
-    [string]$Computername,
-    $Credential = [System.Management.Automation.PSCredential]::Empty
-  )
- 
-  Begin {
-    Write-Message -Level Verbose -Message "Starting $($MyInvocation.Mycommand)"
-  } #begin
- 
-  Process {
-    Write-Message -Level Verbose -Message "Testing $computername"
-    Try {
-      $r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
-      $True 
-    }
-    Catch {
-      Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_ -Continue
-      return $false
-    }
-    
-  } #Process
- 
-  End {
-    Write-Message -Level Verbose -Message "Ending $($MyInvocation.Mycommand)"
-  } #end
- 
+	[cmdletbinding()]
+	param(
+	[Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
+	[ValidateNotNullorEmpty()]
+	[string]$Computername,
+	$Credential = [System.Management.Automation.PSCredential]::Empty,
+	[switch]$Silent
+	)
+
+	begin {
+	Write-Message -Level Verbose -Message "Starting $($MyInvocation.Mycommand)"
+	} #begin
+
+	process {
+		Write-Message -Level Verbose -Message "Testing $computername"
+		try {
+			$r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
+			$True 
+		}
+		catch {
+			Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_
+			return $false
+		}
+
+	} #Process
+
+	end {
+		Write-Message -Level Verbose -Message "Ending $($MyInvocation.Mycommand)"
+	} #end
+
 } #close function


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality, see #289)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Pester test is included
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
#289 holds pretty much everything. Not sure if this needs to handle also "moves" other than renames, such as "move this datafile to another disk".

This is just a first draft, but it's a working one nonetheless.
Cringe points:
- the templating system (I'm not good at naming things)
- general code style and loops, I feel there's a better way but can't find it
- it tries to proceed a database at a time and stop if anything goes wrong as soon as possible. Unfortunately reverting to the previous state can surely be done but could incur in the same errors, so for the moment...let's hope to not break everything
- the "default recursive behaviour" (see latest examples)
- what to return to the user, as it's a process made of several steps and ATM I can't figure a proper "layout" for the resulting object

For testers: do a backup of everything (or even better, a system image). This can (and probably will) nuclearize everything (again, "new born code alert").

I'm open to reviews and/or comments (don't go too technical on me, let's do that on round 2 or 3) ^_^
