### PR TITLE
Solving Module Import Woes

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 9, 0, 32)
+$currentLibraryVersion = New-Object System.Version(0, 9, 0, 33)
 
 <#
 Library Versioning 101:

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -90,7 +90,11 @@ if ($ImportLibrary) {
 				$start = Get-Date
 				$system = [Appdomain]::CurrentDomain.GetAssemblies() | Where-Object FullName -like "System, *"
 				$msbuild = (Resolve-Path "$(Split-Path $system.Location)\..\..\..\..\Framework$(if ([intptr]::Size -eq 8) { "64" })\$($system.ImageRuntimeVersion)\msbuild.exe").Path
-				$msbuildConfiguration = "/p:Configuration=Release"
+				switch ($PSVersionTable.PSVersion.Major) {
+					3 { $msbuildConfiguration = "/p:Configuration=ps3" }
+					4 { $msbuildConfiguration = "/p:Configuration=ps4" }
+					default { $msbuildConfiguration = "/p:Configuration=Release" }
+				}
 				$msbuildOptions = ""
 				if ($env:APPVEYOR -eq 'True') {
 					# This doesn't seem to work. Keep it here for now

--- a/bin/projects/dbatools/dbatools.Tests/dbatools.Tests.csproj
+++ b/bin/projects/dbatools/dbatools.Tests/dbatools.Tests.csproj
@@ -35,6 +35,24 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ps3|AnyCPU'">
+    <OutputPath>bin\ps3\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ps4|AnyCPU'">
+    <OutputPath>bin\ps4\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/bin/projects/dbatools/dbatools.sln
+++ b/bin/projects/dbatools/dbatools.sln
@@ -10,15 +10,23 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		ps3|Any CPU = ps3|Any CPU
+		ps4|Any CPU = ps4|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.Debug|Any CPU.ActiveCfg = Release|Any CPU
 		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.ps3|Any CPU.ActiveCfg = ps3|Any CPU
+		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.ps3|Any CPU.Build.0 = ps3|Any CPU
+		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.ps4|Any CPU.ActiveCfg = ps4|Any CPU
+		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.ps4|Any CPU.Build.0 = ps4|Any CPU
 		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A0D426F-2E98-4851-8AF8-C1B2B17C052D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.ps3|Any CPU.ActiveCfg = ps3|Any CPU
+		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.ps4|Any CPU.ActiveCfg = ps4|Any CPU
 		{AFD56AD2-F9F0-4C9D-901B-69CA1455C32A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.32")]
-[assembly: AssemblyFileVersion("0.9.0.32")]
+[assembly: AssemblyVersion("0.9.0.33")]
+[assembly: AssemblyFileVersion("0.9.0.33")]

--- a/bin/projects/dbatools/dbatools/Runspace/RunspaceContainer.cs
+++ b/bin/projects/dbatools/dbatools/Runspace/RunspaceContainer.cs
@@ -73,7 +73,11 @@ namespace Sqlcollaborative.Dbatools.Runspace
         /// <param name="Runspace">The runspace to be named</param>
         private void SetName(System.Management.Automation.Runspaces.Runspace Runspace)
         {
+            #if (NORUNSPACENAME)
+
+            #else
             Runspace.Name = Name;
+            #endif
         }
 
         /// <summary>

--- a/bin/projects/dbatools/dbatools/dbatools.csproj
+++ b/bin/projects/dbatools/dbatools/dbatools.csproj
@@ -33,6 +33,26 @@
     <DocumentationFile>..\..\..\dbatools.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ps3|AnyCPU'">
+    <OutputPath>..\..\..\</OutputPath>
+    <DefineConstants>TRACE;NORUNSPACENAME</DefineConstants>
+    <DocumentationFile>..\..\..\dbatools.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ps4|AnyCPU'">
+    <OutputPath>..\..\..\</OutputPath>
+    <DefineConstants>TRACE;NORUNSPACENAME</DefineConstants>
+    <DocumentationFile>..\..\..\dbatools.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Management.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -290,7 +290,15 @@ while (($script:smoRunspace.Runspace.RunspaceAvailability -eq 'Busy') -or ($scri
 	$timeSpent = $timeSpent + 50
 	
 	if ($timeSpent -ge $timeout) {
-		Write-Warning "Timeout waiting for runspaces reached!"
+		Write-Warning @"
+The module import has hit a timeout while waiting for some background tasks to finish.
+This may result in some commands not working as intended.
+This should not happen under reasonable circumstances, please file an issue at:
+https://github.com/sqlcollaborative/dbatools/issues
+Or contact us directly in the #dbatools channel of the SQL Server Community Slack Channel:
+https://dbatools.io/slack/
+Timeout waiting for temporary runspaces reached! The Module import will complete, but some things may not work as intended
+"@
 		$global:smoRunspace = $script:smoRunspace
 		$global:dbatoolsConfigRunspace = $script:dbatoolsConfigRunspace
 		break

--- a/functions/Set-DbaConfig.ps1
+++ b/functions/Set-DbaConfig.ps1
@@ -270,7 +270,7 @@ function Set-DbaConfig
 			[Sqlcollaborative.Dbatools.Configuration.Config]$cfg = [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName]
 			if ((-not $DisableValidation) -and ($cfg.Validation) -and (Test-Bound -ParameterName "Value"))
 			{
-				$testResult = $cfg.Validation.Invoke($Value)
+				$testResult = [scriptblock]::Create($cfg.Validation.ToString()).Invoke($Value)
 				if (-not $TestResult.Success)
 				{
 					Stop-Function -Message "Could not update configuration $internalFullName | Failed validation: $($testResult.Message)" -EnableException $EnableException -Category InvalidResult -Target $internalFullName
@@ -280,7 +280,7 @@ function Set-DbaConfig
 			}
 			if ((-not $DisableHandler) -and ($cfg.Handler) -and (Test-Bound -ParameterName "Value"))
 			{
-				try { $cfg.Handler.Invoke($Value) }
+				try { [scriptblock]::Create($cfg.Handler.ToString()).Invoke($Value) }
 				catch
 				{
 					Stop-Function -Message "Could not update configuration $internalFullName | Failed handling $_" -EnableException $EnableException -Category InvalidResult -Target $internalFullName

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -211,7 +211,7 @@ $scriptBlock = {
 	{
 		if ($DbatoolsConfig.GetType().FullName -eq "System.Management.Automation.ScriptBlock")
 		{
-			$DbatoolsConfig.Invoke()
+			[System.Management.Automation.ScriptBlock]::Create($DbatoolsConfig.ToString()).Invoke()
 		}
 	}
 	#endregion Implement user profile


### PR DESCRIPTION

# Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
## Fixes

 - Fixed configuration system issues with processing user profiles, causing module import to hang
 - Fixed configuration system issues changing settings using `Set-DbaConfig`
 - Fixed error preventing PowerShell version 3 or 4 from using the web install command

## Technical background
### Configuration System issues
Scriptblocks can only be executed on the runspace they were created on. Moving configuration processing to another runspace - which was done to improve import performance - caused the system to ...

 - Try to execute the profile configuration settings (which were created in the main runspace) in a foreign runspace
 - Create the validation and handler scriptblocks to be created in a foreign runspace, causing `Set-DbaConfig` to fail in the main runspace.

This was resolved by having both kinds of scriptblock cloned before invoking them, which has the clones created in the runspace that executes them.

### Web Install issues
Since our web installation deployment does not ship the library, it tries to build it from the project. The recent change to name runspaces however requires a feature only present in PS5. This was noted during development and handled for dlls built on PS5, so that they could run on older systems. However I didn't consider that we also build on older systems through said web installer.

I solved this issue by setting up project configurations per PowerShell versions and excluding the offending code, using a property only PS5, from compilation on systems with PS4 or older. Given that it is a cosmetic feature, this will not cause any compatibility issues.