### PR TITLE
Get-DbaDiskSpace update - Improved IsSqlDisk integration

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 7, 0, 28)
+$currentLibraryVersion = New-Object System.Version(0, 7, 0, 29)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Computer/DiskSpace.cs
+++ b/bin/projects/dbatools/dbatools/Computer/DiskSpace.cs
@@ -63,6 +63,11 @@ namespace Sqlcollaborative.Dbatools.Computer
         /// </summary>
         public DriveType Type { get; set; }
 
+        /// <summary>
+        /// Whether the drive is a sql disk. Nullable, because it is an optional property and may not always be included, thus a third state is necessary.
+        /// </summary>
+        public Nullable<bool> IsSqlDisk { get; set; }
+
         #region Legacy Properties
         /// <summary>
         /// The computer that was scanned. Legacy-Name

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.28")]
-[assembly: AssemblyFileVersion("0.7.0.28")]
+[assembly: AssemblyVersion("0.7.0.29")]
+[assembly: AssemblyFileVersion("0.7.0.29")]

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -173,7 +173,7 @@ function Get-DbaDiskSpace {
 					$countSqlDisks = -1
 					try { $countSqlDisks = $server.Query("Select count(*) as Count from sys.master_files where physical_name like '$($disk.Name)%'").Count }
 					catch { Write-Message -Level Warning -Message "Failed to query for master_files on $computer" -ErrorRecord $_ }
-					Add-Member -Force -InputObject $info -MemberType Noteproperty IsSqlDisk -value ($countSqlDisks -gt 0)
+					$info.IsSqlDisk = ($countSqlDisks -gt 0)
 				}
 				
 				$info

--- a/xml/dbatools.Format.ps1xml
+++ b/xml/dbatools.Format.ps1xml
@@ -19,6 +19,7 @@
 					<TableColumnHeader/>
 					<TableColumnHeader/>
 					<TableColumnHeader/>
+					<TableColumnHeader/>
 				</TableHeaders>
 				<TableRowEntries>
 					<TableRowEntry>
@@ -43,6 +44,9 @@
 							</TableColumnItem>
 							<TableColumnItem>
 								<PropertyName>BlockSize</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<PropertyName>IsSqlDisk</PropertyName>
 							</TableColumnItem>
 						</TableColumnItems>
 					</TableRowEntry>


### PR DESCRIPTION
## Type of Change

 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Added `IsSqlDisk` as object property, rather than adding it to the finished object
 - Added `IsSqlDisk` to default display as column

### Screenshot

![image](https://user-images.githubusercontent.com/23364253/31499402-f903a0e2-af64-11e7-8112-968129de757b.png)
