### PR TITLE
Module Import cleanup

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -51,7 +51,7 @@ if ($ImportLibrary) {
 	try {
 		$libraryBase = $ExecutionContext.SessionState.Module.ModuleBase + "\bin"
 		# In strict security mode, only load from the already pre-compiled binary within the module
-		if ($dbatools_strictsecuritymode) {
+		if ($script:strictSecurityMode) {
 			if (Test-Path -Path "$libraryBase\dbatools.dll") {
 				Add-Type -Path "$libraryBase\dbatools.dll" -ErrorAction Stop
 			}
@@ -64,7 +64,7 @@ if ($ImportLibrary) {
 			$hasProject = Test-Path -Path "$libraryBase\projects\dbatools\dbatools.sln"
 			$hasCompiledDll = Test-Path -Path "$libraryBase\dbatools.dll"
 			
-			if ((-not $dbatools_alwaysbuildlibrary) -and $hasCompiledDll -and ([System.Diagnostics.FileVersionInfo]::GetVersionInfo("$libraryBase\dbatools.dll").FileVersion -eq $currentLibraryVersion)) {
+			if ((-not $script:alwaysBuildLibrary) -and $hasCompiledDll -and ([System.Diagnostics.FileVersionInfo]::GetVersionInfo("$libraryBase\dbatools.dll").FileVersion -eq $currentLibraryVersion)) {
 				$start = Get-Date
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"
@@ -120,7 +120,7 @@ if ($ImportLibrary) {
 							$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999).dll"
 						}
 					}
-					if ($dbatools_alwaysbuildlibrary) { Move-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop }
+					if ($script:alwaysBuildLibrary) { Move-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop }
 					else { Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop }
 					Add-Type -Path $libraryTempPath -ErrorAction Stop
 				}

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 9, 0, 31)
+$currentLibraryVersion = New-Object System.Version(0, 9, 0, 32)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.31")]
-[assembly: AssemblyFileVersion("0.9.0.31")]
+[assembly: AssemblyVersion("0.9.0.32")]
+[assembly: AssemblyFileVersion("0.9.0.32")]

--- a/bin/projects/dbatools/dbatools/dbaSystem/StartTimeEntry.cs
+++ b/bin/projects/dbatools/dbatools/dbaSystem/StartTimeEntry.cs
@@ -22,14 +22,21 @@ namespace Sqlcollaborative.Dbatools.dbaSystem
         public DateTime Timestamp { get; set; }
 
         /// <summary>
+        /// The runspace the entry was written on
+        /// </summary>
+        public Guid Runspace;
+
+        /// <summary>
         /// Creates a new StartTimeEntry
         /// </summary>
         /// <param name="Action">The action that has been taken</param>
         /// <param name="Timestamp">When was the action taken?</param>
-        public StartTimeEntry(string Action, DateTime Timestamp)
+        /// <param name="Runspace">The runspace the entry was written on</param>
+        public StartTimeEntry(string Action, DateTime Timestamp, Guid Runspace)
         {
             this.Action = Action;
             this.Timestamp = Timestamp;
+            this.Runspace = Runspace;
         }
     }
 }

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -315,7 +315,6 @@ if ($script:dbatoolsConfigRunspace)
 
 [Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleImported = $true;
 Write-ImportTime -Text "Waiting for runspaces to finish"
-$global:debug_removeme = $script:dbatools_ImportPerformance
 #endregion Post-Import Cleanup
 
 # SIG # Begin signature block

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -216,8 +216,13 @@ $scriptBlock = {
 	}
 	#endregion Implement user profile
 }
-$script:dbatoolsConfigRunspace = [System.Management.Automation.PowerShell]::Create()
-try { $script:dbatoolsConfigRunspace.Runspace.Name = "dbatools-import-config" }
-catch { }
-$script:dbatoolsConfigRunspace.AddScript($scriptBlock).AddArgument($global:dbatools_config)
-$script:dbatoolsConfigRunspace.BeginInvoke()
+if ($script:serialImport) {
+	$scriptBlock.Invoke($global:dbatools_config)
+}
+else {
+	$script:dbatoolsConfigRunspace = [System.Management.Automation.PowerShell]::Create()
+	try { $script:dbatoolsConfigRunspace.Runspace.Name = "dbatools-import-config" }
+	catch { }
+	$script:dbatoolsConfigRunspace.AddScript($scriptBlock).AddArgument($global:dbatools_config)
+	$script:dbatoolsConfigRunspace.BeginInvoke()
+}

--- a/internal/scripts/dbatools-maintenance.ps1
+++ b/internal/scripts/dbatools-maintenance.ps1
@@ -7,6 +7,7 @@ $scriptBlock = {
 	$script:___ScriptName = 'dbatools-maintenance'
 	
 	# Import module in a way where internals are available
+	$dbatools_disableTimeMeasurements = $true
 	Import-Module "$([Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleBase)\dbatools.psm1"
 	
 	try {

--- a/internal/scripts/smoLibraryImport.ps1
+++ b/internal/scripts/smoLibraryImport.ps1
@@ -179,8 +179,13 @@ Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.MaintenancePlan
 #>
 }
 
-$script:smoRunspace = [System.Management.Automation.PowerShell]::Create()
-try { $script:smoRunspace.Runspace.Name = "dbatools-import-smo" }
-catch { }
-$script:smoRunspace.AddScript($scriptBlock).AddArgument($script:PSModuleRoot)
-$script:smoRunspace.BeginInvoke()
+if ($script:serialImport) {
+	$scriptBlock.Invoke($script:PSModuleRoot)
+}
+else {
+	$script:smoRunspace = [System.Management.Automation.PowerShell]::Create()
+	try { $script:smoRunspace.Runspace.Name = "dbatools-import-smo" }
+	catch { }
+	$script:smoRunspace.AddScript($scriptBlock).AddArgument($script:PSModuleRoot)
+	$script:smoRunspace.BeginInvoke()
+}


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Clean up module import sequence, makes it easier to read
 - Small diagnostics bugfix
 - Central list of defines that list the import options and can be controlled by GPO
 - Adds an option to disable parallel processing (for example for unattended tasks that do not require fast import but care about CPU spikes)
 - Adds a timeout to waiting for pending runspaces