### PR TITLE
Set-DbaStartParameter now works with offline instances

### DIFF
--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -13,7 +13,7 @@ For full details of what each parameter does, please refer to this MSDN article 
 .PARAMETER SqlInstance
 The SQL Server instance to be modified
 
-If the Sql Instance is offline path parameters will be ignored as we cannot test the instance's access to the path. If you want to force this to work then please see the Force switch
+If the Sql Instance is offline path parameters will be ignored as we cannot test the instance's access to the path. If you want to force this to work then please use the Force switch
 
 .PARAMETER SqlCredential
 Windows or Sql Login Credential with permission to log into the SQL instance
@@ -24,11 +24,17 @@ Windows Credential with permission to log on to the server running the SQL insta
 .PARAMETER MasterData
 Path to the data file for the Master database
 
+Will be ignored if SqlInstance is offline or the Offline switch is set. To override this behaviour use the Force switch. This is to ensure you understand the risk as we cannot validate the path if the instance is offline
+
 .PARAMETER MasterLog
 Path to the log file for the Master database
 
+Will be ignored if SqlInstance is offline or the Offline switch is set. To override this behaviour use the Force switch. This is to ensure you understand the risk as we cannot validate the path if the instance is offline
+
 .PARAMETER ErrorLog
 path to the SQL Server error log file 
+
+Will be ignored if SqlInstance is offline or the Offline switch is set. To override this behaviour use the Force switch. This is to ensure you understand the risk as we cannot validate the path if the instance is offline
 
 .PARAMETER TraceFlags
 A comma separated list of TraceFlags to be applied at SQL Server startup
@@ -85,10 +91,10 @@ using this parameter will set TraceFlagsOverride to true, so existing Trace Flag
 .PARAMETER Offline
 Setting this switch will try perform the requested actions without conntect to the SQL Server Instance, this will speed things up if you know the Instance is offline.
 
-Note, that with this switch Paths will be ignored unless you also speficy Force
+When working offline, path inputs (MasterData, MasterLog and ErrorLog) will be ignored, unless Force is specifiec
 
 .PARAMETER Force
-This skips testing the paths passed in. This is useful if you are working with an offline SQL Server instance
+By default we test the values passed in via MasterData, MasterLog, ErrorLog
 
 .PARAMETER WhatIf 
 Shows what would happen if the command were to run. No actions are actually performed. 
@@ -140,6 +146,13 @@ This will set Trace Flags 8032 and 8048 to the startup parameters, removing any 
 Set-DbaStartupParameter -SqlInstance sql2016 -SingleUser:$false -TraceFlagsOverride -Offline
 
 This will remove all trace flags and set SinguleUser to false from an offline instance
+
+.EXAMPLE
+Set-DbaStartupParameter -SqlInstance sql2016 -ErrorLog c:\Sql\ -Offline
+
+This will attempt to change the ErrorLog path to c:\sql\. However, with the offline switch this will not happen. To force it, use the -Force switch like so:
+
+Set-DbaStartupParameter -SqlInstance sql2016 -ErrorLog c:\Sql\ -Offline -Force
 
 .EXAMPLE
 

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -13,7 +13,7 @@ For full details of what each parameter does, please refer to this MSDN article 
 .PARAMETER SqlInstance
 The SQL Server instance to be modified
 
-If the Sql Instance is offline path parameters will be ignored as we cannot test the instance's access to the path. If you want to force this to work then please see the TrustPath switch
+If the Sql Instance is offline path parameters will be ignored as we cannot test the instance's access to the path. If you want to force this to work then please see the Force switch
 
 .PARAMETER SqlCredential
 Windows or Sql Login Credential with permission to log into the SQL instance
@@ -85,9 +85,9 @@ using this parameter will set TraceFlagsOverride to true, so existing Trace Flag
 .PARAMETER Offline
 Setting this switch will try perform the requested actions without conntect to the SQL Server Instance, this will speed things up if you know the Instance is offline.
 
-Note, that with this switch Paths will be ignored unless you also speficy TrustPath
+Note, that with this switch Paths will be ignored unless you also speficy Force
 
