### PR TITLE
Set-DbaMaxDop fails due to missing instance name

### DIFF
--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -124,7 +124,7 @@ function Set-DbaMaxDop {
 		$servers = $collection | Select-Object SqlInstance -Unique
 		
 		foreach ($server in $servers) {
-			if ($server.Instance -ne $null) {
+			if ($server.InstanceName -ne $null) {
 				$servername = $server.InstanceName
 			}
 			else {

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -182,7 +182,7 @@ function Set-DbaMaxDop {
 				}
 			}
 			
-			foreach ($row in $collection | Where-Object { $_.InstanceName -eq $servername }) {
+			foreach ($row in $collection | Where-Object { $_.SqlInstance -eq $servername }) {
 				if ($UseRecommended -and ($row.RecommendedMaxDop -eq $row.CurrentInstanceMaxDop) -and !($dbscopedconfiguration)) {
 					Write-Output "$servername is configured properly :) No change required."
 					Continue

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -121,11 +121,11 @@ function Set-DbaMaxDop {
 		$collection | Add-Member -Force -NotePropertyName OldInstanceMaxDopValue -NotePropertyValue 0
 		$collection | Add-Member -Force -NotePropertyName OldDatabaseMaxDopValue -NotePropertyValue 0
 		
-		$servers = $collection | Select-Object Instance -Unique
+		$servers = $collection | Select-Object SqlInstance -Unique
 		
 		foreach ($server in $servers) {
 			if ($server.Instance -ne $null) {
-				$servername = $server.Instance
+				$servername = $server.InstanceName
 			}
 			else {
 				$servername = $server
@@ -182,7 +182,7 @@ function Set-DbaMaxDop {
 				}
 			}
 			
-			foreach ($row in $collection | Where-Object { $_.Instance -eq $servername }) {
+			foreach ($row in $collection | Where-Object { $_.InstanceName -eq $servername }) {
 				if ($UseRecommended -and ($row.RecommendedMaxDop -eq $row.CurrentInstanceMaxDop) -and !($dbscopedconfiguration)) {
 					Write-Output "$servername is configured properly :) No change required."
 					Continue

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -124,8 +124,8 @@ function Set-DbaMaxDop {
 		$servers = $collection | Select-Object SqlInstance -Unique
 		
 		foreach ($server in $servers) {
-			if ($server.InstanceName -ne $null) {
-				$servername = $server.InstanceName
+			if ($server.SqlInstance -ne $null) {
+				$servername = $server.SqlInstance
 			}
 			else {
 				$servername = $server


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #2657)

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix this command to run on servers with named instances, currently it is using the wrong names as they are given from Test-DBAMaxDOP

### Approach
Using names assigned to Test-DBAMaxDOP
