### PR TITLE
fixed progress bar and timeouts

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -212,9 +212,9 @@ Function Invoke-DbaAdvancedRestore{
                             $script = $Restore.Script($server)
                         }
                         elseif ($VerifyOnly) {
-                            Write-Progress -id 2 -activity "Verifying $Database backup file on $servername" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                             $Verify = $Restore.sqlverify($server)
-                            Write-Progress -id 2 -activity "Verifying $Database backup file on $servername" -status "Complete" -Completed
+                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance" -status "Complete" -Completed
     
                             if ($verify -eq $true) {
                                 return "Verify successful"
@@ -224,10 +224,10 @@ Function Invoke-DbaAdvancedRestore{
                             }
                         }
                         else {
-                            Write-Progress -id 2 -activity "Restoring $Database to $ServerName" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                             $script = $Restore.Script($Server)
                             $Restore.sqlrestore($Server)
-                            Write-Progress -id 2 -activity "Restoring $Database to $ServerName" -status "Complete" -Completed
+                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -status "Complete" -Completed
                         }
                     }
                     catch {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -342,7 +342,8 @@ function Restore-DbaDatabase {
         [string]$FormatBackupInformation,
         [switch]$StopAfterFormatBackupInformation,
         [string]$TestBackupInformation,
-        [switch]$StopAfterTestBackupInformation
+        [switch]$StopAfterTestBackupInformation,
+        [int]$StatementTimeout = 0
 
     )
     begin {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #2634 (partiallly))
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixed the timeout issue, no defaults to no timeout
Progress bars during restore will show the destination name

Also, @potatoqualitee could you add these to the exported function in psd1:
Select-DbaBackupInformation
Format-DbaBackupInformation
Test-DbaBackupInformation
Invoke-DbaAdvancedRestore

They're all meant to be public for debugging and for people to build up their own pipelines for stranger things. Blog posts to follow, but noticed they weren't public when I writing the examples

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
