### PR TITLE
Touchup and address messaging issues - Read-DbaBackupHeader

### DIFF
--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -84,7 +84,7 @@ function Read-DbaBackupHeader {
 
             Gets the backup header information from the SQL Server backup file stored at https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak on Azure
     #>
-	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword")]
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword",'')]
     <# AzureCredential is utilized in this command is not a formal Credential object. #>
 	[CmdletBinding()]
 	param (
@@ -139,11 +139,11 @@ function Read-DbaBackupHeader {
 				catch {
 					# Write-Exception $_
 					if ($deviceType -eq 'FILE') {
-						Stop-Function -Message "Problem found with $file" -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
+						Stop-Function -Message "Problem found with $file" -Target $file -ErrorRecord $_ -Exception $_.Exception.InnerException.InnerException -Continue
 
 					}
 					else {
-                        Stop-Function -Message "Unable to read $file, check credential $AzureCredential and network connectivity" -Target $file -ErrorRecord $_ -Excpetion $_.Exception -Continue
+                        Stop-Function -Message "Unable to read $file, check credential $AzureCredential and network connectivity" -Target $file -ErrorRecord $_ -Excpetion $_.Exception.InnerException.InnerException -Continue
 					}
 				}
 
@@ -183,10 +183,10 @@ function Read-DbaBackupHeader {
 					catch {
 						$shortName = Split-Path $file -Leaf
 						if (!(Test-DbaSqlPath -SqlInstance $server -Path $file)) {
-							Stop-Function -Message "File $shortName does not exist or access denied. The SQL Server service account may not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
+							Stop-Function -Message "File $shortName does not exist or access denied. The SQL Server service account may not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception.InnerException.InnerException -Continue
 						}
 						else {
-                            Stop-Function -Message "File list for $shortName could not be determined. This is likely due to the file not existing, the backup version being incompatible or unsupported, connectivity issues or tiemouts with the SQL Server, or the SQL Server service account does not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
+                            Stop-Function -Message "File list for $shortName could not be determined. This is likely due to the file not existing, the backup version being incompatible or unsupported, connectivity issues or tiemouts with the SQL Server, or the SQL Server service account does not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception.InnerException.InnerException -Continue
 						}
 					}
                     $row.FileList = $allFiles

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -1,253 +1,215 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 
-Function Read-DbaBackupHeader {
-<#
-.SYNOPSIS 
-Reads and displays detailed information about a SQL Server backup
+function Read-DbaBackupHeader {
+	<#
+        .SYNOPSIS
+            Reads and displays detailed information about a SQL Server backup
 
-.DESCRIPTION
-Reads full, differential and transaction log backups. An online SQL Server is required to parse the backup files and the path specified must be relative to that SQL Server.
-	
-.PARAMETER SqlInstance
-The SQL Server instance. 
+        .DESCRIPTION
+            Reads full, differential and transaction log backups. An online SQL Server is required to parse the backup files and the path specified must be relative to that SQL Server.
 
-.PARAMETER SqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. 
+        .PARAMETER SqlInstance
+            The SQL Server instance.
 
-.PARAMETER Path
-Path to SQL Server backup file. This can be a full, differential or log backup file.
-Accepts valid filesystem paths and URLs
-	
-.PARAMETER Simple
-Returns fewer columns for an easy overview
-	
-.PARAMETER FileList
-Returns detailed information about the files within the backup
+        .PARAMETER SqlCredential
+            Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted.
 
-.PARAMETER AzureCredential
-Name of the SQL Server credential that should be used for Azure storage access	
+        .PARAMETER Path
+            Path to SQL Server backup file. This can be a full, differential or log backup file.
+            Accepts valid filesystem paths and URLs
 
-.PARAMETER EnableException
-		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-		
-.NOTES
-Tags: DisasterRecovery, Backup, Restore
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+        .PARAMETER Simple
+            Returns fewer columns for an easy overview
 
-.LINK
-https://dbatools.io/Read-DbaBackupHeader
+        .PARAMETER FileList
+            Returns detailed information about the files within the backup
 
-.EXAMPLE
-Read-DbaBackupHeader -SqlInstance sql2016 -Path S:\backups\mydb\mydb.bak
+        .PARAMETER AzureCredential
+            Name of the SQL Server credential that should be used for Azure storage access
 
-Logs into sql2016 using Windows authentication and reads the local file on sql2016, S:\backups\mydb\mydb.bak.
-	
-If you are running this command on a workstation and connecting remotely, remember that sql2016 cannot access files on your own workstation.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message. This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.EXAMPLE
-Read-DbaBackupHeader -SqlInstance sql2016 -Path \\nas\sql\backups\mydb\mydb.bak, \\nas\sql\backups\otherdb\otherdb.bak
+        .NOTES
+            Tags: DisasterRecovery, Backup, Restore
+            dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+            Copyright (C) 2016 Chrissy LeMaire
+            License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-Logs into sql2016 and reads two backup files - mydb.bak and otherdb.bak. The SQL Server service account must have rights to read this file.
-	
-.EXAMPLE
-Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak -Simple
-	
-Logs into the local workstation (or computer) and shows simplified output about C:\temp\myfile.bak. The SQL Server service account must have rights to read this file.
+        .LINK
+            https://dbatools.io/Read-DbaBackupHeader
 
-.EXAMPLE
-$backupinfo = Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak
-$backupinfo.FileList
-	
-Displays detailed information about each of the datafiles contained in the backupset.
+        .EXAMPLE
+            Read-DbaBackupHeader -SqlInstance sql2016 -Path S:\backups\mydb\mydb.bak
 
-.EXAMPLE
-Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak -FileList
-	
-Also returns detailed information about each of the datafiles contained in the backupset.
+            Logs into sql2016 using Windows authentication and reads the local file on sql2016, S:\backups\mydb\mydb.bak.
 
-.EXAMPLE
-"C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak" | Read-DbaBackupHeader -SqlInstance sql2016
+            If you are running this command on a workstation and connecting remotely, remember that sql2016 cannot access files on your own workstation.
 
-Similar to running Read-DbaBackupHeader -SqlInstance sql2016 -Path "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak"
-	
-.EXAMPLE
-Get-ChildItem \\nas\sql\*.bak | Read-DbaBackupHeader -SqlInstance sql2016
+        .EXAMPLE
+            Read-DbaBackupHeader -SqlInstance sql2016 -Path \\nas\sql\backups\mydb\mydb.bak, \\nas\sql\backups\otherdb\otherdb.bak
 
-Gets a list of all .bak files on the \\nas\sql share and reads the headers using the server named "sql2016". This means that the server, sql2016, must have read access to the \\nas\sql share.
+            Logs into sql2016 and reads two backup files - mydb.bak and otherdb.bak. The SQL Server service account must have rights to read this file.
 
-.EXAMPLE
-Read-DbaBackupHeader -Path https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak
- -AzureCredential AzureBackupUser
+        .EXAMPLE
+            Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak -Simple
 
-Gets the backup header information from the SQL Server backup file stored at https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak on Azure
-#>
-    [CmdletBinding()]
-    Param (
-        [parameter(Mandatory = $true)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter]
-        $SqlInstance,
-        
-        [PsCredential]
-        $SqlCredential,
-        
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [object[]]
-        $Path,
-        
-        [switch]
-        $Simple,
-        
-        [switch]
-        $FileList,
-        
-        [string]
-        $AzureCredential,
-        
-        [switch]
-        [Alias('Silent')]$EnableException
-    )
-    
-    begin {
-        $LoopCnt = 1
-        
-        try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        }
-        catch {
-            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            return
-        }
-    }
-    
-    process {
-        if (Test-FunctionInterrupt) { return }
-        $PathCount = $path.length
-        Write-Message -Level Verbose -Message "$pathcount files to scan"
-        foreach ($file in $path) {
-            if ($null -ne $file.FullName) { $file = $file.FullName }
-            Write-Progress -Id 1 -Activity Updating -Status 'Progress' -CurrentOperation "Scanning Restore headers on File $LoopCnt - $file"
-            
-            Write-Message -Level Verbose -Message "Scanning file $file"
-            $restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
-            if ($file -like 'http*') {
-                $DeviceType = 'URL'
-                $restore.CredentialName = $AzureCredential
+            Logs into the local workstation (or computer) and shows simplified output about C:\temp\myfile.bak. The SQL Server service account must have rights to read this file.
+
+        .EXAMPLE
+            $backupinfo = Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak
+            $backupinfo.FileList
+
+            Displays detailed information about each of the datafiles contained in the backupset.
+
+        .EXAMPLE
+            Read-DbaBackupHeader -SqlInstance . -Path C:\temp\myfile.bak -FileList
+
+            Also returns detailed information about each of the datafiles contained in the backupset.
+
+        .EXAMPLE
+            "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak" | Read-DbaBackupHeader -SqlInstance sql2016
+
+            Similar to running Read-DbaBackupHeader -SqlInstance sql2016 -Path "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak"
+
+        .EXAMPLE
+            Get-ChildItem \\nas\sql\*.bak | Read-DbaBackupHeader -SqlInstance sql2016
+
+            Gets a list of all .bak files on the \\nas\sql share and reads the headers using the server named "sql2016". This means that the server, sql2016, must have read access to the \\nas\sql share.
+
+        .EXAMPLE
+            Read-DbaBackupHeader -Path https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak
+            -AzureCredential AzureBackupUser
+
+            Gets the backup header information from the SQL Server backup file stored at https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak on Azure
+    #>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword")]
+    <# AzureCredential is utilized in this command is not a formal Credential object. #>
+	[CmdletBinding()]
+	param (
+		[parameter(Mandatory = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstance]$SqlInstance,
+		[PsCredential]$SqlCredential,
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[object[]]$Path,
+		[switch]$Simple,
+		[switch]$FileList,
+		[string]$AzureCredential,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	begin {
+		$loopCnt = 1
+		try {
+			$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+		}
+		catch {
+			Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			return
+		}
+	}
+
+	process {
+		if (Test-FunctionInterrupt) { return }
+		$pathCount = $Path.Length
+		Write-Message -Level Verbose -Message "$pathCount files to scan"
+		foreach ($file in $Path) {
+			if ($null -ne $file.FullName) {
+                $file = $file.FullName
             }
-            else {
-                $DeviceType = 'FILE'
-            }
-            $device = New-Object Microsoft.SqlServer.Management.Smo.BackupDeviceItem $file, $DeviceType
-            $restore.Devices.Add($device)
-            if ((Test-DbaSqlPath -SqlInstance $server -Path $file) -or $DeviceType -eq 'URL') {
-				<#	try
-					{
-						$allfiles = $restore.ReadFileList($server)
+			Write-Progress -Id 1 -Activity Updating -Status 'Progress' -CurrentOperation "Scanning Restore headers on File $loopCnt - $file"
+
+			Write-Message -Level Verbose -Message "Scanning file $file"
+			$restore = New-Object Microsoft.SqlServer.Management.Smo.Restore
+			if ($file -like 'http*') {
+				$deviceType = 'URL'
+				$restore.CredentialName = $AzureCredential
+			}
+			else {
+				$deviceType = 'FILE'
+			}
+			$device = New-Object Microsoft.SqlServer.Management.Smo.BackupDeviceItem $file, $deviceType
+			$restore.Devices.Add($device)
+			if ((Test-DbaSqlPath -SqlInstance $server -Path $file) -or $deviceType -eq 'URL') {
+				try {
+					$dataTable = $restore.ReadBackupHeader($server)
+				}
+				catch {
+					# Write-Exception $_
+					if ($deviceType -eq 'FILE') {
+						Stop-Function -Message "Problem found with $file" -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
+
 					}
-					catch
-					{
-						$shortname = Split-Path $file -Leaf
-						if (!(Test-DbaSqlPath -SqlInstance $server -Path $file))
-						{
-							Write-Warning "File $shortname does not exist or access denied. The SQL Server service account may not have access to the source directory."
+					else {
+                        Stop-Function -Message "Unable to read $file, check credential $AzureCredential and network connectivity" -Target $file -ErrorRecord $_ -Excpetion $_.Exception -Continue
+					}
+					Return
+				}
+
+				$null = $dataTable.Columns.Add("FileList", [object])
+
+				$mb = $dataTable.Columns.Add("BackupSizeMB", [int])
+				$mb.Expression = "BackupSize / 1024 / 1024"
+				$gb = $dataTable.Columns.Add("BackupSizeGB")
+				$gb.Expression = "BackupSizeMB / 1024"
+
+				if ($null -eq $dataTable.Columns['CompressedBackupSize']) {
+					$formula = "0"
+				}
+				else {
+					$formula = "CompressedBackupSize / 1024 / 1024"
+				}
+
+				$cmb = $dataTable.Columns.Add("CompressedBackupSizeMB", [int])
+				$cmb.Expression = $formula
+				$cgb = $dataTable.Columns.Add("CompressedBackupSizeGB")
+				$cgb.Expression = "CompressedBackupSizeMB / 1024"
+
+				$null = $dataTable.Columns.Add("SqlVersion")
+
+				$null = $dataTable.Columns.Add("BackupPath")
+				$dbVersion = $dataTable.Rows[0].DatabaseVersion
+
+				$backupSlot = 1
+				foreach ($row in $dataTable) {
+					$row.SqlVersion = (Convert-DbVersionToSqlVersion $dbVersion)
+					$row.BackupPath = $file
+					try {
+						$restore.FileNumber = $backupSlot
+						<# Select-Object does a quick and dirty conversion from datatable to PS object #>
+						$allFiles = $restore.ReadFileList($server) | Select-Object *
+					}
+					catch {
+						$shortName = Split-Path $file -Leaf
+						if (!(Test-DbaSqlPath -SqlInstance $server -Path $file)) {
+							Stop-Function -Message "File $shortName does not exist or access denied. The SQL Server service account may not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
 						}
-						else
-						{
-							Write-Warning "File list for $shortname could not be determined. This is likely due to the file not existing, the backup version being incompatible or unsupported, connectivity issues or tiemouts with the SQL Server, or the SQL Server service account does not have access to the source directory."
+						else {
+                            Stop-Function -Message "File list for $shortName could not be determined. This is likely due to the file not existing, the backup version being incompatible or unsupported, connectivity issues or tiemouts with the SQL Server, or the SQL Server service account does not have access to the source directory." -Target $file -ErrorRecord $_ -Exception $_.Exception -Continue
 						}
 					}
-					
+                    $row.FileList = $allFiles
+					$backupSlot++
+				}
+			}
+			else {
+				Write-Message -Level Warning -Message "File $shortName does not exist or access denied. The SQL Server service account may not have access to the source directory."
+				return
+			}
+			if ($Simple) {
+				$dataTable | Select-Object DatabaseName, BackupFinishDate, RecoveryModel, BackupSizeMB, CompressedBackupSizeMB, DatabaseCreationDate, UserName, ServerName, SqlVersion, BackupPath
+			}
+			elseif ($FileList) {
+				$dataTable.filelist
+			}
+			else {
+				$dataTable
+			}
 
-				}#>
-                try {
-                    $datatable = $restore.ReadBackupHeader($server)
-                }
-                catch {
-                    Write-Exception $_
-                    if ($DeviceType -eq 'FILE') {
-                        Write-Message -Level Warning -Message "Problem with $file"
-                    }
-                    else {
-                        Write-Message -Level Warning -Message "Cannot reach $file, check credential name and network connectivity"
-                    }
-                    Return
-                }
-
-                $fl = $datatable.Columns.Add("FileList", [object])
-                #$datatable.rows[0].FileList = $allfiles.rows
-                
-                $mb = $datatable.Columns.Add("BackupSizeMB", [int])
-                $mb.Expression = "BackupSize / 1024 / 1024"
-                $gb = $datatable.Columns.Add("BackupSizeGB")
-                $gb.Expression = "BackupSizeMB / 1024"
-                
-                if ($null -eq $datatable.Columns['CompressedBackupSize']) {
-                    $formula = "0"
-                }
-                else {
-                    $formula = "CompressedBackupSize / 1024 / 1024"
-                }
-                
-                $cmb = $datatable.Columns.Add("CompressedBackupSizeMB", [int])
-                $cmb.Expression = $formula
-                $cgb = $datatable.Columns.Add("CompressedBackupSizeGB")
-                $cgb.Expression = "CompressedBackupSizeMB / 1024"
-                
-                $null = $datatable.Columns.Add("SqlVersion")
-                
-                
-                $null = $datatable.Columns.Add("BackupPath")
-                #	$datatable.Columns["BackupPath"].DefaultValue = $Path
-                $dbversion = $datatable.Rows[0].DatabaseVersion
-                
-                #	$datatable.Rows[0].SqlVersion = (Convert-DbVersionToSqlVersion $dbversion)
-                $BackupSlot = 1
-                ForEach ($row in $DataTable) {
-                    $row.SqlVersion = (Convert-DbVersionToSqlVersion $dbversion)
-                    $row.BackupPath = $file
-                    try {
-                        $restore.FileNumber = $BackupSlot
-                        #Select-Object does a quick and dirty conversion from datatable to PS object
-                        $allfiles = $restore.ReadFileList($server) | select-object *
-                    }
-                    catch {
-                        $shortname = Split-Path $file -Leaf
-                        if (!(Test-DbaSqlPath -SqlInstance $server -Path $file)) {
-                            Write-Message -Level Warning -Message "File $shortname does not exist or access denied. The SQL Server service account may not have access to the source directory."
-                        }
-                        else {
-                            Write-Message -Level Warning -Message "File list for $shortname could not be determined. This is likely due to the file not existing, the backup version being incompatible or unsupported, connectivity issues or tiemouts with the SQL Server, or the SQL Server service account does not have access to the source directory."
-                        }
-                        
-                        #Write-Exception $_
-                        #return
-                    }
-                    $row.FileList = $allfiles
-                    $BackupSlot++
-                   
-                }
-            }
-            else {
-                Write-Message -Level Warning -Message "File $shortname does not exist or access denied. The SQL Server service account may not have access to the source directory."
-                return
-            }
-            if ($Simple) {
-                $datatable | Select-Object DatabaseName, BackupFinishDate, RecoveryModel, BackupSizeMB, CompressedBackupSizeMB, DatabaseCreationDate, UserName, ServerName, SqlVersion, BackupPath
-            }
-            elseif ($FileList) {
-                $datatable.filelist
-            }
-            else {
-                $datatable
-            }
-            
-            Remove-Variable DataTable -ErrorAction SilentlyContinue
-        }
-        $LoopCnt++
-    }
+			Remove-Variable dataTable -ErrorAction SilentlyContinue
+		}
+		$loopCnt++
+	}
 }
-

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -145,7 +145,6 @@ function Read-DbaBackupHeader {
 					else {
                         Stop-Function -Message "Unable to read $file, check credential $AzureCredential and network connectivity" -Target $file -ErrorRecord $_ -Excpetion $_.Exception -Continue
 					}
-					Return
 				}
 
 				$null = $dataTable.Columns.Add("FileList", [object])
@@ -196,7 +195,6 @@ function Read-DbaBackupHeader {
 			}
 			else {
 				Write-Message -Level Warning -Message "File $shortName does not exist or access denied. The SQL Server service account may not have access to the source directory."
-				return
 			}
 			if ($Simple) {
 				$dataTable | Select-Object DatabaseName, BackupFinishDate, RecoveryModel, BackupSizeMB, CompressedBackupSizeMB, DatabaseCreationDate, UserName, ServerName, SqlVersion, BackupPath

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -137,7 +137,6 @@ function Read-DbaBackupHeader {
 					$dataTable = $restore.ReadBackupHeader($server)
 				}
 				catch {
-					# Write-Exception $_
 					if ($deviceType -eq 'FILE') {
 						Stop-Function -Message "Problem found with $file" -Target $file -ErrorRecord $_ -Exception $_.Exception.InnerException.InnerException -Continue
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Addressing use of `Write-Exception` and updating the messaging system in this command. Use of `Write-Message` in some areas replaced with proper call to `Stop-Function`. I hopefully have this where the actual error that you hit on T-SQL executions is showing properly now. I added `$_.Exception.InnerException.InnerException` that should now show the actual error you hit.

I also removed the `return` calls as this command accepts multiple paths and will stop running on the first file that hits an error, or hits the catch blocks. It will now continue on trying the other paths passed into the command.

![image](https://user-images.githubusercontent.com/11204251/33699606-c97a6f22-dad9-11e7-9870-bd31a660ec8d.png)

### Commands to test
<!-- if these are the examples in the help just note it as such -->
This command is referenced by three commands in the module, I ran each one locally just to make sure and each test passed with flying green colors:

![image](https://user-images.githubusercontent.com/11204251/33699507-251c9e5a-dad9-11e7-9de7-02fbf8fb4b54.png)

![image](https://user-images.githubusercontent.com/11204251/33699522-448902e2-dad9-11e7-8e66-3fb2e328d7ff.png)

![image](https://user-images.githubusercontent.com/11204251/33699534-5980fede-dad9-11e7-9f81-227ab96fd127.png)

So if this fails in Appveyor...screw you Appveyor! 