### PR TITLE
Fix error trying to remove schema when not exists.

### DIFF
--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -1,5 +1,5 @@
 function Remove-DbaOrphanUser {
-	<#
+    <#
 		.SYNOPSIS
 			Drop orphan users with no existing login to map
 
@@ -91,263 +91,263 @@ function Remove-DbaOrphanUser {
 			Removes user OrphanUser from all databases even if they have a matching Login. Any schema that the user owns will change ownership to dbo.
 
 	#>
-	[CmdletBinding(SupportsShouldProcess = $true)]
-	Param (
-		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[Alias("Credential")]
-		[PSCredential]
-		$SqlCredential,
-		[Alias("Databases")]
-		[object[]]$Database,
-		[object[]]$ExcludeDatabase,
-		[parameter(Mandatory = $false, ValueFromPipeline = $true)]
-		[object[]]$User,
-		[switch]$Force,
-		[switch][Alias('Silent')]$EnableException
-	)
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    Param (
+        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [Alias("Credential")]
+        [PSCredential]
+        $SqlCredential,
+        [Alias("Databases")]
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [object[]]$User,
+        [switch]$Force,
+        [switch][Alias('Silent')]$EnableException
+    )
 
-	process {
+    process {
 
-		foreach ($Instance in $SqlInstance) {
-			Write-Message -Level Verbose -Message "Attempting to connect to $Instance."
-			try {
-				$server = Connect-SqlInstance -SqlInstance $Instance -SqlCredential $SqlCredential
-			}
-			catch {
-				Write-Message -Level Warning -Message "Can't connect to $Instance or access denied. Skipping."
-				continue
-			}
+        foreach ($Instance in $SqlInstance) {
+            Write-Message -Level Verbose -Message "Attempting to connect to $Instance."
+            try {
+                $server = Connect-SqlInstance -SqlInstance $Instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Write-Message -Level Warning -Message "Can't connect to $Instance or access denied. Skipping."
+                continue
+            }
 
-			if (!$Database) {
-				$databases = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true }
-			}
-			else {
-				if ($pipedatabase) {
-					$Source = $pipedatabase[0].parent.name
-					$databases = $pipedatabase.name
-				}
-				else {
-					$databases = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true -and ($Database -contains $_.Name) }
-				}
-			}
+            if (!$Database) {
+                $databases = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true }
+            }
+            else {
+                if ($pipedatabase) {
+                    $Source = $pipedatabase[0].parent.name
+                    $databases = $pipedatabase.name
+                }
+                else {
+                    $databases = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true -and ($Database -contains $_.Name) }
+                }
+            }
 
-			if ($ExcludeDatabase) {
-				$databases = $server.Databases | Where-Object {$_.Name -notin $ExcludeDatabase -and $_.IsAccessible -eq $true -and $_.IsSystemObject -eq $false }
-			}
+            if ($ExcludeDatabase) {
+                $databases = $server.Databases | Where-Object {$_.Name -notin $ExcludeDatabase -and $_.IsAccessible -eq $true -and $_.IsSystemObject -eq $false }
+            }
 
-			$CallStack = Get-PSCallStack | Select-Object -Property *
-			if ($CallStack.Count -eq 1) {
-				$StackSource = $CallStack[0].Command
-			}
-			else {
-				#-2 because index base is 0 and we want the one before the last (the last is the actual command)
-				$StackSource = $CallStack[($CallStack.Count - 2)].Command
-			}
+            $CallStack = Get-PSCallStack | Select-Object -Property *
+            if ($CallStack.Count -eq 1) {
+                $StackSource = $CallStack[0].Command
+            }
+            else {
+                #-2 because index base is 0 and we want the one before the last (the last is the actual command)
+                $StackSource = $CallStack[($CallStack.Count - 2)].Command
+            }
 
-			if ($databases) {
-				$start = [System.Diagnostics.Stopwatch]::StartNew()
+            if ($databases) {
+                $start = [System.Diagnostics.Stopwatch]::StartNew()
 
-				foreach ($db in $databases) {
-					try {
-						#if SQL 2012 or higher only validate databases with ContainmentType = NONE
-						if ($server.versionMajor -gt 10) {
-							if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None) {
-								Write-Message -Level Warning -Message "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
-								Continue
-							}
-						}
+                foreach ($db in $databases) {
+                    try {
+                        #if SQL 2012 or higher only validate databases with ContainmentType = NONE
+                        if ($server.versionMajor -gt 10) {
+                            if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None) {
+                                Write-Message -Level Warning -Message "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
+                                Continue
+                            }
+                        }
 
-						if ($StackSource -eq "Repair-DbaOrphanUser") {
-							Write-Message -Level Verbose -Message "Call origin: Repair-DbaOrphanUser."
-							#Will use collection from parameter ($User)
-						}
-						else {
-							Write-Message -Level Verbose -Message "Validating users on database $db."
+                        if ($StackSource -eq "Repair-DbaOrphanUser") {
+                            Write-Message -Level Verbose -Message "Call origin: Repair-DbaOrphanUser."
+                            #Will use collection from parameter ($User)
+                        }
+                        else {
+                            Write-Message -Level Verbose -Message "Validating users on database $db."
 
-							if ($User.Count -eq 0) {
-								#the third validation will remove from list sql users without login. The rule here is Sid with length higher than 16
-								$User = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
-							}
-							else {
-								if ($pipedatabase) {
-									$Source = $pipedatabase[0].parent.name
-									$User = $pipedatabase.name
-								}
-								else {
-									#the fourth validation will remove from list sql users without login. The rule here is Sid with length higher than 16
-									$User = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($User -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
-								}
-							}
-						}
+                            if ($User.Count -eq 0) {
+                                #the third validation will remove from list sql users without login. The rule here is Sid with length higher than 16
+                                $User = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
+                            }
+                            else {
+                                if ($pipedatabase) {
+                                    $Source = $pipedatabase[0].parent.name
+                                    $User = $pipedatabase.name
+                                }
+                                else {
+                                    #the fourth validation will remove from list sql users without login. The rule here is Sid with length higher than 16
+                                    $User = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($User -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
+                                }
+                            }
+                        }
 
-						if ($User.Count -gt 0) {
-							Write-Message -Level Verbose -Message "Orphan users found."
-							foreach ($dbuser in $User) {
-								$SkipUser = $false
+                        if ($User.Count -gt 0) {
+                            Write-Message -Level Verbose -Message "Orphan users found."
+                            foreach ($dbuser in $User) {
+                                $SkipUser = $false
 
-								$ExistLogin = $null
+                                $ExistLogin = $null
 
-								if ($StackSource -ne "Repair-DbaOrphanUser") {
-									#Need to validate Existing Login because the call does not came from Repair-DbaOrphanUser
-									$ExistLogin = $server.logins | Where-Object {
-										$_.Isdisabled -eq $False -and
-										$_.IsSystemObject -eq $False -and
-										$_.IsLocked -eq $False -and
-										$_.Name -eq $dbuser.Name
-									}
-								}
+                                if ($StackSource -ne "Repair-DbaOrphanUser") {
+                                    #Need to validate Existing Login because the call does not came from Repair-DbaOrphanUser
+                                    $ExistLogin = $server.logins | Where-Object {
+                                        $_.Isdisabled -eq $False -and
+                                        $_.IsSystemObject -eq $False -and
+                                        $_.IsLocked -eq $False -and
+                                        $_.Name -eq $dbuser.Name
+                                    }
+                                }
 
-								#Schemas only appears on SQL Server 2005 (v9.0)
-								if ($server.versionMajor -gt 8) {
+                                #Schemas only appears on SQL Server 2005 (v9.0)
+                                if ($server.versionMajor -gt 8) {
 
-									#Validate if user owns any schema
-									$Schemas = @()
+                                    #reset variables
+                                    $AlterSchemaOwner = ""
+                                    $DropSchema = ""
 
-									$Schemas = $db.Schemas | Where-Object Owner -eq $dbuser.Name
+                                    #Validate if user owns any schema
+                                    $Schemas = @()
+                                    $Schemas = $db.Schemas | Where-Object Owner -eq $dbuser.Name
 
-									if (@($Schemas).Count -gt 0) {
-										Write-Message -Level Verbose -Message "User $dbuser owns one or more schemas."
+                                    if (@($Schemas).Count -gt 0) {
+                                        Write-Message -Level Verbose -Message "User $dbuser owns one or more schemas."
 
-										$AlterSchemaOwner = ""
-										$DropSchema = ""
-
-										foreach ($sch in $Schemas) {
-											<#
+                                        foreach ($sch in $Schemas) {
+                                            <#
 												On sql server 2008 or lower the EnumObjects method does not accept empty parameter.
 												0x1FFFFFFF is the way we can say we want everything known by those versions
 
 												When it is an higher version we can use empty to get all
 											#>
-											if ($server.versionMajor -lt 11) {
-												$NumberObjects = ($db.EnumObjects(0x1FFFFFFF) | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
-											}
-											else {
-												$NumberObjects = ($db.EnumObjects() | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
-											}
+                                            if ($server.versionMajor -lt 11) {
+                                                $NumberObjects = ($db.EnumObjects(0x1FFFFFFF) | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
+                                            }
+                                            else {
+                                                $NumberObjects = ($db.EnumObjects() | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
+                                            }
 
-											if ($NumberObjects -gt 0) {
-												if ($Force) {
-													Write-Message -Level Verbose -Message "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
+                                            if ($NumberObjects -gt 0) {
+                                                if ($Force) {
+                                                    Write-Message -Level Verbose -Message "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
 
-													if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used.")) {
-														$AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used.")) {
+                                                        $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
-														[pscustomobject]@{
-															Instance          = $server.Name
-															Database          = $db.Name
-															SchemaName        = $sch.Name
-															Action            = "ALTER OWNER"
-															SchemaOwnerBefore = $sch.Owner
-															SchemaOwnerAfter  = "dbo"
-														}
-													}
-												}
-												else {
-													Write-Message -Level Warning -Message "Schema '$($sch.Name)' owned by user $($dbuser.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$dbuser'."
-													$SkipUser = $true
-													break
-												}
-											}
-											else {
-												if ($sch.Name -eq $dbuser.Name) {
-													Write-Message -Level Verbose -Message "The schema '$($sch.Name)' have the same name as user $dbuser. Schema will be dropped."
+                                                        [pscustomobject]@{
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "ALTER OWNER"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "dbo"
+                                                        }
+                                                    }
+                                                }
+                                                else {
+                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' owned by user $($dbuser.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$dbuser'."
+                                                    $SkipUser = $true
+                                                    break
+                                                }
+                                            }
+                                            else {
+                                                if ($sch.Name -eq $dbuser.Name) {
+                                                    Write-Message -Level Verbose -Message "The schema '$($sch.Name)' have the same name as user $dbuser. Schema will be dropped."
 
-													if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'.")) {
-														$DropSchema += "DROP SCHEMA [$($sch.Name)]"
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'.")) {
+                                                        $DropSchema += "DROP SCHEMA [$($sch.Name)]"
 
-														[pscustomobject]@{
-															Instance          = $server.Name
-															Database          = $db.Name
-															SchemaName        = $sch.Name
-															Action            = "DROP"
-															SchemaOwnerBefore = $sch.Owner
-															SchemaOwnerAfter  = "N/A"
-														}
-													}
-												}
-												else {
-													Write-Message -Level Warning -Message "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
+                                                        [pscustomobject]@{
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "DROP"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "N/A"
+                                                        }
+                                                    }
+                                                }
+                                                else {
+                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
 
-													if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'.")) {
-														$AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
+                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'.")) {
+                                                        $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
-														[pscustomobject]@{
-															Instance          = $server.Name
-															Database          = $db.Name
-															SchemaName        = $sch.Name
-															Action            = "ALTER OWNER"
-															SchemaOwnerBefore = $sch.Owner
-															SchemaOwnerAfter  = "dbo"
-														}
-													}
-												}
-											}
-										}
+                                                        [pscustomobject]@{
+                                                            Instance          = $server.Name
+                                                            Database          = $db.Name
+                                                            SchemaName        = $sch.Name
+                                                            Action            = "ALTER OWNER"
+                                                            SchemaOwnerBefore = $sch.Owner
+                                                            SchemaOwnerAfter  = "dbo"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
 
-									}
-									else {
-										Write-Message -Level Verbose -Message "User $dbuser does not own any schema. Will be dropped."
-									}
+                                    }
+                                    else {
+                                        Write-Message -Level Verbose -Message "User $dbuser does not own any schema. Will be dropped."
+                                    }
 
-									$query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbuser
+                                    $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbuser
 
-									Write-Message -Level Debug -Message $query
-								}
-								else {
-									$query = "EXEC master.dbo.sp_droplogin @loginame = N'$($dbuser.name)'"
-								}
+                                    Write-Message -Level Debug -Message $query
+                                }
+                                else {
+                                    $query = "EXEC master.dbo.sp_droplogin @loginame = N'$($dbuser.name)'"
+                                }
 
-								if ($ExistLogin) {
-									if (-not $SkipUser) {
-										if ($Force) {
-											if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser using -Force")) {
-												$server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-												Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name). -Force parameter was used!"
-											}
-										}
-										else {
-											Write-Message -Level Warning -Message "Orphan user $($dbuser.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
-											Continue
-										}
-									}
-								}
-								else {
-									if (-not $SkipUser) {
-										if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
-											$server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-											Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
-										}
-									}
-								}
-							}
-						}
-						else {
-							Write-Message -Level Verbose -Message "No orphan users found on database $db."
-						}
-						#reset collection
-						$User = $null
-					}
-					catch {
-						Stop-Function -Message "Failure" -ErrorRecord $_ -Target $db -Continue
-					}
-				}
-			}
-			else {
-				Write-Message -Level Verbose -Message "There are no databases to analyse."
-			}
-		}
-	}
-	end {
+                                if ($ExistLogin) {
+                                    if (-not $SkipUser) {
+                                        if ($Force) {
+                                            if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser using -Force")) {
+                                                $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                                Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name). -Force parameter was used!"
+                                            }
+                                        }
+                                        else {
+                                            Write-Message -Level Warning -Message "Orphan user $($dbuser.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
+                                            Continue
+                                        }
+                                    }
+                                }
+                                else {
+                                    if (-not $SkipUser) {
+                                        if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
+                                            $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                            Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else {
+                            Write-Message -Level Verbose -Message "No orphan users found on database $db."
+                        }
+                        #reset collection
+                        $User = $null
+                    }
+                    catch {
+                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $db -Continue
+                    }
+                }
+            }
+            else {
+                Write-Message -Level Verbose -Message "There are no databases to analyse."
+            }
+        }
+    }
+    end {
 
-		$totaltime = $start.Elapsed
+        $totaltime = $start.Elapsed
 
-		#If the call don't come from Repair-DbaOrphanUser function, show elapsed time
-		if ($StackSource -ne "Repair-DbaOrphanUser") {
-			Write-Message -Level Verbose -Message "Total Elapsed time: $totaltime"
-		}
+        #If the call don't come from Repair-DbaOrphanUser function, show elapsed time
+        if ($StackSource -ne "Repair-DbaOrphanUser") {
+            Write-Message -Level Verbose -Message "Total Elapsed time: $totaltime"
+        }
 
-		Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Remove-SqlOrphanUser
-	}
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Remove-SqlOrphanUser
+    }
 }


### PR DESCRIPTION
This happens in special cases where exists schemas with the same name that the (user) owner.

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2754)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix #2754

### Approach
I was able to reproduce the issue.
Two variable reset need to happen outside the if.