### PR TITLE
Update gitignore - Visual Studio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dbatools-exceptions.txt
 *.psproj
 dbatools.psprojs
 
+# ignore the settings folder and files for Visual Studio
+.vs/*
+
 # VIM backup files
 *~
 
@@ -16,3 +19,4 @@ msbuild.log
 
 # Local constant file
 tests/constants.local.ps1
+


### PR DESCRIPTION
Adding ignore of the `.vs` folder created when you use Visual Studio with PowerShell projects. This is similar to the `.vscode` directory used by VS Code.
