### PR TITLE
Get-XpDirTreeRestoreFile, use SMO for fixed queries

### DIFF
--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -48,13 +48,13 @@ function Get-XpDirTreeRestoreFile {
 		$Path = $Path + "\"
 	}
 	
-	If (!(Test-DbaSqlPath -SqlInstance $server -path $path)) {
+	If (!(Test-DbaSqlPath -SqlInstance $Server -path $path)) {
 		Stop-Function -Message "SqlInstance $SqlInstance cannot access $path" -EnableException $true
 	}
 	
 	$query = "EXEC master.sys.xp_dirtree '$Path',1,1;"
-	$queryResult = Invoke-Sqlcmd2 -ServerInstance $SqlInstance -Credential $SqlCredential -Database tempdb -Query $query
-	#$queryResult = $Server.Query($query)
+	#$queryResult = Invoke-Sqlcmd2 -ServerInstance $SqlInstance -Credential $SqlCredential -Database tempdb -Query $query
+	$queryResult = $Server.Query($query)
 	
 	$dirs = $queryResult | where-object file -eq 0
 	$Results = @()
@@ -63,7 +63,7 @@ function Get-XpDirTreeRestoreFile {
 	ForEach ($d in $dirs) {
 		$fullpath = "$path$($d.Subdirectory)"
 		Write-Message -Level Verbose -Message "Enumerating subdirectory '$fullpath'"
-		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $SqlInstance
+		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $Server -SqlCredential $SqlCredential
 	}
 	return $Results
 	

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -66,7 +66,7 @@ function Get-XpDirTreeRestoreFile {
 	ForEach ($d in $dirs) {
 		$fullpath = "$path$($d.Subdirectory)"
 		Write-Message -Level Verbose -Message "Enumerating subdirectory '$fullpath'"
-		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $Server -SqlCredential $SqlCredential
+		$Results += Get-XpDirTreeRestoreFile -path $fullpath -SqlInstance $Server
 	}
 	return $Results
 	

--- a/internal/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/Get-XpDirTreeRestoreFile.ps1
@@ -51,8 +51,11 @@ function Get-XpDirTreeRestoreFile {
 	If (!(Test-DbaSqlPath -SqlInstance $Server -path $path)) {
 		Stop-Function -Message "SqlInstance $SqlInstance cannot access $path" -EnableException $true
 	}
-	
-	$query = "EXEC master.sys.xp_dirtree '$Path',1,1;"
+	if ($Server.VersionMajor -lt 9) {
+		$query = "EXEC master..xp_dirtree '$Path',1,1;"
+	} else {
+		$query = "EXEC master.sys.xp_dirtree '$Path',1,1;"
+	}
 	#$queryResult = Invoke-Sqlcmd2 -ServerInstance $SqlInstance -Credential $SqlCredential -Database tempdb -Query $query
 	$queryResult = $Server.Query($query)
 	


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
For fixed queries, now that the annoying SMO connection bug is fixed, better to use .Query(). This fixed a bit of issues where the "smo" server object gets passed to invoke-sqlcmd2 (which autoconverts to a string, which drops the dns suffix, ending in a big pool of red blood). I was playing with Get-DbaBackupInformation ^_^ . Incidentally, backup-*/restore-* related cmdlets which make a lot of function cooperate now seems to be a bit speedier (probably because a proper reuse of the connection pool).
tl;dr : whenever the query is fixed (i.e. you don't need parameters) stick with SMO, else, go with invoke-sqlcmd2

