### PR TITLE
Fix credential parameter/variable for sql authentication

### DIFF
--- a/functions/Export-DbaExecutionPlan.ps1
+++ b/functions/Export-DbaExecutionPlan.ps1
@@ -1,17 +1,17 @@
 function Export-DbaExecutionPlan {
 <#
 .SYNOPSIS
-Exports execution plans to disk. 
-	
+Exports execution plans to disk.
+
 .DESCRIPTION
-Exports execution plans to disk. Can pipe from Export-DbaExecutionPlan 
-	
-Thanks to 
+Exports execution plans to disk. Can pipe from Export-DbaExecutionPlan
+
+Thanks to
 	https://www.simple-talk.com/sql/t-sql-programming/dmvs-for-query-plan-metadata/
 	and
 	http://www.scarydba.com/2017/02/13/export-plans-cache-sqlplan-file/
 for the idea and query.
-	
+
 .PARAMETER SqlInstance
 The SQL Server that you're connecting to.
 
@@ -33,11 +33,11 @@ Datetime object used to narrow the results to a date
 .PARAMETER Path
 The directory where all of the sqlxml files will be exported
 
-.PARAMETER WhatIf 
-Shows what would happen if the command were to run. No actions are actually performed. 
+.PARAMETER WhatIf
+Shows what would happen if the command were to run. No actions are actually performed.
 
-.PARAMETER Confirm 
-Prompts you for confirmation before executing any changing operations within the command. 
+.PARAMETER Confirm
+Prompts you for confirmation before executing any changing operations within the command.
 
 .PARAMETER PipedObject
 Internal parameter
@@ -56,11 +56,11 @@ Export-DbaExecutionPlan -SqlInstance sqlserver2014a
 
 Exports all execution plans for sqlserver2014a.
 
-.EXAMPLE   
+.EXAMPLE
 Export-DbaExecutionPlan -SqlInstance sqlserver2014a -Database db1, db2 -SinceLastExecution '7/1/2016 10:47:00'
 
 Exports all execution plans for databases db1 and db2 on sqlserver2014a since July 1, 2016 at 10:47 AM.
-	
+
 #>
 	[cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Default")]
 	Param (
@@ -83,19 +83,19 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 		[Parameter(ParameterSetName = 'Piped', Mandatory, ValueFromPipeline)]
 		[object[]]$PipedObject
 	)
-	
+
 	begin
-	{	
+	{
 		if ($SinceCreation -ne $null)
 		{
 			$SinceCreation = $SinceCreation.ToString("yyyy-MM-dd HH:mm:ss")
 		}
-		
+
 		if ($SinceLastExecution -ne $null)
 		{
 			$SinceLastExecution = $SinceLastExecution.ToString("yyyy-MM-dd HH:mm:ss")
 		}
-		
+
 		function Process-Object ($object)
 		{
 			$instancename = $object.SqlInstance
@@ -104,11 +104,11 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 			$sqlhandle = "0x"; $object.sqlhandle | ForEach-Object { $sqlhandle += ("{0:X}" -f $_).PadLeft(2, "0") }
 			$sqlhandle = $sqlhandle.TrimStart('0x02000000').TrimEnd('0000000000000000000000000000000000000000')
 			$shortname = "$instancename-$dbname-$queryposition-$sqlhandle"
-			
+
 			foreach ($queryplan in $object.BatchQueryPlanRaw)
 			{
 				$filename = "$path\$shortname-batch.sqlplan"
-				
+
 				try
 				{
 					If ($Pscmdlet.ShouldProcess("localhost", "Writing XML file to $filename"))
@@ -121,11 +121,11 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 					Write-Verbose "Skipped query plan for $filename because it is null"
 				}
 			}
-			
+
 			foreach ($statementplan in $object.SingleStatementPlanRaw)
 			{
 				$filename = "$path\$shortname.sqlplan"
-				
+
 				try
 				{
 					If ($Pscmdlet.ShouldProcess("localhost", "Writing XML file to $filename"))
@@ -138,7 +138,7 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 					Write-Verbose "Skipped statement plan for $filename because it is null"
 				}
 			}
-			
+
 			If ($Pscmdlet.ShouldProcess("console", "Showing output object"))
 			{
 				Add-Member -Force -InputObject $object -MemberType NoteProperty -Name OutputFile -Value $filename
@@ -146,105 +146,105 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 			}
 		}
 	}
-	
+
 	PROCESS
 	{
 		if (!(Test-Path $Path))
 		{
 			$null = New-Item -ItemType Directory -Path $Path
 		}
-		
+
 		if ($PipedObject)
 		{
-			
+
 			foreach ($object in $pipedobject)
 			{
 				Process-Object $object
 				return
 			}
 		}
-		
+
 		foreach ($instance in $sqlinstance)
 		{
 			try
 			{
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
-				
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+
 				if ($server.VersionMajor -lt 9)
 				{
 					Write-Warning "SQL Server 2000 not supported"
 					continue
 				}
-				
-				$select = "SELECT DB_NAME(deqp.dbid) as DatabaseName, OBJECT_NAME(deqp.objectid) as ObjectName, 
-					detqp.query_plan AS SingleStatementPlan, 
+
+				$select = "SELECT DB_NAME(deqp.dbid) as DatabaseName, OBJECT_NAME(deqp.objectid) as ObjectName,
+					detqp.query_plan AS SingleStatementPlan,
 					deqp.query_plan AS BatchQueryPlan,
 					ROW_NUMBER() OVER ( ORDER BY Statement_Start_offset ) AS QueryPosition,
 					sql_handle as SqlHandle,
 					plan_handle as PlanHandle,
 					creation_time as CreationTime,
 					last_execution_time as LastExecutionTime"
-				
+
 				$from = " FROM sys.dm_exec_query_stats deqs
 				        CROSS APPLY sys.dm_exec_text_query_plan(deqs.plan_handle,
 							deqs.statement_start_offset,
 							deqs.statement_end_offset) AS detqp
 				        CROSS APPLY sys.dm_exec_query_plan(deqs.plan_handle) AS deqp
 				        CROSS APPLY sys.dm_exec_sql_text(deqs.plan_handle) AS execText"
-				
+
 				if ($ExcludeDatabase -or $Database -or $SinceCreation.length -gt 0 -or $SinceLastExecution.length -gt 0 -or $ExcludeEmptyQueryPlan -eq $true)
 				{
 					$where = " WHERE "
 				}
-				
+
 				$wherearray = @()
-				
+
 				if ($Database -gt 0)
 				{
 					$dblist = $Database -join "','"
 					$wherearray += " DB_NAME(deqp.dbid) in ('$dblist') "
 				}
-				
+
 				if ($SinceCreation -ne $null)
 				{
 					Write-Verbose "Adding creation time"
 					$wherearray += " creation_time >= '$SinceCreation' "
 				}
-				
+
 				if ($SinceLastExecution -ne $null)
 				{
 					Write-Verbose "Adding last execution time"
 					$wherearray += " last_execution_time >= '$SinceLastExecution' "
 				}
-				
+
 				if ($ExcludeDatabase)
 				{
 					$dblist = $ExcludeDatabase -join "','"
 					$wherearray += " DB_NAME(deqp.dbid) not in ('$dblist') "
 				}
-				
+
 				if ($ExcludeEmptyQueryPlan)
 				{
 					$wherearray += " detqp.query_plan is not null"
 				}
-				
+
 				if ($where.length -gt 0)
 				{
 					$wherearray = $wherearray -join " and "
 					$where = "$where $wherearray"
 				}
-				
+
 				$sql = "$select $from $where"
 				Write-Debug $sql
-								
+
 				$datatable = $server.ConnectionContext.ExecuteWithResults($sql).Tables
-				
+
 				foreach ($row in ($datatable.Rows))
 				{
-					
+
 					$sqlhandle = "0x"; $row.sqlhandle | ForEach-Object { $sqlhandle += ("{0:X}" -f $_).PadLeft(2, "0") }
 					$planhandle = "0x"; $row.planhandle | ForEach-Object { $planhandle += ("{0:X}" -f $_).PadLeft(2, "0") }
-					
+
 					$object = [pscustomobject]@{
 						ComputerName = $server.NetName
 						InstanceName = $server.ServiceName
@@ -260,7 +260,7 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
 						BatchQueryPlanRaw = [xml]$row.BatchQueryPlan
 						SingleStatementPlanRaw = [xml]$row.SingleStatementPlan
 					}
-					
+
 					Process-Object $object
 				}
 			}

--- a/functions/Get-DbaServerAudit.ps1
+++ b/functions/Get-DbaServerAudit.ps1
@@ -11,14 +11,14 @@ Gets SQL Security Audit information for each instance(s) of SQL Server.
 SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function
 to be executed against multiple SQL Server instances.
 
-.PARAMETER Credential
+.PARAMETER SqlCredential
 PSCredential object to connect as. If not specified, current Windows login will be used.
 
 .PARAMETER EnableException
 		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-		
+
 .NOTES
 Author: Garry Bargsley (@gbargsley), http://blog.garrybargsley.com
 
@@ -42,21 +42,22 @@ Returns all Security Audits for the local and sql2016 SQL Server instances
 	Param (
 		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
 		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential]$Credential,
+		[Alias("Credential")]
+		[PSCredential]$SqlCredential,
 		[switch][Alias('Silent')]$EnableException
 	)
-	
+
 	process {
 		foreach ($instance in $SqlInstance)
 		{
 			try {
 				Write-Message -Level Verbose -Message "Connecting to $instance"
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
 			catch {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
-			
+
 			if ($server.versionMajor -lt 10) {
 				Write-Warning "Server Audits are only supported in SQL Server 2008 and above. Quitting."
 				continue
@@ -65,7 +66,7 @@ Returns all Security Audits for the local and sql2016 SQL Server instances
 				Add-Member -Force -InputObject $audit -MemberType NoteProperty -Name ComputerName -value $audit.Parent.NetName
 				Add-Member -Force -InputObject $audit -MemberType NoteProperty -Name InstanceName -value $audit.Parent.ServiceName
 				Add-Member -Force -InputObject $audit -MemberType NoteProperty -Name SqlInstance -value $audit.Parent.DomainInstanceName
-				
+
 				Select-DefaultView -InputObject $audit -Property ComputerName, InstanceName, SqlInstance, Name, 'Enabled as IsEnabled', FilePath, FileName
 			}
 			if($server.Audits.Count -eq 0) {

--- a/functions/Repair-DbaServerName.ps1
+++ b/functions/Repair-DbaServerName.ps1
@@ -2,25 +2,25 @@ function Repair-DbaServerName {
 	<#
 		.SYNOPSIS
 			Renames @@SERVERNAME to match with the Windows name.
-			
+
 		.DESCRIPTION
 			When a SQL Server's host OS is renamed, the SQL Server should be as well. This helps with Availability Groups and Kerberos.
 
 			This command renames @@SERVERNAME to match with the Windows name. The new name is automatically determined. It does not matter if you use an alias to connect to the SQL instance.
-					
+
 			If the automatically determined new name matches the old name, the command will not run.
-				
+
 			https://www.mssqltips.com/sqlservertip/2525/steps-to-change-the-server-name-for-a-sql-server-machine/
-			
+
 		.PARAMETER SqlInstance
 			The SQL Server that you're connecting to.
 
-		.PARAMETER Credential
+		.PARAMETER SqlCredential
 			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
-			$scred = Get-Credential, then pass $scred object to the -Credential parameter.
+			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-			Windows Authentication will be used if Credential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 
 			To connect as a different Windows user, run PowerShell as that user.
 
@@ -55,9 +55,9 @@ function Repair-DbaServerName {
 
 			Checks to see if the server name is updatable and automatically performs the change. Replication or mirroring will be broken if necessary.
 
-		.EXAMPLE   
+		.EXAMPLE
 			Repair-DbaServerName -SqlInstance sql2014 -AutoFix -Force
-				
+
 			Checks to see if the server name is updatable and automatically performs the change, bypassing most prompts and confirmations. Replication or mirroring will be broken if necessary.
 	#>
 	[OutputType("System.String")]
@@ -66,58 +66,59 @@ function Repair-DbaServerName {
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential]$Credential,
+		[Alias("Credential")]
+		[PSCredential]$SqlCredential,
 		[switch]$AutoFix,
 		[switch]$Force
 	)
-	
+
 	begin {
 		if ($Force -eq $true) {
 			$ConfirmPreference = "None"
 		}
 	}
-	
+
 	process {
 		foreach ($servername in $SqlInstance) {
 			try {
-				$server = Connect-SqlInstance -SqlInstance $servername -SqlCredential $Credential
+				$server = Connect-SqlInstance -SqlInstance $servername -SqlCredential $SqlCredential
 			}
 			catch {
 				Write-Warning "Can't connect to $servername. Moving on."
 				Continue
 			}
-			
+
 			if ($server.isClustered) {
-				
+
 				Write-Warning "$servername is a cluster. Microsoft does not support renaming clusters."
 				Continue
 			}
-			
+
 			if ($server.VersionMajor -eq 8) {
 				Write-Warning "SQL Server 2000 not supported. Skipping $servername."
 				Continue
 			}
-			
+
 			# Check to see if we can easily proceed
 			Write-Verbose "Executing Test-DbaServerName to see if the server is in a state to be renamed. "
-			
+
 			$nametest = Test-DbaServerName $servername -Detailed -NoWarning
 			$serverinstancename = $nametest.ServerInstanceName
 			$SqlInstancename = $nametest.SqlServerName
-			
+
 			if ($nametest.RenameRequired -eq $false) {
 				return "Good news! $serverinstancename's @@SERVERNAME does not need to be changed. If you'd like to rename it, first rename the Windows server."
 			}
-			
+
 			if ($nametest.updatable -eq $false) {
 				Write-Output "Test-DbaServerName reports that the rename cannot proceed with a rename in this $servername's current state."
-				
+
 				$nametest
-				
+
 				foreach ($nametesterror in $nametest.Blockers) {
 					if ($nametesterror -like '*replication*') {
 						$replication = $true
-						
+
 						if ($AutoFix -eq $false) {
 							throw "Cannot proceed because some databases are involved in replication. You can run exec sp_dropdistributor @no_checks = 1 but that may be pretty dangerous. Alternatively, you can run -AutoFix to automatically fix this issue. AutoFix will also break all database mirrors."
 						}
@@ -129,7 +130,7 @@ function Repair-DbaServerName {
 								$no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Will exit"
 								$options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
 								$result = $host.ui.PromptForChoice($title, $message, $options, 1)
-								
+
 								if ($result -eq 1) {
 									throw "Cannot continue"
 								}
@@ -161,17 +162,17 @@ function Repair-DbaServerName {
 								$no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Will exit"
 								$options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
 								$result = $host.ui.PromptForChoice($title, $message, $options, 1)
-								
+
 								if ($result -eq 1) {
 									Write-Output "Okay, moving on."
 								}
 								else {
 									Write-Output "Removing Mirroring"
-									
+
 									foreach ($database in $server.Databases) {
 										if ($database.IsMirroringEnabled) {
 											$dbname = $database.name
-											
+
 											try {
 												Write-Output "Breaking mirror for $dbname."
 												$database.ChangeMirroringState([Microsoft.SqlServer.Management.Smo.MirroringOption]::Off)
@@ -191,23 +192,23 @@ function Repair-DbaServerName {
 				}
 			}
 			# ^ That's embarrassing
-			
+
 			$instancename = $instance = $server.InstanceName
-			
+
 			if ($instancename.length -eq 0) {
 				$instancename = $instance = "MSSQLSERVER"
 			}
-			
+
 			try {
 				$allsqlservices = Get-Service -ComputerName $server.ComputerNamePhysicalNetBIOS -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -like "SQL*$instance*" -and $_.Status -eq "Running" }
 			}
 			catch {
 				Write-Warning "Can't contact $servername using Get-Service. This means the script will not be able to automatically restart SQL services."
 			}
-			
+
 			if ($nametest.Warnings.length -gt 0) {
 				$reportingservice = Get-Service -ComputerName $server.ComputerNamePhysicalNetBIOS -DisplayName "SQL Server Reporting Services ($instance)" -ErrorAction SilentlyContinue
-				
+
 				if ($reportingservice.Status -eq "Running") {
 					if ($Pscmdlet.ShouldProcess($server.name, "Reporting Services is running for this instance. Would you like to automatically stop this service?")) {
 						$reportingservice | Stop-Service
@@ -215,7 +216,7 @@ function Repair-DbaServerName {
 					}
 				}
 			}
-			
+
 			if ($Pscmdlet.ShouldProcess($server.name, "Performing sp_dropserver to remove the old server name, $SqlInstancename, then sp_addserver to add $serverinstancename")) {
 				$sql = "sp_dropserver '$SqlInstancename'"
 				Write-Debug $sql
@@ -227,10 +228,10 @@ function Repair-DbaServerName {
 					Write-Exception $_
 					throw $_
 				}
-				
+
 				$sql = "sp_addserver '$serverinstancename', local"
 				Write-Debug $sql
-				
+
 				try {
 					$null = $server.Query($sql)
 					Write-Output "Successfully executed $sql."
@@ -241,7 +242,7 @@ function Repair-DbaServerName {
 				}
 				$renamed = $true
 			}
-			
+
 			if ($allsqlservices -eq $null) {
 				Write-Warning "Could not contact $($server.ComputerNamePhysicalNetBIOS) using Get-Service. You must manually restart the SQL Server instance."
 				$needsrestart = $true
@@ -260,11 +261,11 @@ function Repair-DbaServerName {
 					}
 				}
 			}
-			
+
 			if ($renamed -eq $true) {
 				Write-Output "`n$servername successfully renamed from $SqlInstancename to $serverinstancename."
 			}
-			
+
 			if ($needsrestart -eq $true) {
 				Write-Output "SQL Service restart for $serverinstancename still required."
 			}

--- a/functions/Set-DbaDatabaseOwner.ps1
+++ b/functions/Set-DbaDatabaseOwner.ps1
@@ -8,9 +8,9 @@ function Set-DbaDatabaseOwner {
 
 			Best Practice reference: http://weblogs.sqlteam.com/dang/archive/2008/01/13/Database-Owner-Troubles.aspx
 
-		.PARAMETER SqlInstance 
+		.PARAMETER SqlInstance
 			Specifies the SQL Server instance(s) to scan.
-			
+
 		.PARAMETER SqlCredential
 			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
 
@@ -22,10 +22,10 @@ function Set-DbaDatabaseOwner {
 
 		.PARAMETER Database
 			Specifies the database(s) to process. Options for this list are auto-populated from the server. If unspecified, all databases will be processed.
-		
+
 		.PARAMETER ExcludeDatabase
 			Specifies the database(s) to exclude from processing. Options for this list are auto-populated from the server.
-		
+
 		.PARAMETER TargetLogin
 			Specifies the login that you wish check for ownership. This defaults to 'sa' or the sysadmin name if sa was renamed. This must be a valid security principal which exists on the target server.
 
@@ -39,9 +39,9 @@ function Set-DbaDatabaseOwner {
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.NOTES
-			Tags: 
+			Tags:
 			Author: Michael Fal (@Mike_Fal), http://mikefal.net
 
 			Website: https://dbatools.io
@@ -85,7 +85,7 @@ function Set-DbaDatabaseOwner {
 		foreach ($instance in $SqlInstance) {
 			Write-Message -Level Verbose -Message "Connecting to $instance."
 			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $Credential
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
 			catch {
 				Stop-Function -Message "Failure." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
@@ -100,13 +100,13 @@ function Set-DbaDatabaseOwner {
 			if (($server.Logins.Name) -notcontains $TargetLogin) {
 				Stop-Function -Message "$TargetLogin is not a valid login on $instance. Moving on." -Continue -EnableException $EnableException
 			}
-			
+
 			#Owner cannot be a group
 			$TargetLoginObject = $server.Logins | where-object {$PSItem.Name -eq $TargetLogin }| Select-Object -property  Name, LoginType
 			if ($TargetLoginObject.LoginType -eq 'WindowsGroup') {
 				Stop-Function -Message "$TargetLogin is a group, therefore can't be set as owner. Moving on." -Continue -EnableException $EnableException
 			}
-			
+
 			#Get database list. If value for -Database is passed, massage to make it a string array.
 			#Otherwise, use all databases on the instance where owner not equal to -TargetLogin
 			#use where owner and target login do not match


### PR DESCRIPTION
Found some commands that were not using the $SqlCredential variable (using the non-existing $credential instead) which make the command fail.

Some other functions still mention $Credential where should be $SqlCredential the ones I have changed I added the alias so it doesn't break compatibility (and it is the way we have on other commands already).

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2723)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
