### PR TITLE
Backup History IncludeCopyOnly tests

### DIFF
--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -19,7 +19,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		$db | Backup-DbaDatabase -Type Log -BackupDirectory $DestBackupDir
 		$db | Backup-DbaDatabase -Type Log -BackupDirectory $DestBackupDir
 		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database master | Backup-DbaDatabase -Type Full
-	}
+		$db | Backup-DbaDatabase -Type Full -BackupDirectory $DestBackupDir -BackupFileName CopyOnly.bak -CopyOnly
+ 	}
 	
 	AfterAll {
 		$null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname | Remove-DbaDatabase -Confirm:$false
@@ -42,6 +43,21 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		$results = Get-DbaBackupHistory -SqlInstance $script:instance1
 		It "Should be more than one database" {
 			($results | Where-Object Database -match "master").Count | Should BeGreaterThan 0
+		}
+	}
+
+	Context "Testing IncludeCopyOnly with LastFull"{
+		$results = Get-DbaBackupHistory -SqlInstance $script:instance1 -LastFull -Database $dbname
+		$resultsCo = Get-DbaBackupHistory -SqlInstance $script:instance1 -LastFull -IncludeCopyOnly -Database $dbname
+		It "Should return the CopyOnly Backup"{
+			($resultsCo.BackupSetID -ne $Results.BackupSetID) | Should Be $True
+		}
+	}
+
+	Context "Testing IncludeCopyOnly with Last"{
+		$resultsCo = Get-DbaBackupHistory -SqlInstance $script:instance1 -Last -IncludeCopyOnly -Database $dbname
+		It "Should return just the CopyOnly Full Backup"{
+			($resultsCo | Measure-Object).count | Should Be 1
 		}
 	}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Now that the IncludeCopyOnly logic works in Get-DbaBackupHistory, let's keep it that way with some pestering

### Approach
Added extra contexts to check we get different results for 'real' and 'CopyOnly' backups

