### PR TITLE
fixed handling of query text and query plan field in DbaDiagnosticQuery and Export

### DIFF
--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -63,7 +63,7 @@ function Export-DbaDiagnosticQuery {
 		[string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
         [switch]$NoPlanExport,
         [switch]$NoQueryExport,
-		[switch][Alias('Silent')]$EnableException = $false
+		[switch][Alias('Silent')]$EnableException
 	)
 	
 	begin {

--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -63,7 +63,7 @@ function Export-DbaDiagnosticQuery {
 		[string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
         [switch]$NoPlanExport,
         [switch]$NoQueryExport,
-		[switch][Alias('Silent')]$EnableException
+		[switch][Alias('Silent')]$EnableException = $false
 	)
 	
 	begin {
@@ -126,9 +126,11 @@ function Export-DbaDiagnosticQuery {
 			$csvdbfilename = "$Path\$SqlInstance-$dbname-DQ-$number-$queryname-$Suffix.csv"
 			$csvfilename = "$Path\$SqlInstance-DQ-$number-$queryname-$Suffix.csv"
 
-            if (($result | Get-Member | Where-Object Name -eq "Query Plan").Count -gt 0) {
+            $columnnameoptions = "Query Plan", "QueryPlan", "Query_Plan"
+            if (($result | Get-Member | Where-Object Name -in $columnnameoptions).Count -gt 0) {
                 $plannr = 0
-                foreach ($plan in $result."Query Plan") {
+                $columnname = ($result | Get-Member | Where-Object Name -In $columnnameoptions).Name
+                   foreach ($plan in $result."$columname") {
                     $plannr += 1
                     if ($row.DatabaseSpecific) {
                         $planfilename = "$Path\$SqlInstance-$dbname-DQ-$number-$queryname-$plannr-$Suffix.sqlplan"
@@ -144,12 +146,14 @@ function Export-DbaDiagnosticQuery {
                     }
                 }
 
-                $result = $result | Select-Object * -ExcludeProperty "Query Plan"
+                $result = $result | Select-Object * -ExcludeProperty "$columnname"
             }
 
-            if (($result | Get-Member | Where-Object Name -eq "Complete Query Text").Count -gt 0) {
+            $columnnameoptions = "Complete Query Text", "QueryText", "Query Text", "Query_Text"
+            if (($result | Get-Member | Where-Object Name -In $columnnameoptions ).Count -gt 0) {
                 $sqlnr = 0
-                foreach ($sql in $result."Complete Query Text") {
+                $columnname = ($result | Get-Member | Where-Object Name -In $columnnameoptions).Name
+                foreach ($sql in $result."$columnname") {
                     $sqlnr += 1
                     if ($row.DatabaseSpecific) {
                         $sqlfilename = "$Path\$SqlInstance-$dbname-DQ-$number-$queryname-$sqlnr-$Suffix.sql"
@@ -165,7 +169,7 @@ function Export-DbaDiagnosticQuery {
                     }
                 }
 
-                $result = $result | Select-Object * -ExcludeProperty "Complete Query Text"
+                $result = $result | Select-Object * -ExcludeProperty "$columnname"
             }
 
 			switch ($ConvertTo) {

--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -38,6 +38,15 @@ Run only instance level queries
 
 .PARAMETER DatabaseSpecific
 Run only database level queries
+
+.PARAMETER NoQueryTextColumn
+Use this switch to exclude the [Complete Query Text] column from relevant queries
+
+.PARAMETER NoPlanColumn
+Use this switch to exclude the [Query Plan] column from relevant queries
+
+.PARAMETER NoColumnParsing
+Does not parse the [Complete Query Text] and [Query Plan] columns and disregards the NoQueryTextColumn and NoColumnParsing switches	
 	
 .PARAMETER EnableException
 		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -86,6 +95,9 @@ Then it will export the results to Export-DbaDiagnosticQuery.
 		[switch]$UseSelectionHelper,
 		[switch]$InstanceOnly,
 		[switch]$DatabaseSpecific,
+        [Switch]$NoQueryTextColumn,
+        [Switch]$NoPlanColumn,
+        [Switch]$NoColumnParsing,
 		[switch][Alias('Silent')]
 		$EnableException
 	)
@@ -137,7 +149,7 @@ Then it will export the results to Export-DbaDiagnosticQuery.
 		
 		foreach ($file in $scriptfiles) {
 			if ($file.BaseName.Split("_")[2] -eq $currentdate) {
-				$parsedscript = Invoke-DbaDiagnosticQueryScriptParser -filename $file.fullname
+				$parsedscript = Invoke-DbaDiagnosticQueryScriptParser -filename $file.fullname -NoQueryTextColumn:$NoQueryTextColumn -NoPlanColumn:$NoPlanColumn -NoColumnParsing:$NoColumnParsing
 				
 				$newscript = [pscustomobject]@{
 					Version  = $file.Basename.Split("_")[1]

--- a/internal/Invoke-DbaDiagnosticQueryScriptParser.ps1
+++ b/internal/Invoke-DbaDiagnosticQueryScriptParser.ps1
@@ -1,58 +1,81 @@
-﻿function Invoke-DbaDiagnosticQueryScriptParser {
-	[CmdletBinding(DefaultParameterSetName = "Default")]
+﻿function Invoke-DbaDiagnosticQueryScriptParser
+{
+[CmdletBinding(DefaultParameterSetName="Default")] 
 
-	param(
-		[parameter(Mandatory = $true)]
-		[ValidateScript( {Test-Path $_})]
-		[System.IO.FileInfo]$filename
-	)
+Param(
+    [parameter(Mandatory = $true)]
+    [ValidateScript({Test-Path $_})]
+    [System.IO.FileInfo]$filename,
+    [Switch]$NoQueryTextColumn,
+    [Switch]$NoPlanColumn,
+    [Switch]$NoColumnParsing
+    )
 
-	$out = "Parsing file {0}" -f $filename
-	Write-Message -Level Verbose -Message $out
+    $out = "Parsing file {0}"-f $filename
+    write-verbose -Message $out
 
-	$ParsedScript = @()
-	[string]$scriptpart = ""
+    $ParsedScript = @()
+    [string]$scriptpart = ""
 
-	$fullscript = Get-Content -Path $filename
+    $fullscript = Get-Content -Path $filename
 
-	$start = $false
-	$querynr = 0
-	$DBSpecific = $false
+    $start = $false
+    $querynr = 0
+    $DBSpecific = $false
 
-	foreach ($line in $fullscript) {
-		if ($start -eq $false) {
-			if ($line -match "You have the correct major version of SQL Server for this diagnostic information script") {
-				$start = $true
-			}
-			continue
-		}
+    if ($NoQueryTextColumn) {$QueryTextColumn = ""}  else {$QueryTextColumn = ", t.[text] AS [Complete Query Text]"}
+    if ($NoPlanColumn) {$PlanTextColumn = ""} else {$PlanTextColumn = ", qp.query_plan AS [Query Plan]"}
 
-		if ($line.StartsWith("-- Database specific queries ***") -or ($line.StartsWith("-- Switch to user database **"))) {
-			$DBSpecific = $true
-		}
+    foreach($line in $fullscript)
+    {
+        if ($start -eq $false)
+        {
+            if ($line -match "You have the correct major version of SQL Server for this diagnostic information script")
+            {
+                $start = $true
+            }
+            continue
+        }
 
-		if ($line -match "-{2,}\s{1,}(.*) \(Query (\d*)\) \((\D*)\)") {
-			$prev_querydescription = $Matches[1]
-			$prev_querynr = $Matches[2]
-			$prev_queryname = $Matches[3]
+        if ($line.StartsWith("-- Database specific queries ***") -or ($line.StartsWith("-- Switch to user database **")))
+        {
+            $DBSpecific = $true
+        }
 
-			if ($querynr -gt 0) {
-				$properties = @{QueryNr = $querynr; QueryName = $queryname; DBSpecific = $DBSpecific; Description = $queryDescription; Text = $scriptpart}
-				$newscript = New-Object -TypeName PSObject -Property $properties
-				$ParsedScript += $newscript
-				$scriptpart = ""
-			}
+        if (!$NoColumnParsing)
+        {
+            if (($line -match "-- uncomment out these columns if not copying results to Excel") -or ($line -match "-- comment out this column if copying results to Excel"))
+            {
+                $line = $QueryTextColumn + $PlanTextColumn
+            }  
+        }
 
-			$querydescription = $prev_querydescription
-			$querynr = $prev_querynr
-			$queryname = $prev_queryname
-		}
-		else {
-			if (!$line.startswith("--") -and ($line.trim() -ne "") -and ($null -ne $line) -and ($line -ne "\n")) {
-				$scriptpart += $line + "`n"
-			}
-		}
-	}
+        if ($line -match "-{2,}\s{1,}(.*) \(Query (\d*)\) \((\D*)\)")
+        {
+            $prev_querydescription = $Matches[1]
+            $prev_querynr = $Matches[2]
+            $prev_queryname = $Matches[3]
 
-	$ParsedScript
+            if ($querynr -gt 0)
+            {
+                $properties = @{QueryNr = $querynr; QueryName = $queryname; DBSpecific = $DBSpecific; Description = $queryDescription; Text = $scriptpart}
+                $newscript = New-Object -TypeName PSObject -Property $properties
+                $ParsedScript += $newscript
+                $scriptpart = ""
+            }
+
+            $querydescription = $prev_querydescription 
+            $querynr = $prev_querynr 
+            $queryname = $prev_queryname
+        }
+        else
+        {
+            if (!$line.startswith("--") -and ($line.trim() -ne "") -and ($null -ne $line) -and ($line -ne "\n"))
+            {
+                $scriptpart += $line + "`n"           
+            }
+        }
+    }
+
+    $ParsedScript
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes (no issue nr available)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Glenn Berry uses different names for the query text columns and query plan columns in the various sql statements. (sql text, sql_text, sqltext) etc. I'm now catching all options.
This fixes the export to excel. It now no longer tries to put the query text and query plans in Excel but saves them as separate .sql and .sqlplan files. 

I've also changed the parsing of the scripts a bit. Glenn commented out the columns mentioned above in some queries (not all, some had a comment that they should be commented out). I'm uncommenting the columns while parsing so they are alwasys included in the result set. When exporting to Excel I'm making sure they are saved in their own files.
I've also included switches to skip exporting to .sql and / or .sqlplan files
And I've created a switch which will not parse those columns in case someone has specific wishes regarding the result sets and want's me te not touch that.

### Commands to test

 Invoke-DbaDiagnosticQuery -SqlInstance localhost\sql2016 -QueryName "Ad hoc Queries" | Export-DbaDiagnosticQuery -ConvertTo Excel -Path C:\temp

(This breaks without this fix because the column name for the query text is not what I expected)

-NoQueryExport should skip creation of .sql files

(The export to Excel relies on the importexcel module!)
