### PR TITLE
Add REVOKE and GRANT statements

### DIFF
--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -118,7 +118,9 @@ function Get-DbaPermission {
 					, [SecurableType] = COALESCE(o.type_desc,dp.class_desc)
 					, [Securable] = CASE	WHEN class = 0 THEN DB_NAME()
 											WHEN class = 1 THEN ISNULL(s.name + '.','')+OBJECT_NAME(major_id)
-											WHEN class = 3 THEN SCHEMA_NAME(major_id) END
+											WHEN class = 3 THEN SCHEMA_NAME(major_id)
+                                            WHEN class = 6 THEN SCHEMA_NAME(t.schema_id)+'.' + t.name
+                                            END
 					, [Grantee] = USER_NAME(grantee_principal_id)
 					, [GranteeType] = pr.type_desc
                     , [revokeStatement] = 'REVOKE ' + permission_name + ' ON ' + isnull(schema_name(o.object_id)+'.','')+OBJECT_NAME(major_id)+ ' FROM [' + USER_NAME(grantee_principal_id) + ']'
@@ -127,6 +129,7 @@ function Get-DbaPermission {
 					JOIN sys.database_principals pr ON pr.principal_id = dp.grantee_principal_id
 					LEFT OUTER JOIN sys.all_objects o ON o.object_id = dp.major_id
 					LEFT OUTER JOIN sys.schemas s ON s.schema_id = o.schema_id
+                    LEFT OUTER JOIN sys.types t on t.user_type_id = dp.major_id
 
 				$ExcludeSystemObjectssql
 				;"

--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -180,7 +180,7 @@ function Get-DbaPermission {
 			
 			if ($IncludeServerLevel) {
 				Write-Message -Level Debug -Message "T-SQL: $ServPermsql"
-				$server.Query($ServPermsql).Tables.Rows
+				$server.Query($ServPermsql)
 			}
 
 			$dbs = $server.Databases

--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -101,6 +101,8 @@ function Get-DbaPermission {
 												END
 						, [Grantee] = SUSER_NAME(grantee_principal_id)
 						, [GranteeType] = pr.type_desc
+                        , [revokeStatement] = 'REVOKE ' + permission_name + ' ' + COALESCE(OBJECT_NAME(major_id),'') + ' FROM [' + SUSER_NAME(grantee_principal_id) + ']'
+                        , [grantStatement] = 'GRANT ' + permission_name + ' ' + COALESCE(OBJECT_NAME(major_id),'') + ' TO [' + SUSER_NAME(grantee_principal_id) + ']'
 					FROM sys.server_permissions sp
 						JOIN sys.server_principals pr ON pr.principal_id = sp.grantee_principal_id
 						LEFT OUTER JOIN sys.all_objects o ON o.object_id = sp.major_id
@@ -119,6 +121,8 @@ function Get-DbaPermission {
 											WHEN class = 3 THEN SCHEMA_NAME(major_id) END
 					, [Grantee] = USER_NAME(grantee_principal_id)
 					, [GranteeType] = pr.type_desc
+                    , [revokeStatement] = 'REVOKE ' + permission_name + ' ON ' + isnull(schema_name(o.object_id)+'.','')+OBJECT_NAME(major_id)+ ' FROM [' + USER_NAME(grantee_principal_id) + ']'
+                    , [grantStatement] = 'GRANT ' + permission_name + ' ON ' + isnull(schema_name(o.object_id)+'.','')+OBJECT_NAME(major_id)+ ' TO [' + USER_NAME(grantee_principal_id) + ']'
 				FROM sys.database_permissions dp
 					JOIN sys.database_principals pr ON pr.principal_id = dp.grantee_principal_id
 					LEFT OUTER JOIN sys.all_objects o ON o.object_id = dp.major_id

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
+
 Describe "Get-DbaPermission Unit Tests" -Tag "UnitTests" {
 	InModuleScope dbatools {
 		Context "Validate parameters" {
@@ -15,14 +16,24 @@ Describe "Get-DbaPermission Unit Tests" -Tag "UnitTests" {
 				$params.ContainsKey("EnableException") | Should Be $true
 			}
 		}
+}
+Describe "Get-DbaPermission Integration Tests" -Tag "IntegrationTests" {
 		Context "parameters work" {
 			it "returns server level permissions with -IncludeServerLevel" {
                 $results = Get-DbaPermission -SqlInstance $script:instance2 -IncludeServerLevel
-				$results.where({$_.Database -eq ''}).count | Should Be Greater Than 0
+				$results.where({$_.Database -eq ''}).count | Should BeGreaterThan 0
 			}
 			it "returns no server level permissions without -IncludeServerLevel" {
                 $results = Get-DbaPermission -SqlInstance $script:instance2
 				$results.where({$_.Database -eq ''}).count | Should Be 0
+			}
+			it "returns no system object permissions with -NoSystemObjects" {
+                $results = Get-DbaPermission -SqlInstance $script:instance2 -NoSystemObjects
+				$results.where({$_.securable -like 'sys.*'}).count | Should Be 0
+			}
+			it "returns system object permissions without -NoSystemObjects" {
+                $results = Get-DbaPermission -SqlInstance $script:instance2
+				$results.where({$_.securable -like 'sys.*'}).count | Should BeGreaterThan 0
 			}
 		}
 		Context "Validate input" {

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -1,0 +1,25 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+Describe "Get-DbaPermission Unit Tests" -Tag "UnitTests" {
+	InModuleScope dbatools {
+		Context "Validate parameters" {
+			$params = (Get-ChildItem function:\Get-DbaPermission).Parameters	
+			it "should have a parameter named SqlInstance" {
+				$params.ContainsKey("SqlInstance") | Should Be $true
+			}
+			it "should have a parameter named SqlCredential" {
+				$params.ContainsKey("SqlCredential") | Should Be $true
+			}
+			it "should have a parameter named EnableException" {
+				$params.ContainsKey("EnableException") | Should Be $true
+			}
+		}
+		Context "Validate input" {
+			it "Cannot resolve hostname of computer" {
+				mock Resolve-DbaNetworkName {$null}
+				{Get-DbaComputerSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
+			}
+		}
+	}
+}

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -15,6 +15,16 @@ Describe "Get-DbaPermission Unit Tests" -Tag "UnitTests" {
 				$params.ContainsKey("EnableException") | Should Be $true
 			}
 		}
+		Context "parameters work" {
+			it "returns server level permissions with -IncludeServerLevel" {
+                $results = Get-DbaPermission -SqlInstance $script:instance2 -IncludeServerLevel
+				$results.where({$_.Database -eq ''}).count | Should Be Greater Than 0
+			}
+			it "returns no server level permissions without -IncludeServerLevel" {
+                $results = Get-DbaPermission -SqlInstance $script:instance2
+				$results.where({$_.Database -eq ''}).count | Should Be 0
+			}
+		}
 		Context "Validate input" {
 			it "Cannot resolve hostname of computer" {
 				mock Resolve-DbaNetworkName {$null}


### PR DESCRIPTION
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #2643)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
1 Add the T-SQL statements to Grant and Revoke the permissions.
2 Return permissions for User Defined Data Types

### Approach
Alter the T-SQL statements that gather the permissions.
Since the permissions are not objects, there is no script method for them. By supplying the statements as output we work around this problem.
