### PR TITLE
Improvements / TouchUp / Tests for MaxDop Commands

### DIFF
--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -1,9 +1,9 @@
 function Set-DbaMaxDop {
-	<# 
-        .SYNOPSIS 
+	<#
+        .SYNOPSIS
             Sets SQL Server maximum degree of parallelism (Max DOP), then displays information relating to SQL Server Max DOP configuration settings. Works on SQL Server 2005 and higher.
 
-        .DESCRIPTION 
+        .DESCRIPTION
             Uses the Test-DbaMaxDop command to get the recommended value if -MaxDop parameter is not specified.
 
             These are just general recommendations for SQL Server and are a good starting point for setting the "max degree of parallelism" option.
@@ -36,44 +36,43 @@ function Set-DbaMaxDop {
 
         .PARAMETER Collection
             If Test-SQLMaxDop has been executed prior to this function, the results may be passed in via this parameter.
-        
-        .PARAMETER WhatIf
-			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
-		.PARAMETER Confirm
-            If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-        .NOTES 
+        .NOTES
             Tags:
             Author: Claudio Silva (@claudioessilva)
             Website: https://dbatools.io
             Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
             License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-        .LINK 
+        .LINK
             https://dbatools.io/Set-DbaMaxDop
 
-        .EXAMPLE   
+        .EXAMPLE
             Set-DbaMaxDop -SqlInstance sql2008, sql2012
 
             Sets Max DOP to the recommended value for servers sql2008 and sql2012.
 
-        .EXAMPLE 
+        .EXAMPLE
             Set-DbaMaxDop -SqlInstance sql2014 -MaxDop 4
 
             Sets Max DOP to 4 for server sql2014.
 
-        .EXAMPLE 
-            Test-DbaMaxDop -SqlInstance sql2008 | Set-DbaMaxDop 
+        .EXAMPLE
+            Test-DbaMaxDop -SqlInstance sql2008 | Set-DbaMaxDop
 
             Gets the recommended Max DOP from Test-DbaMaxDop and applies it to to sql2008.
 
-        .EXAMPLE 
+        .EXAMPLE
             Set-DbaMaxDop -SqlInstance sql2016 -Database db1
 
             Set recommended Max DOP for database db1 on server sql2016.
 
-        .EXAMPLE 
+        .EXAMPLE
             Set-DbaMaxDop -SqlInstance sql2016 -AllDatabases
 
             Set recommended Max DOP for all databases on server sql2016.
@@ -93,79 +92,72 @@ function Set-DbaMaxDop {
 		[Parameter(ValueFromPipeline = $True)]
 		[object]$Collection,
 		[Alias("All")]
-		[switch]$AllDatabases
+		[switch]$AllDatabases,
+		[switch][Alias('Silent')]$EnableException
 	)
 
 	begin {
-		if ($Database -and $AllDatabases -and $ExcludeDatabase) {
-			throw "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one. Quitting."
-		}
-		
 		$processed = New-Object System.Collections.ArrayList
 		$results = @()
 	}
 	process {
+		if ((Test-Bound -Parameter Database) -and (Test-Bound -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
+			Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one. Quitting."
+			return
+		}
+
 		$dbscopedconfiguration = $false
-		
+
 		if ($MaxDop -eq -1) {
 			$UseRecommended = $true
 		}
-		
-		if ($collection -eq $null) {
+
+		if ((Test-Bound -Not -Parameter Collection)) {
 			$collection = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
 		}
-		elseif ($collection.Instance -eq $null) {
+		elseif ($collection.SqlInstance -eq $null) {
 			$collection = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
 		}
-		
+
 		$collection | Add-Member -Force -NotePropertyName OldInstanceMaxDopValue -NotePropertyValue 0
 		$collection | Add-Member -Force -NotePropertyName OldDatabaseMaxDopValue -NotePropertyValue 0
-		
-		$servers = $collection | Select-Object Instance -Unique
-		
+
+        #If we have servers 2016 or higher we will have a row per database plus the instance level, getting unique we only run one time per instance
+		$servers = $collection | Select-Object SqlInstance -Unique
+
 		foreach ($server in $servers) {
-			if ($server.Instance -ne $null) {
-				$servername = $server.Instance
-			}
-			else {
-				$servername = $server
-			}
-			
-			Write-Verbose "Attempting to connect to $servername"
+			$servername = $server.SqlInstance
+
+			Write-Message -Level Verbose -Message "Connecting to $servername"
 			try {
 				$server = Connect-SqlInstance -SqlInstance $servername -SqlCredential $SqlCredential
 			}
 			catch {
-				Write-Warning "Can't connect to $server or access denied. Skipping."
-				continue
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $servername -Continue
 			}
-			
+
 			if (!(Test-SqlSa -SqlInstance $server)) {
-				Write-Error "Not a sysadmin on $server. Skipping."
-				$server.ConnectionContext.Disconnect()
-				continue
+				Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $currentServer -Continue
 			}
-			
+
 			if ($server.versionMajor -ge 13) {
-				
-				Write-Verbose "Server '$servername' supports Max DOP configuration per database."
-				
-				if (!$Database -and !$ExcludeDatabase) {
+				Write-Message -Level Verbose -Message "Server '$servername' supports Max DOP configuration per database."
+
+				if ((Test-Bound -Not -Parameter Database) -and (Test-Bound -Not -Parameter ExcludeDatabase)) {
 					#Set at instance level
 					$collection = $collection | Where-Object { $_.DatabaseMaxDop -eq "N/A" }
 				}
 				else {
 					$dbscopedconfiguration = $true
-					
-					if (!$AllDatabases -and $Database) {
-						
+
+					if ((Test-Bound -Not -Parameter AllDatabases) -and (Test-Bound -Parameter Database)) {
 						$collection = $collection | Where-Object { $_.Database -in $Database }
 					}
-					elseif (!$AllDatabases -and $ExcludeDatabase) {
+					elseif ((Test-Bound -Not -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
 						$collection = $collection | Where-Object { $_.Database -notin $ExcludeDatabase }
 					}
 					else {
-						if ($AllDatabases) {
+						if (Test-Bound -Parameter AllDatabases) {
 							$collection = $collection | Where-Object { $_.DatabaseMaxDop -ne "N/A" }
 						}
 						else {
@@ -176,43 +168,43 @@ function Set-DbaMaxDop {
 				}
 			}
 			else {
-				if ($database -or $AllDatabases) {
-					Write-Warning "Server '$servername' (v$($server.versionMajor)) does not support Max DOP configuration at the database level. Remember that this option is only available from SQL Server 2016 (v13). Run the command again without using database related parameters. Skipping."
-					Continue
+				if ((Test-Bound -Parameter database) -or (Test-Bound -Parameter AllDatabases)) {
+					Write-Message -Level Warning -Message "Server '$servername' (v$($server.versionMajor)) does not support Max DOP configuration at the database level. Remember that this option is only available from SQL Server 2016 (v13). Run the command again without using database related parameters. Skipping."
+                    Continue
 				}
 			}
-			
-			foreach ($row in $collection | Where-Object { $_.Instance -eq $servername }) {
+
+			foreach ($row in $collection | Where-Object { $_.SqlInstance -eq $servername }) {
 				if ($UseRecommended -and ($row.RecommendedMaxDop -eq $row.CurrentInstanceMaxDop) -and !($dbscopedconfiguration)) {
-					Write-Output "$servername is configured properly :) No change required."
+					Write-Message -Level Verbose -Message "$servername is configured properly. No change required."
 					Continue
 				}
-				
+
 				if ($UseRecommended -and ($row.RecommendedMaxDop -eq $row.DatabaseMaxDop) -and $dbscopedconfiguration) {
-					Write-Output "Database $($row.Database) on $servername is configured properly. No change required."
+					Write-Message -Level Verbose -Message "Database $($row.Database) on $servername is configured properly. No change required."
 					Continue
 				}
-				
+
 				$row.OldInstanceMaxDopValue = $row.CurrentInstanceMaxDop
-				
+
 				try {
 					if ($UseRecommended) {
 						if ($dbscopedconfiguration) {
 							$row.OldDatabaseMaxDopValue = $row.DatabaseMaxDop
-							
+
 							if ($resetDatabases) {
-								Write-Verbose "Changing $($row.Database) database max DOP to $($row.DatabaseMaxDop)."
+								Write-Message -Level Verbose -Message "Changing $($row.Database) database max DOP to $($row.DatabaseMaxDop)."
 								$server.Databases["$($row.Database)"].MaxDop = $row.DatabaseMaxDop
 							}
 							else {
-								Write-Verbose "Changing $($row.Database) database max DOP from $($row.DatabaseMaxDop) to $($row.RecommendedMaxDop)."
+								Write-Message -Level Verbose -Message "Changing $($row.Database) database max DOP from $($row.DatabaseMaxDop) to $($row.RecommendedMaxDop)."
 								$server.Databases["$($row.Database)"].MaxDop = $row.RecommendedMaxDop
 								$row.DatabaseMaxDop = $row.RecommendedMaxDop
 							}
-							
+
 						}
 						else {
-							Write-Verbose "Changing $server SQL Server max DOP from $($row.CurrentInstanceMaxDop) to $($row.RecommendedMaxDop)."
+							Write-Message -Level Verbose -Message "Changing $server SQL Server max DOP from $($row.CurrentInstanceMaxDop) to $($row.RecommendedMaxDop)."
 							$server.Configuration.MaxDegreeOfParallelism.ConfigValue = $row.RecommendedMaxDop
 							$row.CurrentInstanceMaxDop = $row.RecommendedMaxDop
 						}
@@ -220,18 +212,18 @@ function Set-DbaMaxDop {
 					else {
 						if ($dbscopedconfiguration) {
 							$row.OldDatabaseMaxDopValue = $row.DatabaseMaxDop
-							
-							Write-Verbose "Changing $($row.Database) database max DOP from $($row.DatabaseMaxDop) to $MaxDop."
+
+							Write-Message -Level Verbose -Message "Changing $($row.Database) database max DOP from $($row.DatabaseMaxDop) to $MaxDop."
 							$server.Databases["$($row.Database)"].MaxDop = $MaxDop
 							$row.DatabaseMaxDop = $MaxDop
 						}
 						else {
-							Write-Verbose "Changing $servername SQL Server max DOP from $($row.CurrentInstanceMaxDop) to $MaxDop."
+							Write-Message -Level Verbose -Message "Changing $servername SQL Server max DOP from $($row.CurrentInstanceMaxDop) to $MaxDop."
 							$server.Configuration.MaxDegreeOfParallelism.ConfigValue = $MaxDop
 							$row.CurrentInstanceMaxDop = $MaxDop
 						}
 					}
-					
+
 					if ($dbscopedconfiguration) {
 						if ($Pscmdlet.ShouldProcess($row.Database, "Setting max dop on database")) {
 							$server.Databases["$($row.Database)"].Alter()
@@ -242,7 +234,7 @@ function Set-DbaMaxDop {
 							$server.Configuration.Alter()
 						}
 					}
-					
+
 					$results += [pscustomobject]@{
 						ComputerName           = $server.NetName
 						InstanceName           = $server.ServiceName
@@ -256,16 +248,17 @@ function Set-DbaMaxDop {
 						OldInstanceMaxDopValue = $row.OldInstanceMaxDopValue
 					}
 				}
-				catch { Write-Error "Could not modify Max Degree of Parallelism for $server." }
+				catch {
+					Stop-Function -Message "Could not modify Max Degree of Parallelism for $server."  -ErrorRecord $_ -Target $server -Continue
+				}
 			}
-			
+
 			if ($dbscopedconfiguration) {
-				$results | Select-Object Instance, Database, OldDatabaseMaxDopValue, @{ name = "CurrentDatabaseMaxDopValue"; expression = { $_.DatabaseMaxDop } }
+				Select-DefaultView -InputObject $results -Property InstanceName, Database, OldDatabaseMaxDopValue, @{ name = "CurrentDatabaseMaxDopValue"; expression = { $_.DatabaseMaxDop } }
 			}
 			else {
-				$results | Select-Object Instance, OldInstanceMaxDopValue, CurrentInstanceMaxDop
+				Select-DefaultView -InputObject $results -Property InstanceName, OldInstanceMaxDopValue, CurrentInstanceMaxDop
 			}
 		}
 	}
 }
-

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -211,7 +211,9 @@ function Test-DbaMaxDop {
 					}
 				}
 			}
-			Select-DefaultView -InputObject $collection -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
 		}
 	}
+    end {
+        Select-DefaultView -InputObject $collection -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
+    }
 }

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -65,6 +65,7 @@ function Test-DbaMaxDop {
 			Get Max DOP setting for servers sql2016 with the recommended value. As the -Detailed switch was used will also show the 'NUMANodes' and 'NumberOfCores' of each instance. Because it is an 2016 instance will be shown 'InstanceVersion', 'Database' and 'DatabaseMaxDop' columns.
 	#>
 	[CmdletBinding()]
+	[OutputType([System.Collections.ArrayList])]
 	param (
 		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
 		[Alias("ServerInstance", "SqlServer", "SqlServers")]
@@ -166,7 +167,8 @@ function Test-DbaMaxDop {
 				}
 			}
 
-			$collection += [pscustomobject]@{
+			#$collection +=
+            [pscustomobject]@{
 				ComputerName          = $server.NetName
 				InstanceName          = $server.ServiceName
 				SqlInstance           = $server.DomainInstanceName
@@ -178,7 +180,7 @@ function Test-DbaMaxDop {
 				NUMANodes             = $numaNodes
 				NumberOfCores         = $numberOfCores
 				Notes                 = $notes
-			}
+			} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
 
 			# On SQL Server 2016 and higher, MaxDop can be set on a per-database level
 			if ($server.VersionMajor -ge 13) {
@@ -196,7 +198,8 @@ function Test-DbaMaxDop {
 
 					$dbmaxdop = $database.MaxDop
 
-					$collection += [pscustomobject]@{
+					#$collection +=
+                    [pscustomobject]@{
 						ComputerName          = $server.NetName
 						InstanceName          = $server.ServiceName
 						SqlInstance           = $server.DomainInstanceName
@@ -208,10 +211,9 @@ function Test-DbaMaxDop {
 						NUMANodes             = $numaNodes
 						NumberOfCores         = $numberOfCores
 						Notes                 = if ($dbmaxdop -eq 0) { "Will use CurrentInstanceMaxDop value" } else { "$notes" }
-					}
+					}  | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
 				}
 			}
-			Select-DefaultView -InputObject $collection -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
 		}
 	}
 }

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -211,9 +211,7 @@ function Test-DbaMaxDop {
 					}
 				}
 			}
+			Select-DefaultView -InputObject $collection -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
 		}
 	}
-    end {
-        Select-DefaultView -InputObject $collection -Property ComputerName, InstanceName, SqlInstance, Database, DatabaseMaxDop, CurrentInstanceMaxDop, RecommendedMaxDop, Notes
-    }
 }

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -54,24 +54,13 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Set-DbaMaxDop {
 	Context "Input validation" {
 		BeforeAll {
 			Mock Stop-Function { } -ModuleName dbatools
-			Mock Test-FunctionInterrupt { } -ModuleName dbatools
 		}
-		It "Should Call Stop-Function if instance lower than 2016 and try to apply configuration at database level" {
-			Set-DbaMaxDop -SqlInstance $script:instance1 -MaxDop 12 -Database $singledb | Should Be
+		It "Should Call Stop-Function. -Database, -AllDatabases and -ExcludeDatabase are mutually exclusive." {
+			Set-DbaMaxDop -SqlInstance $script:instance1 -MaxDop 12 -Database $singledb -AllDatabases -ExcludeDatabase "master" | Should Be
 		}
 		It "Validates that Stop Function Mock has been called" {
-			## Nope I have no idea why it's two either - RMS
 			$assertMockParams = @{
 				'CommandName'  = 'Stop-Function'
-				'Times'	       = 2
-				'Exactly'	   = $true
-				'Module'	   = 'dbatools'
-			}
-			Assert-MockCalled @assertMockParams
-		}
-		It "Validates that Test-FunctionInterrupt Mock has been called" {
-			$assertMockParams = @{
-				'CommandName'  = 'Test-FunctionInterrupt'
 				'Times'	       = 1
 				'Exactly'	   = $true
 				'Module'	   = 'dbatools'

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -1,0 +1,81 @@
+﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		$singledb = "dbatoolsci_singledb"
+		$dbs = "dbatoolsci_lildb", "dbatoolsci_testMaxDop", $singledb
+		$null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbs | Remove-DbaDatabase -Confirm:$false
+		$server = Connect-DbaInstance -SqlInstance $script:instance2
+		$server2 = Connect-DbaInstance -SqlInstance $script:instance1
+
+		foreach ($db in $dbs) {
+			$server.Query("CREATE DATABASE $db")
+			$server2.Query("CREATE DATABASE $db")
+		}
+
+	}
+	AfterAll {
+		# these for sure
+		Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbs | Remove-DbaDatabase -Confirm:$false
+		Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbs | Remove-DbaDatabase -Confirm:$false
+	}
+
+	Context "Apply to multiple instances" {
+		$results = Set-DbaMaxDop -SqlInstance $script:instance1, $script:instance2 -MaxDop 2
+		foreach ($result in $results) {
+			It 'Returns MaxDop 2 for each instance' {
+				$result.CurrentInstanceMaxDop | Should Be 2
+			}
+		}
+	}
+
+	Context "Connects to 2016+ instance and apply configuration to single database" {
+		$results = Set-DbaMaxDop -SqlInstance $script:instance2 -MaxDop 4 -Database $singledb
+		foreach ($result in $results) {
+			It 'Returns 4 for each database' {
+				$result.DatabaseMaxDop | Should Be 4
+			}
+		}
+	}
+
+	Context "Connects to 2016+ instance and apply configuration to multiple databases" {
+		$results = Set-DbaMaxDop -SqlInstance $script:instance2 -MaxDop 8 -Database $dbs
+		foreach ($result in $results) {
+			It 'Returns 8 for each database' {
+				$result.DatabaseMaxDop | Should Be 8
+			}
+		}
+	}
+}
+
+Describe "$commandname Unit Tests" -Tags "UnitTests", Set-DbaMaxDop {
+	Context "Input validation" {
+		BeforeAll {
+			Mock Stop-Function { } -ModuleName dbatools
+			Mock Test-FunctionInterrupt { } -ModuleName dbatools
+		}
+		It "Should Call Stop-Function if instance lower than 2016 and try to apply configuration at database level" {
+			Set-DbaMaxDop -SqlInstance $script:instance1 -MaxDop 12 -Database $singledb | Should Be
+		}
+		It "Validates that Stop Function Mock has been called" {
+			## Nope I have no idea why it's two either - RMS
+			$assertMockParams = @{
+				'CommandName'  = 'Stop-Function'
+				'Times'	       = 2
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+		It "Validates that Test-FunctionInterrupt Mock has been called" {
+			$assertMockParams = @{
+				'CommandName'  = 'Test-FunctionInterrupt'
+				'Times'	       = 1
+				'Exactly'	   = $true
+				'Module'	   = 'dbatools'
+			}
+			Assert-MockCalled @assertMockParams
+		}
+}

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -78,4 +78,5 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Set-DbaMaxDop {
 			}
 			Assert-MockCalled @assertMockParams
 		}
+	}
 }

--- a/tests/Test-DbaMaxDop.Tests.ps1
+++ b/tests/Test-DbaMaxDop.Tests.ps1
@@ -1,0 +1,46 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Connects to multiple instances" {
+        It 'Returns two rows relative to the instances' {
+            $results = Test-DbaMaxDop -SqlInstance $script:instance1, $script:instance2
+            ($results | Where-Object Database -eq "N/A").Count | Should Be 2
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+		$server = Connect-DbaInstance -SqlInstance $script:instance2
+		$db1 = "dbatoolsci_testMaxDop"
+		$server.Query("CREATE DATABASE $db1")
+		$needed = Get-DbaDatabase -SqlInstance $script:instance2 -Database $db1
+		$setupright = $true
+		if ($needed.Count -ne 1) {
+			$setupright = $false
+			it "has failed setup" {
+				Set-TestInconclusive -message "Setup failed"
+			}
+		}
+	}
+	AfterAll {
+		if (-not $appveyor) {
+			Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2 -Database $db1
+		}
+	}
+
+	Context "Command actually works on SQL Server 2016 or higher instances" {
+		$results = Test-DbaMaxDop -SqlInstance $script:instance2
+
+		It "Should have correct properties" {
+			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Database,DatabaseMaxDop,CurrentInstanceMaxDop,RecommendedMaxDop,Notes'.Split(',')
+            ($results.PSStandardMembers.DefaultDIsplayPropertySet.ReferencedPropertyNames | Select -Unique) | Sort-Object | Should Be ($ExpectedProps | Sort-Object)
+		}
+
+		It "Should have only one result for database name of $db1" {
+            @($results | Where-Object Database -eq $db1).Count | Should Be 1
+		}
+	}
+}

--- a/tests/Test-DbaMaxDop.Tests.ps1
+++ b/tests/Test-DbaMaxDop.Tests.ps1
@@ -36,7 +36,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
 		It "Should have correct properties" {
 			$ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Database,DatabaseMaxDop,CurrentInstanceMaxDop,RecommendedMaxDop,Notes'.Split(',')
-            ($results.PSStandardMembers.DefaultDIsplayPropertySet.ReferencedPropertyNames | Select -Unique) | Sort-Object | Should Be ($ExpectedProps | Sort-Object)
+			foreach ($result in $results) {
+				($result.PSStandardMembers.DefaultDIsplayPropertySet.ReferencedPropertyNames | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+			}
 		}
 
 		It "Should have only one result for database name of $db1" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Fix problem with `Set-DbaMaxDop` reported by @snarp on the slack channel: `WARNING: Can't connect to @{Instance=} or access denied. Skipping.`
- Added tests to `Set-DbaMaxDop`
- Change the way Test-DbaMaxDop outputs. Now output as soon as we create the object. Before if we pass two instances the results contain duplicate rows.
- Added tests to `Test-DbaMaxDop`