### PR TITLE
Get-DbaDatabaseFile - Unified output type

### DIFF
--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -177,6 +177,9 @@ function Get-DbaDatabaseFile {
 					if ($maxsize -gt -1) {
 						$maxsize = [dbasize]($result.MaxSize * 8192)
 					}
+					else {
+						$maxsize = [dbasize]($result.MaxSize)
+					}
 					
 					if ($result.VolumeFreeSpace) {
 						$VolumeFreeSpace = [dbasize]$result.VolumeFreeSpace


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Enforced `[DbaSize]` as output type for `.MaxSize` property in all instances

### Reason

Piping to `Out-DbaDataTable` would fail if the first file had no limit (and thus was represented with a an integer `-1` as max size), since the column types are defined by the first object. When later max sizes too large for int32 came along, this would fail in blood & error.

### Breaking Change

 - This will change the way -1 will show up on screen and in exports to csv (in which cases it will be marked as `Unlimited`). The latter may break some scripts that transfer data via file and then process the file.

### Do not merge

This shouldn't be merged before @potatoqualitee had a chance to look at it and decide whether that amount of breakage is alright.