### PR TITLE
[New Command] Remove-DbaDbUser

### DIFF
--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -1,0 +1,230 @@
+function Remove-DbaDbUser {
+<#
+    .SYNOPSIS
+    Drop database user
+
+    .DESCRIPTION
+    If user is the owner of a schema with the same name and if if the schema does not have any underlying objects the schema will be
+    dropped.  If user owns more than one schema, the owner of the schemas that does not have the same name as the user, will be
+    changed to 'dbo'. If schemas have underlying objects, you must specify the -Force parameter so the user can be dropped.
+       
+    .PARAMETER SqlInstance
+    The SQL Instances that you're connecting to.
+
+    .PARAMETER SqlCredential
+    Credential object used to connect to the SQL Server as a different user.
+
+    .PARAMETER Database
+    Specifies the database(s) to process. Options for this list are auto-populated from the server. If unspecified, all databases will be processed.
+
+    .PARAMETER ExcludeDatabase
+    Specifies the database(s) to exclude from processing. Options for this list are auto-populated from the server.
+
+    .PARAMETER User
+    Specifies the list of users to remove.
+        
+    .PARAMETER UserCollection
+    Internal parameter to support piping from Get-DbaDatabaseUser.
+
+    .PARAMETER Force
+    If enabled this will force the change of the owner to 'dbo' for any schema which owner is the User.
+
+    .PARAMETER WhatIf
+    Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+    If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .PARAMETER EnableException
+    By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+    This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+    Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        
+    .NOTES
+    Tags: Databases, User
+    Author: Doug Meyers (@dgmyrs)
+
+    Website: https://dbatools.io
+    Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+    License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+    .LINK
+    https://dbatools.io/Remove-DbaDbUser
+
+    .EXAMPLE
+    Remove-DbaDbUser -SqlInstance sqlserver2014 -User user1
+
+    Drops user1 from all databases it exists in on server 'sqlserver2014'.
+
+    .EXAMPLE
+    Remove-DbaDbUser -SqlInstance sqlserver2014 -Database database1 -User user1
+
+    Drops user1 from the database1 database on server 'sqlserver2014'.
+
+    .EXAMPLE
+    Remove-DbaDbUser -SqlInstance sqlserver2014 -ExcludeDatabase model -User user1
+
+    Drops user1 from all databases it exists in on server 'sqlserver2014' except for the model database.
+
+    .EXAMPLE
+    Get-DbaDatabaseUser sqlserver2014 | Where-Object Name -In "user1" | Remove-DbaDbUser
+
+    Drops user1 from all databases it exists in on server 'sqlserver2014'.
+
+#>
+    
+    [CmdletBinding(DefaultParameterSetName='User', SupportsShouldProcess = $true)]
+	Param (
+		[parameter(Position=1, Mandatory, ValueFromPipeline, ParameterSetName='User')]
+		[Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        
+        [parameter(ParameterSetName='User')]
+		[Alias("Credential")]
+		[PSCredential]
+        $SqlCredential,
+        
+        [parameter(ParameterSetName='User')]
+		[Alias("Databases")]
+        [object[]]$Database,
+        
+        [parameter(ParameterSetName='User')]
+        [object[]]$ExcludeDatabase,
+        
+        [parameter(Mandatory, ParameterSetName='User')]
+        [object[]]$User,
+
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName='Object')]
+		[Microsoft.SqlServer.Management.Smo.User[]]$UserCollection,
+        
+        [parameter(ParameterSetName='User')]
+        [parameter(ParameterSetName='Object')]
+        [switch]$Force,
+        
+		[switch][Alias('Silent')]$EnableException
+    )
+
+    begin {
+		function Remove-DbUser {
+			[CmdletBinding()]
+			param ([Microsoft.SqlServer.Management.Smo.User[]]$users)
+
+            foreach ($user in $users) {
+                $db = $user.Parent
+                $server = $db.Parent
+                Write-Message -Level Verbose -Message "Removing User $user from Database $db on target $server"
+
+                # Drop Schemas owned by the user before droping the user
+                $schemaUrns = $user.EnumOwnedObjects() | Where-Object Type -EQ Schema
+                if ($schemaUrns) {
+                    Write-Message -Level Verbose -Message "User $user owns $($schemaUrns.Count) schema(s)."
+                    
+                    # Need to gather up the schema changes so they can be done in a non-desctructive order
+                    $alterSchemas = @()
+                    $dropSchemas = @()
+
+                    foreach ($schemaUrn in $schemaUrns) {
+                        $schema = $server.GetSmoObject($schemaUrn)
+
+                        # Drop any schema that is the same name as the user
+                        if ($schema.Name -EQ $user.Name) {
+                            # Check for owned objects early so we can exit before any changes are made
+                            $ownedUrns = $schema.EnumOwnedObjects()
+                            if (-Not $ownedUrns) {
+                                $dropSchemas += $schema
+                            } else {
+                                Write-Message -Level Warning -Message "User owns objects in the database and will not be removed."
+                                foreach ($ownedUrn in $ownedUrns) {
+                                    $obj = $server.GetSmoObject($ownedUrn)
+                                    Write-Message -Level Warning -Message "User $user owns $($obj.GetType().Name) $obj"
+                                }
+                                return  # exit function
+                            }
+                        }
+
+                        # Change the owner of any schema not the same name as the user
+                        if ($schema.Name -NE $user.Name) {
+                            # Check for owned objects early so we can exit before any changes are made
+                            $ownedUrns = $schema.EnumOwnedObjects()
+                            if (($ownedUrns -And $Force) -Or (-Not $ownedUrns)) {
+                                $alterSchemas += $schema
+                            } else {
+                                Write-Message -Level Warning -Message "User $user owns the Schema $schema, which owns $($ownedUrns.Count) Object(s).  If you want to change the schemas' owner to [dbo] and drop the user anyway, use -Force parameter.  User $user will not be removed."
+                                return  #exit the function
+                            }
+                        }
+                    }
+
+                    # Perform the changes with the owner alters first so function can exit w/o a drop if -Force wasn't used
+                    foreach ($schema in $alterSchemas) {
+                        Write-Message -Level Verbose -Message "Owner of Schema $schema will be changed to [dbo]."
+                        if ($PSCmdlet.ShouldProcess($server, "Change the owner of Schema $schema to [dbo].")) {
+                            $schema.Owner = "dbo"
+                            $schema.Alter()
+                        }
+                    }
+
+                    foreach ($schema in $dropSchemas) {
+                        if ($PSCmdlet.ShouldProcess($server, "Drop Schema $schema from Database $db.")) {
+                            $schema.Drop()
+                        }
+                    }
+                }
+
+                # Drop the User
+                if ($PSCmdlet.ShouldProcess($server, "Drop User $user from Database $db.")) {
+                    try {
+                        $user.Drop()
+                        [pscustomobject]@{
+                            SqlInstance = $server.name
+                            Database    = $db.name
+                            User        = $user
+                            Status      = "Dropped"
+                        }
+                    } catch {
+                        Write-Message -Level Verbose -Message "Could not drop $user from Database $db on target $server"
+                        [pscustomobject]@{
+                            SqlInstance = $server.name
+                            Database    = $db.name
+                            User        = $user
+                            Status      = "Not Dropped"
+                        }
+                    }
+                }
+            }
+		}
+	}
+    
+    process {
+        if ($UserCollection) {
+            Remove-DbUser $UserCollection
+        } else {
+            foreach ($instance in $SqlInstance) {
+                try {
+                    Write-Message -Level Verbose -Message "Connecting to $instance"
+                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+                }
+                catch {
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                }
+                
+                $databases = $server.Databases
+                
+                if ($Database) {
+                    $databases = $databases | Where-Object Name -In $Database
+                }
+                if ($ExcludeDatabase) {
+                    $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
+                }
+                
+                foreach ($db in $databases) {
+                    Write-Message -Level Verbose -Message "Get users in Database $db on target $server"
+                    $users = Get-DbaDatabaseUser -SqlInstance $instance -SqlCredential $SqlCredential -Database $db.Name
+                    $users = $users | Where-Object Name -In $User
+                    Remove-DbUser $users
+                }
+            }
+        }
+    }
+
+}

