### PR TITLE
Fix for new database sizing not being reported when -LogsOnly is used

### DIFF
--- a/functions/Invoke-DbaDatabaseShrink.ps1
+++ b/functions/Invoke-DbaDatabaseShrink.ps1
@@ -222,7 +222,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
 							try {
 								Write-Message -Level Verbose -Message "Beginning shrink of log files"
 								$db.LogFiles.Shrink($PercentFreeSpace, $ShrinkMethod)
-								$db.LogFiles.Refresh()
+								$db.Refresh()
 								Write-Message -Level Verbose -Message "Recalculating space usage"
 								$db.RecalculateSpaceUsage()
 								$success = $true


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When -LogsOnly is used, the returned object contains the old $db.Size and $db.SpaceAvailable because the $db object does not get a Refresh() run against it.

### Approach
Changed $db.LogFiles.Refresh() to $db.Refresh() which will refresh everything needed.