### PR TITLE
Sql Server Connect timeout Configurable

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -1,5 +1,5 @@
 ﻿# Current library Version the module expects
-$currentLibraryVersion = New-Object System.Version(0, 9, 0, 33)
+$currentLibraryVersion = New-Object System.Version(0, 9, 1, 34)
 
 <#
 Library Versioning 101:

--- a/bin/projects/dbatools/dbatools/Connection/ConnectionHost.cs
+++ b/bin/projects/dbatools/dbatools/Connection/ConnectionHost.cs
@@ -13,7 +13,7 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// </summary>
         public static Dictionary<string, ManagementConnection> Connections = new Dictionary<string, ManagementConnection>();
 
-        #region Configuration
+        #region Configuration Computer Management
         /// <summary>
         /// The time interval that must pass, before a connection using a known to not work connection protocol is reattempted
         /// </summary>
@@ -68,6 +68,13 @@ namespace Sqlcollaborative.Dbatools.Connection
         /// Whether the CM connection using PowerShell Remoting is disabled globally
         /// </summary>
         public static bool DisableConnectionPowerShellRemoting = true;
-        #endregion Configuration
+        #endregion Configuration Computer Management
+
+        #region Configuration Sql Connection
+        /// <summary>
+        /// The number of seconds before a sql connection attempt times out
+        /// </summary>
+        public static int SqlConnectionTimeout = 15;
+        #endregion Configuration Sql Connection
     }
 }

--- a/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
+++ b/bin/projects/dbatools/dbatools/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.33")]
-[assembly: AssemblyFileVersion("0.9.0.33")]
+[assembly: AssemblyVersion("0.9.1.34")]
+[assembly: AssemblyFileVersion("0.9.1.34")]

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -177,7 +177,7 @@ function Connect-DbaInstance {
 		[string]$ApplicationIntent,
 		[string]$BatchSeparator,
 		[string]$ClientName = "dbatools PowerShell module - dbatools.io - custom connection",
-		[int]$ConnectTimeout,
+		[int]$ConnectTimeout = ([Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout),
 		[switch]$EncryptConnection,
 		[string]$FailoverPartner,
 		[switch]$IsActiveDirectoryUniversalAuth,

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -152,6 +152,8 @@ function Connect-SqlInstance {
 	if ($ConvertedSqlInstance.IsConnectionString) { $server.ConnectionContext.ConnectionString = $ConvertedSqlInstance.InputObject }
 	
 	try {
+		$server.ConnectionContext.ConnectTimeout = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout
+		
 		if ($SqlCredential.Username -ne $null) {
 			$username = ($SqlCredential.Username).TrimStart("\")
 			

--- a/internal/configurations/settings/sql.ps1
+++ b/internal/configurations/settings/sql.ps1
@@ -1,0 +1,2 @@
+﻿# Controls the timeout on sql connects
+Set-DbaConfig -FullName 'sql.connection.timeout' -Value 15 -Initialize -Validation integerpositive -Handler { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout = $args[0] } -Description "The number of seconds before sql server connection attempts are aborted"


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Adds a configuration setting that controls connection timeouts
 - Used in `Connect-SqlInstance` on all connects except when passing a server object
 - Used in `Connect-DbaInstance` as the default value for timeout