### PR TITLE
Enhancement/ci pipeline

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,11 +25,6 @@ environment:
 # Set alternative clone folder
 clone_folder: c:\github\dbatools
 
-artifacts:
-  - path: msbuild.log
-    name: MSBuild Log
-
-
 before_test:
   # grab appveyor lab files and needed requirements for tests in CI
   - ps: .\Tests\appveyor.prep.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,48 +31,21 @@ artifacts:
 
 
 before_test:
-  # Install codecov to upload results
-  - ps: choco install codecov | Out-Null
-
-  # grab appveyor lab files
+  # grab appveyor lab files and needed requirements for tests in CI
   - ps: .\Tests\appveyor.prep.ps1
-  # "Get Pester manually"
-  - ps: Install-Module -Name Pester -Repository PSGallery -Force | Out-Null
-  # "Installing nuget and PSScriptAnalyzer"
-  #- ps: Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
-  #- ps: Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
-  #- ps: Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null
-  # "Setting up the local SQL Server environments"
+
+  # Setting up the local SQL Server environments
   - ps: .\Tests\appveyor.sqlserver.ps1
  
 test_script:
-   # "Test with native PS version"
-    
+   # Test with native PS version
   - ps: .\Tests\appveyor.pester.ps1 -IncludeCoverage
-  
-  # "Test with PS version 3" - Removed because it's not a true test. Even PS4+ .Where() works
-  # - ps: powershell.exe -version 3.0 -executionpolicy bypass -noprofile -file .\Tests\appveyor.pester.ps1
 
-  # "Collecting and uploading results"
-  - ps: |
-        .\Tests\appveyor.pester.ps1 -Finalize -IncludeCoverage
-        Push-AppveyorArtifact PesterResultsCoverage.json -FileName "PesterResultsCoverage"
-        codecov -f PesterResultsCoverage.json
-  # DLL unittests only in default scenario
-  - ps: |
-        if($env:SCENARIO -eq 'default') {
-          choco install opencover.portable | Out-Null
-          OpenCover.Console.exe `
-              -register:user `
-              -target:"vstest.console.exe" `
-              -targetargs:"/logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll" `
-              -output:"coverage.xml" `
-              -filter:"+[dbatools]*" `
-              -returntargetcode | Out-Null
-          Push-AppveyorArtifact coverage.xml -FileName "OpenCover c# report"
-          codecov -f "coverage.xml" | Out-Null
-        }
+  # Collecting results
+  - ps: .\Tests\appveyor.pester.ps1 -Finalize -IncludeCoverage
 
+after_test:
+  - ps: .\Tests\appveyor.post.ps1
 
 #on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/tests/appveyor.SQL2016.ps1
