### PR TITLE
Fix #2789 by correcting test for bound parameters

### DIFF
--- a/functions/Get-DbaProcess.ps1
+++ b/functions/Get-DbaProcess.ps1
@@ -141,7 +141,7 @@ function Get-DbaProcess {
 				$allsessions += $processes | Where-Object { $Database -contains $_.Database -and $_.Spid -notin $allsessions.Spid }
 			}
 						
-			if (Test-Bound -not 'Login', 'Spid', 'ExcludeSpid', 'Host', 'Program', 'Database') {
+			if (Test-Bound -not 'Login', 'Spid', 'ExcludeSpid', 'Hostname', 'Program', 'Database') {
 				$allsessions = $processes
 			}
 			


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #2789 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fix the bug!

### Approach
Corrects the test for bound parameters to match up `Hostname` everywhere

### Commands to test
`get-dbaprocess -hostname MYHOSTNAME | select-object spid,database,host`

Only processes from `MYHOSTNAME` should be returned