### PR TITLE
Adjusting Detailed parameter

### DIFF
--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -26,11 +26,14 @@ function Test-DbaTempDbConfiguration {
 
 			To connect as a different Windows user, run PowerShell as that user.
 
+		.PARAMETER Detailed
+			Output all properties, will be depreciated in 1.0.0 release.
+
 		.PARAMETER EnableException
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.NOTES
 			Tags: tempdb, configuration
 			Author: Michael Fal (@Mike_Fal), http://mikefal.net
@@ -59,9 +62,12 @@ function Test-DbaTempDbConfiguration {
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstance[]]$SqlInstance,
 		[PSCredential]$SqlCredential,
+		[switch]$Detailed,
 		[switch][Alias('Silent')]$EnableException
 	)
 	begin {
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+
 		$result = @()
 	}
 	process {

--- a/functions/Test-DbaValidLogin.ps1
+++ b/functions/Test-DbaValidLogin.ps1
@@ -30,11 +30,14 @@ function Test-DbaValidLogin {
 		.PARAMETER IgnoreDomains
 			Specifies a list of Active Directory domains to ignore. By default, all domains in the forest as well as all trusted domains are traversed.
 
+		.PARAMETER Detailed
+			Output all properties, will be depreciated in 1.0.0 release.
+
 		.PARAMETER EnableException
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.NOTES
 			Author: Stephen Bennett: https://sqlnotesfromtheunderground.wordpress.com/
 			Author: Chrissy LeMaire (@cl), netnerds.net
@@ -73,10 +76,13 @@ function Test-DbaValidLogin {
 		[ValidateSet("LoginsOnly", "GroupsOnly", "None")]
 		[string]$FilterBy = "None",
 		[string[]]$IgnoreDomains,
+		[switch]$Detailed,
 		[switch][Alias('Silent')]$EnableException
 	)
 
 	begin {
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+
 		if ($IgnoreDomains) {
 			$IgnoreDomainsNormalized = $IgnoreDomains.ToUpper()
 			Write-Message -Message ("Excluding logins for domains " + ($IgnoreDomains -join ',')) -Level Verbose
@@ -220,7 +226,7 @@ function Test-DbaValidLogin {
 					TrustedForDelegation              = $additionalProps.TrustedForDelegation
 					UserAccountControl                = $additionalProps.UserAccountControl
 				}
-				
+
 				Select-DefaultView -InputObject $rtn -ExcludeProperty AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation, UserAccountControl
 
 			}
@@ -272,7 +278,7 @@ function Test-DbaValidLogin {
 				}
 
 				Select-DefaultView -InputObject $rtn -ExcludeProperty AccountNotDelegated, AllowReversiblePasswordEncryption, CannotChangePassword, PasswordNeverExpires, SmartcardLogonRequired, TrustedForDelegation, UserAccountControl
-				
+
 			}
 		}
 	}

--- a/tests/Test-DbaTempDbConfiguration.Tests.ps1
+++ b/tests/Test-DbaTempDbConfiguration.Tests.ps1
@@ -17,10 +17,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
 				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
 		#>
-		$paramCount = 3
+		$paramCount = 4
 		$defaultParamCount = 11
 		[object[]]$params = (Get-ChildItem function:\Test-DbaTempDbConfiguration).Parameters.Keys
-		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Detailed'
 		It "Should contain our specific parameters" {
 			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
 		}

--- a/tests/Test-DbaValidLogin.Tests.ps1
+++ b/tests/Test-DbaValidLogin.Tests.ps1
@@ -17,10 +17,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
 				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
 		#>
-		$paramCount = 7
+		$paramCount = 8
 		$defaultParamCount = 11
 		[object[]]$params = (Get-ChildItem function:\Test-DbaValidLogin).Parameters.Keys
-		$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'ExcludeLogin', 'FilterBy', 'IgnoreDomains', 'EnableException'
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'ExcludeLogin', 'FilterBy', 'IgnoreDomains', 'EnableException', 'Detailed'
 		It "Should contain our specific parameters" {
 			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
 		}
@@ -30,7 +30,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 	}
 }
 <#
-Did not include these tests yet as I was unsure if AppVeyor was capable of testing domain logins. Included these for future use. 
+Did not include these tests yet as I was unsure if AppVeyor was capable of testing domain logins. Included these for future use.
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 	Context "Command actually works" {
 		$results = Test-DbaValidLogin -SqlInstance $script:instance2
@@ -38,7 +38,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 			$ExpectedProps = 'AccountNotDelegated,AllowReversiblePasswordEncryption,CannotChangePassword,DisabledInSQLServer,Domain,Enabled,Found,LockedOut,Login,PasswordExpired,PasswordNeverExpires,PasswordNotRequired,Server,SmartcardLogonRequired,TrustedForDelegation,Type,UserAccountControl'.Split(',')
 			($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
 		}
-       
+
 		$Type = 'User'
 		It "Should return true if Account type is: $Type" {
 			($results | Where-Object Type -match $Type) | Should Be $true


### PR DESCRIPTION
Addressing #2217 and reverting some things that inadvertently got changed.

Going with updates added to 2217 for keeping the Detailed parameter in the param block and help until 1.0.0 release. Adding the deprecated command as just notification. The parameter will no longer do anything but just adding it so it does not break scripts.