### PR TITLE
Add case-sensitivity to GroupObject for CS collations

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -655,7 +655,7 @@ function Restore-DbaDatabase {
                 
                 
                 Write-Message -Level Verbose -Message "Starting FileSet"
-                if (($FilteredFiles.DatabaseName | Group-Object | Measure-Object).count -gt 1) {
+                if (($FilteredFiles.DatabaseName | Group-Object -CaseSensitive | Measure-Object).count -gt 1) {
                     $dbs = ($FilteredFiles | Select-Object -Property DatabaseName) -join (',')
                     Stop-Function -Target $FilteredFiles -Message "We can only handle 1 Database at a time - $dbs"
                     return


### PR DESCRIPTION
Ran into an issue where I had manually created a backup of database and it had a different case. Because of this Restore did not work. Group-Object was failing to detect multiple values because by default it is case insensitive but Select-Object below is not. Added case-sensitivity to group-object to avoid this error unknown and instead give a proper error message.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
