### PR TITLE
Add case-sensitivity to GroupObject for CS collations

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -655,7 +655,7 @@ function Restore-DbaDatabase {
                 
                 
                 Write-Message -Level Verbose -Message "Starting FileSet"
-                if (($FilteredFiles.DatabaseName | Group-Object | Measure-Object).count -gt 1) {
+                if (($FilteredFiles.DatabaseName | Group-Object -CaseSensitive | Measure-Object).count -gt 1) {
                     $dbs = ($FilteredFiles | Select-Object -Property DatabaseName) -join (',')
                     Stop-Function -Target $FilteredFiles -Message "We can only handle 1 Database at a time - $dbs"
                     return


### PR DESCRIPTION
Ran into an issue where I had manually created a backup of database and it had a different case. Because of this Restore did not work. Group-Object was failing to detect multiple values because by default it is case insensitive but Select-Object below is not. Added case-sensitivity to group-object to avoid this error unknown and instead give a proper error message.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow CaseSensitivity on group object for case sensitive collations

### Approach
Uses switch already there but not used by default.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/30680994/31958982-4afdf1c6-b8a8-11e7-92a3-ccaf0c760cf7.png)


### Learning
I did this by mistake by running an out-of-band backup manually and not noticing the case I was using when calling the database name.