### PR TITLE
Improve reuse of connections in Restore-DbaDatabase

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -179,7 +179,7 @@ function Get-DbaBackupInformation {
                 ForEach ($f in $path) {
                     if ($f -match '\.\w{3}\Z') {
                         Write-Message -Message "Testing a single file $f " -Level Verbose
-                        if ((Test-DbaSqlPath -Path $f -SqlInstance $SqlInstance -SqlCredential $SqlCredential) -and $p -notlike 'http*') {
+                        if ((Test-DbaSqlPath -Path $f -SqlInstance $server) -and $p -notlike 'http*') {
                             $f = $f | Select-Object *, @{ Name = "FullName"; Expression = { $f } }
                             $files += $f
                         }
@@ -187,7 +187,7 @@ function Get-DbaBackupInformation {
                     else
                     {
                         Write-Message -Message "Testing a folder $f" -Level Verbose
-                        $Files += Get-XpDirTreeRestoreFile -Path $f -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+                        $Files += Get-XpDirTreeRestoreFile -Path $f -SqlInstance $server
                     }
                 }
             } 
@@ -207,7 +207,7 @@ function Get-DbaBackupInformation {
                 }
             }
             
-            $FileDetails = $Files | Read-DbaBackupHeader -SqlInstance $SqlInstance -SqlCredential $sqlcredential
+            $FileDetails = $Files | Read-DbaBackupHeader -SqlInstance $server
 
             $groupdetails = $FileDetails | group-object -Property BackupSetGUID
             

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
         Context "Everything as it should" {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-SqlInstance { $true }
+            Mock Connect-SqlInstance { [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]"done" }
             Mock Get-DbaDatabase { $null }
             Mock Get-DbaDatabaseFile { $null }
             Mock New-DbaSqlDirectory  {$true}
@@ -23,7 +23,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 		Context "Not being able to see backups is bad" {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-SqlInstance { $true }
+            Mock Connect-SqlInstance { [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]"done" }
             Mock Get-DbaDatabase { $null }
             Mock Get-DbaDatabaseFile { $null }
             Mock New-DbaSqlDirectory  {$true}
@@ -40,7 +40,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance { $true }
+            Mock Connect-SqlInstance { [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]"done" }
             Mock Get-DbaDatabase { $null }
             Mock Get-DbaDatabaseFile { $null }
             Mock New-DbaSqlDirectory  {$true}
@@ -57,7 +57,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance { $true }
+            Mock Connect-SqlInstance { [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]"done" }
             Mock Get-DbaDatabase { '1' }
             Mock Get-DbaDatabaseFile { $null }
             Mock New-DbaSqlDirectory  {$true}
@@ -74,7 +74,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation 
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance { $true }
+            Mock Connect-SqlInstance { [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]"done" }
             Mock Get-DbaDatabase { '1' }
             Mock Get-DbaDatabaseFile { $null }
             Mock New-DbaSqlDirectory  {$true}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2634 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes the other half of #2634 by reducing the number of open connections needed by restore-dbadatabase

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
Confirmed lower connection locally by me, and @alevyinroc has confirmed seperately as well

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning

