### PR TITLE
Repair-DbaOrphanUser - Parametername fix

### DIFF
--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -205,7 +205,7 @@ function Repair-DbaOrphanUser {
 							if ($RemoveNotExisting -eq $true) {
 								if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
 									Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser'."
-									Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -Users $UsersToRemove
+									Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove
 								}
 							}
 						}


### PR DESCRIPTION

## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes
 - Fixed a parameter call that caused this function to fail