### PR TITLE
Fix Test-DbaValidLogin -Detailed (#2217)

### DIFF
--- a/functions/Test-DbaValidLogin.ps1
+++ b/functions/Test-DbaValidLogin.ps1
@@ -52,7 +52,7 @@ function Test-DbaValidLogin {
 			Tests all logins in the current Active Directory domain that are either disabled or do not exist on the SQL Server instance Dev01
 
 		.EXAMPLE
-			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Properties *
+			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Property *
 
 			Tests all Active Directory groups that have logins on Dev01, and shows all information for those logins
 

--- a/functions/Test-DbaValidLogin.ps1
+++ b/functions/Test-DbaValidLogin.ps1
@@ -52,14 +52,14 @@ function Test-DbaValidLogin {
 			Tests all logins in the current Active Directory domain that are either disabled or do not exist on the SQL Server instance Dev01
 
 		.EXAMPLE
-			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly
+			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Properties *
 
-			Tests all Active Directory groups that have logins on Dev01.
+			Tests all Active Directory groups that have logins on Dev01, and shows all information for those logins
 
 		.EXAMPLE
-			Test-DbaValidLogin -SqlInstance Dev01 -ExcludeDomains subdomain
+			Test-DbaValidLogin -SqlInstance Dev01 -IgnoreDomains testdomain
 
-			Tests all logins excluding any that are from the subdomain Domain
+			Tests all Domain logins excluding any that are from the testdomain
 
 	#>
 	[CmdletBinding()]
@@ -179,7 +179,7 @@ function Test-DbaValidLogin {
 					AllowReversiblePasswordEncryption = $null
 					CannotChangePassword              = $null
 					PasswordExpired                   = $null
-					Lockedout                         = $null
+					LockedOut                         = $null
 					Enabled                           = $null
 					PasswordNeverExpires              = $null
 					PasswordNotRequired               = $null
@@ -192,7 +192,7 @@ function Test-DbaValidLogin {
 						AllowReversiblePasswordEncryption = [bool]($uac.Value -band $mappingRaw['ENCRYPTED_TEXT_PASSWORD_ALLOWED'])
 						CannotChangePassword              = [bool]($uac.Value -band $mappingRaw['PASSWD_CANT_CHANGE'])
 						PasswordExpired                   = [bool]($uac.Value -band $mappingRaw['PASSWORD_EXPIRED'])
-						Lockedout                         = [bool]($uac.Value -band $mappingRaw['LOCKOUT'])
+						LockedOut                         = [bool]($uac.Value -band $mappingRaw['LOCKOUT'])
 						Enabled                           = !($uac.Value -band $mappingRaw['ACCOUNTDISABLE'])
 						PasswordNeverExpires              = [bool]($uac.Value -band $mappingRaw['DONT_EXPIRE_PASSWD'])
 						PasswordNotRequired               = [bool]($uac.Value -band $mappingRaw['PASSWD_NOTREQD'])
@@ -212,7 +212,7 @@ function Test-DbaValidLogin {
 					AllowReversiblePasswordEncryption = $additionalProps.AllowReversiblePasswordEncryption
 					CannotChangePassword              = $additionalProps.CannotChangePassword
 					PasswordExpired                   = $additionalProps.PasswordExpired
-					Lockedout                         = $additionalProps.Lockedout
+					LockedOut                         = $additionalProps.LockedOut
 					Enabled                           = $additionalProps.Enabled
 					PasswordNeverExpires              = $additionalProps.PasswordNeverExpires
 					PasswordNotRequired               = $additionalProps.PasswordNotRequired
@@ -221,7 +221,7 @@ function Test-DbaValidLogin {
 					UserAccountControl                = $additionalProps.UserAccountControl
 				}
 				
-				Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
+				Select-DefaultView -InputObject $rtn -ExcludeProperty AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation, UserAccountControl
 
 			}
 
@@ -262,7 +262,7 @@ function Test-DbaValidLogin {
 					AllowReversiblePasswordEncryption = $null
 					CannotChangePassword              = $null
 					PasswordExpired                   = $null
-					Lockedout                         = $null
+					LockedOut                         = $null
 					Enabled                           = $null
 					PasswordNeverExpires              = $null
 					PasswordNotRequired               = $null
@@ -271,7 +271,7 @@ function Test-DbaValidLogin {
 					UserAccountControl                = $null
 				}
 
-				Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
+				Select-DefaultView -InputObject $rtn -ExcludeProperty AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation, UserAccountControl
 				
 			}
 		}

--- a/functions/Test-DbaValidLogin.ps1
+++ b/functions/Test-DbaValidLogin.ps1
@@ -30,9 +30,6 @@ function Test-DbaValidLogin {
 		.PARAMETER IgnoreDomains
 			Specifies a list of Active Directory domains to ignore. By default, all domains in the forest as well as all trusted domains are traversed.
 
-		.PARAMETER Detailed
-			If this switch is enabled, more detailed results are returned. This includes the Active Directory account type and whether the login on SQL Server is enabled or disabled.
-
 		.PARAMETER EnableException
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -55,9 +52,9 @@ function Test-DbaValidLogin {
 			Tests all logins in the current Active Directory domain that are either disabled or do not exist on the SQL Server instance Dev01
 
 		.EXAMPLE
-			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly -Detailed
+			Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly
 
-			Tests all Active Directory groups that have logins on Dev01, returning a detailed view.
+			Tests all Active Directory groups that have logins on Dev01.
 
 		.EXAMPLE
 			Test-DbaValidLogin -SqlInstance Dev01 -ExcludeDomains subdomain
@@ -76,7 +73,6 @@ function Test-DbaValidLogin {
 		[ValidateSet("LoginsOnly", "GroupsOnly", "None")]
 		[string]$FilterBy = "None",
 		[string[]]$IgnoreDomains,
-		[switch]$Detailed,
 		[switch][Alias('Silent')]$EnableException
 	)
 
@@ -84,9 +80,6 @@ function Test-DbaValidLogin {
 		if ($IgnoreDomains) {
 			$IgnoreDomainsNormalized = $IgnoreDomains.ToUpper()
 			Write-Message -Message ("Excluding logins for domains " + ($IgnoreDomains -join ',')) -Level Verbose
-		}
-		if ($Detailed) {
-			Write-Message -Message "Detailed is deprecated and will be removed in dbatools 1.0." -Once "DetailedDeprecation" -Level Warning
 		}
 
 		$mappingRaw = @{
@@ -227,12 +220,8 @@ function Test-DbaValidLogin {
 					TrustedForDelegation              = $additionalProps.TrustedForDelegation
 					UserAccountControl                = $additionalProps.UserAccountControl
 				}
-				if ($Detailed) {
-					Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
-				}
-				else {
-					Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl, AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation
-				}
+				
+				Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
 
 			}
 
@@ -281,12 +270,9 @@ function Test-DbaValidLogin {
 					TrustedForDelegation              = $null
 					UserAccountControl                = $null
 				}
-				if ($Detailed) {
-					Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
-				}
-				else {
-					Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl, AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation
-				}
+
+				Select-DefaultView -InputObject $rtn -ExcludeProperty UserAccountControl
+				
 			}
 		}
 	}

--- a/tests/Test-DbaValidLogin.Tests.ps1
+++ b/tests/Test-DbaValidLogin.Tests.ps1
@@ -1,0 +1,52 @@
+<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		<#
+			The $paramCount is adjusted based on the parameters your command will have.
+
+			The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+		#>
+		$paramCount = 7
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Test-DbaValidLogin).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'ExcludeLogin', 'FilterBy', 'IgnoreDomains', 'EnableException'
+		It "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "Command actually works" {
+		$results = Test-DbaValidLogin -SqlInstance $script:instance2
+		It "Should return correct properties" {
+			$ExpectedProps = 'Server,Domain,Login,Type,Found,DisabledInSQLServer,PasswordExpired,LockedOut,Enabled,PasswordNotRequired'.Split(',')
+			($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+		}
+
+		$Type = 'User'
+		It "Should return true if Account type is: $Type" {
+			($results | Where-Object Type -match $Type) | Should Be $true
+		}
+		It "Should return true if Account is Found" {
+			($results).Found | Should Be $true
+		}
+		It "Should return true for Server matching: $script:instance2" {
+			($results).Server -eq $script:instance2 | Should Be $true
+		}
+	}
+}

--- a/tests/Test-DbaValidLogin.Tests.ps1
+++ b/tests/Test-DbaValidLogin.Tests.ps1
@@ -29,24 +29,22 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 		}
 	}
 }
