### PR TITLE
Now does ola properly, and will ignore logs

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -493,7 +493,7 @@ function Restore-DbaDatabase {
                     if ($f -is [System.IO.FileSystemInfo]){
                         $f = $f.fullname
                     }
-                    $BackupHistory += $f | Get-DbaBackupInformation -SqlInstance $RestoreInstance -DirectoryRecurse:$DirectoryRecurse
+                    $BackupHistory += $f | Get-DbaBackupInformation -SqlInstance $RestoreInstance -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup
                 }
             }
             

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -117,7 +117,15 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 		}
 		It "Should be 0 log backups" {
             ($resultsSanLog | Where-Object {$_.Type -eq 'Transaction Log'}).count | Should be 0
-        }
+		}
+		$ResultsSanLog = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $DestBackupDirOla -IgnoreLogBackup -WarningVariable warnvar -WarningAction SilentlyContinue	
+		It "Should Warn if IgnoreLogBackup without Maintenance Solution" {
+			($WarnVar -match  "IgnoreLogBackup can only by used with Maintenance Soultion. Will not be used") | Should Be $True
+		}
+		It "Should ignore IgnoreLogBackup and return 3 backups" {
+			$resultsSanLog.count | Should Be 3
+		}
+
 	}
 
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Maintenance solution switch wasn't working as expected in new version, and IgnoreLogBackup wasn't working at all.

### Approach
Fixed up Get-DbaBackupInformation to take the parameters properly
