### PR TITLE
Write-DbaDataTable, honor NoTableLock

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -267,10 +267,13 @@ function Write-DbaDataTable {
 		}
 
 		$bulkCopyOptions = 0
-		$options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default", "Truncate"
+		$options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default"
 
 		foreach ($option in $options) {
 			$optionValue = Get-Variable $option -ValueOnly -ErrorAction SilentlyContinue
+			if ($option -eq "TableLock" -and (!$NoTableLock)) {
+				$optionValue = $true
+			}
 			if ($optionValue -eq $true) {
 				$bulkCopyOptions += $([Data.SqlClient.SqlBulkCopyOptions]::$option).value__
 			}
@@ -354,7 +357,7 @@ function Write-DbaDataTable {
 		$validTypes = @([System.Data.DataSet], [System.Data.DataTable], [System.Data.DataRow], [System.Data.DataRow[]])
 
 		if ($InputObject.GetType() -notin $validTypes) {
-			Stop-Function -Message "Data is not of the right type (DbDataReader, DataTable, DataRow, or IDataReader). Tip: Try using Out-DbaDataTable to convert the object first."
+			Stop-Function -Message "Data is not of the right type (DbDataReader, DataTable, or DataRow). Tip: Try using Out-DbaDataTable to convert the object first."
 			return
 		}
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Honoring NoTableLock means activating TableLock by default, which was not active.

Also, change the message returned when a non-compatible type is passed in because there's no way for this function to accept an IDataReader (feel free to add an example if you can)