-.PARAMETER TrustPath
+.PARAMETER Force
 This skips testing the paths passed in. This is useful if you are working with an offline SQL Server instance
 
 .PARAMETER WhatIf 
@@ -179,7 +179,7 @@ After the work has been completed, we can push the original startup parameters b
 		[switch]$TraceFlagsOverride,
         [object]$StartUpConfig,
         [switch]$Offline,
-        [switch]$TrustPath,
+        [switch]$Force,
 		[switch][Alias('Silent')]$EnableException        
     )
     process {
@@ -190,7 +190,7 @@ After the work has been completed, we can push the original startup parameters b
                 $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
             }
             catch {
-                Write-Message -Level Warning -Message "Failed to connect to $SqlInstance, will try to work with just WMI. Path options will be ignored unless TrustPath was indicated"
+                Write-Message -Level Warning -Message "Failed to connect to $SqlInstance, will try to work with just WMI. Path options will be ignored unless Force was indicated"
                 $Server = $SqlInstance
                 $Offline = $true
             }
@@ -224,13 +224,13 @@ After the work has been completed, we can push the original startup parameters b
         if (!($currentstartup.SingleUser)) {
             
             if ($newstartup.Masterdata.length -gt 0) {
-                if ($Offline -and -not $TrustPath) {
+                if ($Offline -and -not $Force) {
                     Write-Message -Level Warning -Message "Working offline, skipping untested MasterData path"
                     $ParameterString += "-d$($CurrentStartup.MasterData);"
                     
                 }
                 else {
-                    if ($TrustPath){
+                    if ($Force){
                         $ParameterString += "-d$($newstartup.MasterData);"
                     } elseif (Test-DbaSqlPath -SqlInstance $server -SqlCredential $SqlCredential -Path (Split-Path $newstartup.MasterData -Parent)) {
                         $ParameterString += "-d$($newstartup.MasterData);"
@@ -247,12 +247,12 @@ After the work has been completed, we can push the original startup parameters b
             }
             
             if ($newstartup.ErrorLog.length -gt 0) {
-                if ($Offline -and -not $TrustPath){
+                if ($Offline -and -not $Force){
                     Write-Message -Level Warning -Message "Working offline, skipping untested ErrorLog path"                    
                     $ParameterString += "-e$($CurrentStartup.ErrorLog);"                                           
                 }
                 else {
-                    if ($TrustPath){
+                    if ($Force){
                         $ParameterString += "-e$($newstartup.ErrorLog);"                       
                     }
                     elseif (Test-DbaSqlPath -SqlInstance $server -SqlCredential $SqlCredential -Path (Split-Path $newstartup.ErrorLog -Parent)) {
@@ -270,12 +270,12 @@ After the work has been completed, we can push the original startup parameters b
             }
             
             if ($newstartup.MasterLog.Length -gt 0) {
-                if ($offline -and -not $TrustPath){
+                if ($offline -and -not $Force){
                     Write-Message -Level Warning -Message "Working offline, skipping untested MasterLog path"                                        
                     $ParameterString += "-l$($CurrentStartup.MasterLog);"                       
                 }
                 else{
-                    if ($TrustPath){
+                    if ($Force){
                         $ParameterString += "-l$($newstartup.MasterLog);"                       
                     }
                     elseif (Test-DbaSqlPath -SqlInstance $server -SqlCredential $SqlCredential -Path (Split-Path $newstartup.MasterLog -Parent)) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2822)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes #2822

@sqllensman can you give this a spin just so we've an independent test. Thanks

### Approach
If it can't connect to the specified instance will the proceed using just WMI.  By default it won't apply path changes as they can't be tested.

if TrustPath set, we'll trust the paths and push them in.

using the Offline switch shortcuts the connection test, so you can have 30s of your life for other uses! Needs TrustPath for path changes as well.

### Commands to test
```
Set-DbaStartupParameter -SqlInstance localhost\sqlexpress2016 -Verbose -MinimalStart -Offline
```


