### PR TITLE
Fix Find-DbaDatabase -Detailed (#2217)

### DIFF
--- a/functions/Find-DbaDatabase.ps1
+++ b/functions/Find-DbaDatabase.ps1
@@ -26,6 +26,11 @@ Search for an exact match instead of a pattern
 .PARAMETER Detailed
 Output all properties, will be depreciated in 1.0.0 release.
 
+.PARAMETER EnableException
+By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
 .NOTES
 Tags: DisasterRecovery
 Author: Stephen Bennett: https://sqlnotesfromtheunderground.wordpress.com/
@@ -62,7 +67,8 @@ Returns all database from the SqlInstances that have the same Service Broker GUI
 		[parameter(Mandatory = $true)]
 		[string]$Pattern,
 		[switch]$Exact,
-		[switch]$Detailed
+		[switch]$Detailed,
+		[switch][Alias('Silent')]$EnableException
 	)
 	begin {
 		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed

--- a/functions/Find-DbaDatabase.ps1
+++ b/functions/Find-DbaDatabase.ps1
@@ -24,7 +24,7 @@ Value that is searched for. This is a regular expression match but you can just 
 Search for an exact match instead of a pattern
 
 .PARAMETER Detailed
-Output a more detailed view showing regular output plus Tables, StoredProcedures, Views and ExtendedProperties to see they closely match to help find related databases.
+Output all properties, will be depreciated in 1.0.0 release.
 
 .NOTES
 Tags: DisasterRecovery
@@ -42,11 +42,11 @@ Find-DbaDatabase -SqlInstance "DEV01", "DEV02", "UAT01", "UAT02", "PROD01", "PRO
 Returns all database from the SqlInstances that have a database with Report in the name
 	
 .EXAMPLE
-Find-DbaDatabase -SqlInstance "DEV01", "DEV02", "UAT01", "UAT02", "PROD01", "PROD02" -Pattern TestDB -Exact -Detailed 
+Find-DbaDatabase -SqlInstance "DEV01", "DEV02", "UAT01", "UAT02", "PROD01", "PROD02" -Pattern TestDB -Exact | Select-Object *
 Returns all database from the SqlInstances that have a database named TestDB with a detailed output.
 
 .EXAMPLE
-Find-DbaDatabase -SqlInstance "DEV01", "DEV02", "UAT01", "UAT02", "PROD01", "PROD02" -Property ServiceBrokerGuid -Pattern '-faeb-495a-9898-f25a782835f5' -Detailed 
+Find-DbaDatabase -SqlInstance "DEV01", "DEV02", "UAT01", "UAT02", "PROD01", "PROD02" -Property ServiceBrokerGuid -Pattern '-faeb-495a-9898-f25a782835f5' | Select-Object * 
 Returns all database from the SqlInstances that have the same Service Broker GUID with a deatiled output
 
 #>
@@ -64,6 +64,9 @@ Returns all database from the SqlInstances that have the same Service Broker GUI
 		[switch]$Exact,
 		[switch]$Detailed
 	)
