### PR TITLE
Spelling in help section

### DIFF
--- a/functions/Add-DbaComputerCertificate.ps1
+++ b/functions/Add-DbaComputerCertificate.ps1
@@ -41,12 +41,12 @@ function Add-DbaComputerCertificate {
 	.EXAMPLE
 		Add-DbaComputerCertificate -ComputerName Server1 -Path C:\temp\cert.cer
 		
-		Adds the local C:\temp\cer.cer to the remote server Server1 in LocalMachine\My (Personal).
+		Adds the local C:\temp\cert.cer to the remote server Server1 in LocalMachine\My (Personal).
 	
 	.EXAMPLE
 		Add-DbaComputerCertificate -Path C:\temp\cert.cer
 		
-		Adds the local C:\temp\cer.cer to the local computer's LocalMachine\My (Personal) certificate store.
+		Adds the local C:\temp\cert.cer to the local computer's LocalMachine\My (Personal) certificate store.
 	
 	.NOTES
 		Tags: Certificate


### PR DESCRIPTION
In examples command states C:\temp\cert.cer but in description down below the file name was specified as C:\temp\cer.cer at the t was missing.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ X ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix spelling

