### PR TITLE
variable not matching param ($SqlCredential) name

### DIFF
--- a/functions/Get-DbaDatabaseState.ps1
+++ b/functions/Get-DbaDatabaseState.ps1
@@ -114,7 +114,7 @@ Gets options for all databases of sqlserver2014a and sqlserver2014b instances
 		foreach ($instance in $SqlInstance) {
 			Write-Message -Level Verbose -Message "Connecting to $instance"
 			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
 			catch {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue


### PR DESCRIPTION
The $Credential variable should be $SqlCredential (the parameter).

This way we can connect to the instance using SQL Authentication
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2718
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
