### PR TITLE
[New Command] Get-DbaWaitingTask

### DIFF
--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -10,7 +10,7 @@ function Get-DbaWaitingTask {
 		.PARAMETER SqlInstance
 			The SQL Server instance. Server version must be SQL Server version XXXX or higher.
 
-        .PARAMETER SqlCredential
+		.PARAMETER SqlCredential
 			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
 			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
@@ -18,6 +18,9 @@ function Get-DbaWaitingTask {
 			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 
 			To connect as a different Windows user, run PowerShell as that user.
+			
+		.PARAMETER Spid
+			Find the waiting task of one or more specific process ids
 
 		.PARAMETER IncludeSystemSpid
 			If this switch is enabled, the output will include the system sessions.

--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -1,0 +1,139 @@
+function Get-DbaWaitingTask {
+	<#
+		.SYNOPSIS
+			Displays waiting task.
+
+		.DESCRIPTION
+			This command is based on waiting task T-SQL script published by Paul Randal.
+			Reference: https://www.sqlskills.com/blogs/paul/updated-sys-dm_os_waiting_tasks-script-2/
+
+		.PARAMETER SqlInstance
+			The SQL Server instance. Server version must be SQL Server version XXXX or higher.
+
+        .PARAMETER SqlCredential
+			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+			To connect as a different Windows user, run PowerShell as that user.
+
+		.PARAMETER IncludeSystemSpid
+			If this switch is enabled, the output will include the system sessions.
+
+		.PARAMETER EnableException
+			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+		.NOTES
+            Tags: Waits,Task,WaitTask
+            Author: Shawn Melton (@wsmelton)
+
+			Website: https://dbatools.io
+			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Get-DbaWaitingTask
+
+		.EXAMPLE
+			Get-DbaWaitingTask -SqlInstance sqlserver2014a
+
+			Returns the waiting task for all sessions on sqlserver2014a
+
+		.EXAMPLE
+			Get-DbaWaitingTask -SqlInstance sqlserver2014a -IncludeSystemSpid
+
+			Returns the waiting task for all sessions (user and system) on sqlserver2014a
+	#>
+	[CmdletBinding()]
+	param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "SqlServer", "SqlServers")]
+		[DbaInstance[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[parameter(ValueFromPipelineByPropertyName=$true)]
+		[object[]]$Spid,
+		[switch]$IncludeSystemSpid,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	begin {
+		$sql = "
+			SELECT
+				[owt].[session_id] AS [Spid],
+				[owt].[exec_context_id] AS [Thread],
+				[ot].[scheduler_id] AS [Scheduler],
+				[owt].[wait_duration_ms] AS [WaitMs],
+				[owt].[wait_type] AS [WaitType],
+				[owt].[blocking_session_id] AS [BlockingSpid],
+				[owt].[resource_description] AS [ResourceDesc],
+				CASE [owt].[wait_type]
+					WHEN N'CXPACKET' THEN
+						RIGHT ([owt].[resource_description],
+							CHARINDEX (N'=', REVERSE ([owt].[resource_description])) - 1)
+					ELSE NULL
+				END AS [NodeId],
+				[eqmg].[dop] AS [Dop],
+				[er].[database_id] AS [DbId],
+				[est].text AS [SqlText],
+				[eqp].[query_plan] AS [QueryPlan],
+				CAST ('https://www.sqlskills.com/help/waits/' + [owt].[wait_type] as XML) AS [URL]
+			FROM sys.dm_os_waiting_tasks [owt]
+			INNER JOIN sys.dm_os_tasks [ot] ON
+				[owt].[waiting_task_address] = [ot].[task_address]
+			INNER JOIN sys.dm_exec_sessions [es] ON
+				[owt].[session_id] = [es].[session_id]
+			INNER JOIN sys.dm_exec_requests [er] ON
+				[es].[session_id] = [er].[session_id]
+			FULL JOIN sys.dm_exec_query_memory_grants [eqmg] ON
+				[owt].[session_id] = [eqmg].[session_id]
+			OUTER APPLY sys.dm_exec_sql_text ([er].[sql_handle]) [est]
+			OUTER APPLY sys.dm_exec_query_plan ([er].[plan_handle]) [eqp]
+			WHERE
+				[es].[is_user_process] = $(if (Test-Bound 'IncludeSystemSpid') {0} else {1})
+			ORDER BY
+				[owt].[session_id],
+				[owt].[exec_context_id]
+			OPTION(RECOMPILE);"
+	}
+	process {
+		foreach ($instance in $SqlInstance) {
+			Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			$results = $server.Query($sql)
+			foreach ($row in $results) {
+				if (Test-Bound 'Spid') {
+					if ($row.Spid -notin $Spid) { continue }
+				}
+
+				[PSCustomObject]@{
+					ComputerName = $server.NetName
+					InstanceName = $server.ServiceName
+					SqlInstance  = $server.DomainInstanceName
+					Spid         = $row.Spid
+					Thread       = $row.Thread
+					Scheduler    = $row.Scheduler
+					WaitMs       = $row.WaitMs
+					WaitType     = $row.WaitType
+					BlockingSpid = $row.BlockingSpid
+					ResourceDesc = $row.ResourceDesc
+					NodeId       = $row.NodeId
+					Dop          = $row.Dop
+					DbId         = $row.DbId
+					SqlText      = $row.SqlText
+					QueryPlan    = $row.QueryPlan
+					InfoUrl      = $row.InfoUrl
+				} | Select-DefaultView -ExcludeProperty 'SqlText','QueryPlan','InfoUrl'
+			}
+		}
+	}
+}

--- a/tests/Get-DbaWaitingTask.Tests.ps1
+++ b/tests/Get-DbaWaitingTask.Tests.ps1
@@ -39,7 +39,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	$sql = "SELECT '$flag'; WAITFOR DELAY '$time'"
 	$instance = $script:instance2
 
-	$modulePath = 'C:\Github\dbatools\dbatools.psd1'
+	$modulePath = 'C:\Github\dbatools\dbatools.psm1'
 	$job = 'YouHaveBeenFoundWaiting'
 
 	Start-Job -Name $job -ScriptBlock {

--- a/tests/Get-DbaWaitingTask.Tests.ps1
+++ b/tests/Get-DbaWaitingTask.Tests.ps1
@@ -37,7 +37,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	$flag = "dbatools_$(Get-Random)"
 	$time = '00:15:00'
 	$sql = "SELECT '$flag'; WAITFOR DELAY '$time'"
-	$instance = 'localhost'
+	$instance = $script:instance2
 
 	$modulePath = 'C:\Github\dbatools\dbatools.psd1'
 	$job = 'YouHaveBeenFoundWaiting'
@@ -45,43 +45,44 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	Start-Job -Name $job -ScriptBlock {
 		Import-Module $args[0];
 		(Connect-DbaInstance -SqlInstance $args[1] -ClientName dbatools-waiting).Query($args[2])
-		} -ArgumentList $modulePath, $instance, $sql
+	} -ArgumentList $modulePath, $instance, $sql
 
-	Start-Sleep -Seconds 5
+	<#
+		**This has to sleep as it can take a couple seconds for the job to start**
+		Setting it lower will cause issues, you have to consider the Start-Job has to load the module which takes on average 3-4 seconds itself before it executes the command.
+
+		If someone knows a cleaner method by all means adjust this test.
+	#>
+	Start-Sleep -Seconds 8
+
 	$process = Get-DbaProcess -SqlInstance $instance | Where-Object Program -eq 'dbatools-waiting' | Select-Object -ExpandProperty Spid
 
-	# Context "Command actually works" {
-	# 	$results = Get-DbaWaitingTask -SqlInstance $script:instance2 -Spid $process.Spid
-	# 	It "Should have correct properties" {
-	# 		$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Spid,Thread,Scheduler,WaitMs,WaitType,BlockingSpid,ResourceDesc,NodeId,Dop,DbId,URL,QueryPlan,SqlText'.Split(',')
-	# 		($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-	# 	}
-	# 	Get-Job -Name $Job.Name | Remove-Job -Force -ErrorAction SilentlyContinue
-	# }
-
-	# if ($process.Spid -ne $null) {
+	if ($process -ne $null) {
 		Context "Command actually works" {
 			$results = Get-DbaWaitingTask -SqlInstance $instance -Spid $process
 			It "Should have correct properties" {
 				$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Spid,Thread,Scheduler,WaitMs,WaitType,BlockingSpid,ResourceDesc,NodeId,Dop,DbId,InfoUrl,QueryPlan,SqlText'.Split(',')
 				($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 			}
-Write-Host "$($results.Spid) spid running"
-Write-Host "$($process) process running"
 			It "Should have command of 'WAITFOR'" {
-				$results.Command | Should BeLike "*WAITFOR*"
+				$results.WaitType | Should BeLike "*WAITFOR*"
 			}
 		}
 
-		$isProcess = Get-DbaProcess -SqlInstance $instance -Spid $process.Spid
+		$isProcess = Get-DbaProcess -SqlInstance $instance -Spid $process
 		if ($isProcess) {
-			# Stop-DbaProcess -SqlInstance $script:instance2 -Spid $process
-		}
-		# Get-Job -Name $job | Remove-Job -Force -ErrorAction SilentlyContinue
+			Stop-DbaProcess -SqlInstance $instance -Spid $process
 
-	# }
-	# else {
-	# 	$cmdName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
-	# 	Write-Host "$cmdName - Test process could not be generated" -ForegroundColor Cyan
-	# }
+			# I've had a few cases where first run didn't actually kill the process
+			$isProcess = Get-DbaProcess -SqlInstance $instance -Spid $process
+			if ($isProcess) {
+				Stop-DbaProcess -SqlInstance $instance -Spid $process -ErrorAction SilentlyContinue
+			}
+		}
+		Get-Job -Name $job | Remove-Job -Force -ErrorAction SilentlyContinue
+	}
+	else {
+		$cmdName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+		Write-Host "$cmdName - Test process could not be generated" -ForegroundColor Cyan
+	}
 }

--- a/tests/Get-DbaWaitingTask.Tests.ps1
+++ b/tests/Get-DbaWaitingTask.Tests.ps1
@@ -1,0 +1,87 @@
+<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+
+		$paramCount = 5
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Get-DbaWaitingTask).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Spid', 'IncludeSystemSpid'
+		It "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+<#
+	Integration test are custom to the command you are writing it for,
+		but something similar to below should be included if applicable.
+
+	The below examples are by no means set in stone and there are already
+		a number of test that you can pull examples from in how they are done.
+#>
+
+# Get-DbaNoun
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+
+	$flag = "dbatools_$(Get-Random)"
+	$time = '00:15:00'
+	$sql = "SELECT '$flag'; WAITFOR DELAY '$time'"
+	$instance = 'localhost'
+
+	$modulePath = 'C:\Github\dbatools\dbatools.psd1'
+	$job = 'YouHaveBeenFoundWaiting'
+
+	Start-Job -Name $job -ScriptBlock {
+		Import-Module $args[0];
+		(Connect-DbaInstance -SqlInstance $args[1] -ClientName dbatools-waiting).Query($args[2])
+		} -ArgumentList $modulePath, $instance, $sql
+
+	Start-Sleep -Seconds 5
+	$process = Get-DbaProcess -SqlInstance $instance | Where-Object Program -eq 'dbatools-waiting' | Select-Object -ExpandProperty Spid
+
+	# Context "Command actually works" {
+	# 	$results = Get-DbaWaitingTask -SqlInstance $script:instance2 -Spid $process.Spid
+	# 	It "Should have correct properties" {
+	# 		$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Spid,Thread,Scheduler,WaitMs,WaitType,BlockingSpid,ResourceDesc,NodeId,Dop,DbId,URL,QueryPlan,SqlText'.Split(',')
+	# 		($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+	# 	}
+	# 	Get-Job -Name $Job.Name | Remove-Job -Force -ErrorAction SilentlyContinue
+	# }
+
+	# if ($process.Spid -ne $null) {
+		Context "Command actually works" {
+			$results = Get-DbaWaitingTask -SqlInstance $instance -Spid $process
+			It "Should have correct properties" {
+				$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Spid,Thread,Scheduler,WaitMs,WaitType,BlockingSpid,ResourceDesc,NodeId,Dop,DbId,InfoUrl,QueryPlan,SqlText'.Split(',')
+				($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+			}
+Write-Host "$($results.Spid) spid running"
+Write-Host "$($process) process running"
+			It "Should have command of 'WAITFOR'" {
+				$results.Command | Should BeLike "*WAITFOR*"
+			}
+		}
+
+		$isProcess = Get-DbaProcess -SqlInstance $instance -Spid $process.Spid
+		if ($isProcess) {
+			# Stop-DbaProcess -SqlInstance $script:instance2 -Spid $process
+		}
+		# Get-Job -Name $job | Remove-Job -Force -ErrorAction SilentlyContinue
+
+	# }
+	# else {
+	# 	$cmdName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+	# 	Write-Host "$cmdName - Test process could not be generated" -ForegroundColor Cyan
+	# }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Provides method for DBAs to get information on waiting task via script shared by Paul Randal, querying `sys.dm_os_waiting_tasks`.
### Approach
<!-- How does this change solve that purpose -->
Just the query shared by Paul (referenced in help for blog post). I added a few filters similar to what `Get-DbaWaitStatistics` offered.
### Commands to test
The test for this was a pain to get working right. Per recommendation from Fred it uses `Start-Job` so I can have a known session running, something I know will be returned by the command. 

The big fix to get the test to run was adding `Start-Sleep` and I had to find the right value in seconds for the job to load the module and then actually run the command to have a session.

Since the test requires that I import the psm1 file, since this command is not part of the manifest yet, I had to hard code what I think is the path to the file. **I need to know the preferred method we have for pulling this path, or have it added to the constants file so I can reference it.**

<img width="893" alt="image" src="https://user-images.githubusercontent.com/11204251/32686536-02a7f2ec-c66c-11e7-9054-c90fdf4d649a.png">
