### PR TITLE
Set-DbaTempDbConfiguration: Fix #2531

### DIFF
--- a/functions/Set-DbaTempDbConfiguration.ps1
+++ b/functions/Set-DbaTempDbConfiguration.ps1
@@ -183,8 +183,6 @@ function Set-DbaTempDbConfiguration {
 			$LogFileGrowthMB = 0
 		}
 		
-		$LogSizeMBActual = if (-not $LogFileSizeMB) { $([Math]::Floor($DataFileSizeMB / 4)) }
-
 		# Check current tempdb. Throw an error if current tempdb is larger than config.
 		$CurrentFileCount = $server.Databases['tempdb'].ExecuteWithResults('SELECT count(1) as FileCount FROM sys.database_files WHERE type=0').Tables[0].Rows[0].FileCount
 		$TooBigCount = $server.Databases['tempdb'].ExecuteWithResults("SELECT TOP 1 (size/128) as Size FROM sys.database_files WHERE size/128 > $DataFilesizeSingleMB AND type = 0").Tables[0].Rows[0].Size
@@ -258,7 +256,7 @@ function Set-DbaTempDbConfiguration {
 						DataFileCount        = $DataFileCount
 						DataFileSizeMB       = $DataFileSizeMB
 						SingleDataFileSizeMB = $DataFilesizeSingleMB
-						LogSizeMB            = $LogSizeMBActual
+						LogSizeMB            = $LogFileSizeMB
 						DataPath             = $DataPath
 						LogPath              = $LogPath
 						DataFileGrowthMB     = $DataFileGrowthMB


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix #2531, Set-DbaTempDbConfiguration output object has no value for LogSizeMB when -LogFileSizeMB parameter value is supplied.

### Approach
<!-- How does this change solve that purpose -->
Remove `$LogSizeActualMB` variable which isn't used except for assigning a value to the LogSizeMB property of the output object.
The `$LogSizeActualMB` variable itself is only assigned a value if `$LogFileSizeMB` has no parameter.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
> Set-DbaTempDbConfiguration -ServerInstance SERVERNAME -DataFileSizeMB 65536 -LogFileSizeMB 8000


ComputerName         : SERVERNAME
InstanceName         : MSSQLSERVER
SqlInstance          : SERVERNAME
DataFileCount        : 8
DataFileSizeMB       : 65536
SingleDataFileSizeMB : 8192
LogSizeMB            : 8000
DataPath             : F:\MSSQL10_50.MSSQLSERVER\MSSQL\Data
LogPath              : F:\MSSQL10_50.MSSQLSERVER\MSSQL\Data
DataFileGrowthMB     : 512
LogFileGrowthMB      : 512

[Set-DbaTempDbConfiguration][12:19:20] tempdb reconfigured. You must restart the SQL Service for settings to take effect.
```