### PR TITLE
Add `[backup_finish_date]` to `Get-DbaRestoreHistory` output object.

### DIFF
--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -143,8 +143,9 @@ function Get-DbaRestoreHistory {
 					bs.first_lsn,
 					bs.last_lsn,
 					bs.checkpoint_lsn,
-					bs.database_backup_lsn
-				  "
+					bs.database_backup_lsn,
+					bs.backup_finish_date
+					"
 				}
 				
 				$from = " FROM msdb.dbo.restorehistory rsh


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose

[backup_finish_date] will allow us to compare backup and restore dates output from `Get-DbaBackupHistory` and `Get-DbaRestoreHistory`. We can know how old backup files we used in restore process.

### Commands to test

Here we compare dates on backups used to restore test database and determine do we need to refresh it. In this situation we compare dates for Full and/or Differential backups and restore date on test database.

```powershell
>$backupHistory = Get-DbaBackupHistory -SqlInstance <ProductionServer> -Database <Database> -Last | Where-Object {$_.Type -in @('Full','Differential')} | Select-Object -Last 1
>$restoreHistory = Get-DbaRestoreHistory -SqlInstance <TestServer> -Database <Test_Database> -Last
>$backupHistory.End -gt $restoreHistory.backup_finish_date
$True
```