### PR TITLE
Hiding Get-DbaDatabaseFile warnings in Restore-DbaDatabase

### DIFF
--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -112,8 +112,8 @@ Function Test-DbaBackupInformation {
             }
             
             #Test no destinations exist
-            $DbFileCheck = (Get-DbaDatabaseFile -SqlInstance $RestoreInstance -Database $Database).PhysicalName
-            $OtherFileCheck = (Get-DbaDatabaseFile -SqlInstance $RestoreInstance -ExcludeDatabase $Database).PhysicalName
+            $DbFileCheck = (Get-DbaDatabaseFile -SqlInstance $RestoreInstance -Database $Database -WarningAction SilentlyContinue).PhysicalName
+            $OtherFileCheck = (Get-DbaDatabaseFile -SqlInstance $RestoreInstance -ExcludeDatabase $Database -WarningAction SilentlyContinue).PhysicalName
             ForEach ($path in ($DbHistory | Select-Object -ExpandProperty filelist | Select-Object PhysicalName -Unique).physicalname){
                 if(Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $path){
                     if (($path -in $DBFileCheck) -and ($WithReplace -ne $True -and $Continue -ne $True)) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Hide the warnings from Get-DbaDatabasefile while we check if someone's about to tread on their own toes during a restore

### Approach
Set warningaction to SilentlyContinue on the GDDF calles