+++ b/tests/appveyor.SQL2016.ps1
@@ -44,7 +44,18 @@ while ((Get-Service "SQLAgent`$$instance").Status -ne 'Running' -and $z++ -lt 10
 # Whatever, just sleep an extra 5
 Start-Sleep 5
 
+# this needs to be moved out. Tests that require these things need to run this in a BeforeAll stanza and remove the cruft in an AfterAll one
+# so everybody can run tests without needing this too (which should be used strictly as appveyor-setup-related activities)
+# when this fails for resource contention, the whole build stops for no reason. At most, it should fail only tests that are in the need of the reqs
 Write-Host -Object "$indent Executing startup scripts for SQL Server 2016" -ForegroundColor DarkGreen
+$sql2016Startup = 0
 foreach ($file in (Get-ChildItem C:\github\appveyor-lab\sql2016-startup\*.sql -Recurse -ErrorAction SilentlyContinue)) {
-	Invoke-Sqlcmd2 -ServerInstance $sqlinstance -InputFile $file
+	try {
+		Invoke-Sqlcmd2 -ServerInstance $sqlinstance -InputFile $file -ErrorAction Stop
+	} catch {
+		$sql2016Startup = 1
+	}
+}
+if ($sql2016Startup -eq 1) {
+	Write-Host -Object "$indent something went wrong with startup scripts" -ForegroundColor DarkGreen
 }

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -255,7 +255,6 @@ if (-not $Finalize) {
 #Run a test with the current version of PowerShell
 #Make things faster by removing most output
 if (-not $Finalize) {
-	Write-Output "Testing with PowerShell $PSVersion"
 	Import-Module Pester
 	Set-Variable ProgressPreference -Value SilentlyContinue
 	if ($AllScenarioTests.Count -eq 0) {

--- a/tests/appveyor.post.ps1
+++ b/tests/appveyor.post.ps1
@@ -1,0 +1,17 @@
+﻿Write-Host -Object "appveyor.post: Sending coverage data" -ForeGroundColor DarkGreen
+Push-AppveyorArtifact PesterResultsCoverage.json -FileName "PesterResultsCoverage"
+codecov -f PesterResultsCoverage.json --flag "PS,$($env:SCENARIO)" | Out-Null
+# DLL unittests only in default scenario
+if($env:SCENARIO -eq 'default') {
+  Write-Host -Object "appveyor.post: DLL unittests"  -ForeGroundColor DarkGreen
+  choco install opencover.portable | Out-Null
+  OpenCover.Console.exe `
+    -register:user `
+    -target:"vstest.console.exe" `
+    -targetargs:"/logger:Appveyor bin\projects\dbatools\dbatools.Tests\bin\Debug\dbatools.Tests.dll" `
+    -output:"coverage.xml" `
+    -filter:"+[dbatools]*" `
+    -returntargetcode | Out-Null
+  Push-AppveyorArtifact coverage.xml -FileName "OpenCover c# report"
+  codecov -f "coverage.xml" --flag "C#" | Out-Null
+}

--- a/tests/appveyor.post.ps1
+++ b/tests/appveyor.post.ps1
@@ -1,6 +1,6 @@
 ﻿Write-Host -Object "appveyor.post: Sending coverage data" -ForeGroundColor DarkGreen
 Push-AppveyorArtifact PesterResultsCoverage.json -FileName "PesterResultsCoverage"
-codecov -f PesterResultsCoverage.json --flag "PS,$($env:SCENARIO)" | Out-Null
+codecov -f PesterResultsCoverage.json --flag "ps,$($env:SCENARIO.toLower())" | Out-Null
 # DLL unittests only in default scenario
 if($env:SCENARIO -eq 'default') {
   Write-Host -Object "appveyor.post: DLL unittests"  -ForeGroundColor DarkGreen
@@ -13,5 +13,5 @@ if($env:SCENARIO -eq 'default') {
     -filter:"+[dbatools]*" `
     -returntargetcode | Out-Null
   Push-AppveyorArtifact coverage.xml -FileName "OpenCover c# report"
-  codecov -f "coverage.xml" --flag "C#" | Out-Null
+  codecov -f "coverage.xml" --flag "dll,$($env:SCENARIO.toLower())" | Out-Null
 }

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -1,3 +1,13 @@
-﻿Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-Write-Output "Cloning lab materials"
+﻿Write-Host -Object "appveyor.prep: Cloning lab materials"  -ForegroundColor DarkGreen
 git clone -q --branch=master --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
+#Install codecov to upload results
+Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen
+choco install codecov | Out-Null
+# "Installing nuget and PSScriptAnalyzer"
+#Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
+#Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
+#Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null
+
+# "Get Pester manually"
+Write-Host -Object "appveyor.prep: Install Pester" -ForegroundColor DarkGreen
+Install-Module -Name Pester -Repository PSGallery -Force | Out-Null

--- a/tests/appveyor.sqlserver.ps1
+++ b/tests/appveyor.sqlserver.ps1
@@ -1,8 +1,3 @@
-Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
-# Imports some assemblies
-Write-Host -Object "Importing dbatools" -ForegroundColor DarkGreen
-Import-Module C:\github\dbatools\dbatools.psd1
-
 Write-Host -Object "Creating migration & backup directories" -ForegroundColor DarkGreen
 New-Item -Path C:\temp -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 New-Item -Path C:\temp\migration -ItemType Directory -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [x] Build system
 
### Purpose
On the road of streamlining our CI process, this is the long due "let's shut up a bit the build messages".
The path is long, but set.

### Approach
- Created specialized scripts instead of littering appveyor.yml, whose commands are unsilenceable.
- Added flags for reporting (nice codecov feature, see https://docs.codecov.io/v4.3.6/docs/flags) ... on dbatools 2.0 we could eventually tag tests by pester tags.


Added notes on startup scripts. Let's think to every future committed test that it should work on its own in each user's test server/environment *without* having to match
  the appveyor environment. Specifically, startup scripts on the 2016 instance are there for commodity-testing SQLAgent and ola's related functions.
  Incidentally, they make the build stop if the agent is still starting (resource contention) often. This behaviour has been redacted, the build will go along and - probably - tests
  depending on those resources will be flagged as not passed, appropriately.
  The tests will fail if the startup scripts are not ran...and running them can cause problems because of no checks done pre or no cleanup done post.
  Not all users have spare test environments to obliterate. This pretty much goes in the same way as having each resource created with a dbatoolsci_ prefix and being nice - possibly - everywhere
