### PR TITLE
Fix Get-DbaADObject domain resolution issue

### DIFF
--- a/internal/Get-DbaADObject.ps1
+++ b/internal/Get-DbaADObject.ps1
@@ -118,7 +118,7 @@ Function Get-DbaADObject {
 		function Get-DbaADObjectInternal($Domain, $IdentityType, $obj, $EnableException) {
 			try {
 				# can we simply resolve the passed domain ? This has the benefit of raising almost instantly if the domain is not valid
-				$null = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('Domain', $Domain)
+				$Context = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('Domain', $Domain)
 				$null = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($Context)
 				if ($Credential) {
 					$ctx = New-Object System.DirectoryServices.AccountManagement.PrincipalContext('Domain', $Domain, $Credential.UserName, $Credential.GetNetworkCredential().Password)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2861 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix domain resolution issue with `Get-DbaADObject`.

### Approach
<!-- How does this change solve that purpose -->
The result of the first line is passed to the second - previously, the first line's result was being assigned to `$null` and would cause this to throw.
```powershell
$Context = New-Object System.DirectoryServices.ActiveDirectory.DirectoryContext('Domain', $Domain)
$null = [System.DirectoryServices.ActiveDirectory.Domain]::GetDomain($Context)
```

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```powershell
Test-DbaSpn <servername> # this would issue a warning about AD lookup failing previously
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
