### PR TITLE
appveyor.pester, reorder import logic

### DIFF
--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -48,9 +48,9 @@ $global:dbatools_dotsourcemodule = $true
 #removes previously imported dbatools, if any
 Remove-Module dbatools -ErrorAction Ignore
 #imports the module making sure DLL is loaded ok
-Import-Module "$ModuleBase\dbatools.psd1" -DisableNameChecking
+Import-Module "$ModuleBase\dbatools.psd1"
 #imports the psm1 to be able to use internal functions in tests
-Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking
+Import-Module "$ModuleBase\dbatools.psm1"
 
 function Get-CoverageIndications($Path, $ModuleBase) {
 	# takes a test file path and figures out what to analyze for coverage (i.e. dependencies)

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -47,10 +47,11 @@ $global:dbatools_dotsourcemodule = $true
 
 #removes previously imported dbatools, if any
 Remove-Module dbatools -ErrorAction Ignore
-#imports the module making sure DLL is loaded ok
-Import-Module "$ModuleBase\dbatools.psd1"
 #imports the psm1 to be able to use internal functions in tests
 Import-Module "$ModuleBase\dbatools.psm1"
+#imports the module making sure DLL is loaded ok
+Import-Module "$ModuleBase\dbatools.psd1"
+
 
 function Get-CoverageIndications($Path, $ModuleBase) {
 	# takes a test file path and figures out what to analyze for coverage (i.e. dependencies)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Avoid funny things like the ones happened during #2746

### Approach
Seemingly importing the psm1 doesn't assure a correct DLL module loading (since roughly https://github.com/sqlcollaborative/dbatools/pull/2656 ). We need it to be able to run integrationtests for internal functions so....to sidestep the problem,  we import the psd1 first, to assure DLL is correctly loaded, and then the psm1 file.

