### PR TITLE
Add parameter to Select-Object when finding dbname

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -569,9 +569,9 @@ function Restore-DbaDatabase {
 				Stop-Function -Target $FilteredFiles -Message "We can only handle 1 Database at a time - $dbs"
                 return
             }
-			$OldDatabaseName = ($FilteredFiles | Select-Object -Property DatabaseName -unique).DatabaseName
+			$OldDatabaseName = ($FilteredFiles | Select-Object -Property DatabaseName -unique -First 1).DatabaseName
             IF ($DatabaseName -eq '') {
-                $DatabaseName = $RestoredDatababaseNamePrefix + ($FilteredFiles | Select-Object -Property DatabaseName -unique).DatabaseName
+                $DatabaseName = $RestoredDatababaseNamePrefix + ($FilteredFiles | Select-Object -Property DatabaseName -unique -First 1).DatabaseName
                 Write-Message -Level Verbose -Message "Dbname set from backup = $DatabaseName"
             }
 			


### PR DESCRIPTION
Select-Object needs the -First 1 parameter added due to the fact that Group-Object above is case-insensitive but it is case-sensitive so it's passing multiple values to a parameter that should be a string. Ties to #2500

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X ] Bug fix #2500 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose

Fix a possible array so that the string that the function expects is created

### Approach
- First 1 only takes the first of the array (can only be an array if above didn't catch it as Group-Object is case-insensitive but Select-Object is not.

### Commands to test
Just the one modified in my opinion.
