### PR TITLE
Spelling

### DIFF
--- a/functions/Test-DbaSqlPath.ps1
+++ b/functions/Test-DbaSqlPath.ps1
@@ -76,7 +76,7 @@ function Test-DbaSqlPath {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 
-			Write-Message -Level VeryVerbose -Message "Checking acces to $path for $instance."
+			Write-Message -Level VeryVerbose -Message "Checking access to $path for $instance."
 			$sql = "EXEC master.dbo.xp_fileexist '$path'"
 			try {
 				Write-Message -Level Debug -Message "Executing: $sql."


### PR DESCRIPTION
acces -> access in verbose message

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ X ] Documentation
 - [ ] Build system
 
