### PR TITLE
Add filters to Find-DbaDatabaseGrowthEvent

### DIFF
--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -88,11 +88,14 @@ function Find-DbaDatabaseGrowthEvent {
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
 		[DbaInstance[]]$SqlInstance,
-		[PSCredential]
-		$SqlCredential,
+		[PSCredential]$SqlCredential,
 		[Alias("Databases")]
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
+		[ValidateSet('Growth', 'Shrink')]
+		[string]$EventType,
+		[ValidateSet('Data','Log')]
+		[string]$FileType,
 		[switch][Alias('Silent')]$EnableException
 	)
 

--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -101,7 +101,7 @@ function Find-DbaDatabaseGrowthEvent {
 
 	begin {
 		$eventClass = New-Object System.Collections.ArrayList
-		92..95 | ForEach-Object { $eventClass.Add($_) }
+		92..95 | ForEach-Object { $null = $eventClass.Add($_) }
 
 		if (Test-Bound 'EventType', 'FileType') {
 			switch ($FileType) {
@@ -222,11 +222,10 @@ function Find-DbaDatabaseGrowthEvent {
 
 			#Create dblist name in 'bd1', 'db2' format
 			$dbsList = "'$($($dbs | ForEach-Object {$_.Name}) -join "','")'"
-			Write-Message -Level Debug -Message "Executing SQL Statement:`n $sql"
 			Write-Message -Level Verbose -Message "Executing query against $dbsList on $instance"
 
 			$sql = $sql -replace '_DatabaseList_', $dbsList
-			Write-Message -Level Debug -Message $sql
+			Write-Message -Level Debug -Message "Executing SQL Statement:`n $sql"
 
 			$props = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTime', 'EndTime', 'ChangeInSize'
 

--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#CodeStyle#
 function Find-DbaDatabaseGrowthEvent {
 	<#
 		.SYNOPSIS
@@ -6,11 +7,23 @@ function Find-DbaDatabaseGrowthEvent {
 		.DESCRIPTION
 			Finds any database AutoGrow events in the Default Trace.
 
+			The following events are included:
+				92 - Data File Auto Grow
+				93 - Log File Auto Grow
+				94 - Data File Auto Shrink
+				95 - Log File Auto Shrink
+
 		.PARAMETER SqlInstance
-			The SQL Server that you're connecting to.
+			SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
 
 		.PARAMETER SqlCredential
-			SqlCredential object used to connect to the SQL Server as a different user.
+			Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+			$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+			To connect as a different Windows user, run PowerShell as that user.
 
 		.PARAMETER Database
 			The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
@@ -18,13 +31,23 @@ function Find-DbaDatabaseGrowthEvent {
 		.PARAMETER ExcludeDatabase
 			The database(s) to exclude - this list is auto-populated from the server
 
+		.PARAMETER EventType
+			Provide a filter on growth event type to filter the results.
+
+			Allowed values: Growth, Shrink
+
+		.PARAMETER FileType
+			Provide a filter on file type to filter the results.
+
+			Allowed vaules: Data, Log
+
 		.PARAMETER EnableException
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.NOTES
-			Tags: AutoGrow
+			Tags: AutoGrow,Growth,Database
 			Author: Aaron Nelson
 			Query Extracted from SQL Server Management Studio (SSMS) 2016.
 
@@ -36,25 +59,35 @@ function Find-DbaDatabaseGrowthEvent {
 			https://dbatools.io/Find-DbaDatabaseGrowthEvent
 
 		.EXAMPLE
-			Find-DBADatabaseGrowthEvent -SqlInstance localhost
+			Find-DbaDatabaseGrowthEvent -SqlInstance localhost
 
 			Returns any database AutoGrow events in the Default Trace for every database on the localhost instance.
 
 		.EXAMPLE
-			Find-DBADatabaseGrowthEvent -SqlInstance ServerA\SQL2016, ServerA\SQL2014
+			Find-DbaDatabaseGrowthEvent -SqlInstance ServerA\SQL2016, ServerA\SQL2014
 
 			Returns any database AutoGrow events in the Default Traces for every database on ServerA\sql2016 & ServerA\SQL2014.
 
 		.EXAMPLE
-			Find-DBADatabaseGrowthEvent -SqlInstance ServerA\SQL2016 | Format-Table -AutoSize -Wrap
+			Find-DbaDatabaseGrowthEvent -SqlInstance ServerA\SQL2016 | Format-Table -AutoSize -Wrap
 
 			Returns any database AutoGrow events in the Default Trace for every database on the ServerA\SQL2016 instance in a table format.
+
+		.EXAMPLE
+			Find-DbaDatabaseGrowthEvent -SqlInstance ServerA\SQL2016 -EventType Shrink
+
+			Returns any database Auto Shrink events in the Default Trace for every database on the ServerA\SQL2016 instance.
+
+		.EXAMPLE
+			Find-DbaDatabaseGrowthEvent -SqlInstance ServerA\SQL2016 -EventType Growth -FileType Data
+
+			Returns any database Auto Growth events on data files in the Default Trace for every database on the ServerA\SQL2016 instance.
 	#>
 	[CmdletBinding()]
-	Param (
+	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
 		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
+		[DbaInstance[]]$SqlInstance,
 		[PSCredential]
 		$SqlCredential,
 		[Alias("Databases")]
@@ -156,7 +189,7 @@ function Find-DbaDatabaseGrowthEvent {
 			#Create dblist name in 'bd1', 'db2' format
 			$dbsList = "'$($($dbs | ForEach-Object {$_.Name}) -join "','")'"
 			Write-Message -Level Verbose -Message "Executing query against $dbsList on $instance"
-			
+
 			$sql = $sql -replace '_DatabaseList_', $dbsList
 			Write-Message -Level Debug -Message $sql
 

--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -1,4 +1,4 @@
-#ValidationTags#CodeStyle#
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Find-DbaDatabaseGrowthEvent {
 	<#
 		.SYNOPSIS
@@ -201,23 +201,22 @@ function Find-DbaDatabaseGrowthEvent {
 	}
 	process {
 		foreach ($instance in $SqlInstance) {
-			Write-Message -Level Verbose -Message "Connecting to $instance"
+			Write-Message -Level Verbose -Message "Attempting to connect to $instance"
 			try {
 				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
 			}
 			catch {
-				Write-Message -Level Warning -Message "Can't connect to $instance. Moving on."
-				continue
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 
 			$dbs = $server.Databases
 
 			if ($Database) {
-				$dbs = $dbs | Where-Object Name -in $Database
+				$dbs = $dbs | Where-Object Name -In $Database
 			}
 
 			if ($ExcludeDatabase) {
-				$dbs = $dbs | Where-Object Name -notin $ExcludeDatabase
+				$dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
 			}
 
 			#Create dblist name in 'bd1', 'db2' format
@@ -227,9 +226,9 @@ function Find-DbaDatabaseGrowthEvent {
 			$sql = $sql -replace '_DatabaseList_', $dbsList
 			Write-Message -Level Debug -Message "Executing SQL Statement:`n $sql"
 
-			$props = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTime', 'EndTime', 'ChangeInSize'
+			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTime', 'EndTime', 'ChangeInSize'
 
-			Select-DefaultView -InputObject $server.Query($sql) -Property $props
+			Select-DefaultView -InputObject $server.Query($sql) -Property $defaults
 		}
 	}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
If you are querying a heavy server that has large number of databases, use of PowerShell filtering requires the command to pull all the data out of the default trace before you can filter it. Added parameters that let you filter the data as it is pulled from the default trace. Improves performance on large systems.

Provides the ability to only pull variations of growth or shrink only, and then only evens for data files or log files.
### Approach
<!-- How does this change solve that purpose -->
I didn't want to sit there and put in a bunch of `if/else` statements so went with using `switch`. However how doing that where it would cover any sequence of `log,growth` or `data,shrink` required use of a collection on the event classes. So the logic in the command is backwards, in that I start the collection with all the events in it, and as the filter is tested it removes each event that is not desired.

I'm fairly sure I got the logic right but do please test and break if able.
### Commands to test
![image](https://user-images.githubusercontent.com/11204251/33792414-c38e0af2-dc63-11e7-8c77-7c34a480b281.png)
