### PR TITLE
Restore Suspect Pages

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -281,12 +281,13 @@ function Backup-DbaDatabase {
 				$backup.Incremental = $true
 				$outputType = 'Differential'
 			}
-			
+			$Backup.NoRecovery = $False
 			if ($Type -eq "Log") {
 				Write-Message -Level VeryVerbose -Message "Creating log backup"
 				$Suffix = "trn"
 				$OutputType = 'Log'
 				$SMOBackupType = 'Log'
+				$Backup.NoRecovery = $NoRecovery
 			}
 			
 			if ($type -in 'Full', 'Database') {
@@ -300,7 +301,7 @@ function Backup-DbaDatabase {
 			if ('' -ne $AzureBaseUrl) {
 				$backup.CredentialName = $AzureCredential
 			}
-			$Backup.NoRecovery = $NoRecovery
+
 			Write-Message -Level VeryVerbose -Message "Sorting Paths"
 			
 			#If a backupfilename has made it this far, use it

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -79,6 +79,9 @@ function Backup-DbaDatabase {
 		.PARAMETER AzureCredential
 			The name of the credential on the SQL instance that can write to the AzureBaseUrl.
 
+		.PARAMETER NoRecovery
+			This is passed in to perform a tail log backup if needed
+
 		.PARAMETER EnableException
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -138,6 +141,7 @@ function Backup-DbaDatabase {
 		[int]$BufferCount,
 		[string]$AzureBaseUrl,
 		[string]$AzureCredential,
+		[switch]$NoRecovery,
 		[switch][Alias('Silent')]$EnableException
 	)
 	
@@ -296,7 +300,7 @@ function Backup-DbaDatabase {
 			if ('' -ne $AzureBaseUrl) {
 				$backup.CredentialName = $AzureCredential
 			}
-			
+			$Backup.NoRecovery = $NoRecovery
 			Write-Message -Level VeryVerbose -Message "Sorting Paths"
 			
 			#If a backupfilename has made it this far, use it

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -275,10 +275,11 @@ function Restore-DbaDatabase {
     
     .EXAMPLE
         $SuspectPage = Get-DbaSuspectPage -SqlInstance server\instance1 -Database ProdFinance
-        Get-DbaBackupHistory - SqlInstance server\instance1 -Database -ProdFinance -Last | Restore-DbaDatabase -PageRestore $SuspectPage -PageRestoreTailFolder c:\temp -TrustDbBackupHistory
+        Get-DbaBackupHistory - SqlInstance server\instance1 -Database -ProdFinance -Last | Restore-DbaDatabase -PageRestore $SuspectPage -PageRestoreTailFolder c:\temp -TrustDbBackupHistory -AllowContinues
 
         Gets a list of Suspect Pages using Get-DbaSuspectPage. The uses Get-DbaBackupHistory and Restore-DbaDatabase to perform a restore of the suspect pages and bring them up to date
         If server\instance1 is Enterprise edition this will be done online, if not it will be performed offline
+        AllowContinue is required to make sure we cope with existing files 
 
     .NOTES
         Tags: DisasterRecovery, Backup, Restore

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -8,7 +8,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     $LogFolder = 'C:\temp\logfiles'
     New-Item -Type Directory $DataFolder -ErrorAction SilentlyContinue
     new-Item -Type Directory $LogFolder -ErrorAction SilentlyContinue
-    Context "Properly restores a database on the local drive using Path" {
+<#    Context "Properly restores a database on the local drive using Path" {
         $null = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase -Confirm:$false
         $results = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak
         It "Should Return the proper backup file location" {
@@ -484,5 +484,79 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
            ( $warnvar -like '*KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work') | Should be $True
            $output | Should be $null
         }
+    }
+#>
+    Context "Page level restores"{
+        Get-DbaDatabase -SqlInstance $script:instance1 -ExcludeAllSystemDb | Remove-DbaDatabase -confirm:$false
+        $results = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName PageRestore -DestinationFilePrefix PageRestore
+        $sql = "alter database PageRestore set Recovery Full
+        
+        Create table testpage(
+            Filler char(8000)
+        )
+        
+        insert into testpage values (REPLICATE('a','8000'))
+        insert into testpage values (REPLICATE('b','8000'))
+        insert into testpage values (REPLICATE('c','8000'))
+        insert into testpage values (REPLICATE('d','8000'))
+        
+        Backup database PageRestore to disk='c:\temp\pagerestore.bak'
+        Create table #TmpIndex(
+        PageFiD int,
+        PagePid int,
+        IAMFID int,
+        IAMPid int,
+        ObjectID int,
+        IndexID int,
+        PartitionNumber bigint,
+        ParitionId bigint,
+        iam_chain_type varchar(50),
+        PageType int,
+        IndexLevel int,
+        NextPageFID int,
+        NextPagePID int,
+        prevPageFid int,
+        PrevPagePID int
+        ) 
+        
+        insert #TmpIndex exec ('dbcc ind(PageRestore,testpage,-1)')
+        dbcc ind(PageRestore,testpage,-1)
+        
+        declare @pageid int
+        select top 1 @pageid=PagePid from #TmpIndex where IAMFID is not null and IAmPID is not null
+        
+        --select * from #TmpIndex 
+        --pageid = 256
+        
+        alter database pagerestore set single_user with rollback immediate
+        
+        
+        dbcc writepage(pagerestore,1,@pageid,0,1,0x41,1)
+        dbcc writepage(pagerestore,1,@pageid,1,1,0x41,1)
+        dbcc writepage(pagerestore,1,@pageid,2,1,0x41,1)
+        
+        alter database pagerestore set multi_user 
+        
+        insert into testpage values (REPLICATE('e','8000'))
+        
+        Backup log PageRestore to disk='c:\temp\PageRestore.trn'
+        
+        insert into testpage values (REPLICATE('f','8000'))
+        use master"  
+        $sqlResults = Invoke-Sqlcmd2 -ServerInstance $script:instance1 -Query $sql -Database Pagerestore
+        $sqlResults2 = Invoke-SqlCmd2 -ServerInstance $script:instance1 -Database Master -Query "select * from pagerestore.dbo.testpage where filler like 'a%'" -ErrorVariable errvar -ErrorAction SilentlyContinue
+        It "Should have warned about corruption"{
+            ($errvar -match "SQL Server detected a logical consistency-based I/O error: incorrect checksum \(expected") | Should be $True    
+            ($null -eq $sqlResults2) | SHould be $True
+        }
+        $null = Get-DbaBackupHistory -SqlInstance $script:instance1 -Database pagerestore -last  | Restore-DbaDatabase -SqlInstance $script:instance1 -PageRestore (Get-DbaSuspectPage -SqlInstance $script:instance1 -Database PageRestore) -TrustDbBackupHistory -AllowContinue -DatabaseName PageRestore -PageRestoreTailFolder c:\temp -ErrorAction SilentlyContinue
+        $sqlResults3 = Invoke-SqlCmd2 -ServerInstance $script:instance1 -Query "select * from pagerestore.dbo.testpage where filler like 'f%'" -ErrorVariable errvar3 -ErrorAction SilentlyContinue
+        It "Should work after page restore" {
+            #($null -eq $errvar3) | Should Be $True
+            ($null -eq $sqlResults3) | SHould be $False    
+        }
+
+
+        
     }
 }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -8,7 +8,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     $LogFolder = 'C:\temp\logfiles'
     New-Item -Type Directory $DataFolder -ErrorAction SilentlyContinue
     new-Item -Type Directory $LogFolder -ErrorAction SilentlyContinue
-<#    Context "Properly restores a database on the local drive using Path" {
+    Context "Properly restores a database on the local drive using Path" {
         $null = Get-DbaDatabase -SqlInstance $script:instance1 -NoSystemDb | Remove-DbaDatabase -Confirm:$false
         $results = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak
         It "Should Return the proper backup file location" {
@@ -485,7 +485,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
            $output | Should be $null
         }
     }
-#>
+
     Context "Page level restores"{
         Get-DbaDatabase -SqlInstance $script:instance1 -ExcludeAllSystemDb | Remove-DbaDatabase -confirm:$false
         $results = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName PageRestore -DestinationFilePrefix PageRestore


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
As we had a command Get-DbaSuspectPages thought it'd be nice to have something to fix them as well

### Approach
Gets suspect pages with Get-DbaSuspect pages, then restores those from the last full backup and rolls forward all modification using the log backups. Takes a tail log backup to bring the page(s) right up to date.

If the target system does it online, if not then it's offline.

### Commands to test
```
Get-DbaBackupHistory -SqlInstance localhost\sqlexpress2016 -Database pagerestore -last  | Restore-DbaDatabase -SqlInstance localhost\sqlexpress2016 -PageRestore (Get-DbaSuspectPage -SqlInstance localhost\sqlexpress2016 -Database PageRestore) -TrustDbBackupHistory -AllowContinue -DatabaseName PageRestore -PageRestoreTailFolder c:\temp


