### PR TITLE
Copy-DbaAgentAlert - Fixing logic that checks for alert's existence on destination

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -160,7 +160,7 @@ function Copy-DbaAgentAlert {
 			if ($destAlerts.name -contains $serverAlert.name) {
 				if ($force -eq $false) {
 					$copyAgentAlertStatus.Status = "Skipped"
-					$copyAgentAlertStatus.Notes = "Already exists among the alerts: $($destAlerts.name -join ', ')"
+					$copyAgentAlertStatus.Notes = "Already exists"
 					$copyAgentAlertStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 					Write-Message -Message "Alert [$alertName] exists at destination. Use -Force to drop and migrate." -Level Verbose
 					continue

--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -153,7 +153,6 @@ function Copy-DbaAgentAlert {
 				Status            = $null
 				DateTime          = [Sqlcollaborative.Dbatools.Utility.DbaDateTime](Get-Date)
 			}
-
 			if (($Alert -and $Alert -notcontains $alertName) -or ($ExcludeAlert -and $ExcludeAlert -contains $alertName)) {
 				continue
 			}
@@ -161,12 +160,12 @@ function Copy-DbaAgentAlert {
 			if ($destAlerts.name -contains $serverAlert.name) {
 				if ($force -eq $false) {
 					$copyAgentAlertStatus.Status = "Skipped"
-					$copyAgentAlertStatus.Notes = "Already exists"
+					$copyAgentAlertStatus.Notes = "Already exists among the alerts: $($destAlerts.name -join ', ')"
 					$copyAgentAlertStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 					Write-Message -Message "Alert [$alertName] exists at destination. Use -Force to drop and migrate." -Level Verbose
 					continue
 				}
-
+			
 				if ($PSCmdlet.ShouldProcess($Destination, "Dropping alert $alertName and recreating")) {
 					try {
 						Write-Message -Message "Dropping Alert $alertName on $destServer." -Level Verbose
@@ -174,6 +173,7 @@ function Copy-DbaAgentAlert {
 						$sql = "EXEC msdb.dbo.sp_delete_alert @name = N'$($alertname)';"
 						Write-Message -Message $sql -Level Debug
 						$null = $destServer.Query($sql)
+						$destAlerts.Refresh()
 					}
 					catch {
 						$copyAgentAlertStatus.Status = "Failed"
@@ -183,24 +183,20 @@ function Copy-DbaAgentAlert {
 				}
 			}
 
-			$destSevConflict = $destAlerts | Where-Object Severity -eq $serverAlert.Severity
-			$destSevDbConflict = $destAlerts | Where-Object { $_.Severity -eq $serverAlert.Severity -and $_.DatabaseName -eq $serverAlert.DatabaseName }
-			if ($destSevConflict) {
-				Write-Message -Level Verbose -Message "Alert [$($destSevConflict.Name)] has already been defined to use the severity $($serverAlert.Severity). Skipping."
-				
+			if ($destAlerts | Where-Object { $_.Severity -eq $serverAlert.Severity -and $_.MessageID -eq $serverAlert.MessageID -and $_.DatabaseName -eq $serverAlert.DatabaseName -and $_.EventDescriptionKeyword -eq $serverAlert.EventDescriptionKeyword }) {
+				$conflictMessage = "Alert [$alertName] has already been defined to use"
+				if ($serverAlert.Severity -gt 0) { $conflictMessage += " severity $($serverAlert.Severity)" }
+				if ($serverAlert.MessageID -gt 0) { $conflictMessage += " error number $($serverAlert.MessageID)" }
+				if ($serverAlert.DatabaseName) { $conflictMessage += " on database '$($serverAlert.DatabaseName)'" }
+				if ($serverAlert.EventDescriptionKeyword) { $conflictMessage += " with error text '$($serverAlert.Severity)'" }
+				$conflictMessage += ". Skipping."
+
+				Write-Message -Level Verbose -Message $conflictMessage
 				$copyAgentAlertStatus.Status = "Skipped"
-				$copyAgentAlertStatus.Notes = "Already defined"
+				$copyAgentAlertStatus.Notes = $conflictMessage
 				$copyAgentAlertStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 				continue
 			}
-			if ($destSevDbConflict) {
-				Write-Message -Level Verbose -Message "Alert [$($destSevConflict.Name)] has already been defined to use the severity $($serverAlert.Severity) on database $($severAlert.DatabaseName). Skipping."
-
-				$copyAgentAlertStatus.Status = "Skipped"
-				$copyAgentAlertStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-				continue
-			}
-
 			if ($serverAlert.JobName -and $destServer.JobServer.Jobs.Name -NotContains $serverAlert.JobName) {
 				Write-Message -Level Verbose -Message "Alert [$alertName] has job [$($serverAlert.JobName)] configured as response. The job does not exist on destination $destServer. Skipping."
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2480)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Alerts can not be copied if they use error messages instead of severities. This fix resolves this issue.
Also fixes behavior when -Force is used by refreshing the SMO object after dropping the alert.

### Approach
More detailed comparison between source and destination; refreshing the object after T-SQL command; also code reuse.

### Commands to test
Couldn't write a decent test - mocking Connect-SqlInstance turned out to be a nightmare. Can we have a second agent running on Appveyor? From what I remember, one of the instances is Express without the Agent.
It works as intended in my lab, but I really want to add tests for it.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
