### PR TITLE
Touchup of Test-DbaIdentityUsage

### DIFF
--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -1,76 +1,79 @@
 function Test-DbaIdentityUsage {
 	<#
-	.SYNOPSIS
-		Displays information relating to IDENTITY seed usage.  Works on SQL Server 2008 and above.
+		.SYNOPSIS
+			Displays information relating to IDENTITY seed usage.  Works on SQL Server 2008 and above.
 
-	.DESCRIPTION
-		IDENTITY seeds have max values based off of their data type.  This module will locate identity columns and report the seed usage.
+		.DESCRIPTION
+			IDENTITY seeds have max values based off of their data type.  This module will locate identity columns and report the seed usage.
 
-	.PARAMETER SqlInstance
-		Allows you to specify a comma separated list of servers to query.
+		.PARAMETER SqlInstance
+			Allows you to specify a comma separated list of servers to query.
 
-	.PARAMETER SqlCredential
-		Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
-		$cred = Get-Credential, this pass this $cred to the param.
+		.PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+			$cred = Get-Credential, this pass this $cred to the param.
 
-		Windows Authentication will be used if DestinationSqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.
+			Windows Authentication will be used if DestinationSqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.
 
-	.PARAMETER Database
-		The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
+		.PARAMETER Database
+			The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
 
-	.PARAMETER ExcludeDatabase
-		The database(s) to exclude - this list is auto-populated from the server
+		.PARAMETER ExcludeDatabase
+			The database(s) to exclude - this list is auto-populated from the server
 
-	.PARAMETER Threshold
-		Allows you to specify a minimum % of the seed range being utilized.  This can be used to ignore seeds that have only utilized a small fraction of the range.
+		.PARAMETER Threshold
+			Allows you to specify a minimum % of the seed range being utilized.  This can be used to ignore seeds that have only utilized a small fraction of the range.
 
-	.PARAMETER NoSystemDb
-		Allows you to suppress output on system databases
+		.PARAMETER ExcludeSystemDb
+			Allows you to suppress output on system databases
 
-	.PARAMETER Silent
-		Use this switch to disable any kind of verbose messages
+		.PARAMETER Silent
+			Use this switch to disable any kind of verbose messages
 
-	.NOTES
-		Author: Brandon Abshire, netnerds.net
-		Tags: Identity
+		.NOTES
+			Author: Brandon Abshire, netnerds.net
+			Tags: Identity
 
-		Website: https://dbatools.io
-		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-	.LINK
-		https://dbatools.io/Test-DbaIdentityUsage
+		.LINK
+			https://dbatools.io/Test-DbaIdentityUsage
 
-	.EXAMPLE
-		Test-DbaIdentityUsage -SqlInstance sql2008, sqlserver2012
-		Check identity seeds for servers sql2008 and sqlserver2012.
+		.EXAMPLE
+			Test-DbaIdentityUsage -SqlInstance sql2008, sqlserver2012
 
-	.EXAMPLE
-		Test-DbaIdentityUsage -SqlInstance sql2008 -Database TestDB
-		Check identity seeds on server sql2008 for only the TestDB database
+			Check identity seeds for servers sql2008 and sqlserver2012.
 
-	.EXAMPLE
-		Test-DbaIdentityUsage -SqlInstance sql2008 -Database TestDB -Threshold 20
-		Check identity seeds on server sql2008 for only the TestDB database, limiting results to 20% utilization of seed range or higher
+		.EXAMPLE
+			Test-DbaIdentityUsage -SqlInstance sql2008 -Database TestDB
+
+			Check identity seeds on server sql2008 for only the TestDB database
+
+		.EXAMPLE
+			Test-DbaIdentityUsage -SqlInstance sql2008 -Database TestDB -Threshold 20
+
+			Check identity seeds on server sql2008 for only the TestDB database, limiting results to 20% utilization of seed range or higher
 	#>
 	[CmdletBinding()]
-	Param (
+	param (
 		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
 		[Alias("ServerInstance", "SqlServer", "SqlServers")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential]
-		$SqlCredential,
+		[DbaInstance[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
 		[Alias("Databases")]
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
 		[parameter(Position = 1, Mandatory = $false)]
 		[int]$Threshold = 0,
 		[parameter(Position = 2, Mandatory = $false)]
-		[switch]$NoSystemDb,
+		[Alias("NoSystemDb")]
+		[switch]$ExcludeSystemDb,
 		[switch]$Silent
 	)
 
-	BEGIN {
+	begin {
 
 		$sql = ";WITH CT_DT AS
 		(
@@ -161,7 +164,7 @@ function Test-DbaIdentityUsage {
 				$dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
 			}
 
-			if ($NoSystemDb) {
+			if ($ExcludeSystemDb) {
 				$dbs = $dbs | Where-Object IsSystemObject -eq $false
 			}
 

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -74,6 +74,7 @@ function Test-DbaIdentityUsage {
 	)
 
 	begin {
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter NoSystemDb
 
 		$sql = ";WITH CT_DT AS
 		(


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran Pester test for the command and has passed
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Touched up to our standard, and among other things (but test did pass against local instance)

- Renamed parameter `NoSystemDb` to `ExcludeSystemDb` (put the old parameter name as an alias, and deprecation check)
- Added try/catch specific to execute the query
- Added use of Query() method to execute the query.

### Screenshots

![image](https://user-images.githubusercontent.com/11204251/31626486-7b8e49ce-b26f-11e7-9d7f-3002fcd2d031.png)

