### PR TITLE
Touchup Test-DbaServerName

### DIFF
--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -35,6 +35,7 @@ function Test-DbaServerName {
 
 		.NOTES
 			Tags: SPN, ServerName
+
 			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 			Copyright (C) 2016 Chrissy LeMaire
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -27,7 +27,7 @@ function Test-DbaServerName {
 		.PARAMETER Detailed
 			If this switch is enabled, additional details are returned including whether the server name is updatable. If the server name is not updatable, the reason why will be returned.
 
-		.PARAMETER SkipSsrs
+		.PARAMETER ExcludeSsrs
 			If this switch is enabled, checking for SQL Server Reporting Services will be skipped.
 
 		.PARAMETER Silent
@@ -54,6 +54,11 @@ function Test-DbaServerName {
 			Returns ServerInstanceName, SqlServerName, IsEqual and RenameRequired for sqlserver2014a and sql2016.
 
 		.EXAMPLE
+			Test-DbaServerName -SqlInstance sqlserver2014a, sql2016 -ExcludeSsrs
+
+			Returns ServerInstanceName, SqlServerName, IsEqual and RenameRequired for sqlserver2014a and sql2016, but skips validating if SSRS is installed on both instances.
+
+		.EXAMPLE
 			Test-DbaServerName -SqlInstance sqlserver2014a, sql2016 -Detailed
 
 			Returns ServerInstanceName, SqlServerName, IsEqual and RenameRequired for sqlserver2014a and sql2016.
@@ -69,7 +74,7 @@ function Test-DbaServerName {
 		[PSCredential]$SqlCredential,
 		[switch]$Detailed,
 		[Alias("NoWarning")]
-		[switch]$SkipSsrs,
+		[switch]$ExcludeSsrs,
 		[switch]$Silent
 	)
 

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -121,10 +121,10 @@ function Test-DbaServerName {
 			$rs = $null
 			if ($SkipSsrs -eq $false -or $NoWarning -eq $false) {
 				try {
-					$rs = Get-DbaSqlService -ComputerName Whatever -Instance $server.ServiceName -Type SSRS -Silent -WarningAction Stop
+					$rs = Get-DbaSqlService -ComputerName $instance.ComputerName -Instance $server.ServiceName -Type SSRS -Silent -WarningAction Stop
 				}
 				catch {
-					Write-Message -Level Warning -Message  "Unable to pull information on $ssrsService. This means the script will not be able to automatically restart SQL Services." -ErrorRecord $_ -Target $instance
+					Write-Message -Level Warning -Message  "Unable to pull information on $ssrsService." -ErrorRecord $_ -Target $instance
 				}
 			}
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Making 1.0 standard but also cleaned up a few things in the logic so this needs more formal review.

Not sure I used the Silent parameter correctly when calling `Get-DbaSqlService`, Fred or Simone may need to check that part for me.

### Screenshots

Previous output for default view (not using Detailed)

![image](https://user-images.githubusercontent.com/11204251/31597894-833fcf26-b210-11e7-8f78-9e48ec4481ae.png)

new version replaces the reference to the instance name and changes them to our standard initial properties for the objects

![image](https://user-images.githubusercontent.com/11204251/31597923-9d24af24-b210-11e7-9544-4c1172aebe49.png)

The `NoWarning` parameter didn't sit well so changes this to just `SkipSsrs`, probably could be named something better. Logic either way should not even bother checking for SSRS if they don't care about the warning, so adjusted that logic to not even bother validating SSRS exist. If this is wrong I can put it back.

![image](https://user-images.githubusercontent.com/11204251/31597965-cba294ba-b210-11e7-86e7-ddf2d9797578.png)
![image](https://user-images.githubusercontent.com/11204251/31597978-d80fd0fa-b210-11e7-8325-bb91ff5928a1.png)

Then doing select * has the additional two properties showing

![image](https://user-images.githubusercontent.com/11204251/31598002-f1046e40-b210-11e7-841d-bfa20789ccc5.png)
