### PR TITLE
Restore LSN fix

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -67,6 +67,7 @@
 	
 	# Functions to export from this module
 	FunctionsToExport	    = @(
+		'Select-DbaBackupInformation',
 		'Start-DbaMigration',
 		'Copy-DbaDatabase',
 		'Copy-DbaLogin',

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -67,7 +67,6 @@
 	
 	# Functions to export from this module
 	FunctionsToExport	    = @(
-		'Select-DbaBackupInformation',
 		'Start-DbaMigration',
 		'Copy-DbaDatabase',
 		'Copy-DbaLogin',

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -464,7 +464,7 @@ function Backup-DbaDatabase {
 								LastLsn = $HeaderInfo.LastLsn
 								BackupSetId = $HeaderInfo.BackupSetId
 								LastRecoveryForkGUID = $HeaderInfo.LastRecoveryForkGUID
-							} | Restore-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -DatabaseName DbaVerifyOnly -VerifyOnly
+							} | Restore-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -DatabaseName DbaVerifyOnly -VerifyOnly -TrustDbBackupHistory -DestinationFilePrefix DbaVerifyOnly 
 							if ($verifiedResult[0] -eq "Verify successful") {
 								$failures += $verifiedResult[0]
 								$Verified = $true

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -240,14 +240,17 @@ Function Invoke-DbaAdvancedRestore{
                             $script = $Restore.Script($server)
                         }
                         elseif ($VerifyOnly) {
+                            Write-Message -Message "VerifyOnly restore" -Level Verbose
                             Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                             $Verify = $Restore.sqlverify($server)
                             Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -status "Complete" -Completed
     
                             if ($verify -eq $true) {
+                                Write-Message -Message "VerifyOnly restore Suceeded" -Level Verbose
                                 return "Verify successful"
                             }
                             else {
+                                Write-Message -Message "VerifyOnly restore Failed" -Level Verbose
                                 return "Verify failed"
                             }
                         }

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -152,6 +152,7 @@ Function Invoke-DbaAdvancedRestore{
             }
             Write-Message -Message "WithReplace  = $Withreplace" -Level Verbose
             $backups = $InternalHistory | Where-Object {$_.Database -eq $Database} | Sort-Object -Property Type, FirstLsn
+            $BackupCnt = 1
             ForEach ($backup in $backups){
                 $Restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
                 if (($backup -ne $backups[-1] -and $StandbyDirectory -eq '') -or $true -eq $NoRecovery){
@@ -225,18 +226,18 @@ Function Invoke-DbaAdvancedRestore{
                                 $script = $script.TrimEnd() + ' WITH KEEP_CDC'
                             }
                             if ($true -ne $OutputScriptOnly){
-                                Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                                Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                                 $null = $server.ConnectionContext.ExecuteNonQuery($script)
-                                Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -status "Complete" -Completed
+                                Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -status "Complete" -Completed
                             }
                         }
                         elseif ($OutputScriptOnly) {
                             $script = $Restore.Script($server)
                         }
                         elseif ($VerifyOnly) {
-                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                             $Verify = $Restore.sqlverify($server)
-                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance" -status "Complete" -Completed
+                            Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -status "Complete" -Completed
     
                             if ($verify -eq $true) {
                                 return "Verify successful"
@@ -246,10 +247,10 @@ Function Invoke-DbaAdvancedRestore{
                             }
                         }
                         else {
-                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
                             $script = $Restore.Script($Server)
                             $Restore.sqlrestore($Server)
-                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance" -status "Complete" -Completed
+                            Write-Progress -id 2 -activity "Restoring $Database to $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -status "Complete" -Completed
                         }
                     }
                     catch {
@@ -296,6 +297,7 @@ Function Invoke-DbaAdvancedRestore{
                     }
                 }
                 Write-Progress -id 1 -Activity "Restoring" -Completed
+                $BackupCnt++
             }
             if ($server.ConnectionContext.exists) {
                 $server.ConnectionContext.Disconnect()

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -164,11 +164,16 @@ Function Invoke-DbaAdvancedRestore{
                 else {
                     $Restore.NoRecovery = $False
                 }
-                if ($restoretime -gt (Get-Date)) {
+                if ($restoretime -gt (Get-Date) -or $Restore.RestoreTime -gt (Get-Date)) {
                     $Restore.ToPointInTime = $null
                 }
                 else {
-                    $Restore.ToPointInTime = $RestoreTime
+                    if ($RestoreTime -ne $Restore.RestoreTime){
+                        $Restore.ToPointInTime = $backup.RestoreTime                       
+                    }
+                    else{
+                        $Restore.ToPointInTime = $RestoreTime
+                    }
                 }
                 $Restore.Database = $database
                 $Restore.ReplaceDatabase = $WithReplace

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -601,7 +601,7 @@ function Restore-DbaDatabase {
             }
             
             Write-Message -Message "Passing in to restore" -Level Verbose
-            $FilteredBackupHistory | Where-Object {$_.IsVerified -eq $true} | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC
+            $FilteredBackupHistory | Where-Object {$_.IsVerified -eq $true} | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC -VerifyOnly:$VerifyOnly
         
         }
     }

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -107,6 +107,11 @@ function Select-DbaBackupInformation{
     }
     
     end{ 
+        ForEach ($History in $InternalHistory){
+            if ("RestoreTime" -notin $History.PSobject.Properties.name){
+               $History | Add-Member -Name 'RestoreTime' -Type NoteProperty -Value $RestoreTime
+            }
+        }
         if ((Test-Bound -ParameterName DatabaseName) -and '' -ne $DatabaseName){
             Write-Message -Message "Filtering by DatabaseName" -Level Verbose 
             $InternalHistory = $InternalHistory | Where-Object {$_.Database -in $DatabaseName}

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -157,7 +157,7 @@ function Select-DbaBackupInformation{
                 $dbHistory += $DatabaseHistory | Where-Object {$_.Type -in ('Log','Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -eq $Full.CheckpointLSN} | Sort-Object -Property LastLsn  | Select-Object -First 1
             }
 
-            $dbHistory
+            $dbHistory | Select-Object -Unique BackupSetID
         }    
     }
 }

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -132,18 +132,18 @@ function Select-DbaBackupInformation{
             }
             #Get All t-logs up to restore time
             if($IgnoreFull -eq $true){
-                $LogBaseLsn = ($ContinuePoints | Where-Object {$_.Database -eq $Database}).redo_start_lsn
+                [bigint]$LogBaseLsn = ($ContinuePoints | Where-Object {$_.Database -eq $Database}).redo_start_lsn
                 $FirstRecoveryForkID  = ($ContinuePoints | Where-Object {$_.Database -eq $Database}).FirstRecoveryForkID
                 Write-Message -Message "Continuing, setting fake LastLsn - $LogBaseLSN" -Level Verbose
             }
             else {
                 Write-Message -Message "Setting LogBaseLSN" -Level Verbose
-                $LogBaseLsn = ($dbHistory | Sort-Object -Property LastLsn -Descending | select-object -First 1).lastLsn
+                [bigint]$LogBaseLsn = ($dbHistory | Sort-Object -Property LastLsn -Descending | select-object -First 1).lastLsn.ToString()
                 $FirstRecoveryForkID = $Full.FirstRecoveryForkID
             }
 
             if ($true -ne $IgnoreLogs){
-                $FilteredLogs = $DatabaseHistory | Where-Object {$_.Type -in ('Log','Transaction Log') -and $_.Start -le $RestoreTime  -and $_.LastLSN -ge $LogBaseLsn} | Sort-Object -Property LastLsn
+                $FilteredLogs = $DatabaseHistory | Where-Object {$_.Type -in ('Log','Transaction Log') -and $_.Start -le $RestoreTime  -and $_.LastLSN.ToString() -ge $LogBaseLsn  -and $_.FirstLSN -ne $_.LastLSN}  | Sort-Object -Property LastLsn, FirstLsn
                 $GroupedLogs = $FilteredLogs | Group-Object -Property LastLSN, FirstLSN
                 ForEach ($Group in $GroupedLogs){
                     $dbhistory += $DatabaseHistory | Where-Object {$_.BackupSetID -eq $Group.group[0].BackupSetID}

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -157,7 +157,7 @@ function Select-DbaBackupInformation{
                 $dbHistory += $DatabaseHistory | Where-Object {$_.Type -in ('Log','Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -eq $Full.CheckpointLSN} | Sort-Object -Property LastLsn  | Select-Object -First 1
             }
 
-            $dbHistory | Select-Object -Unique BackupSetID
+            $dbHistory | Sort-Object -Property BackupSetId -Unique
         }    
     }
 }

--- a/internal/Test-DbaLsnChain.ps1
+++ b/internal/Test-DbaLsnChain.ps1
@@ -115,14 +115,15 @@ Checks that the Restore chain in $FilteredFiles is complete and can be fully res
             {
                 if ($TranLogBackups[$i].FirstLSN -ge $TlogAnchor.LastLSN)
                 {
-                    Write-Warning "$FunctionName - Break in LSN Chain between $($TlogAnchor.BackupPath) and $($TranLogBackups[($i)].BackupPath) "
+                    Write-Warning "$FunctionName - Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
+                    Write-Verbose "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"
                     return $false
                     break
                 }
             }else {
                 if ($TranLogBackups[($i-1)].LastLsn -ne $TranLogBackups[($i)].FirstLSN -and ($TranLogBackups[($i)] -ne $TranLogBackups[($i-1)]))
                 {
-                    Write-Warning "$FunctionName - Break in transaction log between $($TranLogBackups[($i-1)].BackupPath) and $($TranLogBackups[($i)].BackupPath) "
+                    Write-Warning "$FunctionName - Break in transaction log between $($TranLogBackups[($i-1)].FullName) and $($TranLogBackups[($i)].FullName) "
                     return $false
                     break
                 }

--- a/internal/Test-DbaLsnChain.ps1
+++ b/internal/Test-DbaLsnChain.ps1
@@ -113,7 +113,7 @@ Checks that the Restore chain in $FilteredFiles is complete and can be fully res
             Write-Verbose "looping t logs"
             if ($i -eq 0)
             {
-                if ($TranLogBackups[$i].FirstLSN -ge $TlogAnchor.LastLSN)
+                if ($TranLogBackups[$i].FirstLSN -gt $TlogAnchor.LastLSN)
                 {
                     Write-Warning "$FunctionName - Break in LSN Chain between $($TlogAnchor.FullName) and $($TranLogBackups[($i)].FullName) "
                     Write-Verbose "Anchor $($TlogAnchor.LastLSN) - FirstLSN $($TranLogBackups[$i].FirstLSN)"

--- a/internal/Test-DbaLsnChain.ps1
+++ b/internal/Test-DbaLsnChain.ps1
@@ -88,7 +88,7 @@ Checks that the Restore chain in $FilteredFiles is complete and can be fully res
             }
         }
         $DiffAnchor = $TestHistory | Where-Object {$_.$TypeName -in ('Database Differential','Differential')}
-        #Check for no more than a single Differential backup
+        #Check for no more than a single Differential backup 
         if (($DiffAnchor.FirstLSN | Select-Object -unique | Measure-Object).count -gt 1)
         {
             Write-Warning "$FunctionName - More than 1 differential backup, not  supported"

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -191,7 +191,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Properly restores an instance using ola-style backups" {
         $results = Get-ChildItem $script:appveyorlabrepo\sql2008-backups | Restore-DbaDatabase -SqlInstance $script:instance1
         It "Restored files count should be 28" {
-            $results.DatabaseName.Count | Should Be 28
+            $results.DatabaseName.Count | Should Be 22
         }
         It "Should return successful restore" {
             ($results.RestoreComplete -contains $false) | Should Be $false

--- a/tests/Select-DbaBackupInformation.Tests.ps1
+++ b/tests/Select-DbaBackupInformation.Tests.ps1
@@ -10,7 +10,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 			$Output = Select-DbaBackupInformation -BackupHistory $header #-EnableException:$true
 			
 			It "Should return an array of 3 items" {
-				$Output.count | Should be 3
+				$Output.count | Should be 2
 			}
 			It "Should return 1 Full backups" {
 				($Output | Where-Object { $_.BackupTypeDescription -eq 'Database' } | Measure-Object).count | Should Be 1
@@ -19,7 +19,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 				($Output | Where-Object { $_.BackupTypeDescription -eq 'Database Differential' } | Measure-Object).count | Should Be 0
 			}
 			It "Should return 2 log backups" {
-				($Output | Where-Object { $_.BackupTypeDescription -eq 'Transaction Log' } | Measure-Object).count | Should Be 2
+				($Output | Where-Object { $_.BackupTypeDescription -eq 'Transaction Log' } | Measure-Object).count | Should Be 1
 			}
 		}
 		Context "General Diff Restore" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, partially fixes #2674 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
@zhunya was finding that he was getting errors with empty tlog backups being part of the restore chain. We now *don't* return the empty tlog records at all.

This passes all usual pester tests. 2 tests needed modifying as we are now returning less tlogs in those cases.

As the empty tlog error only affects a very small number of users, and they all appear to have been happy with the previous fix I don't think this will change outcomes for most of our users.

Oleg, could you give this branch another spin just to confirm it all works and then we're good to go

