### PR TITLE
Added configuration for module import options

### DIFF
--- a/functions/Set-DbaConfig.ps1
+++ b/functions/Set-DbaConfig.ps1
@@ -278,21 +278,20 @@ function Set-DbaConfig
 				}
 				$Value = $testResult.Value
 			}
-			if ((-not $DisableHandler) -and ($cfg.Handler) -and (Test-Bound -ParameterName "Value"))
-			{
-				try { [scriptblock]::Create($cfg.Handler.ToString()).Invoke($Value) }
-				catch
-				{
-					Stop-Function -Message "Could not update configuration $internalFullName | Failed handling $_" -EnableException $EnableException -Category InvalidResult -Target $internalFullName
-					return
-				}
-			}
 			
 			if (Test-Bound -ParameterName "Hidden") { [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName].Hidden = $Hidden }
 			if (Test-Bound -ParameterName "Value") { [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName].Value = $Value }
 			if (Test-Bound -ParameterName "Description") { [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName].Description = $Description }
 			if (Test-Bound -ParameterName "Handler") { [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName].Handler = $Handler }
 			if (Test-Bound -ParameterName "Validation") { [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Configurations[$internalFullName].Validation = [Sqlcollaborative.Dbatools.Configuration.ConfigurationHost]::Validation[$Validation.ToLower()] }
+			
+			if ((-not $DisableHandler) -and ($cfg.Handler) -and (Test-Bound -ParameterName "Value")) {
+				try { [scriptblock]::Create($cfg.Handler.ToString()).Invoke($Value) }
+				catch {
+					Stop-Function -Message "Could not update configuration $internalFullName | Failed handling $_" -EnableException $EnableException -Category InvalidResult -Target $internalFullName
+					return
+				}
+			}
 		}
 	}
 	#endregion Regular configuration update

--- a/internal/configurations/settings/import.ps1
+++ b/internal/configurations/settings/import.ps1
@@ -1,0 +1,55 @@
+﻿# Handle dotsourcing on import
+Set-DbaConfig -Name 'Import.DoDotSource' -Value $false -Initialize -Validation bool -Handler {
+	try {
+		if (-not (Test-Path "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System")) { $null = New-Item "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -ItemType Container -Force -ErrorAction Stop }
+		if ($args[0]) { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name DoDotSource -PropertyType DWORD -Value 1 -Force -ErrorAction Stop }
+		else { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name DoDotSource -PropertyType DWORD -Value 0 -Force -ErrorAction Stop }
+		# Scope Boundary exception: $cfg is defined in Set-DbaConfig
+		Register-DbaConfig -Config $cfg
+	}
+	catch {
+		Write-Message -Level Warning -Message "Failed to apply configuration 'Import.DoDotSource'" -ErrorRecord $_ -Target 'Import.DoDotSource'
+	}
+} -Description "Causes the module to be imported using dotsourcing. Security policy may require it, also useful for debugging. This configuration setting persists across all PowerShell consoles for this user!"
+
+# Handle dotsourcing on import
+Set-DbaConfig -Name 'Import.StrictSecurityMode' -Value $false -Initialize -Validation bool -Handler {
+	try {
+		if (-not (Test-Path "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System")) { $null = New-Item "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -ItemType Container -Force -ErrorAction Stop }
+		if ($args[0]) { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name StrictSecurityMode -PropertyType DWORD -Value 1 -Force -ErrorAction Stop }
+		else { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name StrictSecurityMode -PropertyType DWORD -Value 0 -Force -ErrorAction Stop }
+		# Scope Boundary exception: $cfg is defined in Set-DbaConfig
+		Register-DbaConfig -Config $cfg
+	}
+	catch {
+		Write-Message -Level Warning -Message "Failed to apply configuration 'Import.StrictSecurityMode'" -ErrorRecord $_ -Target 'Import.StrictSecurityMode'
+	}
+} -Description "Causes the module to import its components only from the module directory. This makes it harder to update the module, but may be required by security policy. This configuration setting persists across all PowerShell consoles for this user!"
+
+# Handle dotsourcing on import
+Set-DbaConfig -Name 'Import.AlwaysBuildLibrary' -Value $false -Initialize -Validation bool -Handler {
+	try {
+		if (-not (Test-Path "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System")) { $null = New-Item "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -ItemType Container -Force -ErrorAction Stop }
+		if ($args[0]) { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name AlwaysBuildLibrary -PropertyType DWORD -Value 1 -Force -ErrorAction Stop }
+		else { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name AlwaysBuildLibrary -PropertyType DWORD -Value 0 -Force -ErrorAction Stop }
+		# Scope Boundary exception: $cfg is defined in Set-DbaConfig
+		Register-DbaConfig -Config $cfg
+	}
+	catch {
+		Write-Message -Level Warning -Message "Failed to apply configuration 'Import.AlwaysBuildLibrary'" -ErrorRecord $_ -Target 'Import.AlwaysBuildLibrary'
+	}
+} -Description "Causes the module to compile the library from source on every import. Of interest for developers only, as this imposes a significant increase in import time. This configuration setting persists across all PowerShell consoles for this user!"
+
+# Handle dotsourcing on import
+Set-DbaConfig -Name 'Import.SerialImport' -Value $false -Initialize -Validation bool -Handler {
+	try {
+		if (-not (Test-Path "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System")) { $null = New-Item "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -ItemType Container -Force -ErrorAction Stop }
+		if ($args[0]) { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name SerialImport -PropertyType DWORD -Value 1 -Force -ErrorAction Stop }
+		else { $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name SerialImport -PropertyType DWORD -Value 0 -Force -ErrorAction Stop }
+		# Scope Boundary exception: $cfg is defined in Set-DbaConfig
+		Register-DbaConfig -Config $cfg
+	}
+	catch {
+		Write-Message -Level Warning -Message "Failed to apply configuration 'Import.SerialImport'" -ErrorRecord $_ -Target 'Import.SerialImport'
+	}
+} -Description "Enabling this will cause the module to perform import in a serial manner, not parallelizing anything. This will impose a significant delay on import, but reduces the CPU impact during import. Setting this for an unattended script may be useful to avoid resource alerts. Can be set on script level by placing the following code in the first line: '`$dbatools_serialimport = `$true'. This configuration setting persists across all PowerShell consoles for this user!"


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Bugfix: `Set-DbaConfig` was running the handler before applying changes, rather than after. This was causing issues with registering changes as part of the handler.
 - New feature: Added configurations for the import options dbatools offers

### Notes

Those new configuration settings automatically register themselves in registry (local user scope) so they persist across sessions. This is necessary, as the configuration system is loaded during the import itself obviously, thus setting this will only affect the next import after that.

Implements https://github.com/sqlcollaborative/dbatools/issues/2638