### PR TITLE
version on top to override settings in appveyor UI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 ﻿# See http://www.appveyor.com/docs/appveyor-yml for many more options
 
 build: false
+version: 0.9.{build}
 
 # Set build info
 environment: 


### PR DESCRIPTION
(do Identity)

version was just added as an environmental variable (maybe is useful in c# tests ?)

However [appveyor docs](https://www.appveyor.com/docs/build-configuration/#appveyoryml-and-ui-coexistence) dictate that to override the build number set in appveyor UI, "version" should be at the root of the setting "tree"