### PR TITLE
Library import offload

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -68,17 +68,8 @@ if ($ImportLibrary) {
 				$start = Get-Date
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"
-					$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999).dll"
-					while (Test-Path -Path $libraryTempPath) {
-						try {
-							Remove-Item -Path $libraryTempPath -Force -ErrorAction Stop
-						}
-						catch {
-							$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999).dll"
-						}
-					}
-					Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop
-					Add-Type -Path $libraryTempPath -ErrorAction Stop
+					Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $script:DllRoot -Force -ErrorAction Stop
+					Add-Type -Path "$script:DllRoot\dbatools.dll" -ErrorAction Stop
 				}
 				catch {
 					Write-Verbose -Message "Failed to copy&import, attempting to import straight from the module directory"
@@ -115,18 +106,9 @@ if ($ImportLibrary) {
 				
 				try {
 					Write-Verbose -Message "Found library, trying to copy & import"
-					$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999).dll"
-					while (Test-Path -Path $libraryTempPath) {
-						try {
-							Remove-Item -Path $libraryTempPath -Force -ErrorAction Stop
-						}
-						catch {
-							$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999).dll"
-						}
-					}
-					if ($script:alwaysBuildLibrary) { Move-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop }
-					else { Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $libraryTempPath -Force -ErrorAction Stop }
-					Add-Type -Path $libraryTempPath -ErrorAction Stop
+					if ($script:alwaysBuildLibrary) { Move-Item -Path "$libraryBase\dbatools.dll" -Destination $script:DllRoot -Force -ErrorAction Stop }
+					else { Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $script:DllRoot -Force -ErrorAction Stop }
+					Add-Type -Path "$script:DllRoot\dbatools.dll" -ErrorAction Stop
 				}
 				catch {
 					Write-Verbose -Message "Failed to copy&import, attempting to import straight from the module directory"

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -50,7 +50,7 @@
 	RequiredModules		    = @()
 	
 	# Assemblies that must be loaded prior to importing this module
-	RequiredAssemblies	    = @("bin\dbatools.dll")
+	RequiredAssemblies	    = @()
 	
 	# Script files () that are run in the caller's environment prior to importing this module
 	ScriptsToProcess	    = @()

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -197,6 +197,7 @@ Write-ImportTime -Text "Script: Asynchronous TEPP Cache"
 . Import-ModuleFile "$script:PSModuleRoot\internal\scripts\dbatools-maintenance.ps1"
 Write-ImportTime -Text "Script: Maintenance"
 
+#region Aliases
 # I renamed this function to be more accurate - 1ms
 @(
 @{"AliasName" = "Copy-SqlAgentCategory"
@@ -361,6 +362,7 @@ Write-ImportTime -Text "Script: Maintenance"
 ) | ForEach-Object {
 if (-not (Test-Path Alias:$($_.AliasName))) { Set-Alias -Scope Global -Name $($_.AliasName) -Value $($_.Definition) }
 }
+#endregion Aliases
 
 #region Post-Import Cleanup
 Write-ImportTime -Text "Loading Aliases"

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -119,7 +119,18 @@ Write-ImportTime -Text  "Validated defines"
 Get-ChildItem -Path "$script:PSModuleRoot\bin\*.dll" -Recurse | Unblock-File -ErrorAction SilentlyContinue
 Write-ImportTime -Text  "Unblocking Files"
 
-if (-not ([Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleImported)) {
+# Define folder in which to copy dll files before importing
+if ($script:strictSecurityMode) { $script:DllRoot = "$script:PSModuleRoot\bin" }
+else {
+	$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999)"
+	while (Test-Path -Path $libraryTempPath) {
+		$libraryTempPath = "$($env:TEMP)\dbatools-$(Get-Random -Minimum 1000000 -Maximum 9999999)"
+	}
+	$script:DllRoot = $libraryTempPath
+	$null = New-Item -Path $libraryTempPath -ItemType Directory
+}
+
+if (-not ([System.Management.Automation.PSTypeName]'Microsoft.SqlServer.Management.Smo.Server').Type) {
 	. Import-ModuleFile "$script:PSModuleRoot\internal\scripts\smoLibraryImport.ps1"
 	Write-ImportTime -Text "Starting import SMO libraries"
 }

--- a/internal/maintenance/tempcleanup.ps1
+++ b/internal/maintenance/tempcleanup.ps1
@@ -1,4 +1,4 @@
 ﻿$scriptBlock = {
-	Get-ChildItem -Path $env:TEMP -Filter dbatools*.dll | Remove-Item -ErrorAction Ignore
+	Get-ChildItem -Path $env:TEMP -Filter dbatools* | Remove-Item -ErrorAction Ignore -Recurse
 }
 Register-DbaMaintenanceTask -Name "tempcleanup" -ScriptBlock $scriptBlock -Once -Delay (New-TimeSpan -Minutes 1) -Priority Low

--- a/internal/scripts/smoLibraryImport.ps1
+++ b/internal/scripts/smoLibraryImport.ps1
@@ -2,134 +2,163 @@
 	Param (
 		$ModuleRoot,
 		
-		$DllRoot
+		$DllRoot,
+		
+		$DoCopy
 	)
 	
-	try
-	{
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.BatchParser.dll" -ErrorAction Stop
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.BatchParserClient.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.BulkInsertTaskConnections.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DTSRuntimeWrap.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DtsServer.Interop.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DTSUtilities.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ForEachFileEnumeratorWrap.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ManagedDTS.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.ODataConnectionManager.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.ODataSrc.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.PipelineHost.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.PackageFormatUpdate.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Replication.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SqlCEDest.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SQLTask.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TxScript.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XE.Core.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XEvent.Configuration.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XEvent.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XEvent.Linq.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XmlSrc.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Rmo.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DTSPipelineWrap.dll"
-		Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ScriptTask.dll" -ErrorAction Stop
-	}
-	catch
-	{
-		# don't care ;)
+	function Copy-Assembly {
+		[CmdletBinding()]
+		Param (
+			[string]$ModuleRoot,
+			[string]$DllRoot,
+			[bool]$DoCopy,
+			[string]$Name
+		)
+		
+		if (-not $DoCopy) {
+			return
+		}
+		if ("$ModuleRoot\bin\smo" -eq $DllRoot) {
+			return
+		}
+		
+		if (-not (Test-Path $DllRoot)) {
+			$null = New-Item -Path $DllRoot -ItemType Directory -ErrorAction Ignore
+		}
+		
+		Copy-Item -Path "$ModuleRoot\bin\smo\$Name.dll" -Destination $DllRoot
 	}
 	
-	Add-Type -Path "$ModuleRoot\bin\smo\Accessibility.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\EnvDTE.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.AnalysisServices.AppLocal.Core.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.AnalysisServices.AppLocal.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.Azure.KeyVault.Core.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.Data.Edm.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.Data.OData.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.Practices.TransientFaultHandling.Core.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.DataTransfer.Common.Utils.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ASTasks.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ConnectionInfo.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ConnectionInfoExtended.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DataProfiler.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DataProfilingTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Diagnostics.STrace.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Dmf.Common.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Dmf.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DMQueryTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DTEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Dts.Design.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Dts.DtsClient.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DtsMsg.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Edition.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ExecProcTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ExpressionTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.FileSystemTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ForEachADOEnumerator.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ForEachFromVarEnumerator.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ForEachNodeListEnumerator.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ForEachSMOEnumerator.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.FtpTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.GridControl.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Instapi.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.ClusterManagement.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.Common.ObjectModel.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.ISServerDBUpgrade.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.Server.Common.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.Server.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.Server.IPC.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.server.shared.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.IntegrationServices.TaskScheduler.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ManagedConnections.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.Collector.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.CollectorEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.CollectorTasks.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.HadrDMF.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.HelpViewer.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.IntegrationServices.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.IntegrationServicesEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.RegisteredServers.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.Sdk.Sfc.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.SmartAdminPolicies.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.SqlParser.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.SystemMetadataProvider.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.Utility.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.UtilityEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.XEvent.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.XEventDbScoped.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.XEventDbScopedEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Management.XEventEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.MSMQTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.PipelineXML.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.PolicyEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.RegSvrEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Replication.BusinessLogicSupport.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SendMailTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.ServiceBrokerEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Smo.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SmoExtended.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SqlClrProvider.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SqlEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SQLTaskConnectionsWrap.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SqlTDiagM.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SqlWmiManagement.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.SString.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferDatabasesTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferErrorMessagesTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferJobsTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferLoginsTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferObjectsTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferSqlServerObjectsTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.TransferStoredProceduresTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Types.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Types.resources.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.VSTAScriptingLib.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.WebServiceTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.WMIDRTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.WmiEnum.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.WMIEWTask.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.XMLTask.dll"
-	# x86
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.Dmf.Adapters.dll"
-	Add-Type -Path "$ModuleRoot\bin\smo\Microsoft.SqlServer.DmfSqlClrWrapper.dll"
+	#region Names
+$names = @(
+		'Microsoft.SqlServer.BatchParser',
+		'Microsoft.SqlServer.BatchParserClient',
+		'Microsoft.SqlServer.BulkInsertTaskConnections',
+		'Microsoft.SqlServer.DTSRuntimeWrap',
+		'Microsoft.SqlServer.DtsServer.Interop',
+		'Microsoft.SqlServer.DTSUtilities',
+		'Microsoft.SqlServer.ForEachFileEnumeratorWrap',
+		'Microsoft.SqlServer.ManagedDTS',
+		'Microsoft.SqlServer.IntegrationServices.ODataConnectionManager',
+		'Microsoft.SqlServer.IntegrationServices.ODataSrc',
+		'Microsoft.SqlServer.PipelineHost',
+		'Microsoft.SqlServer.PackageFormatUpdate',
+		'Microsoft.SqlServer.Replication',
+		'Microsoft.SqlServer.SqlCEDest',
+		'Microsoft.SqlServer.SQLTask',
+		'Microsoft.SqlServer.TxScript',
+		'Microsoft.SqlServer.XE.Core',
+		'Microsoft.SqlServer.XEvent.Configuration',
+		'Microsoft.SqlServer.XEvent',
+		'Microsoft.SqlServer.XEvent.Linq',
+		'Microsoft.SqlServer.XmlSrc',
+		'Microsoft.SqlServer.Rmo',
+		'Microsoft.SqlServer.DTSPipelineWrap',
+		'Microsoft.SqlServer.ScriptTask',
+		
+		'Accessibility',
+		'EnvDTE',
+		'Microsoft.AnalysisServices.AppLocal.Core',
+		'Microsoft.AnalysisServices.AppLocal',
+		'Microsoft.Azure.KeyVault.Core',
+		'Microsoft.Data.Edm',
+		'Microsoft.Data.OData',
+		'Microsoft.Practices.TransientFaultHandling.Core',
+		'Microsoft.DataTransfer.Common.Utils',
+		'Microsoft.SqlServer.ASTasks',
+		'Microsoft.SqlServer.ConnectionInfo',
+		'Microsoft.SqlServer.ConnectionInfoExtended',
+		'Microsoft.SqlServer.DataProfiler',
+		'Microsoft.SqlServer.DataProfilingTask',
+		'Microsoft.SqlServer.Diagnostics.STrace',
+		'Microsoft.SqlServer.Dmf.Common',
+		'Microsoft.SqlServer.Dmf',
+		'Microsoft.SqlServer.DMQueryTask',
+		'Microsoft.SqlServer.DTEnum',
+		'Microsoft.SqlServer.Dts.Design',
+		'Microsoft.SqlServer.Dts.DtsClient',
+		'Microsoft.SqlServer.DtsMsg',
+		'Microsoft.SqlServer.Edition',
+		'Microsoft.SqlServer.ExecProcTask',
+		'Microsoft.SqlServer.ExpressionTask',
+		'Microsoft.SqlServer.FileSystemTask',
+		'Microsoft.SqlServer.ForEachADOEnumerator',
+		'Microsoft.SqlServer.ForEachFromVarEnumerator',
+		'Microsoft.SqlServer.ForEachNodeListEnumerator',
+		'Microsoft.SqlServer.ForEachSMOEnumerator',
+		'Microsoft.SqlServer.FtpTask',
+		'Microsoft.SqlServer.GridControl',
+		'Microsoft.SqlServer.Instapi',
+		'Microsoft.SqlServer.IntegrationServices.ClusterManagement',
+		'Microsoft.SqlServer.IntegrationServices.Common.ObjectModel',
+		'Microsoft.SqlServer.IntegrationServices.ISServerDBUpgrade',
+		'Microsoft.SqlServer.IntegrationServices.Server.Common',
+		'Microsoft.SqlServer.IntegrationServices.Server',
+		'Microsoft.SqlServer.IntegrationServices.Server.IPC',
+		'Microsoft.SqlServer.IntegrationServices.server.shared',
+		'Microsoft.SqlServer.IntegrationServices.TaskScheduler',
+		'Microsoft.SqlServer.ManagedConnections',
+		'Microsoft.SqlServer.Management.Collector',
+		'Microsoft.SqlServer.Management.CollectorEnum',
+		'Microsoft.SqlServer.Management.CollectorTasks',
+		'Microsoft.SqlServer.Management.HadrDMF',
+		'Microsoft.SqlServer.Management.HelpViewer',
+		'Microsoft.SqlServer.Management.IntegrationServices',
+		'Microsoft.SqlServer.Management.IntegrationServicesEnum',
+		'Microsoft.SqlServer.Management.RegisteredServers',
+		'Microsoft.SqlServer.Management.Sdk.Sfc',
+		'Microsoft.SqlServer.Management.SmartAdminPolicies',
+		'Microsoft.SqlServer.Management.SqlParser',
+		'Microsoft.SqlServer.Management.SystemMetadataProvider',
+		'Microsoft.SqlServer.Management.Utility',
+		'Microsoft.SqlServer.Management.UtilityEnum',
+		'Microsoft.SqlServer.Management.XEvent',
+		'Microsoft.SqlServer.Management.XEventDbScoped',
+		'Microsoft.SqlServer.Management.XEventDbScopedEnum',
+		'Microsoft.SqlServer.Management.XEventEnum',
+		'Microsoft.SqlServer.MSMQTask',
+		'Microsoft.SqlServer.PipelineXML',
+		'Microsoft.SqlServer.PolicyEnum',
+		'Microsoft.SqlServer.RegSvrEnum',
+		'Microsoft.SqlServer.Replication.BusinessLogicSupport',
+		'Microsoft.SqlServer.SendMailTask',
+		'Microsoft.SqlServer.ServiceBrokerEnum',
+		'Microsoft.SqlServer.Smo',
+		'Microsoft.SqlServer.SmoExtended',
+		'Microsoft.SqlServer.SqlClrProvider',
+		'Microsoft.SqlServer.SqlEnum',
+		'Microsoft.SqlServer.SQLTaskConnectionsWrap',
+		'Microsoft.SqlServer.SqlTDiagm',
+		'Microsoft.SqlServer.SqlWmiManagement',
+		'Microsoft.SqlServer.SString',
+		'Microsoft.SqlServer.TransferDatabasesTask',
+		'Microsoft.SqlServer.TransferErrorMessagesTask',
+		'Microsoft.SqlServer.TransferJobsTask',
+		'Microsoft.SqlServer.TransferLoginsTask',
+		'Microsoft.SqlServer.TransferObjectsTask',
+		'Microsoft.SqlServer.TransferSqlServerObjectsTask',
+		'Microsoft.SqlServer.TransferStoredProceduresTask',
+		'Microsoft.SqlServer.Types',
+		'Microsoft.SqlServer.Types.resources',
+		'Microsoft.SqlServer.VSTAScriptingLib',
+		'Microsoft.SqlServer.WebServiceTask',
+		'Microsoft.SqlServer.WMIDRTask',
+		'Microsoft.SqlServer.WmiEnum',
+		'Microsoft.SqlServer.WMIEWTask',
+		'Microsoft.SqlServer.XMLTask',
+		
+		'Microsoft.SqlServer.Dmf.Adapters',
+		'Microsoft.SqlServer.DmfSqlClrWrapper'
+	)
+	#endregion Names
+	
+	foreach ($name in $names) {
+		Copy-Assembly -ModuleRoot $ModuleRoot -DllRoot $DllRoot -DoCopy $DoCopy -Name $name
+	}
+	foreach ($name in $names) {
+		Add-Type -Path "$DllRoot\$name.dll"
+	}
 	
 	<#
 Likely don't need yet
@@ -182,12 +211,12 @@ Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.MaintenancePlan
 }
 
 if ($script:serialImport) {
-	$scriptBlock.Invoke($script:PSModuleRoot)
+	$scriptBlock.Invoke($script:PSModuleRoot, "$script:DllRoot\smo", (-not $script:strictSecurityMode))
 }
 else {
 	$script:smoRunspace = [System.Management.Automation.PowerShell]::Create()
 	try { $script:smoRunspace.Runspace.Name = "dbatools-import-smo" }
 	catch { }
-	$script:smoRunspace.AddScript($scriptBlock).AddArgument($script:PSModuleRoot)
+	$script:smoRunspace.AddScript($scriptBlock).AddArgument($script:PSModuleRoot).AddArgument("$script:DllRoot\smo").AddArgument((-not $script:strictSecurityMode))
 	$script:smoRunspace.BeginInvoke()
 }

--- a/internal/scripts/smoLibraryImport.ps1
+++ b/internal/scripts/smoLibraryImport.ps1
@@ -1,6 +1,8 @@
 ﻿$scriptBlock = {
 	Param (
-		$ModuleRoot
+		$ModuleRoot,
+		
+		$DllRoot
 	)
 	
 	try


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose

 - Resolve library-related import issues
 - Resolve library-related update issues

### Changes

 - New: By default, all smo libraries will be copied to temp and imported from temp. This avoids locking module files and enables update from website on older systems.
 - Fix: dbatools library is no longer imported as part of the manifest. This enables dbatools to unblock itself, resolving "library or dependencies not found" exceptions on import
 - Updated: dbatools library is also copied to that temporary folder before importing, same as smo (used to be copied to temp straight)
 - Updated: Maintenance task that cleans up in temp now cleans up the folders with all libraries, instead of just dbatools library

### Notes

 - The import behavior for the smo libraries also supports the dbatools configuration for strict security mode, enabling dbas to disable the copy