### PR TITLE
Restore VerifyOnly working as it once did again.

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -146,7 +146,7 @@ Function Invoke-DbaAdvancedRestore{
         $Databases  = $InternalHistory.Database | select-Object -unique
         ForEach ($Database in $Databases){
             If ($Database -in $Server.databases.name) {
-                if (($ScriptOnly -eq $true) -or ($verifyonly -ne $true)) {
+                if (($ScriptOnly -ne $true) -or ($verifyonly -ne $true)) {
                     if ($Pscmdlet.ShouldProcess("Killing processes in $Database on $SqlInstance as it exists and WithReplace specified  `n", "Cannot proceed if processes exist, ", "Database Exists and WithReplace specified, need to kill processes to restore")) {
                         try {
                             Write-Message -Level Verbose -Message "Set $Database single_user to kill processes"

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -606,8 +606,8 @@ function Restore-DbaDatabase {
             if ($StopAfterFormatBackupInformation){
                 return
             }
-            
-            $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance  -WithReplace:$WithReplace -Continue:$Continue
+            Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
+            $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance  -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly
             
             if ( Test-Bound -ParameterName TestBackupInformation){
                 Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -46,7 +46,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should return successful restore" {
             $results.RestoreComplete | Should Be $true
         }
-	}
+    }
+    
+    Context "Test VerifyOnly works with db in existance" {
+        $results = Get-ChildItem $script:appveyorlabrepo\singlerestore\singlerestore.bak | Restore-DbaDatabase -SqlInstance $script:instance1  -VerifyOnly
+        It "Should have verified Successfully" {
+            $results[0] | Should Be "Verify successful"
+        }
+    }
 	
 	Get-DbaProcess $script:instance1 -NoSystemSpid | Stop-DbaProcess -WarningVariable warn -WarningAction SilentlyContinue
     Context "Database is properly removed again after gci tests" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2857 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
VerifyOnly wasn't propagating through the new pipeline

### Approach
Added the correct 'skips' as it doesn't matter if the files/db exist for a verify as it's only a logical test.
