### PR TITLE
Repair get-dbamemoryusage

### DIFF
--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -81,6 +81,7 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 		}
 		
 		$scriptblock = {
+            param( $Memcounters, $Plancounters, $BufManpagecounters, $SSAScounters, $SSIScounters )
 			Write-Verbose "Searching for Memory Manager Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet '*sql*:Memory Manager*' -ErrorAction SilentlyContinue).paths
@@ -204,7 +205,7 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 			if ($reply.FullComputerName) {
 				$Computer = $reply.FullComputerName
 				Write-Message -Level Verbose -Message "Connecting to $Computer"
-				Invoke-Command2 -ComputerName $Computer -Credential $Credential -ScriptBlock $scriptblock
+				Invoke-Command2 -ComputerName $Computer -Credential $Credential -ScriptBlock $scriptblock -argumentlist $Memcounters, $Plancounters, $BufManpagecounters, $SSAScounters, $SSIScounters
 			}
 			else {
 				Write-Message -Level Warning -Message "Can't resolve $Computer."

--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -82,7 +82,7 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 		
 		$scriptblock = {
             param( $Memcounters, $Plancounters, $BufManpagecounters, $SSAScounters, $SSIScounters )
-			Write-Verbose "Searching for Memory Manager Counters on $Computer"
+			Write-Message -Level Verbose -Message "Searching for Memory Manager Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet '*sql*:Memory Manager*' -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -102,10 +102,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Verbose "No Memory Manager Counters on $Computer"
+				Write-Message -Level Verbose -Message "No Memory Manager Counters on $Computer"
 			}
 			
-			Write-Verbose "Searching for Plan Cache Counters on $Computer"
+			Write-Message -Level Verbose -Message "Searching for Plan Cache Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet '*sql*:Plan Cache*' -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -125,10 +125,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Verbose "No Plan Cache Counters on $Computer"
+				Write-Message -Level Verbose -Message "No Plan Cache Counters on $Computer"
 			}
 			
-			Write-Verbose "Searching for Buffer Manager Counters on $Computer"
+			Write-Message -Level Verbose -Message "Searching for Buffer Manager Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "*Buffer Manager*" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -148,10 +148,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Verbose "No Buffer Manager Counters on $Computer"
+				Write-Message -Level Verbose -Message "No Buffer Manager Counters on $Computer"
 			}
 			
-			Write-Verbose "Searching for SSAS Counters on $Computer"
+			Write-Message -Level Verbose -Message "Searching for SSAS Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "MSAS*:Memory" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -171,10 +171,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Verbose "No SSAS Counters on $Computer"
+				Write-Message -Level Verbose -Message "No SSAS Counters on $Computer"
 			}
 			
-			Write-Verbose "Searching for SSIS Counters on $Computer"
+			Write-Message -Level Verbose -Message "Searching for SSIS Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "*SSIS*" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |

--- a/functions/Get-DbaMemoryUsage.ps1
+++ b/functions/Get-DbaMemoryUsage.ps1
@@ -82,7 +82,7 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 		
 		$scriptblock = {
             param( $Memcounters, $Plancounters, $BufManpagecounters, $SSAScounters, $SSIScounters )
-			Write-Message -Level Verbose -Message "Searching for Memory Manager Counters on $Computer"
+			Write-Verbose "Searching for Memory Manager Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet '*sql*:Memory Manager*' -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -102,10 +102,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Message -Level Verbose -Message "No Memory Manager Counters on $Computer"
+				Write-Verbose "No Memory Manager Counters on $Computer"
 			}
 			
-			Write-Message -Level Verbose -Message "Searching for Plan Cache Counters on $Computer"
+			Write-Verbose "Searching for Plan Cache Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet '*sql*:Plan Cache*' -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -125,10 +125,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Message -Level Verbose -Message "No Plan Cache Counters on $Computer"
+				Write-Verbose "No Plan Cache Counters on $Computer"
 			}
 			
-			Write-Message -Level Verbose -Message "Searching for Buffer Manager Counters on $Computer"
+			Write-Verbose "Searching for Buffer Manager Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "*Buffer Manager*" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -148,10 +148,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Message -Level Verbose -Message "No Buffer Manager Counters on $Computer"
+				Write-Verbose "No Buffer Manager Counters on $Computer"
 			}
 			
-			Write-Message -Level Verbose -Message "Searching for SSAS Counters on $Computer"
+			Write-Verbose "Searching for SSAS Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "MSAS*:Memory" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |
@@ -171,10 +171,10 @@ Returns a gridview displaying Server, counter instance, counter, number of pages
 				}
 			}
 			catch {
-				Write-Message -Level Verbose -Message "No SSAS Counters on $Computer"
+				Write-Verbose "No SSAS Counters on $Computer"
 			}
 			
-			Write-Message -Level Verbose -Message "Searching for SSIS Counters on $Computer"
+			Write-Verbose "Searching for SSIS Counters on $Computer"
 			try {
 				$availablecounters = (Get-Counter -ListSet "*SSIS*" -ErrorAction SilentlyContinue).paths
 				(Get-Counter -Counter $availablecounters -ErrorAction SilentlyContinue).countersamples |


### PR DESCRIPTION
 - [X ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
By moving all logic into a scriptblock without using params, the variables weren't passed on, and the filtering didn't work.
The purpose of this function is to show the amount of memory sql server uses.
Without the params, 'BufferCache Hit Ratio','PLE' and others were shown too.

### Approach
Add `param()` to the scriptblock
add `-ArgumentList` to the `Invoke-comand2`
