### PR TITLE
Adjust Get-DbaDatabaseFile - Add "friendly" growth size

### DIFF
--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -186,7 +186,12 @@ function Get-DbaDatabaseFile {
 						$free = $disks | Where-Object { $_.drive -eq $result.PhysicalName.Substring(0, 1) } | Select-Object 'MB Free' -ExpandProperty 'MB Free'
 						$VolumeFreeSpace = [dbasize]($free * 1024 * 1024)
 					}
-					
+					if($result.GrowthType -eq "Percent") {
+						$nextgrowtheventadd = [dbasize]$size * ($result.Growth * 0.01)
+					}
+					else {
+						$nextgrowtheventadd = $result.Growth * 8
+					}
 					
 					[PSCustomObject]@{
 						ComputerName             = $server.NetName
@@ -203,6 +208,7 @@ function Get-DbaDatabaseFile {
 						MaxSize                  = $maxsize
 						Growth                   = $result.Growth
 						GrowthType               = $result.GrowthType
+						NextGrowthEventSize	 = $nextgrowtheventadd
 						Size                     = $size
 						UsedSpace                = $usedspace
 						AvailableSpace           = $AvailableSpace


### PR DESCRIPTION
Added friendly growth size calculation to output. Classifying for both Percent and kb it is named "NextGrowthEventSize" which should be static for kb but will change based on filesize for percent growth.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ X ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes  #2471

### Approach
Calculates how much space the next growth event will take with different calculations for kb vs percent.

### Commands to test
Get-DbaDatabaseFile
