### PR TITLE
Add all current data and log file paths to the find paths

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -191,6 +191,13 @@ function Find-DbaOrphanedFile {
 			# Reset all the arrays
 			$dirtreefiles = $valid = $paths = $matching = @()
 
+			$filestructure = Get-SqlFileStructure $server
+			
+			# Get any paths associated with current data and log files
+			foreach ($file in $filestructure) {
+				$paths += Split-Path -Path $file
+			}
+
 			# Get the default data and log directories from the instance
 			Write-Message -Level Debug -Message "Adding paths"
 			$paths += $server.RootDirectory + "\DATA"

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -219,8 +219,6 @@ function Find-DbaOrphanedFile {
 			}
 			$dirtreefiles = $dirtreefiles | Where-Object { $_ } | Sort-Object Comparison -Unique
 
-			$filestructure = Get-SqlFileStructure $server
-
 			foreach ($file in $filestructure) {
 				$valid += [IO.Path]::GetFullPath($(Format-Path $file))
 			}

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -195,7 +195,7 @@ function Find-DbaOrphanedFile {
 			
 			# Get any paths associated with current data and log files
 			foreach ($file in $filestructure) {
-				$paths += Split-Path -Path $file
+				$paths += Split-Path -Path $file -Parent
 			}
 
 			# Get the default data and log directories from the instance


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2725)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Find-DbaOrphanedFile does not currently look in all attached directories.

### Approach
<!-- How does this change solve that purpose -->
Use the already present Get-SqlFileStructure to pull the paths of all existing data and log files, and add that to the $paths checked.