+	begin {
+		Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+	}
 	process {
 		foreach ($instance in $SqlInstance) {
 			try {
@@ -91,45 +94,32 @@ Returns all database from the SqlInstances that have the same Service Broker GUI
 			}
 			
 			foreach ($db in $dbs) {
-				if ($Detailed) {
-					$extendedproperties = @()
-					foreach ($xp in $db.ExtendedProperties) {
-						$extendedproperties += [PSCustomObject]@{
-							Name  = $db.ExtendedProperties[$xp.Name].Name
-							Value = $db.ExtendedProperties[$xp.Name].Value
-						}
+				
+				$extendedproperties = @()
+				foreach ($xp in $db.ExtendedProperties) {
+					$extendedproperties += [PSCustomObject]@{
+						Name  = $db.ExtendedProperties[$xp.Name].Name
+						Value = $db.ExtendedProperties[$xp.Name].Value
 					}
-					
-					if ($extendedproperties.count -eq 0) { $extendedproperties = 0 }
-					
-					[PSCustomObject]@{
-						ComputerName       = $server.NetName
-						InstanceName       = $server.ServiceName
-						SqlInstance        = $server.Name
-						Name               = $db.Name
-						SizeMB             = $db.Size
-						Owner              = $db.Owner
-						CreateDate         = $db.CreateDate
-						ServiceBrokerGuid  = $db.ServiceBrokerGuid
-						Tables             = ($db.Tables | Where-Object { $_.IsSystemObject -eq $false }).Count
-						StoredProcedures   = ($db.StoredProcedures | Where-Object { $_.IsSystemObject -eq $false }).Count
-						Views              = ($db.Views | Where-Object { $_.IsSystemObject -eq $false }).Count
-						ExtendedProperties = $extendedproperties
-						Database           = $db
-					} | Select-DefaultView -ExcludeProperty Database
 				}
-				else {
-					[PSCustomObject]@{
-						ComputerName = $server.NetName
-						InstanceName = $server.ServiceName
-						SqlInstance  = $server.Name
-						Name         = $db.Name
-						SizeMB       = $db.Size
-						Owner        = $db.Owner
-						CreateDate   = $db.CreateDate
-						Database     = $db
-					} | Select-DefaultView -ExcludeProperty Database
-				}
+					
+				if ($extendedproperties.count -eq 0) { $extendedproperties = 0 }
+					
+				[PSCustomObject]@{
+					ComputerName       = $server.NetName
+					InstanceName       = $server.ServiceName
+					SqlInstance        = $server.Name
+					Name               = $db.Name
+					SizeMB             = $db.Size
+					Owner              = $db.Owner
+					CreateDate         = $db.CreateDate
+					ServiceBrokerGuid  = $db.ServiceBrokerGuid
+					Tables             = ($db.Tables | Where-Object { $_.IsSystemObject -eq $false }).Count
+					StoredProcedures   = ($db.StoredProcedures | Where-Object { $_.IsSystemObject -eq $false }).Count
+					Views              = ($db.Views | Where-Object { $_.IsSystemObject -eq $false }).Count
+					ExtendedProperties = $extendedproperties
+					Database           = $db
+				} | Select-DefaultView -ExcludeProperty Database, ExtendedProperties, ServiceBrokerGuid, StoredProcedures, Tables, Views 
 			}
 		}
 	}

--- a/tests/Find-DbaDatabase.Tests.ps1
+++ b/tests/Find-DbaDatabase.Tests.ps1
@@ -1,0 +1,58 @@
+<#
+	The below statement stays in for every test you build.
+#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+<#
+	Unit test is required for any command added
+#>
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		<#
+			The $paramCount is adjusted based on the parameters your command will have.
+
+			The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+				- Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+				- Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+		#>
+		$paramCount = 7
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\$CommandName).Parameters.Keys
+		$knownParameters = 'SqlInstance','SqlCredential','Property','Pattern','Exact','EnableException','Detailed'
+		It "Should contain our specific parameters" {
+			( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+		}
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "Command actually works" {
+		$results = Find-DbaDatabase -SqlInstance $script:instance2 -Pattern Master
+		It "Should return correct properties" {
+			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Name,SizeMB,Owner,CreateDate,ServiceBrokerGuid,Tables,StoredProcedures,Views,ExtendedProperties,Database'.Split(',')
+			($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+		}
+        
+        
+		$results = Find-DbaDatabase -SqlInstance $script:instance2 -Pattern Master
+		It "Should return true if Database Master is Found" {
+			($results | Where-Object Name -match 'Master' ) | Should Be $true
+		}
+        It "Should return true if Creation Date of Master is '4/8/2003 9:13:36 AM'" {
+            $($results.CreateDate.ToFileTimeutc()[0]) -eq 126942668163900000  | Should Be $true
+        }
+
+        $results = Find-DbaDatabase -SqlInstance $script:instance1,$script:instance2 -Pattern Master
+		It "Should return true if Executed Against 2 instances: $script:instance1 and $script:instance2" {
+			($results.InstanceName | Select-Object -Unique).count -eq 2 | Should Be $true
+		}
+        $results = Find-DbaDatabase -SqlInstance $script:instance2 -Property ServiceBrokerGuid -Pattern -0000-0000-000000000000
+        It "Should return true if Database Found via Property Filter" {
+            $results.ServiceBrokerGuid | Should BeLike '*-0000-0000-000000000000'
+        }
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ x] Pester test is included
 - [ ] Nunit test is included
 - [ x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

- To Replace the Parameter -Detailed with Select-DefaultView in Find-DbaDatabase
- To Update any Examples or Documentation to Reflect the Changes
- To Include a Unit and Intigration Test for the Cmdlet since it does not exist.

### Approach
<!-- How does this change solve that purpose -->
- Removed the Functionality of -Detailed, but kept a warning via Test-DbaDeprecation
- Added a Parameter for $EnableException as Test-DbaDeprecation seemed to require it
- Created a pester test to validate the parameters and basic functionality by looking up the Master DB 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

Find-DbaDatabase -SqlInstance TestDB -Pattern Master | Select-Object *
