### PR TITLE
Remove (comment out) call to Connect() method

### DIFF
--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -109,9 +109,9 @@ function Connect-SqlInstance {
 	#region Input Object was a server object
 	if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 		$server = $ConvertedSqlInstance.InputObject
-		# if ($server.ConnectionContext.IsOpen -eq $false) {
-		# 	$server.ConnectionContext.Connect()
-		# }
+		 if ($server.ConnectionContext.IsOpen -eq $false) {
+		 	$null = $server.Name
+		 }
 
 		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
 		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
@@ -175,22 +175,22 @@ function Connect-SqlInstance {
 	}
 	catch { }
 
-	# try {
-	# 	$server.ConnectionContext.Connect()
-	# }
-	# catch {
-	# 	$message = $_.Exception.InnerException.InnerException
-	# 	if ($message) {
-	# 		$message = $message.ToString()
-	# 		$message = ($message -Split '-->')[0]
-	# 		$message = ($message -Split 'at System.Data.SqlClient')[0]
-	# 		$message = ($message -Split 'at System.Data.ProviderBase')[0]
-	# 		throw "Can't connect to $ConvertedSqlInstance`: $message "
-	# 	}
-	# 	else {
-	# 		throw $_
-	# 	}
-	# }
+	try {
+		$null = $server.Name
+	 }
+	 catch {
+		$message = $_.Exception.InnerException.InnerException
+	 	if ($message) {
+	 		$message = $message.ToString()
+	 		$message = ($message -Split '-->')[0]
+	 		$message = ($message -Split 'at System.Data.SqlClient')[0]
+	 		$message = ($message -Split 'at System.Data.ProviderBase')[0]
+	 		throw "Can't connect to $ConvertedSqlInstance`: $message "
+	 	}
+	 	else {
+	 		throw $_
+	 	}
+	 }
 
 	if ($MinimumVersion -and $server.VersionMajor) {
 		if ($server.versionMajor -lt $MinimumVersion) {

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -2,37 +2,37 @@ function Connect-SqlInstance {
     <#
         .SYNOPSIS
             Internal function to establish smo connections.
-        
+
         .DESCRIPTION
             Internal function to establish smo connections.
-    
+
             Can interpret any of the following types of information:
             - String
             - Smo Server objects
             - Smo Linked Server objects
-        
+
         .PARAMETER SqlInstance
             The SQL Server instance to restore to.
 
         .PARAMETER SqlCredential
-            Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
-        
+            Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
+
         .PARAMETER ParameterConnection
             Whether this call is for dynamic parameters only.
-        
+
         .PARAMETER RegularUser
             The connection doesn't require SA privileges.
             By default, the assumption is that SA is required.
-    
+
         .PARAMETER MinimumVersion
            The minimum version that the calling command will support
-	
+
         .EXAMPLE
             Connect-SqlInstance -SqlInstance sql2014
-    
+
             Connect to the Server sql2014 with native credentials.
     #>
-	
+
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)][object]$SqlInstance,
@@ -41,7 +41,7 @@ function Connect-SqlInstance {
 		[switch]$RegularUser = $true,
 		[int]$MinimumVersion
 	)
-	
+
 	#region Utility functions
 	function Invoke-TEPPCacheUpdate {
 		[CmdletBinding()]
@@ -49,7 +49,7 @@ function Connect-SqlInstance {
 			[System.Management.Automation.ScriptBlock]
 			$ScriptBlock
 		)
-		
+
 		try {
 			[ScriptBlock]::Create($scriptBlock).Invoke()
 		}
@@ -58,7 +58,7 @@ function Connect-SqlInstance {
 			if ($_.Exception.InnerException.InnerException.GetType().FullName -eq "Microsoft.SqlServer.Management.Sdk.Sfc.InvalidVersionEnumeratorException") {
 				return
 			}
-			
+
 			if ($ENV:APPVEYOR_BUILD_FOLDER -or ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DeveloperMode)) { throw }
 			<#
 			elseif ([Sqlcollaborative.Dbatools.dbaSystem.DebugHost]::DevelopmentBranch) {
@@ -71,12 +71,12 @@ function Connect-SqlInstance {
 		}
 	}
 	#endregion Utility functions
-	
+
 	#region Ensure Credential integrity
     <#
     Usually, the parameter type should have been not object but off the PSCredential type.
     When binding null to a PSCredential type parameter on PS3-4, it'd then show a prompt, asking for username and password.
-    
+
     In order to avoid that and having to refactor lots of functions (and to avoid making regular scripts harder to read), we created this workaround.
     #>
 	if ($SqlCredential) {
@@ -85,13 +85,13 @@ function Connect-SqlInstance {
 		}
 	}
 	#endregion Ensure Credential integrity
-	
+
 	#region Safely convert input into instance parameters
     <#
     This is a bit ugly, but:
     In some cases functions would directly pass their own input through when the parameter on the calling function was typed as [object[]].
     This would break the base parameter class, as it'd automatically be an array and the parameterclass is not designed to handle arrays (Shouldn't have to).
-    
+
     Note: Multiple servers in one call were never supported, those old functions were liable to break anyway and should be fixed soonest.
     #>
 	if ($SqlInstance.GetType() -eq [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]) {
@@ -99,28 +99,28 @@ function Connect-SqlInstance {
 	}
 	else {
 		[DbaInstanceParameter]$ConvertedSqlInstance = [DbaInstanceParameter]($SqlInstance | Select-Object -First 1)
-		
+
 		if ($SqlInstance.Count -gt 1) {
 			Write-Message -Level Warning -EnableException $true -Message "More than on server was specified when calling Connect-SqlInstance from $((Get-PSCallStack)[1].Command)"
 		}
 	}
 	#endregion Safely convert input into instance parameters
-	
+
 	#region Input Object was a server object
 	if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 		$server = $ConvertedSqlInstance.InputObject
-		if ($server.ConnectionContext.IsOpen -eq $false) {
-			$server.ConnectionContext.Connect()
-		}
-		
+		# if ($server.ConnectionContext.IsOpen -eq $false) {
+		# 	$server.ConnectionContext.Connect()
+		# }
+
 		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
 		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
-		
+
 		# Update cache for instance names
 		if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower()) {
 			[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $ConvertedSqlInstance.FullSmoName.ToLower()
 		}
-		
+
 		# Update lots of registered stuff
 		if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
 			$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
@@ -131,11 +131,11 @@ function Connect-SqlInstance {
 		return $server
 	}
 	#endregion Input Object was a server object
-	
+
 	#region Input Object was anything else
 	# This seems a little complex but is required because some connections do TCP,SqlInstance
 	$loadedSmoVersion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName -like "Microsoft.SqlServer.SMO,*" }
-	
+
 	if ($loadedSmoVersion) {
 		$loadedSmoVersion = $loadedSmoVersion | ForEach-Object {
 			if ($_.Location -match "__") {
@@ -146,17 +146,17 @@ function Connect-SqlInstance {
 			}
 		}
 	}
-	
+
 	$server = New-Object Microsoft.SqlServer.Management.Smo.Server $ConvertedSqlInstance.FullSmoName
 	$server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
 	if ($ConvertedSqlInstance.IsConnectionString) { $server.ConnectionContext.ConnectionString = $ConvertedSqlInstance.InputObject }
-	
+
 	try {
 		$server.ConnectionContext.ConnectTimeout = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout
-		
+
 		if ($SqlCredential.Username -ne $null) {
 			$username = ($SqlCredential.Username).TrimStart("\")
-			
+
 			if ($username -like "*\*") {
 				$username = $username.Split("\")[1]
 				$authtype = "Windows Authentication with Credential"
@@ -174,36 +174,36 @@ function Connect-SqlInstance {
 		}
 	}
 	catch { }
-	
-	try {
-		$server.ConnectionContext.Connect()
-	}
-	catch {
-		$message = $_.Exception.InnerException.InnerException
-		if ($message) {
-			$message = $message.ToString()
-			$message = ($message -Split '-->')[0]
-			$message = ($message -Split 'at System.Data.SqlClient')[0]
-			$message = ($message -Split 'at System.Data.ProviderBase')[0]
-			throw "Can't connect to $ConvertedSqlInstance`: $message "
-		}
-		else {
-			throw $_
-		}
-	}
-	
+
+	# try {
+	# 	$server.ConnectionContext.Connect()
+	# }
+	# catch {
+	# 	$message = $_.Exception.InnerException.InnerException
+	# 	if ($message) {
+	# 		$message = $message.ToString()
+	# 		$message = ($message -Split '-->')[0]
+	# 		$message = ($message -Split 'at System.Data.SqlClient')[0]
+	# 		$message = ($message -Split 'at System.Data.ProviderBase')[0]
+	# 		throw "Can't connect to $ConvertedSqlInstance`: $message "
+	# 	}
+	# 	else {
+	# 		throw $_
+	# 	}
+	# }
+
 	if ($MinimumVersion -and $server.VersionMajor) {
 		if ($server.versionMajor -lt $MinimumVersion) {
 			throw "SQL Server version $MinimumVersion required - $server not supported."
 		}
 	}
-	
+
 	if (-not $RegularUser) {
 		if ($server.ConnectionContext.FixedServerRoles -notmatch "SysAdmin") {
 			throw "Not a sysadmin on $ConvertedSqlInstance. Quitting."
 		}
 	}
-	
+
 	if ($loadedSmoVersion -ge 11) {
 		try {
 			if ($Server.ServerType -ne 'SqlAzureDatabase') {
@@ -214,7 +214,7 @@ function Connect-SqlInstance {
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.View], 'IsSystemObject')
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.StoredProcedure], 'IsSystemObject')
 				$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.UserDefinedFunction], 'IsSystemObject')
-				
+
 				if ($server.VersionMajor -eq 8) {
 					# 2000
 					$server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Version')
@@ -233,18 +233,18 @@ function Connect-SqlInstance {
 			}
 		}
 		catch {
-			# perhaps a DLL issue, continue going	
+			# perhaps a DLL issue, continue going
 		}
 	}
-	
+
 	# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
 	[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::SetInstance($ConvertedSqlInstance.FullSmoName.ToLower(), $server.ConnectionContext.Copy(), ($server.ConnectionContext.FixedServerRoles -match "SysAdmin"))
-	
+
 	# Update cache for instance names
 	if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $ConvertedSqlInstance.FullSmoName.ToLower()) {
 		[Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $ConvertedSqlInstance.FullSmoName.ToLower()
 	}
-	
+
 	# Update lots of registered stuff
 	if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled) {
 		$FullSmoName = $ConvertedSqlInstance.FullSmoName.ToLower()
@@ -252,7 +252,7 @@ function Connect-SqlInstance {
 			Invoke-TEPPCacheUpdate -ScriptBlock $scriptBlock
 		}
 	}
-	
+
 	return $server
 	#endregion Input Object was anything else
 }

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -109,8 +109,10 @@ function Connect-SqlInstance {
 	#region Input Object was a server object
 	if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 		$server = $ConvertedSqlInstance.InputObject
-		 if ($server.ConnectionContext.IsOpen -eq $false) {
-		 	$null = $server.Name
+		if ($server.ConnectionContext.IsOpen -eq $false) {
+			# .Connect() in ConnectionContext messes with the pool. So let's cause a connect implicitly, while making minimal impact
+			# Out-Null is required. Isn't that weird? $null = doesn't work. I guess it needed to enumerate.
+		 	$server.Logins.Name | Out-Null
 		 }
 
 		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
@@ -174,9 +176,11 @@ function Connect-SqlInstance {
 		}
 	}
 	catch { }
-
+	
 	try {
-		$null = $server.Name
+		# .Connect() in ConnectionContext messes with the pool. So let's cause a connect implicitly, while making minimal impact
+		# Out-Null is required. Isn't that weird? $null = doesn't work. I guess it needed to enumerate.
+		$server.Logins.Name | Out-Null
 	 }
 	 catch {
 		$message = $_.Exception.InnerException.InnerException

--- a/internal/Connect-SqlInstance.ps1
+++ b/internal/Connect-SqlInstance.ps1
@@ -109,10 +109,8 @@ function Connect-SqlInstance {
 	#region Input Object was a server object
 	if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
 		$server = $ConvertedSqlInstance.InputObject
-		if ($server.ConnectionContext.IsOpen -eq $false) {
-			# .Connect() in ConnectionContext messes with the pool. So let's cause a connect implicitly, while making minimal impact
-			# Out-Null is required. Isn't that weird? $null = doesn't work. I guess it needed to enumerate.
-		 	$server.Logins.Name | Out-Null
+		 if ($server.ConnectionContext.IsOpen -eq $false) {
+		 	$null = $server.Name
 		 }
 
 		# Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
@@ -176,11 +174,9 @@ function Connect-SqlInstance {
 		}
 	}
 	catch { }
-	
+
 	try {
-		# .Connect() in ConnectionContext messes with the pool. So let's cause a connect implicitly, while making minimal impact
-		# Out-Null is required. Isn't that weird? $null = doesn't work. I guess it needed to enumerate.
-		$server.Logins.Name | Out-Null
+		$null = $server.Name
 	 }
 	 catch {
 		$message = $_.Exception.InnerException.InnerException


### PR DESCRIPTION
Discussed in Slack channel on issues with commands like `Get-DbaProcess` and others in the module causing two issues:

1. Multiple connections being generated (on average you get two for one call to the command)
2. The connections associated with the command itself (not including TEPP connection) does not "close" until the PowerShell session is closed.

Various areas of SMO docs point to two things that we do that will cause the above issues:

- Specifically calling `Connect()` will not allow that connection to be put back into the connection pool when it is done.
- Specifically calling `Connect()` will not automagically close the connection for you unless you explicitly call `Close()` or `Dispose()` on the `$server` object.

_Note each test below was done using a fresh PowerShell session._

## Testing 1

Just running `Get-DbaProcess` causes two connections to be made:
1. Is connection associated with call to `Connect-SqlInstance` by the command itself
2. Is from TEPP implementation and is known non-issue connection.

Leaving the above running the connection associated with populating the TEPP cache will be killed in 5-6 minutes. The connection associated with the call to the connect command will not be killed until your PowerShell session exits.

## Testing 2

Running:

```powershell
for ($i = 0; $i -le 50; $i++) { Write-Output "Iteration #: $i"; $null = Get-DbaProcess -SqlInstance manatarms\sql12}
```

Causes 18 connections to be generated, and all those connections don't go away until I close the PowerShell session.

## Testing 3

Implement changes from this PR and run command from test 1 again. Result: Only two connections are generated and both are killed within a 6 minute period.

## Testing 4

Implement changes from this PR and run command from test 2 again. Result: Only two connections are generated and both are killed within a 6 minute period.

🎉 🎈 🐎 🐎 
