### PR TITLE
internals, trailing spaces, folding, analyzer

### DIFF
--- a/internal/Connect-AsServer.ps1
+++ b/internal/Connect-AsServer.ps1
@@ -1,7 +1,7 @@
 Function Connect-AsServer
 {
-<# 
-.SYNOPSIS 
+<#
+.SYNOPSIS
 Internal function that creates SMO server object.
 
 .DESCRIPTION
@@ -29,23 +29,23 @@ Connects to SSAS on the local server
 		[object]$AsServer,
 		[switch]$ParameterConnection
 	)
-	
+
 	if ($AsServer.GetType() -eq [Microsoft.AnalysisServices.Server])
 	{
-		
+
 		if ($ParameterConnection)
 		{
 			$paramserver = New-Object Microsoft.AnalysisServices.Server
 			$paramserver.Connect("Data Source=$($AsServer.Name);Connect Timeout=2")
 			return $paramserver
 		}
-		
+
 		if ($AsServer.Connected -eq $false) { $AsServer.Connect("Data Source=$($AsServer.Name);Connect Timeout=3") }
 		return $AsServer
 	}
-	
+
 	$server = New-Object Microsoft.AnalysisServices.Server
-	
+
 	try
 	{
 		if ($ParameterConnection)
@@ -63,6 +63,6 @@ Connects to SSAS on the local server
 		$message = ($message -Split 'at System.Data.ProviderBase')[0]
 		throw "Can't connect to $asserver`: $message "
 	}
-	
+
 	return $server
 }

