### PR TITLE
Test-PSRemoting, did I smell a rogue -Continue ?

### DIFF
--- a/internal/Test-PSRemoting.ps1
+++ b/internal/Test-PSRemoting.ps1
@@ -5,34 +5,34 @@ Function Test-PSRemoting {
 Jeff Hicks
 https://www.petri.com/test-network-connectivity-powershell-test-connection-cmdlet
 #>
-  [cmdletbinding()]
- 
-  Param(
-    [Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
-    [ValidateNotNullorEmpty()]
-    [string]$Computername,
-    $Credential = [System.Management.Automation.PSCredential]::Empty
-  )
- 
-  Begin {
-    Write-Message -Level Verbose -Message "Starting $($MyInvocation.Mycommand)"
-  } #begin
- 
-  Process {
-    Write-Message -Level Verbose -Message "Testing $computername"
-    Try {
-      $r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
-      $True 
-    }
-    Catch {
-      Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_ -Continue
-      return $false
-    }
-    
-  } #Process
- 
-  End {
-    Write-Message -Level Verbose -Message "Ending $($MyInvocation.Mycommand)"
-  } #end
- 
+	[cmdletbinding()]
+	param(
+	[Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
+	[ValidateNotNullorEmpty()]
+	[string]$Computername,
+	$Credential = [System.Management.Automation.PSCredential]::Empty,
+	[switch]$Silent
+	)
+
+	begin {
+		Write-Message -Level VeryVerbose -Message "Starting $($MyInvocation.Mycommand)"
+	} #begin
+
+	process {
+		Write-Message -Level VeryVerbose -Message "Testing $computername"
+		try {
+			$r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
+			$True 
+		}
+		catch {
+			Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_
+			return $false
+		}
+
+	} #Process
+
+	end {
+		Write-Message -Level VeryVerbose -Message "Ending $($MyInvocation.Mycommand)"
+	} #end
+
 } #close function

--- a/internal/Test-PSRemoting.ps1
+++ b/internal/Test-PSRemoting.ps1
@@ -7,32 +7,23 @@ https://www.petri.com/test-network-connectivity-powershell-test-connection-cmdle
 #>
 	[cmdletbinding()]
 	param(
-	[Parameter(Position=0,Mandatory,HelpMessage = "Enter a computername",ValueFromPipeline)]
-	[ValidateNotNullorEmpty()]
-	[string]$Computername,
+	[Parameter(Position=0,Mandatory,ValueFromPipeline)]
+	[DbaInstance]$ComputerName,
 	$Credential = [System.Management.Automation.PSCredential]::Empty,
 	[switch]$Silent
 	)
 
-	begin {
-		Write-Message -Level VeryVerbose -Message "Starting $($MyInvocation.Mycommand)"
-	} #begin
-
 	process {
-		Write-Message -Level VeryVerbose -Message "Testing $computername"
+		Write-Message -Level VeryVerbose -Message "Testing $($ComputerName.Computername)"
 		try {
-			$r = Test-WSMan -ComputerName $Computername -Credential $Credential -Authentication Default -ErrorAction Stop
-			$True 
+			$r = Test-WSMan -ComputerName $ComputerName.ComputerName -Credential $Credential -Authentication Default -ErrorAction Stop
+			$true
 		}
 		catch {
-			Stop-Function -Message "Remote testing failed for computer $ComputerName" -Target $ComputerName -ErrorRecord $_
-			return $false
+			Write-Message -Level Verbose -Message "Testing $($ComputerName.Computername)" -Target $ComputerName -ErrorRecord $_
+			$false
 		}
 
 	} #Process
-
-	end {
-		Write-Message -Level VeryVerbose -Message "Ending $($MyInvocation.Mycommand)"
-	} #end
 
 } #close function

--- a/tests/Test-PSRemoting.Tests.ps1
+++ b/tests/Test-PSRemoting.Tests.ps1
@@ -1,0 +1,41 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag "UnitTests" {
+	Context "Validate parameters" {
+		$paramCount = 3
+		<# 
+			Get commands, Default count = 11
+			Commands with SupportShouldProcess = 13
+		#>
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Test-PSRemoting).Parameters.Keys
+		$knownParameters = 'ComputerName', 'Credential', 'Silent'
+		It "Contains our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Contains $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	Context "returns a boolean with no exceptions" {
+		$result = Test-PSRemoting -ComputerName "funny"
+		It "returns $false when failing" {
+			$result | Should Be $false
+		}
+		$result = Test-PSRemoting -ComputerName localhost
+		It "returns $true when succeeding" {
+			$result | Should Be $true
+		}
+	}
+	Context "handles an instance, using just the computername" {
+		$result = Test-PSRemoting -ComputerName $script:instance1
+		It "returns $true when succeeding" {
+			$result | Should Be $true
+		}
+	}
+}


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 - [x] Refinement
 
### Purpose
The title says it all. 
Refine Test-PSRemoting (and learn, in the process). Did I get this right @FriedrichWeinmann ? 

