### PR TITLE
Fix attempt backup twice when using -Certificate

### DIFF
--- a/functions/Backup-DbaDatabaseCertificate.ps1
+++ b/functions/Backup-DbaDatabaseCertificate.ps1
@@ -237,8 +237,10 @@ function Backup-DbaDatabaseCertificate {
                 $DBCertificateCollection = Get-DbaDatabaseCertificate -SqlInstance $server -Database $db
                 if ($Certificate) {
 					$CertificateCollection += $DBCertificateCollection | Where-Object Name -In $Certificate
-				}
-				$CertificateCollection += $DBCertificateCollection | Where-Object Name -NotLike "##*"
+                }
+                else {
+                    $CertificateCollection += $DBCertificateCollection | Where-Object Name -NotLike "##*"
+                }
 				if (!$CertificateCollection) {
 					Write-Message -Level Output -Message "No certificates found to export in $db."
 					continue


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2720)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

### Approach
Added the `else` block. This way the specific certificate already added to the final collection won't be added a 2nd time.