--- a/internal/Convert-ByteToHexString.ps1
+++ b/internal/Convert-ByteToHexString.ps1
@@ -1,15 +1,15 @@
 function Convert-ByteToHexString {
-<#
+	<#
 	.SYNOPSIS
 	Converts byte object into hex string
-	
+
 	.DESCRIPTION
 	Converts byte object ([byte[]]@(1,100,23,54)) into the hex string (e.g. '0x01641736')
 	Used when working with SMO logins and their byte parameters: sids and hashed passwords
-		
+
 	.PARAMETER InputObject
 	Input byte[] object (e.g. [byte[]]@(18,52))
-	
+
 	.NOTES
 	Tags: Login, Internal
 	Author: Kirill Kravtsov (@nvarscar)
@@ -19,15 +19,16 @@ function Convert-ByteToHexString {
 
 	.EXAMPLE
 	Convert-ByteToHexString ([byte[]]@(1,100,23,54))
-	
+
 	Returns hex string '0x01641736'
-	
+
 	.EXAMPLE
 	Convert-ByteToHexString 18,52
-	
+
 	Returns hex string '0x1234'
 #>
-	Param ([byte[]]$InputObject)
-	$outString = "0x"; $InputObject | ForEach-Object { $outString += ("{0:X}" -f $_).PadLeft(2, "0") }
-	Return $outString
+	param ([byte[]]$InputObject)
+	$outString = "0x"
+	$InputObject | ForEach-Object { $outString += ("{0:X}" -f $_).PadLeft(2, "0") }
+	$outString
 }

--- a/internal/Convert-DbVersionToSqlVersion.ps1
+++ b/internal/Convert-DbVersionToSqlVersion.ps1
@@ -1,6 +1,6 @@
 Function Convert-DbVersionToSqlVersion {
-<# 
-.SYNOPSIS 
+	<#
+.SYNOPSIS
 Internal function that makes db versions human readable
 
 .DESCRIPTION
@@ -11,16 +11,15 @@ Analysis Server
 
 .EXAMPLE
 Convert-DbVersionToSqlVersion -dbversion 856
-	
+
 Returns "SQL Server vNext CTP1"
 
 #>
 	param (
 		[string]$dbversion
 	)
-	
-	$dbversion = switch ($dbversion)
-	{
+
+	$dbversion = switch ($dbversion) {
 		856 { "SQL Server vNext CTP1" }
 		852 { "SQL Server 2016" }
 		829 { "SQL Server 2016 Prerelease" }
@@ -37,6 +36,6 @@ Returns "SQL Server vNext CTP1"
 		408 { "SQL Server 6.5" }
 		default { $dbversion }
 	}
-	
+
 	return $dbversion
 }

--- a/internal/Convert-HexStringToByte.ps1
+++ b/internal/Convert-HexStringToByte.ps1
@@ -1,15 +1,15 @@
 function Convert-HexStringToByte {
-<#
+	<#
 	.SYNOPSIS
 	Converts hex string into byte object
-	
+
 	.DESCRIPTION
 	Converts hex string (e.g. '0x01641736') into the byte object ([byte[]]@(1,100,23,54))
 	Used when working with SMO logins and their byte parameters: sids and hashed passwords
-		
+
 	.PARAMETER InputObject
 	Input hex string (e.g. '0x1234' or 'DBA2FF')
-	
+
 	.NOTES
 	Tags: Login, Internal
 	Author: Kirill Kravtsov (@nvarscar)
@@ -19,19 +19,19 @@ function Convert-HexStringToByte {
 
 	.EXAMPLE
 	Convert-HexStringToByte '0x01641736'
-	
+
 	Returns byte[] object [byte[]]@(1,100,23,54)
-	
+
 	.EXAMPLE
 	Convert-HexStringToByte '1234'
-	
+
 	Returns byte[] object [byte[]]@(18,52)
 #>
-	Param (
+	param (
 		[string]$InputObject
 	)
 	$hexString = $InputObject.TrimStart("0x")
 	if ($hexString.Length % 2 -eq 1) { $hexString = '0' + $hexString }
-	[byte[]]$outByte = $null; $outByte += 0 .. (($hexString.Length)/2-1) | ForEach-Object { [Int16]::Parse($hexString.Substring($_*2, 2), 'HexNumber') }
+	[byte[]]$outByte = $null; $outByte += 0 .. (($hexString.Length) / 2 - 1) | ForEach-Object { [Int16]::Parse($hexString.Substring($_ * 2, 2), 'HexNumber') }
 	Return $outByte
 }

--- a/internal/Get-CodePage.ps1
+++ b/internal/Get-CodePage.ps1
@@ -1,7 +1,7 @@
 ﻿function Get-CodePage {
 	<#
 		.SYNOPSIS
-			Converts Microsoft's code page ID to human readable format 
+			Converts Microsoft's code page ID to human readable format
 
 		.DESCRIPTION
 			Converts Microsoft's code page ID to human readable format

--- a/internal/Get-DBASQLServiceErrorMessage.ps1
+++ b/internal/Get-DBASQLServiceErrorMessage.ps1
@@ -4,7 +4,7 @@ Function Get-DBASQLServiceErrorMessage {
     Internal function. Returns the list of error code messages for Windows service management.
 
 #>
-	Param(
+	param(
 		[parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 1)]
 			[int]$ErrorNumber
 	)

--- a/internal/Get-DbaADObject.ps1
+++ b/internal/Get-DbaADObject.ps1
@@ -1,86 +1,86 @@
 #ValidationTags#FlowControl,Pipeline#
 Function Get-DbaADObject {
 	<#
-.SYNOPSIS
-Get-DbaADObject tries to facilitate searching AD with dbatools, which ATM can't require AD cmdlets.
+	.SYNOPSIS
+	Get-DbaADObject tries to facilitate searching AD with dbatools, which ATM can't require AD cmdlets.
 
-.DESCRIPTION
-As working with multiple domains, forests, ldap filters, partitions, etc is quite hard to grasp, let's try to do "the right thing" here and
-facilitate everybody's work with it. It either returns the exact matched result or None if it isn't found. You can inspect the raw object
-calling GetUnderlyingObject() on the returned object.
+	.DESCRIPTION
+	As working with multiple domains, forests, ldap filters, partitions, etc is quite hard to grasp, let's try to do "the right thing" here and
+	facilitate everybody's work with it. It either returns the exact matched result or None if it isn't found. You can inspect the raw object
+	calling GetUnderlyingObject() on the returned object.
 
-.PARAMETER ADObject
-Pass in both the domain and the login name in Domain\sAMAccountName format (the one everybody is accustomed to)
-You can also pass a UserPrincipalName format (with the correct IdentityType, either with Domain\UserPrincipalName or UserPrincipalName@Domain)
-Beware: the "Domain" part of the UPN *can* be different from the real domain, see "UPN suffixes" (https://msdn.microsoft.com/en-us/library/windows/desktop/aa380525(v=vs.85).aspx)
-It's always best to pass the real domain name in (see the examples)
-For any other format, please beware that the domain part must always be specified (again, for the best result, before the slash)
+	.PARAMETER ADObject
+	Pass in both the domain and the login name in Domain\sAMAccountName format (the one everybody is accustomed to)
+	You can also pass a UserPrincipalName format (with the correct IdentityType, either with Domain\UserPrincipalName or UserPrincipalName@Domain)
+	Beware: the "Domain" part of the UPN *can* be different from the real domain, see "UPN suffixes" (https://msdn.microsoft.com/en-us/library/windows/desktop/aa380525(v=vs.85).aspx)
+	It's always best to pass the real domain name in (see the examples)
+	For any other format, please beware that the domain part must always be specified (again, for the best result, before the slash)
 
-.PARAMETER Type
-You *should* always know what you are asking for. Please pass in Computer,Group or User to help speeding up the search
+	.PARAMETER Type
+	You *should* always know what you are asking for. Please pass in Computer,Group or User to help speeding up the search
 
-.PARAMETER IdentityType
-By default objects are searched using sAMAccountName format, here you can pass different representation that need to match the passed in ADObject
+	.PARAMETER IdentityType
+	By default objects are searched using sAMAccountName format, here you can pass different representation that need to match the passed in ADObject
 
-.PARAMETER Credential
-Use this credential to connect to the domain and search for the needed ADObject. If not passed, uses the current process' one.
+	.PARAMETER Credential
+	Use this credential to connect to the domain and search for the needed ADObject. If not passed, uses the current process' one.
 
-.PARAMETER SearchAllDomains
-Search for the object in all domains connected to the current one. If you are unsure what domain the object is coming from,
-using this switch will search through all domains in your forest and also in the ones that are trusted. This is HEAVY, but it can save
-some headaches.
+	.PARAMETER SearchAllDomains
+	Search for the object in all domains connected to the current one. If you are unsure what domain the object is coming from,
+	using this switch will search through all domains in your forest and also in the ones that are trusted. This is HEAVY, but it can save
+	some headaches.
 
-.PARAMETER EnableException
-		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-		
-.NOTES
-Author: Niphlod, https://github.com/niphlod
-Tags:
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+	.PARAMETER EnableException
+			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.EXAMPLE
-Get-DbaADObject -ADObject "contoso\ctrlb" -Type User
+	.NOTES
+	Author: Niphlod, https://github.com/niphlod
+	Tags:
+	dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+	Copyright (C) 2016 Chrissy LeMaire
+	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-Searches in the contoso domain for a ctrlb user
+	.EXAMPLE
+	Get-DbaADObject -ADObject "contoso\ctrlb" -Type User
 
-.EXAMPLE
-Get-DbaADObject -ADObject "ctrlb@contoso.com" -Type User -IdentityType UserPrincipalName
+	Searches in the contoso domain for a ctrlb user
 
-Searches in the contoso domain for a ctrlb user using the UserPrincipalName format. Again, beware of the UPN suffixes in elaborate AD structures!
+	.EXAMPLE
+	Get-DbaADObject -ADObject "ctrlb@contoso.com" -Type User -IdentityType UserPrincipalName
 
-.EXAMPLE
-Get-DbaADObject -ADObject "contoso\ctrlb@super.contoso.com" -Type User -IdentityType UserPrincipalName
+	Searches in the contoso domain for a ctrlb user using the UserPrincipalName format. Again, beware of the UPN suffixes in elaborate AD structures!
 
-Searches in the contoso domain for a ctrlb@super.contoso.com user using the UserPrincipalName format. This kind of search is better than the previous one
-because it takes into account possible UPN suffixes
+	.EXAMPLE
+	Get-DbaADObject -ADObject "contoso\ctrlb@super.contoso.com" -Type User -IdentityType UserPrincipalName
 
-.EXAMPLE
-Get-DbaADObject -ADObject "ctrlb@super.contoso.com" -Type User -IdentityType UserPrincipalName -SearchAllDomains
+	Searches in the contoso domain for a ctrlb@super.contoso.com user using the UserPrincipalName format. This kind of search is better than the previous one
+	because it takes into account possible UPN suffixes
 
-As a last resort, searches in all the current forest for a ctrlb@super.contoso.com user using the UserPrincipalName format
+	.EXAMPLE
+	Get-DbaADObject -ADObject "ctrlb@super.contoso.com" -Type User -IdentityType UserPrincipalName -SearchAllDomains
 
-.EXAMPLE
-Get-DbaADObject -ADObject "contoso\sqlcollaborative" -Type Group
+	As a last resort, searches in all the current forest for a ctrlb@super.contoso.com user using the UserPrincipalName format
 
-Searches in the contoso domain for a sqlcollaborative group
+	.EXAMPLE
+	Get-DbaADObject -ADObject "contoso\sqlcollaborative" -Type Group
 
-.EXAMPLE
-Get-DbaADObject -ADObject "contoso\SqlInstance2014$" -Type Group
+	Searches in the contoso domain for a sqlcollaborative group
 
-Searches in the contoso domain for a SqlInstance2014 computer (remember the ending $ for computer objects)
+	.EXAMPLE
+	Get-DbaADObject -ADObject "contoso\SqlInstance2014$" -Type Group
 
-.EXAMPLE
-Get-DbaADObject -ADObject "contoso\ctrlb" -Type User -EnableException
+	Searches in the contoso domain for a SqlInstance2014 computer (remember the ending $ for computer objects)
 
-Searches in the contoso domain for a ctrlb user, suppressing all error messages and throw exceptions that can be caught instead
+	.EXAMPLE
+	Get-DbaADObject -ADObject "contoso\ctrlb" -Type User -EnableException
+
+	Searches in the contoso domain for a ctrlb user, suppressing all error messages and throw exceptions that can be caught instead
 
 #>
 	[CmdletBinding()]
-	Param (
+	param (
 		[string[]]$ADObject,
 		[ValidateSet("User", "Group", "Computer")]
 		[string]$Type,
@@ -88,11 +88,11 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 		[ValidateSet("DistinguishedName", "Guid", "Name", "SamAccountName", "Sid", "UserPrincipalName")]
 		[string]$IdentityType = "SamAccountName",
 
-		$Credential,
+		[PSCredential]$Credential,
 		[switch]$SearchAllDomains,
 		[switch][Alias('Silent')]$EnableException
 	)
-	BEGIN {
+	begin {
 		try {
 			Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 		}
@@ -114,12 +114,12 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 				$searchClass = [System.DirectoryServices.AccountManagement.Principal]
 			}
 		}
-		
+
 		function Get-DbaADObjectInternal($Domain, $IdentityType, $obj, $EnableException) {
 			try {
 				# can we simply resolve the passed domain ? This has the benefit of raising almost instantly if the domain is not valid
-				$Context = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('Domain', $Domain)
-				$DContext = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($Context)
+				New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('Domain', $Domain) | Out-Null
+				[System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($Context) | Out-Null
 				if ($Credential) {
 					$ctx = New-Object System.DirectoryServices.AccountManagement.PrincipalContext('Domain', $Domain, $Credential.UserName, $Credential.GetNetworkCredential().Password)
 				}
@@ -134,7 +134,7 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 			}
 		}
 	}
-	PROCESS {
+	process {
 		if (Test-FunctionInterrupt) { return }
 		foreach ($ADObj in $ADObject) {
 			# passing the domain as the first part before the \ wins always in defining the domain to search into
@@ -150,7 +150,7 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 						$obj, $Domain = $Splitted
 					}
 					else {
-						# if searching for a UserPrincipalName format without a specific domain passed in before the slash, 
+						# if searching for a UserPrincipalName format without a specific domain passed in before the slash,
 						# we can assume there are no custom UPN suffixes in place
 						$obj, $Domain = $AdObj, $Splitted[1]
 					}
@@ -178,7 +178,7 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 						}
 					}
 					# we are very unlucky, let's search also in all trusted domains
-					$AllTrusted = ($ForestObject.GetAllTrustRelationships().TopLevelNames | where Status -eq 'Enabled').Name
+					$AllTrusted = ($ForestObject.GetAllTrustRelationships().TopLevelNames | Where-Object Status -eq 'Enabled').Name
 					foreach ($ForestDomain in $AllTrusted) {
 						Write-Message -Message "Searching for $obj under domain $ForestDomain in $IdentityType format" -Level 4 -EnableException $EnableException
 						$found = Get-DbaADObjectInternal -Domain $ForestDomain -IdentityType $IdentityType -obj $obj
@@ -193,7 +193,6 @@ Searches in the contoso domain for a ctrlb user, suppressing all error messages 
 				Write-Message -Message "Searching for $obj under domain $domain in $IdentityType format" -Level 4 -EnableException $EnableException
 				Get-DbaADObjectInternal -Domain $Domain -IdentityType $IdentityType -obj $obj
 			}
-			
 		}
 	}
 }

--- a/internal/Get-DbaRunspace.ps1
+++ b/internal/Get-DbaRunspace.ps1
@@ -1,30 +1,30 @@
 function Get-DbaRunspace {
-<#
+	<#
 	.SYNOPSIS
 		Returns registered runspaces.
-	
+
 	.DESCRIPTION
 		Returns a list of runspaces that have been registered with dbatools
-	
+
 	.PARAMETER Name
 		Default: "*"
 		Only registered runspaces of similar names are returned.
-	
+
 	.EXAMPLE
 		PS C:\> Get-DbaRunspace
-	
+
 		Returns all registered runspaces
-	
+
 	.EXAMPLE
 		PS C:\> Get-DbaRunspace -Name 'mymodule.maintenance'
-	
+
 		Returns the runspace registered under the name 'mymodule.maintenance'
 #>
 	[CmdletBinding()]
-	Param (
+	param (
 		[string]
 		$Name = "*"
 	)
-	
+
 	[Sqlcollaborative.Dbatools.Runspace.RunspaceHost]::Runspaces.Values | Where-Object Name -Like $Name
 }

--- a/internal/Get-DbaService.ps1
+++ b/internal/Get-DbaService.ps1
@@ -1,75 +1,75 @@
 function Get-DbaService {
-<#
+	<#
 	.SYNOPSIS
 		Uses WMI/CIM to scan for the existance of a specific windows services.
-	
+
 	.DESCRIPTION
 		Uses WMI/CIM to scan for the existance of a specific windows services.
-	
+
 		Use Get-DbaSqlService if you are interested in scanning for sql server services exclusively.
-	
+
 	.PARAMETER ComputerName
 		The computer to target. Uses localhost by default.
-	
+
 	.PARAMETER Name
 		The name of the service to search for.
-	
+
 	.PARAMETER DisplayName
 		The display-name of the service to search for.
-	
+
 	.PARAMETER Credential
 		The credentials to use when connecting to the computer.
-	
+
 	.PARAMETER DoNotUse
 		Connection Protocols that should not be used when retrieving the information.
-	
+
 	.PARAMETER EnableException
 		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-		
+
 	.EXAMPLE
 		Get-DbaService -Name LanmanServer
-	
+
 		Returns information on the LanmanServer service from localhost.
-	
+
 	.EXAMPLE
 		Get-ADComputer -Filter * | Get-DbaService -Name Browser
-	
+
 		First retrieves all computer accounts from active directory, then scans all of those computers for the browser service.
 		Note: THis may take seriously long time, you may also want to filter out computers that are offline before scanning for services.
-	
+
 	.EXAMPLE
 		Get-DbaService -ComputerName "server1","server2","server3" -Name Lanman%
-	
+
 		Scans the servers server1, server2 and server3 for all services whose name starts with 'lanman'
 #>
 	[CmdletBinding()]
-	Param (
+	param (
 		[string[]]
 		$Name,
-		
+
 		[string[]]
 		$DisplayName,
-		
+
 		[Parameter(ValueFromPipeline = $true)]
 		[Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter[]]
 		$ComputerName = $env:COMPUTERNAME,
-		
+
 		[System.Management.Automation.PSCredential]
 		$Credential,
-		
+
 		[Sqlcollaborative.Dbatools.Connection.ManagementConnectionType[]]
 		$DoNotUse,
-		
+
 		[switch]
 		[Alias('Silent')]$EnableException
 	)
-	
+
 	begin {
 		Write-Message -Level InternalComment -Message "Starting"
 		Write-Message -Level System -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
-		
+
 		if (-not (Test-Bound "Name") -and -not (Test-Bound "DisplayName")) {
 			$Name = "%"
 		}
@@ -92,7 +92,7 @@ function Get-DbaService {
 					}
 				}
 			}
-			
+
 			foreach ($serviceDisplayName in $DisplayName) {
 				Write-Message -Level Verbose -Message "Searching for services with display name: $serviceDisplayName" -Target $computer.ComputerName
 				try {

--- a/internal/Get-DirectoryRestoreFile.ps1
+++ b/internal/Get-DirectoryRestoreFile.ps1
@@ -1,42 +1,42 @@
 function Get-DirectoryRestoreFile {
-    <#
+	<#
 .SYNOPSIS
 Internal Function to get SQL Server backfiles from a specified folder
 
 .DESCRIPTION
-Takes path, checks for validity. Scans for usual backup file 
+Takes path, checks for validity. Scans for usual backup file
 #>
-    [CmdletBinding()]
-    Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [string]$Path,
-        [switch]$Recurse,
-        [switch][Alias('Silent')]$EnableException
-    )
-       
-    Write-Message -Level Verbose -Message "Starting"
-    Write-Message -Level Verbose -Message "Checking Path"
-    if ((Test-Path $Path) -ne $true) {
-        Stop-Function -Message "$Path is not reachable"
+	[CmdletBinding()]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[string]$Path,
+		[switch]$Recurse,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	Write-Message -Level Verbose -Message "Starting"
+	Write-Message -Level Verbose -Message "Checking Path"
+	if ((Test-Path $Path) -ne $true) {
+		Stop-Function -Message "$Path is not reachable"
 		return
-    }
-    #Path needs to end \* to use includes, which is faster than Where-Object
-    $PathCheckArray = $path.ToCharArray()
-    if ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -eq '*') {
-        #We're good    
-    }
-    elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -eq '*') {
-        $Path = ($PathCheckArray[0..(($PathCheckArray.length) - 2)] -join ('')) + "\*"
-    }
-    elseif ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -ne '*') {
-        #Append a * to the end
-        $Path = "$Path*"
-    }
-    elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -ne '*') {
-        #Append a \* to the end
-        $Path = "$Path\*"
-    }
-    Write-Message -Level Verbose -Message "Scanning $path"
-    $Results = Get-ChildItem -path $Path -Recurse:$Recurse | Where-Object {$_.PsIsContainer -eq $false}
-    return $Results
+	}
+	#Path needs to end \* to use includes, which is faster than Where-Object
+	$PathCheckArray = $path.ToCharArray()
+	if ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -eq '*') {
+		#We're good
+	}
+	elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -eq '*') {
+		$Path = ($PathCheckArray[0..(($PathCheckArray.length) - 2)] -join ('')) + "\*"
+	}
+	elseif ($PathCheckArray[-2] -eq '\' -and $PathCheckArray[-1] -ne '*') {
+		#Append a * to the end
+		$Path = "$Path*"
+	}
+	elseif ($PathCheckArray[-2] -ne '\' -and $PathCheckArray[-1] -ne '*') {
+		#Append a \* to the end
+		$Path = "$Path\*"
+	}
+	Write-Message -Level Verbose -Message "Scanning $path"
+	$Results = Get-ChildItem -path $Path -Recurse:$Recurse | Where-Object {$_.PsIsContainer -eq $false}
+	return $Results
 }

--- a/internal/Get-JobList.ps1
+++ b/internal/Get-JobList.ps1
@@ -18,7 +18,7 @@ function Get-JobList {
 		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-		
+
 	.EXAMPLE
 		Get-JobList -SqlInstance sql2016
 
@@ -65,7 +65,7 @@ function Get-JobList {
 		[switch][Alias('Silent')]$EnableException
 	)
 	process {
-		$server= Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+		$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 
 		$jobs = $server.JobServer.Jobs
 		if ( (Test-Bound 'JobFilter') -or (Test-Bound 'StepFilter') ) {
@@ -107,7 +107,6 @@ function Get-JobList {
 							if ($stepFound.Count -gt 0) {
 								$job
 							}
-							
 						}
 					}
 					elseif ($StepName.Count -gt 1) {

--- a/internal/Get-Language.ps1
+++ b/internal/Get-Language.ps1
@@ -1,7 +1,7 @@
 ﻿function Get-Language {
 	<#
 		.SYNOPSIS
-			Converts Microsoft's language ID to human readable format 
+			Converts Microsoft's language ID to human readable format
 
 		.DESCRIPTION
 			Converts Microsoft's language ID to human readable format
@@ -19,11 +19,11 @@
 		[int]$id
 	)
 	process {
-		
+
 		$culture = [System.Globalization.CultureInfo]::GetCultureInfo($id)
-		
-		$excludeProps = 'Parent','IetfLanguageTag','CompareInfo','TextInfo','IsNeutralCulture','NumberFormat','DateTimeFormat','Calendar'
-			,'OptionalCalendars','UseUserOverride','IsReadOnly'
+
+		$excludeProps = 'Parent', 'IetfLanguageTag', 'CompareInfo', 'TextInfo', 'IsNeutralCulture', 'NumberFormat', 'DateTimeFormat', 'Calendar'
+		, 'OptionalCalendars', 'UseUserOverride', 'IsReadOnly'
 		Select-DefaultView -InputObject $culture -ExcludeProperty $excludeProps
 	}
 }

--- a/internal/Get-OfflineSqlFileStructure.ps1
+++ b/internal/Get-OfflineSqlFileStructure.ps1
@@ -1,4 +1,4 @@
-Function Get-OfflineSqlFileStructure
+function Get-OfflineSqlFileStructure
 {
 <#
 .SYNOPSIS
@@ -18,21 +18,21 @@ Internal function. Returns dictionary object that contains file structures for S
 		[bool]$ReuseSourceFolderStructure,
 		[PSCredential]$SqlCredential
 	)
-	
+
 	$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-	
+
 	$destinationfiles = @{ };
 	$logfiles = $filelist | Where-Object { $_.Type -eq "L" }
 	$datafiles = $filelist | Where-Object { $_.Type -ne "L" }
 	$filestream = $filelist | Where-Object { $_.Type -eq "S" }
-	
+
 	if ($filestream)
 	{
 		$sql = "select coalesce(SERVERPROPERTY('FilestreamConfiguredLevel'),0) as fs"
 		$fscheck = $server.databases['master'].ExecuteWithResults($sql)
 		if ($fscheck.tables.fs -eq 0) { return $false }
 	}
-	
+
 	# Data Files
 	foreach ($file in $datafiles)
 	{
@@ -48,11 +48,11 @@ Internal function. Returns dictionary object that contains file structures for S
 			$filename = Split-Path $($file.PhysicalName) -leaf
 			$d.physical = "$directory\$filename"
 		}
-		
+
 		$d.logical = $file.LogicalName
 		$destinationfiles.add($file.LogicalName, $d)
 	}
-	
+
 	# Log Files
 	foreach ($file in $logfiles)
 	{
@@ -67,10 +67,10 @@ Internal function. Returns dictionary object that contains file structures for S
 			$filename = Split-Path $($file.PhysicalName) -leaf
 			$d.physical = "$directory\$filename"
 		}
-		
+
 		$d.logical = $file.LogicalName
 		$destinationfiles.add($file.LogicalName, $d)
 	}
-	
+
 	return $destinationfiles
 }

--- a/internal/Get-OlaHRestoreFile.ps1
+++ b/internal/Get-OlaHRestoreFile.ps1
@@ -4,27 +4,27 @@ function Get-OlaHRestoreFile {
 Internal Function to get SQL Server backfiles from a specified folder that's formatted according to Ola Hallengreen's scripts.
 
 .DESCRIPTION
-Takes path, checks for validity. Scans for usual backup file 
+Takes path, checks for validity. Scans for usual backup file
 #>
     [CmdletBinding()]
-    Param (
+    param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Path,
         [switch]$IgnoreLogBackup,
         [switch][Alias('Silent')]$EnableException
     )
-	
+
     Write-Message -Level Verbose -Message "Starting"
     Write-Message -Level Verbose -Message "Checking Path"
-	
+
     if ((Test-Path $Path) -ne $true) {
         Write-Message -Level Warning -Message "$Path is not valid"
         return
     }
-	
+
     #There should be at least FULL folder, DIFF and LOG are nice as well
     Write-Message -Level Verbose -Message "Checking we have a FULL folder"
-	
+
     if (Test-Path -Path $Path\FULL) {
         Write-Message -Level Verbose -Message "We have a FULL folder, scanning"
         $Results = Get-ChildItem -Path $Path\FULL -Filter *.bak
@@ -37,7 +37,6 @@ Takes path, checks for validity. Scans for usual backup file
         else {
             Write-Message -Level Warning -Message "No valid backup found - even tried MaintenanceSolution structure"
         }
-		
         return
     }
     if (!$IgnoreLogBackup) {
@@ -53,6 +52,5 @@ Takes path, checks for validity. Scans for usual backup file
         Write-Message -Level Verbose -Message "$FunctionName - We have a DIFF folder, scanning"
         $Results += Get-ChildItem -Path $Path\DIFF -filter *.bak
     }
-	
     return $Results
 }

--- a/internal/Get-PasswordHash.ps1
+++ b/internal/Get-PasswordHash.ps1
@@ -1,62 +1,62 @@
 function Get-PasswordHash {
-<#
+	<#
 	.SYNOPSIS
 	Generates a password hash for SQL Server login
-	
+
 	.DESCRIPTION
 	Generates a hash string based on the plaintext or securestring password and a SQL Server version. Salt is optional
-		
+
 	.PARAMETER Password
 	Either plain text or Securestring password
-	
+
 	.PARAMETER SqlMajorVersion
 	Major version of the SQL Server. Defines the hash algorithm.
-	
+
 	.PARAMETER byteSalt
 	Optional. Inserts custom salt into the hash instead of randomly generating new salt
-		
+
 	.NOTES
 	Tags: Login, Internal
 	Author: Kirill Kravtsov (@nvarscar)
 	dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
 	Copyright (C) 2016 Chrissy LeMaire
-	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0	
-	
+	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
 	.EXAMPLE
 	Get-PasswordHash $securePassword 11
-	
+
 	Generates password hash for SQL 2012
-	
+
 	.EXAMPLE
 	Get-PasswordHash $securePassword 9 $byte
-	
+
 	Generates password hash for SQL 2005 using custom salt from the $byte variable
-	
+
 #>
-	Param (
+	param (
 		[object]$Password,
 		$SqlMajorVersion,
 		[byte[]]$byteSalt
 	)
 	#Choose hash algorithm
-	if ($SqlMajorVersion -lt 11) { 
-		$algorithm = 'SHA1' 
+	if ($SqlMajorVersion -lt 11) {
+		$algorithm = 'SHA1'
 		$hashVersion = '0100'
 	}
-	else { 
+	else {
 		$algorithm = 'SHA512'
 		$hashVersion = '0200'
 	}
-	
-	#Generate salt	
+
+	#Generate salt
 	if (!$byteSalt) {
 		0 .. 3 | ForEach-Object { $byteSalt += Get-Random -Minimum 0 -Maximum 255 }
 	}
-	
+
 	#Convert salt to a hex string
 	[string]$stringSalt = ""
 	$byteSalt | ForEach-Object { $stringSalt += ("{0:X}" -f $_).PadLeft(2, "0") }
-	
+
 	#Extract password
 	if ($Password.GetType().Name -eq 'SecureString') {
 		$cred = New-Object System.Management.Automation.PSCredential -ArgumentList 'foo', $Password
@@ -70,15 +70,15 @@ function Get-PasswordHash {
 	$data = $enc.GetBytes($plainPassword)
 	#Run hash algorithm
 	$hash = [Security.Cryptography.HashAlgorithm]::Create($algorithm)
-	$bytes = $hash.ComputeHash($data+$byteSalt)
+	$bytes = $hash.ComputeHash($data + $byteSalt)
 	#Construct hex string
 	$hashString = "0x$hashVersion$stringSalt"
 	$bytes | ForEach-Object { $hashString += ("{0:X2}" -f $_).PadLeft(2, "0") }
 	#Add UPPERCASE hash for SQL 2000 and lower
 	if ($SqlMajorVersion -lt 9) {
 		$data = $enc.GetBytes($plainPassword.ToUpper())
-		$bytes = $hash.ComputeHash($data+$byteSalt)
+		$bytes = $hash.ComputeHash($data + $byteSalt)
 		$bytes | ForEach-Object { $hashString += ("{0:X2}" -f $_).PadLeft(2, "0") }
 	}
-	Return $hashString
+	return $hashString
 }

--- a/internal/Get-RestoreContinuableDatabase.ps1
+++ b/internal/Get-RestoreContinuableDatabase.ps1
@@ -1,39 +1,33 @@
-function Get-RestoreContinuableDatabase
-{
-<#
-.SYNOPSIS
-Gets a list of databases from a SQL instance that are in a state for further restores
+function Get-RestoreContinuableDatabase {
+	<#
+    .SYNOPSIS
+    Gets a list of databases from a SQL instance that are in a state for further restores
 
-.DESCRIPTION
-Takes a SQL instance and checks for databases with a redo_start_lsn value, and returns the database name and that value
--gt SQl 2005 it comes from master.sys.master_files
--eq SQL 2000 DBCC DBINFO
+    .DESCRIPTION
+    Takes a SQL instance and checks for databases with a redo_start_lsn value, and returns the database name and that value
+    -gt SQl 2005 it comes from master.sys.master_files
+    -eq SQL 2000 DBCC DBINFO
 #>
 	[CmdletBinding()]
-	Param (
+	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [object]$SqlInstance,
-        [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+		[object]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[switch][Alias('Silent')]$EnableException
 	)
 
-
-		try 
-		{
-            $Server = Connect-SqlInstance -Sqlinstance $SqlInstance -SqlCredential $SqlCredential	
-		}
-		catch {
-
-			Write-Warning "$FunctionName - Cannot connect to $SqlInstance" 
-			break
-		}
-        if ($Server.VersionMajor -ge 9)
-        {
-            $sql  = "select distinct db_name(database_id) as 'Database', redo_start_lsn, redo_start_fork_guid as 'FirstRecoveryForkID' from master.sys.master_files where redo_start_lsn is not NULL"
-        }
-        else
-        {
-            $sql ="
+	try {
+		$Server = Connect-SqlInstance -Sqlinstance $SqlInstance -SqlCredential $SqlCredential
+	}
+	catch {
+		Write-Message -Level Warning -Message "Cannot connect to $SqlInstance"
+		break
+	}
+	if ($Server.VersionMajor -ge 9) {
+		$sql = "select distinct db_name(database_id) as 'Database', redo_start_lsn, redo_start_fork_guid as 'FirstRecoveryForkID' from master.sys.master_files where redo_start_lsn is not NULL"
+	}
+	else {
+		$sql = "
               CREATE TABLE #db_info
                 (
                 ParentObject NVARCHAR(128) COLLATE database_default ,
@@ -41,6 +35,6 @@ Takes a SQL instance and checks for databases with a redo_start_lsn value, and r
                 Field        NVARCHAR(128) COLLATE database_default,
                 Value        SQL_VARIANT
                 )"
-        }
-        $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows
+	}
+	$server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows
 }

--- a/internal/Get-SaLoginName.ps1
+++ b/internal/Get-SaLoginName.ps1
@@ -1,5 +1,25 @@
-Function Get-SaLoginName
-{
+function Get-SaLoginName {
+	<#
+	.SYNOPSIS
+	Gets the login matching the standard "sa" user
+
+	.DESCRIPTION
+	Gets the login matching the standard "sa" user, useful in case of renames
+
+	.PARAMETER SqlInstance
+	The SQL Server instance.
+
+	.PARAMETER SqlCredential
+	Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted).
+
+	.EXAMPLE
+	Get-SaLoginName -SqlInstance base\sql2016
+
+	.NOTES
+		Website: https://dbatools.io
+		Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+		License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+	#>
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory = $true)]
@@ -7,10 +27,9 @@ Function Get-SaLoginName
 		[object]$SqlInstance,
 		[PSCredential]$SqlCredential
 	)
-	
-	
+
 	$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 	$saname = ($server.logins | Where-Object { $_.id -eq 1 }).Name
-	
+
 	return $saname
 }

--- a/internal/Get-SmoServerForDynamicParams.ps1
+++ b/internal/Get-SmoServerForDynamicParams.ps1
@@ -1,25 +1,23 @@
-Function Get-SmoServerForDynamicParams
-{
+function Get-SmoServerForDynamicParams {
+	##############################
+	# THIS DOES NOT SEEM TO BE USED
+	##############################
 	if ($fakeBoundParameter.length -eq 0) { return }
-	
+
 	$SqlInstance = $fakeBoundParameter['SqlInstance']
 	$sqlcredential = $fakeBoundParameter['SqlCredential']
-	
-	if ($SqlInstance -eq $null)
-	{
+
+	if ($null -eq $SqlInstance) {
 		$SqlInstance = $fakeBoundParameter['sqlinstance']
 	}
-	if ($SqlInstance -eq $null)
-	{
+	if ($null -eq $SqlInstance) {
 		$SqlInstance = $fakeBoundParameter['source']
 	}
-	if ($sqlcredential -eq $null)
-	{
+	if ($null -eq $sqlcredential) {
 		$sqlcredential = $fakeBoundParameter['Credential']
 	}
-	
-	if ($SqlInstance)
-	{
+
+	if ($SqlInstance) {
 		Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -ParameterConnection
 	}
 }

--- a/internal/Get-SqlDefaultPaths.ps1
+++ b/internal/Get-SqlDefaultPaths.ps1
@@ -1,10 +1,10 @@
-Function Get-SqlDefaultPaths
-{
-<#
-.SYNOPSIS
-Internal function. Returns the default data and log paths for SQL Server. Needed because SMO's server.defaultpath is sometimes null.
+function Get-SqlDefaultPaths {
+	<#
+	.SYNOPSIS
+		Internal function. Returns the default data and log paths for SQL Server. Needed because SMO's server.defaultpath is sometimes null.
 #>
 	[CmdletBinding()]
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
 	param (
 		[Parameter(Mandatory = $true)]
 		[ValidateNotNullOrEmpty()]
@@ -15,55 +15,44 @@ Internal function. Returns the default data and log paths for SQL Server. Needed
 		[string]$filetype,
 		[PSCredential]$SqlCredential
 	)
-	
-	try 
-	{
-		if ($SqlInstance -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject])
-		{
-			Write-verbose "$FunctionName - Opening SQL Server connection"
-			$NewConnection = $True
-			$Server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential	
+
+	try {
+		if ($SqlInstance -isnot [Microsoft.SqlServer.Management.Smo.SqlSmoObject]) {
+			$Server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 		}
-		else
-		{
-			Write-Verbose "$FunctionName - reusing SMO connection"
+		else {
 			$server = $SqlInstance
 		}
 	}
 	catch {
-
-		Write-Warning "$FunctionName - Cannot connect to $SqlInstance" 
+		Write-Message -Lvel Warning -Message "Cannot connect to $SqlInstance"
 		break
 	}
 	switch ($filetype) { "mdf" { $filetype = "data" } "ldf" { $filetype = "log" } }
-	
-	if ($filetype -eq "log")
-	{
+
+	if ($filetype -eq "log") {
 		# First attempt
 		$filepath = $server.DefaultLog
 		# Second attempt
 		if ($filepath.Length -eq 0) { $filepath = $server.Information.MasterDbLogPath }
 		# Third attempt
-		if ($filepath.Length -eq 0)
-		{
+		if ($filepath.Length -eq 0) {
 			$sql = "select SERVERPROPERTY('InstanceDefaultLogPath') as physical_name"
 			$filepath = $server.ConnectionContext.ExecuteScalar($sql)
 		}
 	}
-	else
-	{
+	else {
 		# First attempt
 		$filepath = $server.DefaultFile
 		# Second attempt
 		if ($filepath.Length -eq 0) { $filepath = $server.Information.MasterDbPath }
 		# Third attempt
-		if ($filepath.Length -eq 0)
-		{
+		if ($filepath.Length -eq 0) {
 			$sql = "select SERVERPROPERTY('InstanceDefaultDataPath') as physical_name"
 			$filepath = $server.ConnectionContext.ExecuteScalar($sql)
 		}
 	}
-	
+
 	if ($filepath.Length -eq 0) { throw "Cannot determine the required directory path" }
 	$filepath = $filepath.TrimEnd("\")
 	return $filepath


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Port internals to 1.0. Slowly, but we'll get there ^_^

### Approach
VSCode default formatting, ScriptAnalyzer fixes, trailing spaces removal.

@potatoqualitee: IMHO we can remove alltogether Get-SmoServerForDynamicParams : it doesn't seem to be used for ps1 files, and I don't think any other part of the code uses it given we switched to TEPP
