### PR TITLE
Adding keep_CDC ability to restore

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -108,7 +108,7 @@ Function Format-DbaBackupInformation{
     Begin{
         
         Write-Message -Message "Starting" -Level Verbose
-        if (Test-Bound -ParameterName ReplaceDatabaseName) {
+        if ($null -ne $ReplaceDatabaseName) {
             if ($ReplaceDatabaseName -is [string] -or $ReplaceDatabaseName.ToString() -ne 'System.Collections.Hashtable'){
                 Write-Message -Message "String passed in for DB rename" -Level Verbose
                 $ReplaceDatabaseNameType = 'single'

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -115,7 +115,7 @@ Function Invoke-DbaAdvancedRestore{
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             return
         }
-        if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory)){
+        if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))){
             Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
             return
         }
@@ -128,6 +128,7 @@ Function Invoke-DbaAdvancedRestore{
         }
     }
     end{
+        if (Test-FunctionInterrupt) { return }
         $Databases  = $InternalHistory.Database | select-Object -unique
         ForEach ($Database in $Databases){
             If ($Database -in $Server.databases.name) {
@@ -225,7 +226,7 @@ Function Invoke-DbaAdvancedRestore{
                             }
                             if ($true -ne $OutputScriptOnly){
                                 Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
-                                $output = $server.ConnectionContext.ExecuteNonQuery($script)
+                                $null = $server.ConnectionContext.ExecuteNonQuery($script)
                                 Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -status "Complete" -Completed
                             }
                         }

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -115,6 +115,10 @@ Function Invoke-DbaAdvancedRestore{
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             return
         }
+        if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory)){
+            Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
+            return
+        }
         $ScriptOnly  = $false
         $InternalHistory = @()
     }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -337,7 +337,7 @@ function Restore-DbaDatabase {
         [string]$DestinationFileSuffix,
         [parameter(ParameterSetName="Recovery")]
         [switch]$Recover,
-        [parameter(ParameterSetName="Recovery")]
+        [parameter(ParameterSetName="Restore")]
         [switch]$KeepCDC,        
         [switch]$AllowContinue,
         [string]$GetBackupInformation,

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -166,6 +166,9 @@ function Restore-DbaDatabase {
     .PARAMETER StatementTimeOut
         Timeout in minutes. Defaults to infinity (restores can take a while.)
 
+    .PARAMETER KeepCDC
+        Indicates whether CDC information should be restored as part of the database
+    
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -334,6 +337,8 @@ function Restore-DbaDatabase {
         [string]$DestinationFileSuffix,
         [parameter(ParameterSetName="Recovery")]
         [switch]$Recover,
+        [parameter(ParameterSetName="Recovery")]
+        [switch]$KeepCDC,        
         [switch]$AllowContinue,
         [string]$GetBackupInformation,
         [switch]$StopAfterGetBackupInformation,
@@ -591,7 +596,7 @@ function Restore-DbaDatabase {
             }
             
             Write-Message -Message "Passing in to restore" -Level Verbose
-            $FilteredBackupHistory | Where-Object {$_.IsVerified -eq $true} | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount
+            $FilteredBackupHistory | Where-Object {$_.IsVerified -eq $true} | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC
         
         }
     }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -415,7 +415,7 @@ function Restore-DbaDatabase {
                     return
                 }
             }
-            if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory)){
+            if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))){
                 Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
                 return
             }
@@ -449,11 +449,12 @@ function Restore-DbaDatabase {
             $DestinationDataDirectory = $DefaultPath.Data
             $DestinationLogDirectory = $DefaultPath.Log
         }
-        $backupFiles = @()
+
         $BackupHistory = @()
         #$useDestinationDefaultDirectories = $true
     }
     process{
+        if (Test-FunctionInterrupt) { return }
         if ($PSCmdlet.ParameterSetName -eq "Restore") {
             if ($PipeDatabaseName -eq $true){$DatabaseName  = ''}
             Write-Message -message "ParameterSet  = Restore" -Level Verbose
@@ -531,7 +532,7 @@ function Restore-DbaDatabase {
                 Catch {
                     $RestoreComplete = $False
                     $ExitError = $_.Exception.InnerException
-                    Write-Message -Level Warning -Message "Failed to recover $Database on $RestoreInstance," 
+                    Write-Message -Level Warning -Message "Failed to recover $Database on $RestoreInstance, `n $ExitError" 
                 }
                 Finally {
                     [PSCustomObject]@{

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -415,6 +415,10 @@ function Restore-DbaDatabase {
                     return
                 }
             }
+            if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory)){
+                Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
+                return
+            }
             if ($Continue) {
                 $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $RestoreInstance
                 #$WithReplace = $true 

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -461,4 +461,28 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.Script | Should match 'MAXTRANSFERSIZE = 131072' 
         }
     }
+
+    Context "All user databases are removed post Output vs Input test" {
+        $results = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase -Confirm:$false
+        It "Should say the status was dropped" {
+            Foreach ($db in $results) { $db.Status | Should Be "Dropped" }
+        }
+    }
+
+    Context "Checking CDC parameter " {
+        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace
+        It "Should have KEEP_CDC in the SQL" {
+            ($output -like '*KEEP_CDC*') | Should be $True
+        }
+        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -NoRecovery
+        It "Should not ouput, and warn if Norecovery and KeepCDC specified"{
+           ( $warnvar -like '*KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work') | Should be $True
+           $output | Should be $null
+        }
+        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -StandbyDirectory c:\temp\
+        It "Should not ouput, and warn if StandbyDirectory and KeepCDC specified"{
+           ( $warnvar -like '*KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work') | Should be $True
+           $output | Should be $null
+        }
+    }
 }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -474,12 +474,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should have KEEP_CDC in the SQL" {
             ($output -like '*KEEP_CDC*') | Should be $True
         }
-        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -NoRecovery
+        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -NoRecovery -WarningAction SilentlyContinue
         It "Should not ouput, and warn if Norecovery and KeepCDC specified"{
            ( $warnvar -like '*KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work') | Should be $True
            $output | Should be $null
         }
-        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -StandbyDirectory c:\temp\
+        $output = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace -WarningVariable warnvar -StandbyDirectory c:\temp\ -WarningAction SilentlyContinue
         It "Should not ouput, and warn if StandbyDirectory and KeepCDC specified"{
            ( $warnvar -like '*KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work') | Should be $True
            $output | Should be $null


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allows users who rely on CDC to use Restore-DbaDatabase to restore dbs

### Approach
Injects KEEP_CDC into the recovery restore of series of files

### Commands to test
Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appeyorlabrepo\singlerestore\singlerestore.bak  -DatabaseName $DatabaseName -OutputScriptOnly -KeepCDC -WithReplace


### Learning
As much as we ":heart:" SMO it doesn't do everything, so sometimes dropping down to string manipulation is the only option