--- a/tests/Remove-DbaDbUser.Tests.ps1
+++ b/tests/Remove-DbaDbUser.Tests.ps1
@@ -1,0 +1,66 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Verifying User is removed" {
+        BeforeAll {
+            $server = Connect-DbaInstance -SqlInstance $script:instance1
+            $db = Get-DbaDatabase $server -Database tempdb
+            $securePassword = ConvertTo-SecureString "password" -AsPlainText -Force
+            $loginTest = New-DbaLogin $server -Login dbatoolsci_remove_dba_db_user -Password $securePassword
+        }
+        BeforeEach {
+            $user = New-Object Microsoft.SqlServer.Management.SMO.User($db, $loginTest.Login)
+            $user.Login = $loginTest.Login
+            $user.Create()
+        }
+        AfterEach {
+            $user = $db.Users[$loginTest.Login]
+            if ($user) {
+                $schemaUrns = $user.EnumOwnedObjects() | Where-Object Type -EQ Schema
+                foreach ($schemaUrn in $schemaUrns) {
+                    $schema = $server.GetSmoObject($schemaUrn)
+                    $ownedUrns = $schema.EnumOwnedObjects()
+                    foreach ($ownedUrn in $ownedUrns) {
+                        $obj = $server.GetSmoObject($ownedUrn)
+                        $obj.Drop()
+                    }
+                    $schema.Drop()
+                }
+                $user.Drop()
+            }
+        }
+        AfterAll {
+            $login = $server.Logins.Item($loginTest.Login)
+            if ($login) {
+                $login.Drop()
+            }
+        }
+	
+		It "drops a user with no ownerships" {
+            Remove-DbaDbUser $server -Database tempdb -User $user.Name
+			$db.Users[$user.Name] | Should BeNullOrEmpty
+        }
+        
+        It "drops a user with a schema of the same name, but no objects owned by the schema" {
+            $schema = New-Object Microsoft.SqlServer.Management.SMO.Schema($db, $user.Name)
+            $schema.Owner = $user.Name
+            $schema.Create()
+            Remove-DbaDbUser $server -Database tempdb -User $user.Name
+			$db.Users[$user.Name] | Should BeNullOrEmpty
+        }
+
+        It "does NOT drop a user that owns objects other than a schema" {
+            $schema = New-Object Microsoft.SqlServer.Management.SMO.Schema($db, $user.Name)
+            $schema.Owner = $user.Name
+            $schema.Create()
+            $table = New-Object Microsoft.SqlServer.Management.SMO.Table($db, "dbtoolsci_remove_dba_db_user", $user.Name)
+            $col1 = New-Object Microsoft.SqlServer.Management.SMO.Column($table, "col1", [Microsoft.SqlServer.Management.SMO.DataType]::Int)
+            $table.Columns.Add($col1)
+            $table.Create()
+            Remove-DbaDbUser $server -Database tempdb -User $user.Name
+            $db.Users[$user.Name] | Should Be $user
+        }
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
New Command Remove-DbaDbUser

### Approach
Users without any owned objects will be removed.  Users with a schema of the same name as the user that doesn't own objects will also be removed.  Users that own a schema of the same name as the user that also has objects owned by the schema will not be removed.  Users that own a schema of another name that has owned objects will only be removed after the schema owner is changed to dbo, and only if the -Force param is used.

