### PR TITLE
Moved special character impacting variable usage

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1061,7 +1061,7 @@ function Copy-DbaDatabase {
 						$backupResult = $BackupTmpResult.BackupComplete
 						if ($backupResult -eq $false) {
 							$serviceAccount = $sourceServer.ServiceAccount
-							Write-Message -Level Verbose -Message "Backup Failed. Does SQL Server account $serviceAccount have access to $NetworkShare? Aborting routine for this database."
+							Write-Message -Level Verbose -Message "Backup Failed. Does SQL Server account $serviceAccount have access to $NetworkShare ? Aborting routine for this database."
 							
 							$copyDatabaseStatus.Status = "Failed"
 							$copyDatabaseStatus.Notes = "Backup failed. Verify service account access to $NetworkShare"


### PR DESCRIPTION
$NetworkShare was not displaying due to a question mark impacting it.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2558)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Minor edit to a variable in a Write command to allow it to show.

### Approach
Added a space to move special character

### Commands to test
Copy-DbaDatabase
Force a failure

### Screenshots
![image](https://user-images.githubusercontent.com/27346136/32216300-9a57bf4e-be1c-11e7-8e0e-0d701b607c09.png)

