### PR TITLE
Test-DbaPowerPlan, preserve full info

### DIFF
--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -82,7 +82,7 @@ function Test-DbaPowerPlan {
 		foreach ($computer in $ComputerName) {
 			$server = Resolve-DbaNetworkName -ComputerName $computer -Credential $credential
 
-			$computerResolved = $server.ComputerName
+			$computerResolved = $server.FullComputerName
 
 			if (!$computerResolved) {
 				Stop-Function -Message "Couldn't resolve hostname. Skipping." -Continue


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Preserve info about the inputted computername. Using "ComputerName" from Resolve-DbaNetworkName cuts the domain part, and not everyone can rely on the default dns suffix nor netbios.
