### PR TITLE
Add try/catch to Start and Stop DbaXESession functions

### DIFF
--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -89,7 +89,7 @@ function Start-DbaXESession {
 					try {
 						$xe.Start()
 					} catch {
-						Write-Error -Message "Could not start XEvent Session $session on $instance"
+						Stop-Function -Message "Could not start XEvent Session on $instance" -Target $session -ErrorRecord $_
 					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already running"

--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -89,7 +89,7 @@ function Start-DbaXESession {
 					try {
 						$xe.Start()
 					} catch {
-						Stop-Function -Message "Could not start XEvent Session on $instance" -Target $session -ErrorRecord $_
+						Stop-Function -Message "Could not start XEvent Session on $instance" -Target $session -ErrorRecord $_ -Continue
 					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already running"

--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -86,11 +86,15 @@ function Start-DbaXESession {
 				$session = $xe.Name
 				if (-Not $xe.isRunning) {
 					Write-Message -Level Verbose -Message "Starting XEvent Session $session on $instance."
-					$xe.Start()
-					Get-DbaXESession -SqlInstance $xe.Parent -Session $session
+					try {
+						$xe.Start()
+					} catch {
+						Write-Error -Message "Could not start XEvent Session $session on $instance"
+					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already running"
 				}
+				Get-DbaXESession -SqlInstance $xe.Parent -Session $session
 			}
 		}
 	}

--- a/functions/Stop-DbaXESession.ps1
+++ b/functions/Stop-DbaXESession.ps1
@@ -89,7 +89,7 @@ function Stop-DbaXESession {
 					try {
 						$xe.Stop()
 					} catch {
-						Stop-Function -Message "Could not stop XEvent Session on $instance" -Target $session -ErrorRecord $_
+						Stop-Function -Message "Could not stop XEvent Session on $instance" -Target $session -ErrorRecord $_ -Continue
 					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already stopped"

--- a/functions/Stop-DbaXESession.ps1
+++ b/functions/Stop-DbaXESession.ps1
@@ -86,11 +86,15 @@ function Stop-DbaXESession {
 				$session = $xe.Name
 				if ($xe.isRunning) {
 					Write-Message -Level Verbose -Message "Stopping XEvent Session $session on $instance."
-					$xe.Stop()
-					Get-DbaXESession -SqlInstance $xe.Parent -Session $session
+					try {
+						$xe.Stop()
+					} catch {
+						Write-Error -Message "Could not stop XEvent Session $session on $instance"
+					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already stopped"
 				}
+				Get-DbaXESession -SqlInstance $xe.Parent -Session $session
 			}
 		}
 	}

--- a/functions/Stop-DbaXESession.ps1
+++ b/functions/Stop-DbaXESession.ps1
@@ -89,7 +89,7 @@ function Stop-DbaXESession {
 					try {
 						$xe.Stop()
 					} catch {
-						Write-Error -Message "Could not stop XEvent Session $session on $instance"
+						Stop-Function -Message "Could not stop XEvent Session on $instance" -Target $session -ErrorRecord $_
 					}
 				} else {
 					Write-Message -Level Warning -Message "$session on $instance is already stopped"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add try/catch to Stop/Start XESession

### Approach
<!-- How does this change solve that purpose -->
Write-Error on catch, and return Get-DbaXESession in either case.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Included in Tests file
