### PR TITLE
pester autodetection, fix

### DIFF
--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -13,9 +13,9 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 	To test any module from any path, use https://github.com/juneb/PesterTDD/Module.Help.Tests.ps1
 #>
 if ($SkipHelpTest) { return }
-. "$ModuleBase\tests\InModule.Help.Exceptions.ps1"
+. "$PSScriptRoot\InModule.Help.Exceptions.ps1"
 
-$excludedNames = (Get-ChildItem "$ModuleBase\internal" | Where-Object Name -like "*.ps1" ).BaseName
+$excludedNames = (Get-ChildItem "$PSScriptRoot\..\internal" | Where-Object Name -like "*.ps1" ).BaseName
 $commands = Get-Command -Module (Get-Module dbatools) -CommandType Cmdlet, Function, Workflow | Where-Object Name -notin $excludedNames
 
 
@@ -24,13 +24,13 @@ $commands = Get-Command -Module (Get-Module dbatools) -CommandType Cmdlet, Funct
 
 
 foreach ($command in $commands) {
-    $commandName = $command.Name
-    
-    # Skip all functions that are on the exclusions list
-    if ($global:FunctionHelpTestExceptions -contains $commandName) { continue }
-    
-    # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
-    $Help = Get-Help $commandName -ErrorAction SilentlyContinue
+	$commandName = $command.Name
+	
+	# Skip all functions that are on the exclusions list
+	if ($global:FunctionHelpTestExceptions -contains $commandName) { continue }
+	
+	# The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+	$Help = Get-Help $commandName -ErrorAction SilentlyContinue
 	$testhelperrors = 0
 	$testhelpall = 0
 	Describe "Test help for $commandName" {

--- a/tests/InModule.Help.Tests.ps1
+++ b/tests/InModule.Help.Tests.ps1
@@ -15,9 +15,8 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 if ($SkipHelpTest) { return }
 . "$PSScriptRoot\InModule.Help.Exceptions.ps1"
 
-$excludedNames = (Get-ChildItem "$PSScriptRoot\..\internal" | Where-Object Name -like "*.ps1" ).BaseName
-$commands = Get-Command -Module (Get-Module dbatools) -CommandType Cmdlet, Function, Workflow | Where-Object Name -notin $excludedNames
-
+$includedNames = (Get-ChildItem "$PSScriptRoot\..\functions" | Where-Object Name -like "*.ps1" ).BaseName
+$commands = Get-Command -Module (Get-Module dbatools) -CommandType Cmdlet, Function, Workflow | Where-Object Name -in $includedNames
 
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -236,7 +236,7 @@ if (-not $Finalize) {
 						$FoundFlag += 1
 					}
 				}
-				if ($FoundFlag -eq $ScanFor.Count) {
+				if ($FoundFlag -eq $ScanFor.Count -or $FoundFlag -eq 0) {
 					$ScanTests += $test
 				}
 			}


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fix a problem in autodetection. There are (and there will be additional) tests which are not using neither $script:instance1 nor $script:instance2, like InModule.Help.Tests.ps1
