### PR TITLE
Added tests for databasecertificate cmdlets

### DIFF
--- a/tests/Get-DbaDatabaseCertificate.Tests.ps1
+++ b/tests/Get-DbaDatabaseCertificate.Tests.ps1
@@ -1,0 +1,39 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	Context "Can get a database certificate" {
+		BeforeAll {
+			$masterKey = New-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+			$null = New-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database TempDb -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+			
+			$certificateName1 = "Cert_$(Get-random)"
+			$certificateName2 = "Cert_$(Get-random)"
+			$null = New-DbaDatabaseCertificate -SqlInstance $script:instance1 -Name $certificateName1
+			$null = New-DbaDatabaseCertificate -SqlInstance $script:instance1 -Name $certificateName2 -Database "TempDb"
+		}
+		AfterAll {
+			$null = Remove-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName1 -database Master -Confirm:$false
+			$null = Remove-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName2 -database TempDb -Confirm:$false
+			$null = Remove-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database TempDb
+			if($masterKey) { $null = Remove-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master }
+		}
+		
+		$cert = Get-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName1		
+		It "returns database certificate created in default, master database" {
+			"$($cert.Database)" -match 'master' | Should Be $true
+		}
+
+		$cert = Get-DbaDatabaseCertificate -SqlInstance $script:instance1 -Database TempDb	
+		It "returns database certificate created in TempDb database, looked up by certificate name" {
+			"$($cert.Name)" -match $certificateName2 | Should Be $true
+		}
+
+		$cert = Get-DbaDatabaseCertificate -SqlInstance $script:instance1 -ExcludeDatabase master
+		It "returns database certificates excluding those in the master database" {
+			"$($cert.Database)" -notmatch 'master' | Should Be $true
+		}
+
+	}
+}

--- a/tests/New-DbaDatabaseCertificate.Tests.ps1
+++ b/tests/New-DbaDatabaseCertificate.Tests.ps1
@@ -1,0 +1,31 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	Context "Can create a database certificate" {
+		BeforeAll {
+			$masterKey = New-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+			$null = New-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database TempDb -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+            $certificateName1 = "Cert_$(Get-random)"
+            $certificateName2 = "Cert_$(Get-random)"
+		}
+		AfterAll {
+            $null = Remove-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName1 -database Master -Confirm:$false
+            $null = Remove-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName2 -database TempDb -Confirm:$false
+            if($masterKey) { $null = Remove-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master }
+            $null = Remove-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database TempDb
+        }
+        		
+        $results = New-DbaDatabaseCertificate -SqlInstance $script:instance1 -Name $certificateName1
+        
+		It "Successfully creates a new database certificate in default, master database" {
+            "$($results.name)" -match $certificateName1 | Should Be $true
+        }
+                
+        $results = New-DbaDatabaseCertificate -SqlInstance $script:instance1 -Name $certificateName2 -Database TempDb
+		It "Successfully creates a new database certificate in the TempDb database" {
+		    "$($results.Database)" -match "TempDb"  | Should Be $true
+        }
+	}
+}

--- a/tests/Remove-DbaDatabaseCertificate.Tests.ps1
+++ b/tests/Remove-DbaDatabaseCertificate.Tests.ps1
@@ -1,0 +1,22 @@
+$commandname = $MyInvocation.MyCommand.Name.Replace(".ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	Context "Can remove a database certificate" {
+		BeforeAll {
+			$masterKey = New-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
+			
+			$certificateName1 = "Cert_$(Get-random)"
+			$null = New-DbaDatabaseCertificate -SqlInstance $script:instance1 -Name $certificateName1
+		}
+		AfterAll {
+			if($masterKey) { $null = Remove-DbaDatabaseMasterKey -SqlInstance $script:instance1 -Database Master }
+		}
+		
+		$results = Remove-DbaDatabaseCertificate -SqlInstance $script:instance1 -Certificate $certificateName1 -database Master -Confirm:$false
+		It "Successfully removes database certificate in master" {
+			"$($results.Status)" -match 'Success' | Should Be $true
+		}
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Added Pester Tests for:
- New-DbaDatabaseCertificate
- Get-DbaDatabaseCertificate
- Remove-DbaDatabaseCertificate

### Approach
<!-- How does this change solve that purpose -->

Tests were missing for these cmdlets

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![image](https://user-images.githubusercontent.com/981370/32512775-27a92b22-c3c6-11e7-81a9-aac04569915e.png)

![image](https://user-images.githubusercontent.com/981370/32512791-30cfb874-c3c6-11e7-8513-70c37866ec02.png)

![image](https://user-images.githubusercontent.com/981370/32512798-36d5fb84-c3c6-11e7-806a-36c75bb51323.png)
