### PR TITLE
Copy-DbaAgentAlert: fixing incorrect variable usage

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -152,7 +152,7 @@ function Copy-DbaAgentAlert {
 				DateTime          = [Sqlcollaborative.Dbatools.Utility.DbaDateTime](Get-Date)
 			}
 
-			if ($Alert -and $Alert -notcontains $alertName -and $ExcludeAlert -contains $alertName) {
+			if (($Alert -and $Alert -notcontains $alertName) -or ($ExcludeAlert -and $ExcludeAlert -contains $alertName)) {
 				continue
 			}
 

--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -197,8 +197,8 @@ function Copy-DbaAgentAlert {
 				continue
 			}
 
-			if ($serverAlert.JobName -and $dest.JobServer.Jobs.Name -NotContains $serverAlert.JobName) {
-				Write-Message -Level Warning -Message "Alert [$alertName] has job [$($serverAlert.JobName)] configured as response. The job does not exist on destination $dest. Skipping."
+			if ($serverAlert.JobName -and $destServer.JobServer.Jobs.Name -NotContains $serverAlert.JobName) {
+				Write-Message -Level Warning -Message "Alert [$alertName] has job [$($serverAlert.JobName)] configured as response. The job does not exist on destination $destServer. Skipping."
 
 				$copyAgentAlertStatus.Status = "Skipped"
 				$copyAgentAlertStatus


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2480)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing #2480

### Approach
Using correct variable

### Commands to test
`Copy-DbaAgentAlert -Source mfgSKVdb -Destination zvr_skv_mes1\mfgSKVdb -Alert 'Sev. 17 Errors' -Force`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
