### PR TITLE
Fix notes value for file growth rule

### DIFF
--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -188,7 +188,7 @@ function Test-DbaTempDbConfiguration {
 			}
 
 			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name IsBestPractice -Value $isBestPractice
-			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value 'Set grow with explicit values, not by percent.'
+			Add-Member -Force -InputObject $value -MemberType NoteProperty -Name Notes -Value 'Set file growth to explicit values, not by percent.'
 			$result += $value
 
 			Write-Message -Level Verbose -Message "File growth settings evaluated."


### PR DESCRIPTION
Make notes value for file growth rule specific to test being performed.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation/Notes
 - [ ] Build system
 
