### PR TITLE
Grammar

### DIFF
--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -36,7 +36,7 @@ function Copy-DbaServerAuditSpecification {
 			The Server Audit Specification(s) to process. Options for this list are auto-populated from the server. If unspecified, all Server Audit Specifications will be processed.
 
 		.PARAMETER ExcludeAuditSpecification
-			The Server Audit Specification(s) to exclude. Options for this list are is auto-populated from the server
+			The Server Audit Specification(s) to exclude. Options for this list are auto-populated from the server
 
 		.PARAMETER WhatIf
 			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.


### PR DESCRIPTION
Options for this list are is auto-populated from the server changed to:
Options for this list are auto-populated from the server dropping the word is.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ X ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Grammar extra is was added in documentation

