### PR TITLE
better regex for splitting paths from string in Get-DbaStartupParameter

### DIFF
--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -156,9 +156,9 @@ function Get-DbaStartupParameter {
 							ComputerName         = $computerName
 							InstanceName         = $instanceName
 							SqlInstance          = $ogInstance
-							MasterData           = $masterdata.TrimStart('-d')
-							MasterLog            = $masterlog.TrimStart('-l')
-							ErrorLog             = $errorlog.TrimStart('-e')
+							MasterData           = $masterdata -replace '^-[dD]',''
+							MasterLog            = $masterlog -replace '^-[lL]',''
+							ErrorLog             = $errorlog -replace '^-[eE]',''
 							TraceFlags           = $traceflags -join ','
 							CommandPromptStart   = $commandprompt
 							MinimalStart         = $minimalstart


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>  )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable --### Purposes 
Fixes a bug where people with errorlog on e:\\ masterdata on d:\\ or masterlog on l:\\ would get bad results 

### Approach
Switched for another replace option

Using -replace rather than .replace so I can use a regexp

