### PR TITLE
restore speed improvements

### DIFF
--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -142,13 +142,14 @@ Function Test-DbaBackupInformation {
             }
 
             #Test all backups readable
-            Foreach ($path in ($DbHistory | Select-Object -ExpandProperty FullName)){
-                if(!(Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $path)){
+            $allpaths = $DbHistory | Select-Object -ExpandProperty FullName
+            $allpaths_validity = Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $allpaths
+            Foreach($path in $allpaths_validity) {
+                if ($path.fileexists -eq $false) {
                     Write-Message -Message "Backup File $path cannot be read" -Level Warning
                     $VerificationErrors++
                 }
             }
-
             #Test for LSN chain
             if ($true -ne $Continue){   
                 if (!($DbHistory | Test-DbaLsnChain)) {

--- a/functions/Test-DbaSqlPath.ps1
+++ b/functions/Test-DbaSqlPath.ps1
@@ -56,41 +56,53 @@ function Test-DbaSqlPath {
 
 	#>
 	[CmdletBinding()]
-	[OutputType([bool])]
 	param (
 		[Parameter(Mandatory = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstance[]]$SqlInstance,
+		[DbaInstance]$SqlInstance,
 		[PSCredential]$SqlCredential,
 		[Parameter(Mandatory = $true)]
-		[string]$Path,
+		[string[]]$Path,
 		[switch][Alias('Silent')]$EnableException
 	)
-
+	begin {
+		try {
+			$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+		}
+		catch {
+			Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
+		}
+	}
 	process {
-		foreach ($instance in $SqlInstance) {
-			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+		if (Test-FunctionInterrupt) { return }
+		
+		$counter = [pscustomobject] @{ Value = 0 }
+		$groupSize = 100
+		$groups = $Path | Group-Object -Property { [math]::Floor($counter.Value++ / $groupSize) }
+		foreach($g in $groups) {
+			$paths_batch = $g.Group
+			$q = @()
+			foreach($p in $paths_batch) {
+				$q += "EXEC master.dbo.xp_fileexist '$p'"
 			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
-
-			Write-Message -Level VeryVerbose -Message "Checking access to $path for $instance."
-			$sql = "EXEC master.dbo.xp_fileexist '$path'"
-			try {
-				Write-Message -Level Debug -Message "Executing: $sql."
-				$fileExist = $server.Query($sql)
-			}
-
-			catch {
-				Stop-Function -Message "Failed to test the path $Path." -ErrorRecord $_ -Target $instance -Continue
-			}
-			if ($fileExist[0] -eq 1 -or $fileExist[1] -eq 1) {
-				return $true
-			}
-			else {
-				return $false
+			$sql = $q -join ';'
+			$batchresult = $server.ConnectionContext.ExecuteWithResults($sql)
+			if ($Path.Count -eq 1) {
+				if ($batchresult.Tables.rows[0] -eq $true -or $batchresult.Tables.rows[1] -eq $true) {
+					return $true
+				} else {
+					return $false
+				}
+			} else {
+				$i = 0
+				foreach($r in $batchresult.tables.rows) {
+					$doespass = $r[0] -eq $true -or $r[1] -eq $true
+					[pscustomobject]@{
+						filepath = $paths_batch[$i]
+						fileexists = $doespass
+					}
+					$i += 1
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Make restore faster. I played a bit with Get-DbaBackupInformation and piping to Restore-DbaDatabase. The current method showed that with a bit of latency (150/200ms) to the backend Test-DbaSqlPath (and it accepting one test at a time) introduces toooooo much slowness. 
Let's try to be the "Operations Studio" rather than the full bloated "Management Studio". 
Please note that this addresses speed without introducing ANY shortcuts, so the restore process remains as sound as it is right now. 

### Approach
Test-DbaSqlPath can be made test multiple paths at the same time. Piping blows, foreaching too. This PR introduces a new Test-DbaSqlPath, whose rationale is:
- the original version accepted multiple instances, while returning at the first result returned. As such, it now just accepts one sql instance, which is the 100% usecase scenario around dbatools
- the original version just returns a bool. While it *could* have been rigged to return an array of bools, it was then left to the caller to rebuild what path was correctly existing and what not. This returns a bool if the passed path is one (to avoid breaking things that rely on that spec) BUT returns a pscustomobject with the list of paths checked and the result

At this point, feel free to destroy this version and ask me to implement Test-DbaSqlPath**s** and/or change the name of the properties returned BUT... this serves as an example, and there are several places around that could benefit from this new "algorithm". Changing Test-DbaBackupInformation to use the new and improved method resulted in a drop from 394 to 211 seconds (almost 100% speedup) while restoring a chain of  1256 files.

tl;dr: I hope all cogs around backup/restore start sitting down a bit to be able to do a proper review and introduce speedups where needed. This is truly where dbatools can shine against "competitors"... 
Right now, e.g., Restore-DbaDatabase spends 5 or 6 seconds just enumerating database files via Get-DbaDatabaseFile (to be sure the path where the file *would* be restored doesn't exist yet). 
This approach is as sound as it can be but for a destination instance with 100 dbs it introduces a 10 minutes delay. The approach seen on Find-DbaOrphanedFiles (or, even, just xp_dirtreeing or Get-DbaFileing the paths where Restore-DbaDatabase already knows it'll drop the files) would reduce it to 5 seconds at most. 

On a related note ( yes @FriedrichWeinmann, I'm back bashing ^_^) messaging really does need to address a function that with a single switch (-Verbose) produces a transcript of 4 MB instead of nothing. I know these are among the most complicated functions we have but in each case (no verbose, *the shell sits around for 4 minutes without giving any indication of the progress* **vs** verbose, *the shell spitting out infos about each db's compatibility level going 3 or 4 levels deep in callers*) the objective of messaging, which is "informing the user" and/or "give a proper feedback", here "blows".
