### PR TITLE
Get-DbaAgentOperator Repair

### DIFF
--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -95,17 +95,17 @@ function Get-DbaAgentOperator {
 				$operators = $server.JobServer.Operators
 			}
 			
-            foreach ($operator in $operators) {
+            foreach ($operat in $operators) {
 				
-                $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operator.Name }
-                $lastemail = [dbadatetime]$operator.LastEmailDate
+                $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operat.Name }
+                $lastemail = [dbadatetime]$operat.LastEmailDate
 				
-                Add-Member -Force -InputObject $operator -MemberType NoteProperty -Name ComputerName -Value $server.NetName
-                Add-Member -Force -InputObject $operator -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
-                Add-Member -Force -InputObject $operator -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
-                Add-Member -Force -InputObject $operator -MemberType NoteProperty -Name RelatedJobs -Value $jobs
-                Add-Member -Force -InputObject $operator -MemberType NoteProperty -Name LastEmail -Value $lastemail
-                Select-DefaultView -InputObject $operator -Property $defaults
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name RelatedJobs -Value $jobs
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name LastEmail -Value $lastemail
+                Select-DefaultView -InputObject $operat -Property $defaults
             }
         }
     }

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -1,0 +1,22 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		$server = Connect-DbaInstance -SqlInstance $script:instance2
+		$sql = "EXEC msdb.dbo.sp_add_operator @name=N'dbatoolsci_operator', @enabled=1, @pager_days=0"
+		$server.Query($sql)
+	}
+	AfterAll {
+		$sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator'"
+		$server.Query($sql)
+	}
+	Context "Count Number of Database Maintenance Agent Jobs on localhost" {
+		$results = Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator dbatoolsci_operator
+		It "return one result" {
+			$results.Count | Should Be 1
+		}
+	}
+	
+}

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -7,16 +7,23 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		$server = Connect-DbaInstance -SqlInstance $script:instance2
 		$sql = "EXEC msdb.dbo.sp_add_operator @name=N'dbatoolsci_operator', @enabled=1, @pager_days=0"
 		$server.Query($sql)
+		$sql = "EXEC msdb.dbo.sp_add_operator @name=N'dbatoolsci_operator2', @enabled=1, @pager_days=0"
+		$server.Query($sql)
 	}
 	AfterAll {
 		$sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator'"
 		$server.Query($sql)
+		$sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator2'"
+		$server.Query($sql)
 	}
-	Context "Count Number of Database Maintenance Agent Jobs on localhost" {
+	Context "Get back some Operators" {
+		$results = Get-DbaAgentOperator -SqlInstance $script:instance2
+		It "return at least two results" {
+			$results.Count -ge 2 | Should Be $true
+		}
 		$results = Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator dbatoolsci_operator
 		It "return one result" {
 			$results.Count | Should Be 1
 		}
 	}
-	
 }

--- a/tests/Get-DbaAgentOperator.Tests.ps1
+++ b/tests/Get-DbaAgentOperator.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		$sql = "EXEC msdb.dbo.sp_delete_operator @name=N'dbatoolsci_operator2'"
 		$server.Query($sql)
 	}
-	Context "Get back some Operators" {
+	Context "Get back some operators" {
 		$results = Get-DbaAgentOperator -SqlInstance $script:instance2
 		It "return at least two results" {
 			$results.Count -ge 2 | Should Be $true


### PR DESCRIPTION
## Type of Change
 - [X ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fix the misbehaviour: this function did return only the operators of the first sql instance. 

### Approach
A parameter "Operator" was added, but this was already used in a foreach loop. After the first iteration through the sql instances, this parameter would contain the result of the last iteration through the operators of the first instance. For all consecutive sqlinstances, the check for operators being equal to the $operator would return nothing.
Renaming the variable in the 'foreach operator' loop, solved this.
