### PR TITLE
appveyor.pester, early return for not needed builds

### DIFF
--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -304,9 +304,6 @@ else {
 		Write-Output "You can download it from https://ci.appveyor.com/api/buildjobs/$($env:APPVEYOR_JOB_ID)/tests"
 	}
 	#>
-	if ($AllScenarioTests.Count -eq 0) {
-		return
-	}
 	#What failed? How many tests did we run ?
 	$results = @(Get-ChildItem -Path "$ModuleBase\PesterResults*.xml" | Import-Clixml)
 	

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -258,6 +258,10 @@ if (-not $Finalize) {
 	Write-Output "Testing with PowerShell $PSVersion"
 	Import-Module Pester
 	Set-Variable ProgressPreference -Value SilentlyContinue
+	if ($AllScenarioTests.Count -eq 0) {
+		Write-Host -ForegroundColor DarkGreen "Nothing to do in this scenario"
+		return
+	}
 	# invoking a single invoke-pester consumes too much memory, let's go file by file
 	$AllTestsWithinScenario = Get-ChildItem -File -Path $AllScenarioTests
 	$Counter = 0
@@ -300,7 +304,9 @@ else {
 		Write-Output "You can download it from https://ci.appveyor.com/api/buildjobs/$($env:APPVEYOR_JOB_ID)/tests"
 	}
 	#>
-	
+	if ($AllScenarioTests.Count -eq 0) {
+		return
+	}
 	#What failed? How many tests did we run ?
 	$results = @(Get-ChildItem -Path "$ModuleBase\PesterResults*.xml" | Import-Clixml)
 	


### PR DESCRIPTION
(do RecoveryModel)

shortcircuit scenarios to not end up as in https://github.com/sqlcollaborative/dbatools/pull/2603