-
+<#
+Did not include these tests yet as I was unsure if AppVeyor was capable of testing domain logins. Included these for future use. 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	Context "Command actually works" {
 		$results = Test-DbaValidLogin -SqlInstance $script:instance2
 		It "Should return correct properties" {
-			$ExpectedProps = 'Server,Domain,Login,Type,Found,DisabledInSQLServer,PasswordExpired,LockedOut,Enabled,PasswordNotRequired'.Split(',')
+			$ExpectedProps = 'AccountNotDelegated,AllowReversiblePasswordEncryption,CannotChangePassword,DisabledInSQLServer,Domain,Enabled,Found,LockedOut,Login,PasswordExpired,PasswordNeverExpires,PasswordNotRequired,Server,SmartcardLogonRequired,TrustedForDelegation,Type,UserAccountControl'.Split(',')
 			($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 		}
-
+       
 		$Type = 'User'
 		It "Should return true if Account type is: $Type" {
 			($results | Where-Object Type -match $Type) | Should Be $true
 		}
 		It "Should return true if Account is Found" {
-			($results).Found | Should Be $true
-		}
-		It "Should return true for Server matching: $script:instance2" {
-			($results).Server -eq $script:instance2 | Should Be $true
+			($results | Where-Object Found).Found | Should Be $true
 		}
 	}
-}
+}#>


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X] Bug fix (non-breaking change, fixes #2217 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ X] Pester test is included
 - [ ] Nunit test is included
 - [ X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
- To remove all references in Test-DbaValidLogin to the -Detailed parameter in favor of Select-DefaultView (As requested in Issue #2217)
- To update the documentation and examples reflecting the change. 
- To provide a basic parameter UnitTest for this cmdlet.
### Approach
<!-- How does this change solve that purpose -->
- Looked at the work already done on Test-DbaTempDbConfiguration
- Analyzed how Select-DefaultView works
- Wrote a Pester test to validate the Parameters I had changed.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Example 2 shows the updated syntax for returning all properties from the cmdlet.

Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Property * 

