### PR TITLE
Get-XpDirTreeRestoreFile, preserve instance info

### DIFF
--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -60,7 +60,7 @@ function Get-XpDirTreeRestoreFile {
 	ForEach ($d in $dirs) {
 		$fullpath = "$path$($d.Subdirectory)"
 		Write-Message -Level Verbose -Message "Enumerating subdirectory '$fullpath'"
-		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $server
+		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $SqlInstance
 	}
 	return $Results
 	


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
DirTreeing recursively works wonders if everything is SMO, but mixing it up with invoke-sqlcmd2 needs to avoid cutting up precious infos (in this case, the suffix part).

This is an example log with the current implementation
```
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:04] Connecting to yyyyyyyy.foo.bar.baz
VERBOSE: [Test-DbaSqlPath][14:54:05] Checking access to \\yyyyyyyy.foo.bar.baz\restoretemp$\ for YYYYYYYY.
VERBOSE: Running Invoke-Sqlcmd2 with ParameterSet 'Ins-Que'.  Performing query 'EXEC master.sys.xp_dirtree
'\\xxxxxxxxxxx.foo.bar.baz\restoretemp$\',1,1;'.
VERBOSE: Querying ServerInstance 'yyyyyyyy.foo.bar.baz'
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:06] Enumerating subdirectory '\\xxxxxxxxxxx.foo.bar.baz\restoretemp$\DB_EXAMPLE'
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:06] Connecting to YYYYYYYY
VERBOSE: [Test-DbaSqlPath][14:54:06] Checking access to \\yyyyyyyy.foo.bar.baz\restoretemp$\DB_EXAMPLE\ for
YYYYYYYY.
VERBOSE: Running Invoke-Sqlcmd2 with ParameterSet 'Ins-Que'.  Performing query 'EXEC master.sys.xp_dirtree
'\\yyyyyyyy.foo.bar.baz\restoretemp$\DB_EXAMPLE\',1,1;'.
VERBOSE: Querying ServerInstance 'YYYYYYYY'


---sea of red blood, because YYYYYYYY is not resolvable, only yyyyyyyy.foo.bar.baz is
```

This one is with the changes included in this PR
```
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:04] Connecting to yyyyyyyy.foo.bar.baz
VERBOSE: [Test-DbaSqlPath][14:54:05] Checking access to \\yyyyyyyy.foo.bar.baz\restoretemp$\ for YYYYYYYY.
VERBOSE: Running Invoke-Sqlcmd2 with ParameterSet 'Ins-Que'.  Performing query 'EXEC master.sys.xp_dirtree
'\\xxxxxxxxxxx.foo.bar.baz\restoretemp$\',1,1;'.
VERBOSE: Querying ServerInstance 'yyyyyyyy.foo.bar.baz'
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:06] Enumerating subdirectory '\\xxxxxxxxxxx.foo.bar.baz\restoretemp$\DB_EXAMPLE'
VERBOSE: [Get-XpDirTreeRestoreFile][14:54:06] Connecting to YYYYYYYY
VERBOSE: [Test-DbaSqlPath][14:54:06] Checking access to \\yyyyyyyy.foo.bar.baz\restoretemp$\DB_EXAMPLE\ for
YYYYYYYY.
VERBOSE: Running Invoke-Sqlcmd2 with ParameterSet 'Ins-Que'.  Performing query 'EXEC master.sys.xp_dirtree
'\\yyyyyyyy.foo.bar.baz\restoretemp$\DB_EXAMPLE\',1,1;'.
VERBOSE: Querying ServerInstance 'yyyyyyyy.foo.bar.baz'

---Continues fine
```

### Approach
Passing down the same thing that comes as the input


