### PR TITLE
New commands AgentJobCategory fixes #561 #2887

### DIFF
--- a/functions/Get-DbaAgentJobCategory.ps1
+++ b/functions/Get-DbaAgentJobCategory.ps1
@@ -1,0 +1,132 @@
+function Get-DbaAgentJobCategory {
+	<#
+.SYNOPSIS 
+Get-DbaAgentJobCategory retrieves the job categories
+
+.DESCRIPTION
+Get-DbaAgentJobCategory makes is possible to retrieve the job categories.
+
+.PARAMETER SqlInstance
+SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+
+.PARAMETER SqlCredential
+Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
+To connect as a different Windows user, run PowerShell as that user.
+
+.PARAMETER Category
+The name of the category to filter out. If no category is used all catgories will be returned.
+
+.PARAMETER CategoryType
+The type of category. This can be "LocalJob", "MultiServerJob" or "None".
+If no category is used all catgories types will be returned.
+
+.PARAMETER Force
+The force parameter will ignore some errors in the parameters and assume defaults.
+
+.PARAMETER WhatIf 
+Shows what would happen if the command were to run. No actions are actually performed. 
+
+.PARAMETER Confirm 
+Prompts you for confirmation before executing any changing operations within the command. 
+
+.PARAMETER EnableException 
+		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+		
+.NOTES 
+Author: Sander Stad (@sqlstad, sqlstad.nl)
+Tags: Agent, Job, Job Category
+	
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+.LINK
+https://dbatools.io/Get-DbaAgentJobCategory
+
+.EXAMPLE   
+Get-DbaAgentJobCategory -SqlInstance sql1
+
+Return all the job categories
+
+.EXAMPLE
+Get-DbaAgentJobCategory -SqlInstance sql1 -Category 'Log Shipping'
+
+Return all the job categories that have the name 'Log Shipping'
+
+.EXAMPLE
+Get-DbaAgentJobCategory -SqlInstance sstad-pc -CategoryType MultiServerJob
+
+Return all the job categories that have a type MultiServerJob
+
+#>
+	[CmdletBinding(DefaultParameterSetName = "Default")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Parameter(Mandatory = $false)]
+		[ValidateNotNullOrEmpty()]
+		[string[]]$Category,
+		[ValidateSet("LocalJob", "MultiServerJob", "None")]
+		[string]$CategoryType,
+		[switch]$Force,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	process {
+
+		foreach ($instance in $SqlInstance) {
+			try {
+				Write-Message -Level Verbose -Message "Connecting to $instance."
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			# get all the job categories
+			$jobCategories = $server.JobServer.JobCategories |
+				Where-Object {
+				($_.Name -in $Category -or !$Category) -and
+				($_.CategoryType -in $CategoryType -or !$CategoryType)
+			}
+
+			# Set the default output 
+			$defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'ID', 'CategoryType', 'JobCount'
+
+			# Loop through each of the categories
+			try {
+				foreach ($cat in $jobCategories) {
+
+					# Get the jobs associated with the category
+					$jobCount = ($server.JobServer.Jobs | Where-Object {$_.CategoryID -eq $cat.ID}).Count
+
+					# Add new properties to the category object
+					Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name ComputerName -value $server.NetName
+					Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+					Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+					Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name JobCount -Value $jobCount
+
+					# Show the result
+					Select-DefaultView -InputObject $cat -Property $defaults
+				}
+			} 
+			catch {
+				Stop-Function -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified" -Continue
+			}
+
+		} # for each instance
+
+	} # end process
+
+	end {
+		if (Test-FunctionInterrupt) { return }
+		Write-Message -Message "Finished retrieving job category." -Level Verbose
+	}
+
+
+}

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -298,7 +298,8 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 						}
 					}
 					else {
-						Stop-Function -Message "Job category $Category doesn't exist on $instance. Use -Force to create it." -Target $instance -Continue
+						Stop-Function -Message "Job category $Category doesn't exist on $instance. Use -Force to create it." -Target $instance 
+						return
 					}
 				}
 				else {

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -48,12 +48,12 @@ License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 https://dbatools.io/New-DbaAgentJobCategory
 
 .EXAMPLE   
-New-DbaAgentJobCategory -SqlInstance sstad-pc -Category 'Category 1'
+New-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 1'
 
 Creates a new job category with the name 'Category 1'
 
 .EXAMPLE
-New-DbaAgentJobCategory -SqlInstance sstad-pc -Category 'Category 2' -CategoryType MultiServerJob
+New-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 2' -CategoryType MultiServerJob
 
 Creates a new job category with the name 'Category 2' and assign the category type for a multi server job
 

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -1,0 +1,123 @@
+function New-DbaAgentJobCategory {
+	<#
+.SYNOPSIS 
+New-DbaAgentJobCategory creates a new job categorie
+
+.DESCRIPTION
+New-DbaAgentJobCategory makes is possible to create a job category that can be used with jobs.
+It returns an array of the job(s) created  
+
+.PARAMETER SqlInstance
+SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+
+.PARAMETER SqlCredential
+Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
+To connect as a different Windows user, run PowerShell as that user.
+
+.PARAMETER Category
+The name of the category
+
+.PARAMETER CategoryType
+The type of category. This can be "LocalJob", "MultiServerJob" or "None".
+The default is "LocalJob" and will automatically be set when no option is chosen.
+
+.PARAMETER Force
+The force parameter will ignore some errors in the parameters and assume defaults.
+
+.PARAMETER WhatIf 
+Shows what would happen if the command were to run. No actions are actually performed. 
+
+.PARAMETER Confirm 
+Prompts you for confirmation before executing any changing operations within the command. 
+
+.PARAMETER EnableException 
+		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+		
+.NOTES 
+Author: Sander Stad (@sqlstad, sqlstad.nl)
+Tags: Agent, Job, Job Category
+	
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+.LINK
+https://dbatools.io/New-DbaAgentJobCategory
+
+.EXAMPLE   
+New-DbaAgentJobCategory -SqlInstance sstad-pc -Category 'Category 1'
+
+Creates a new job category with the name 'Category 1'
+
+.EXAMPLE
+New-DbaAgentJobCategory -SqlInstance sstad-pc -Category 'Category 2' -CategoryType MultiServerJob
+
+Creates a new job category with the name 'Category 2' and assign the category type for a multi server job
+
+#>
+
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Parameter(Mandatory = $true)]
+		[ValidateNotNullOrEmpty()]
+		[string]$Category,
+		[ValidateSet("LocalJob", "MultiServerJob", "None")]
+		[string]$CategoryType,
+		[switch]$Force,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	begin {
+		# Check the category type
+		if (-not $CategoryType) {
+			# Setting category type to default
+			Write-Message -Message "Setting the category type to 'LocalJob'" -Level Verbose
+			$CategoryType = "LocalJob"
+		}
+	}
+
+	process {
+
+		foreach ($instance in $sqlinstance) {
+			# Try connecting to the instance
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+			
+			# Check if the category already exists
+			if ($Category -in $server.JobServer.JobCategories.Name) {
+				Stop-Function -Message "Job category $Category already exists on $instance" -Target $instance -Continue
+			}
+			else {
+				if ($PSCmdlet.ShouldProcess($instance, "Adding the job category $Category")) {
+					try {
+						$jobcategory = New-Object Microsoft.SqlServer.Management.Smo.Agent.JobCategory($server.JobServer, $Category)
+						$jobcategory.CategoryType = $CategoryType
+
+						$jobcategory.Create()
+					}
+					catch {
+						Stop-Function -Message "Something went wrong creating the job category" -Target $Job -Continue -ErrorRecord $_
+					}
+				}
+			}
+		}
+	}
+
+	end {
+		if (Test-FunctionInterrupt) { return }
+		Write-Message -Message "Finished creating job category." -Level Verbose
+	}
+
+}

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -81,8 +81,6 @@ Creates a new job category with the name 'Category 2' and assign the category ty
 			Write-Message -Message "Setting the category type to 'LocalJob'" -Level Verbose
 			$CategoryType = "LocalJob"
 		}
-
-
 	}
 
 	process {
@@ -109,6 +107,8 @@ Creates a new job category with the name 'Category 2' and assign the category ty
 							$jobcategory.CategoryType = $CategoryType
 
 							$jobcategory.Create()
+
+							$server.JobServer.Refresh()
 						}
 						catch {
 							Stop-Function -Message "Something went wrong creating the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
@@ -116,9 +116,10 @@ Creates a new job category with the name 'Category 2' and assign the category ty
 
 					} # if should process
 
-					return $jobcategory
-
 				} # end else category exists
+
+				# Return the job category
+				Get-DbaAgentJobCategory -SqlInstance $instance -Category $cat
 
 			} # for each category
 

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -45,7 +45,19 @@ License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 https://dbatools.io/Remove-DbaAgentJobCategory
 
 .EXAMPLE   
+Remove-DbaAgentJobCategory -SqlInstance sql1 -Category Category1
 
+Remove the job category Category1 from the instance
+
+.EXAMPLE   
+Remove-DbaAgentJobCategory -SqlInstance sql1 -Category Category1, Category2, Category3
+
+Remove multiple job categories from the instance
+
+.EXAMPLE   
+Remove-DbaAgentJobCategory -SqlInstance sql1, sql2, sql3 -Category Category1, Category2, Category3
+
+Remove multiple job categories from the multiple instances
 
 #>
 	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -1,0 +1,111 @@
+function Remove-DbaAgentJobCategory {
+
+	<#
+.SYNOPSIS 
+Remove-DbaAgentJobCategory removes a job category
+
+.DESCRIPTION
+Remove-DbaAgentJobCategory makes is possible to remove a job category.
+Be assured that the category you want to remove is not used with other jobs. If another job uses this category it will be get the category [Uncategorized (Local)].
+
+.PARAMETER SqlInstance
+SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+
+.PARAMETER SqlCredential
+Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
+To connect as a different Windows user, run PowerShell as that user.
+
+.PARAMETER Category
+The name of the category
+
+.PARAMETER Force
+The force parameter will ignore some errors in the parameters and assume defaults.
+
+.PARAMETER WhatIf 
+Shows what would happen if the command were to run. No actions are actually performed. 
+
+.PARAMETER Confirm 
+Prompts you for confirmation before executing any changing operations within the command. 
+
+.PARAMETER EnableException 
+		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+		
+.NOTES 
+Author: Sander Stad (@sqlstad, sqlstad.nl)
+Tags: Agent, Job, Job Category
+	
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+.LINK
+https://dbatools.io/Remove-DbaAgentJobCategory
+
+.EXAMPLE   
+
+
+#>
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Parameter(Mandatory = $false)]
+		[ValidateNotNullOrEmpty()]
+		[string[]]$Category,
+		[switch]$Force,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	process {
+
+		foreach ($instance in $sqlinstance) {
+			# Try connecting to the instance
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			# Loop through each of the categories
+			foreach ($cat in $Category) {
+
+				# Check if the job category exists
+				if ($cat -notin $server.JobServer.JobCategories.Name) {
+					Stop-Function -Message "Job category $cat doesn't exist on $instance" -Target $instance -Continue
+				}
+
+				# Remove the category
+				if ($PSCmdlet.ShouldProcess($instance, "Changing the job category $Category")) {
+					try {
+						# Get the category
+						$currentCategory = $server.JobServer.JobCategories[$cat]
+
+						Write-Message -Message "Removing job category $cat" -Level Verbose
+
+						$currentCategory.Drop()
+					}
+					catch {
+						Stop-Function -Message "Something went wrong removing the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
+					}
+
+				} #if should process
+
+			} # for each category
+
+		} # for each instance
+
+	} # end process
+
+	end {
+		if (Test-FunctionInterrupt) { return }
+		Write-Message -Message "Finished removing job category." -Level Verbose
+	}
+
+}

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -171,8 +171,8 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
 		[string]$NetsendOperator,
 		[string]$PageOperator,
 		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-        [object]$DeleteLevel,
-        [switch]$Force,
+		[object]$DeleteLevel,
+		[switch]$Force,
 		[switch][Alias('Silent')]$EnableException
 	)
 	
@@ -331,30 +331,32 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
 						}
 						
 					}
-                    
-					# Check if the job category exists
-					if ($Category -notin $server.JobServer.JobCategories.Name) {
-						if ($Force) {
-							if ($PSCmdlet.ShouldProcess($instance, "Creating job category on $instance")) {
-								try {
-									# Create the category
-                                    New-DbaAgentJobCategory -SqlInstance $instance -Category $Category
+					
+					if ($Category) {
+						# Check if the job category exists
+						if ($Category -notin $server.JobServer.JobCategories.Name) {
+							if ($Force) {
+								if ($PSCmdlet.ShouldProcess($instance, "Creating job category on $instance")) {
+									try {
+										# Create the category
+										New-DbaAgentJobCategory -SqlInstance $instance -Category $Category
                                     
-                                    Write-Message -Message "Setting job category to $Category" -Level Verbose
-                                    $currentjob.Category = $Category
+										Write-Message -Message "Setting job category to $Category" -Level Verbose
+										$currentjob.Category = $Category
+									}
+									catch {
+										Stop-Function -Message "Couldn't create job category $Category from $instance" -Target $instance -Continue -ErrorRecord $_
+									}
 								}
-								catch {
-									Stop-Function -Message "Couldn't create job category $Category from $instance" -Target $instance -Continue -ErrorRecord $_
-								}
+							}
+							else {
+								Stop-Function -Message "Job category $Category doesn't exist on $instance. Use -Force to create it." -Target $instance -Continue
 							}
 						}
 						else {
-							Stop-Function -Message "Job category $Category doesn't exist on $instance. Use -Force to create it." -Target $instance -Continue
+							Write-Message -Message "Setting job category to $Category" -Level Verbose
+							$currentjob.Category = $Category
 						}
-					}
-					else {
-						Write-Message -Message "Setting job category to $Category" -Level Verbose
-						$currentjob.Category = $Category
 					}
 
 					if ($OwnerLogin) {

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -1,6 +1,6 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Set-DbaAgentJob {
-    <#
+	<#
 .SYNOPSIS 
 Set-DbaAgentJob updates a job.
 
@@ -79,6 +79,9 @@ Specifies when to delete the job.
 Allowed values 0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always"
 The text value van either be lowercase, uppercase or something in between as long as the text is correct.
 
+.PARAMETER Force
+The force parameter will ignore some errors in the parameters and assume defaults.
+
 .PARAMETER WhatIf
 Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -138,378 +141,361 @@ sql1, sql2, sql3 | Set-DbaAgentJob -Job Job1 -Description 'Job One'
 Changes a job with the name "Job1" on multiple servers to have another description using pipe line
 
 #>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
-    param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
-
-        [Parameter(Mandatory = $false)]
-        [PSCredential]$SqlCredential,
-		
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [object[]]$Job,
-
-        [Parameter(Mandatory = $false)]
-        [object[]]$Schedule,
-
-        [Parameter(Mandatory = $false)]
-        [int[]]$ScheduleId,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$NewName,
-		
-        [Parameter(Mandatory = $false)]
-        [switch]$Enabled,
-		
-        [Parameter(Mandatory = $false)]
-        [switch]$Disabled,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$Description,
-		
-        [Parameter(Mandatory = $false)]
-        [int]$StartStepId,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$Category,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$OwnerLogin,
-		
-        [Parameter(Mandatory = $false)]
-        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-        [object]$EventLogLevel,
-		
-        [Parameter(Mandatory = $false)]
-        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-        [object]$EmailLevel,
-		
-        [Parameter(Mandatory = $false)]
-        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-        [object]$NetsendLevel,
-		
-        [Parameter(Mandatory = $false)]
-        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
-        [object]$PageLevel,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$EmailOperator,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$NetsendOperator,
-		
-        [Parameter(Mandatory = $false)]
-        [string]$PageOperator,
-		
-        [Parameter(Mandatory = $false)]
-        [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Parameter(Mandatory = $true)]
+		[ValidateNotNullOrEmpty()]
+		[object[]]$Job,
+		[object[]]$Schedule,
+		[int[]]$ScheduleId,
+		[string]$NewName,
+		[switch]$Enabled,
+		[switch]$Disabled,
+		[string]$Description,
+		[int]$StartStepId,
+		[string]$Category,
+		[string]$OwnerLogin,
+		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+		[object]$EventLogLevel,
+		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+		[object]$EmailLevel,
+		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+		[object]$NetsendLevel,
+		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
+		[object]$PageLevel,
+		[string]$EmailOperator,
+		[string]$NetsendOperator,
+		[string]$PageOperator,
+		[ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$DeleteLevel,
-		
-        [switch][Alias('Silent')]$EnableException
-    )
+        [switch]$Force,
+		[switch][Alias('Silent')]$EnableException
+	)
 	
-    begin {
-        # Check of the event log level is of type string and set the integer value
-        if (($EventLogLevel -notin 0, 1, 2, 3) -and ($EventLogLevel -ne $null)) {
-            $EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-        }
+	begin {
+		# Check of the event log level is of type string and set the integer value
+		if (($EventLogLevel -notin 0, 1, 2, 3) -and ($EventLogLevel -ne $null)) {
+			$EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+		}
 		
-        # Check of the email level is of type string and set the integer value
-        if (($EmailLevel -notin 0, 1, 2, 3) -and ($EmailLevel -ne $null)) {
-            $EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-        }
+		# Check of the email level is of type string and set the integer value
+		if (($EmailLevel -notin 0, 1, 2, 3) -and ($EmailLevel -ne $null)) {
+			$EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+		}
 		
-        # Check of the net send level is of type string and set the integer value
-        if (($NetsendLevel -notin 0, 1, 2, 3) -and ($NetsendLevel -ne $null)) {
-            $NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-        }
+		# Check of the net send level is of type string and set the integer value
+		if (($NetsendLevel -notin 0, 1, 2, 3) -and ($NetsendLevel -ne $null)) {
+			$NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+		}
 		
-        # Check of the page level is of type string and set the integer value
-        if (($PageLevel -notin 0, 1, 2, 3) -and ($PageLevel -ne $null)) {
-            $PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-        }
+		# Check of the page level is of type string and set the integer value
+		if (($PageLevel -notin 0, 1, 2, 3) -and ($PageLevel -ne $null)) {
+			$PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+		}
 		
-        # Check of the delete level is of type string and set the integer value
-        if (($DeleteLevel -notin 0, 1, 2, 3) -and ($DeleteLevel -ne $null)) {
-            $DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
-        }
+		# Check of the delete level is of type string and set the integer value
+		if (($DeleteLevel -notin 0, 1, 2, 3) -and ($DeleteLevel -ne $null)) {
+			$DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
+		}
 		
-        # Check the e-mail operator name
-        if (($EmailLevel -ge 1) -and (-not $EmailOperator)) {
-            Stop-Function -Message "Please set the e-mail operator when the e-mail level parameter is set." -Target $sqlinstance
-            return
-        }
+		# Check the e-mail operator name
+		if (($EmailLevel -ge 1) -and (-not $EmailOperator)) {
+			Stop-Function -Message "Please set the e-mail operator when the e-mail level parameter is set." -Target $sqlinstance
+			return
+		}
 		
-        # Check the e-mail operator name
-        if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
-            Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $sqlinstance
-            return
-        }
+		# Check the e-mail operator name
+		if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
+			Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $sqlinstance
+			return
+		}
 		
-        # Check the e-mail operator name
-        if (($PageLevel -ge 1) -and (-not $PageOperator)) {
-            Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $sqlinstance
-            return
-        }
-    }
+		# Check the e-mail operator name
+		if (($PageLevel -ge 1) -and (-not $PageOperator)) {
+			Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $sqlinstance
+			return
+		}
+	}
 	
-    process {
+	process {
 		
-        if (Test-FunctionInterrupt) { return }
+		if (Test-FunctionInterrupt) { return }
 		
-        foreach ($instance in $sqlinstance) {
+		foreach ($instance in $sqlinstance) {
 			
-            # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
-            try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            }
-            catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
+			# Try connecting to the instance
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
 			
-            foreach ($j in $Job) {
+			foreach ($j in $Job) {
 				
-                # Check if the job exists
-                if ($Server.JobServer.Jobs.Name -notcontains $j) {
-                    Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
-                }
-                else {
-                    # Get the job
-                    try {
-                        $currentjob = $server.JobServer.Jobs[$j]
+				# Check if the job exists
+				if ($Server.JobServer.Jobs.Name -notcontains $j) {
+					Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
+				}
+				else {
+					# Get the job
+					try {
+						$currentjob = $server.JobServer.Jobs[$j]
 						
-                        # Refresh the object
-                        $currentjob.Refresh()
-                    }
-                    catch {
-                        Stop-Function -Message "Something went wrong retrieving the job" -Target $j -ErrorRecord $_ -Continue
-                    }
+						# Refresh the object
+						$currentjob.Refresh()
+					}
+					catch {
+						Stop-Function -Message "Something went wrong retrieving the job" -Target $j -ErrorRecord $_ -Continue
+					}
 					
-                    #region job options
-                    # Settings the options for the job
-                    if ($NewName) {
-                        Write-Message -Message "Setting job name to $NewName" -Level Verbose
-                        $currentjob.Rename($NewName)
-                    }
+					#region job options
+					# Settings the options for the job
+					if ($NewName) {
+						Write-Message -Message "Setting job name to $NewName" -Level Verbose
+						$currentjob.Rename($NewName)
+					}
 					
-                    if ($Schedule) {
-                        # Loop through each of the schedules
-                        foreach ($s in $Schedule) {
-                            if ($Server.JobServer.SharedSchedules.Name -contains $s) {
-                                # Get the schedule ID
-                                $sID = $Server.JobServer.SharedSchedules[$s].ID
+					if ($Schedule) {
+						# Loop through each of the schedules
+						foreach ($s in $Schedule) {
+							if ($Server.JobServer.SharedSchedules.Name -contains $s) {
+								# Get the schedule ID
+								$sID = $Server.JobServer.SharedSchedules[$s].ID
 							
-                                # Add schedule to job
-                                Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
-                                $currentjob.AddSharedSchedule($sID)
-                            }
-                            else {
-                                Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
-                            }
+								# Add schedule to job
+								Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
+								$currentjob.AddSharedSchedule($sID)
+							}
+							else {
+								Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
+							}
 						
-                        }
-                    }
+						}
+					}
 
-                    if ($ScheduleId) {
-                        # Loop through each of the schedules IDs
-                        foreach ($sID in $ScheduleId) {
-                            # Check if the schedule is 
-                            if ($Server.JobServer.SharedSchedules.ID -contains $sID) {
-                                # Add schedule to job
-                                Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
-                                $currentjob.AddSharedSchedule($sID)
+					if ($ScheduleId) {
+						# Loop through each of the schedules IDs
+						foreach ($sID in $ScheduleId) {
+							# Check if the schedule is 
+							if ($Server.JobServer.SharedSchedules.ID -contains $sID) {
+								# Add schedule to job
+								Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
+								$currentjob.AddSharedSchedule($sID)
                                 
-                            }
-                            else {
-                                Stop-Function -Message "Schedule ID $sID cannot be found on instance $instance" -Target $sID -Continue
-                            }
-                        }
-                    }
+							}
+							else {
+								Stop-Function -Message "Schedule ID $sID cannot be found on instance $instance" -Target $sID -Continue
+							}
+						}
+					}
 
-                    if ($Enabled) {
-                        Write-Message -Message "Setting job to enabled" -Level Verbose
-                        $currentjob.IsEnabled = $true
-                    }
+					if ($Enabled) {
+						Write-Message -Message "Setting job to enabled" -Level Verbose
+						$currentjob.IsEnabled = $true
+					}
 					
-                    if ($Disabled) {
-                        Write-Message -Message "Setting job to disabled" -Level Verbose
-                        $currentjob.IsEnabled = $false
-                    }
+					if ($Disabled) {
+						Write-Message -Message "Setting job to disabled" -Level Verbose
+						$currentjob.IsEnabled = $false
+					}
 					
-                    if ($Description) {
-                        Write-Message -Message "Setting job description to $Description" -Level Verbose
-                        $currentjob.Description = $Description
-                    }
+					if ($Description) {
+						Write-Message -Message "Setting job description to $Description" -Level Verbose
+						$currentjob.Description = $Description
+					}
 					
-                    if ($StartStepId) {
-                        # Get the job steps
-                        $currentjobSteps = $currentjob.JobSteps
+					if ($StartStepId) {
+						# Get the job steps
+						$currentjobSteps = $currentjob.JobSteps
 						
-                        # Check if there are any job steps
-                        if ($currentjobSteps.Count -ge 1) {
-                            # Check if the start step id value is one of the job steps in the job
-                            if ($currentjobSteps.ID -contains $StartStepId) {
-                                Write-Message -Message "Setting job start step id to $StartStepId" -Level Verbose
-                                $currentjob.StartStepID = $StartStepId
-                            }
-                            else {
-                                Write-Message -Message "The step id is not present in job $j on instance $instance" -Warning
-                            }
+						# Check if there are any job steps
+						if ($currentjobSteps.Count -ge 1) {
+							# Check if the start step id value is one of the job steps in the job
+							if ($currentjobSteps.ID -contains $StartStepId) {
+								Write-Message -Message "Setting job start step id to $StartStepId" -Level Verbose
+								$currentjob.StartStepID = $StartStepId
+							}
+							else {
+								Write-Message -Message "The step id is not present in job $j on instance $instance" -Warning
+							}
 							
-                        }
-                        else {
-                            Stop-Function -Message "There are no job steps present for job $j on instance $instance" -Target $instance -Continue
-                        }
+						}
+						else {
+							Stop-Function -Message "There are no job steps present for job $j on instance $instance" -Target $instance -Continue
+						}
 						
-                    }
+					}
+                    
+					# Check if the job category exists
+					if ($Category -notin $server.JobServer.JobCategories.Name) {
+						if ($Force) {
+							if ($PSCmdlet.ShouldProcess($instance, "Creating job category on $instance")) {
+								try {
+									# Create the category
+                                    New-DbaAgentJobCategory -SqlInstance $instance -Category $Category
+                                    
+                                    Write-Message -Message "Setting job category to $Category" -Level Verbose
+                                    $currentjob.Category = $Category
+								}
+								catch {
+									Stop-Function -Message "Couldn't create job category $Category from $instance" -Target $instance -Continue -ErrorRecord $_
+								}
+							}
+						}
+						else {
+							Stop-Function -Message "Job category $Category doesn't exist on $instance. Use -Force to create it." -Target $instance -Continue
+						}
+					}
+					else {
+						Write-Message -Message "Setting job category to $Category" -Level Verbose
+						$currentjob.Category = $Category
+					}
+
+					if ($OwnerLogin) {
+						# Check if the login name is present on the instance
+						if ($Server.Logins.Name -contains $OwnerLogin) {
+							Write-Message -Message "Setting job owner login name to $OwnerLogin" -Level Verbose
+							$currentjob.OwnerLoginName = $OwnerLogin
+						}
+						else {
+							Stop-Function -Message "The given owner log in name $OwnerLogin does not exist on instance $instance" -Target $instance -Continue
+						}
+					}
 					
-                    if ($Category) {
-                        Write-Message -Message "Setting job category to $Category" -Level Verbose
-                        $currentjob.Category = $Category
-                    }
+					if ($EventLogLevel) {
+						Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
+						$currentjob.EventLogLevel = $EventLogLevel
+					}
 					
-                    if ($OwnerLogin) {
-                        # Check if the login name is present on the instance
-                        if ($Server.Logins.Name -contains $OwnerLogin) {
-                            Write-Message -Message "Setting job owner login name to $OwnerLogin" -Level Verbose
-                            $currentjob.OwnerLoginName = $OwnerLogin
-                        }
-                        else {
-                            Stop-Function -Message "The given owner log in name $OwnerLogin does not exist on instance $instance" -Target $instance -Continue
-                        }
-                    }
-					
-                    if ($EventLogLevel) {
-                        Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
-                        $currentjob.EventLogLevel = $EventLogLevel
-                    }
-					
-                    if ($EmailLevel) {
-                        # Check if the notifiction needs to be removed
-                        if ($EmailLevel -eq 0) {
-                            # Remove the operator
-                            $currentjob.OperatorToEmail = $null
+					if ($EmailLevel) {
+						# Check if the notifiction needs to be removed
+						if ($EmailLevel -eq 0) {
+							# Remove the operator
+							$currentjob.OperatorToEmail = $null
 							
-                            # Remove the notification
-                            $currentjob.EmailLevel = $EmailLevel
-                        }
-                        else {
-                            # Check if either the operator e-mail parameter is set or the operator is set in the job
-                            if ($EmailOperator -or $currentjob.OperatorToEmail) {
-                                Write-Message -Message "Setting job e-mail level to $EmailLevel" -Level Verbose
-                                $currentjob.EmailLevel = $EmailLevel
-                            }
-                            else {
-                                Stop-Function -Message "Cannot set e-mail level $EmailLevel without a valid e-mail operator name" -Target $instance -Continue
-                            }
-                        }
-                    }
+							# Remove the notification
+							$currentjob.EmailLevel = $EmailLevel
+						}
+						else {
+							# Check if either the operator e-mail parameter is set or the operator is set in the job
+							if ($EmailOperator -or $currentjob.OperatorToEmail) {
+								Write-Message -Message "Setting job e-mail level to $EmailLevel" -Level Verbose
+								$currentjob.EmailLevel = $EmailLevel
+							}
+							else {
+								Stop-Function -Message "Cannot set e-mail level $EmailLevel without a valid e-mail operator name" -Target $instance -Continue
+							}
+						}
+					}
 					
-                    if ($NetsendLevel) {
-                        # Check if the notifiction needs to be removed
-                        if ($NetsendLevel -eq 0) {
-                            # Remove the operator
-                            $currentjob.OperatorToNetSend = $null
+					if ($NetsendLevel) {
+						# Check if the notifiction needs to be removed
+						if ($NetsendLevel -eq 0) {
+							# Remove the operator
+							$currentjob.OperatorToNetSend = $null
 							
-                            # Remove the notification
-                            $currentjob.NetSendLevel = $NetsendLevel
-                        }
-                        else {
-                            # Check if either the operator netsend parameter is set or the operator is set in the job
-                            if ($NetsendOperator -or $currentjob.OperatorToNetSend) {
-                                Write-Message -Message "Setting job netsend level to $NetsendLevel" -Level Verbose
-                                $currentjob.NetSendLevel = $NetsendLevel
-                            }
-                            else {
-                                Stop-Function -Message "Cannot set netsend level $NetsendLevel without a valid netsend operator name" -Target $instance -Continue
-                            }
-                        }
-                    }
+							# Remove the notification
+							$currentjob.NetSendLevel = $NetsendLevel
+						}
+						else {
+							# Check if either the operator netsend parameter is set or the operator is set in the job
+							if ($NetsendOperator -or $currentjob.OperatorToNetSend) {
+								Write-Message -Message "Setting job netsend level to $NetsendLevel" -Level Verbose
+								$currentjob.NetSendLevel = $NetsendLevel
+							}
+							else {
+								Stop-Function -Message "Cannot set netsend level $NetsendLevel without a valid netsend operator name" -Target $instance -Continue
+							}
+						}
+					}
 					
-                    if ($PageLevel) {
-                        # Check if the notifiction needs to be removed
-                        if ($PageLevel -eq 0) {
-                            # Remove the operator
-                            $currentjob.OperatorToPage = $null
+					if ($PageLevel) {
+						# Check if the notifiction needs to be removed
+						if ($PageLevel -eq 0) {
+							# Remove the operator
+							$currentjob.OperatorToPage = $null
 							
-                            # Remove the notification
-                            $currentjob.PageLevel = $PageLevel
-                        }
-                        else {
-                            # Check if either the operator pager parameter is set or the operator is set in the job
-                            if ($PageOperator -or $currentjob.OperatorToPage) {
-                                Write-Message -Message "Setting job pager level to $PageLevel" -Level Verbose
-                                $currentjob.PageLevel = $PageLevel
-                            }
-                            else {
-                                Stop-Function -Message "Cannot set page level $PageLevel without a valid netsend operator name" -Target $instance -Continue
-                            }
-                        }
-                    }
+							# Remove the notification
+							$currentjob.PageLevel = $PageLevel
+						}
+						else {
+							# Check if either the operator pager parameter is set or the operator is set in the job
+							if ($PageOperator -or $currentjob.OperatorToPage) {
+								Write-Message -Message "Setting job pager level to $PageLevel" -Level Verbose
+								$currentjob.PageLevel = $PageLevel
+							}
+							else {
+								Stop-Function -Message "Cannot set page level $PageLevel without a valid netsend operator name" -Target $instance -Continue
+							}
+						}
+					}
 					
-                    # Check the current setting of the job's email level
-                    if ($EmailOperator) {
-                        # Check if the operator name is present
-                        if ($Server.JobServer.Operators.Name -contains $EmailOperator) {
-                            Write-Message -Message "Setting job e-mail operator to $EmailOperator" -Level Verbose
-                            $currentjob.OperatorToEmail = $EmailOperator
-                        }
-                        else {
-                            Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
-                        }
-                    }
+					# Check the current setting of the job's email level
+					if ($EmailOperator) {
+						# Check if the operator name is present
+						if ($Server.JobServer.Operators.Name -contains $EmailOperator) {
+							Write-Message -Message "Setting job e-mail operator to $EmailOperator" -Level Verbose
+							$currentjob.OperatorToEmail = $EmailOperator
+						}
+						else {
+							Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
+						}
+					}
 					
-                    if ($NetsendOperator) {
-                        # Check if the operator name is present
-                        if ($Server.JobServer.Operators.Name -contains $NetsendOperator) {
-                            Write-Message -Message "Setting job netsend operator to $NetsendOperator" -Level Verbose
-                            $currentjob.OperatorToNetSend = $NetsendOperator
-                        }
-                        else {
-                            Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
-                        }
-                    }
+					if ($NetsendOperator) {
+						# Check if the operator name is present
+						if ($Server.JobServer.Operators.Name -contains $NetsendOperator) {
+							Write-Message -Message "Setting job netsend operator to $NetsendOperator" -Level Verbose
+							$currentjob.OperatorToNetSend = $NetsendOperator
+						}
+						else {
+							Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
+						}
+					}
 					
-                    if ($PageOperator) {
-                        # Check if the operator name is present
-                        if ($Server.JobServer.Operators.Name -contains $PageOperator) {
-                            Write-Message -Message "Setting job pager operator to $PageOperator" -Level Verbose
-                            $currentjob.OperatorToPage = $PageOperator
-                        }
-                        else {
-                            Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $instance -Continue
-                        }
-                    }
+					if ($PageOperator) {
+						# Check if the operator name is present
+						if ($Server.JobServer.Operators.Name -contains $PageOperator) {
+							Write-Message -Message "Setting job pager operator to $PageOperator" -Level Verbose
+							$currentjob.OperatorToPage = $PageOperator
+						}
+						else {
+							Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $instance -Continue
+						}
+					}
 					
-                    if ($DeleteLevel) {
-                        Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
-                        $currentjob.DeleteLevel = $DeleteLevel
-                    }
-                    #endregion job options
+					if ($DeleteLevel) {
+						Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
+						$currentjob.DeleteLevel = $DeleteLevel
+					}
+					#endregion job options
 					
-                    # Execute 
-                    if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
-                        try {
-                            Write-Message -Message "Changing the job" -Level Verbose
+					# Execute 
+					if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
+						try {
+							Write-Message -Message "Changing the job" -Level Verbose
 							
-                            # Change the job
-                            $currentjob.Alter()
-                        }
-                        catch {
-                            Stop-Function -Message "Something went wrong changing the job" -ErrorRecord $_ -Target $instance -Continue
-                        }
-                        Get-DbaAgentJob -SqlInstance $server | Where-Object Name -eq $currentjob.name
-                    }
-                }
-            } # foreach object job
-        } # foreach instance
-    } # Process
+							# Change the job
+							$currentjob.Alter()
+						}
+						catch {
+							Stop-Function -Message "Something went wrong changing the job" -ErrorRecord $_ -Target $instance -Continue
+						}
+						Get-DbaAgentJob -SqlInstance $server | Where-Object Name -eq $currentjob.name
+					}
+				}
+			} # foreach object job
+		} # foreach instance
+	} # Process
 	
-    end {
-        if (Test-FunctionInterrupt) { return }
+	end {
+		if (Test-FunctionInterrupt) { return }
 		Write-Message -Message "Finished changing job(s)" -Level Verbose
-    }
+	}
 }

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -1,0 +1,155 @@
+function Set-DbaAgentJobCategory {
+	<#
+.SYNOPSIS 
+Set-DbaAgentJobCategory changes a job category
+
+.DESCRIPTION
+Set-DbaAgentJobCategory makes is possible to change a job category.
+
+.PARAMETER SqlInstance
+SQL Server instance. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+
+.PARAMETER SqlCredential
+Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+$scred = Get-Credential, then pass $scred object to the -SqlCredential parameter. 
+To connect as a different Windows user, run PowerShell as that user.
+
+.PARAMETER Category
+The name of the category
+
+.PARAMETER NewName
+New name of the job category
+
+.PARAMETER Force
+The force parameter will ignore some errors in the parameters and assume defaults.
+
+.PARAMETER WhatIf 
+Shows what would happen if the command were to run. No actions are actually performed. 
+
+.PARAMETER Confirm 
+Prompts you for confirmation before executing any changing operations within the command. 
+
+.PARAMETER EnableException 
+		By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+		This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+		Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+		
+.NOTES 
+Author: Sander Stad (@sqlstad, sqlstad.nl)
+Tags: Agent, Job, Job Category
+	
+Website: https://dbatools.io
+Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+.LINK
+https://dbatools.io/Set-DbaAgentJobCategory
+
+.EXAMPLE   
+New-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 1' -NewName 'Category 2'
+
+Change the name of the category from 'Category 1' to 'Category 2'
+
+.EXAMPLE 
+Set-DbaAgentJobCategory -SqlInstance sql1, sql2 -Category Category1, Category2 -NewName cat1, cat2
+
+Rename multiple jobs in one go on multiple servers
+
+#>
+
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+	param (
+		[parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter[]]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[Parameter(Mandatory = $false)]
+		[ValidateNotNullOrEmpty()]
+		[string[]]$Category,
+		[string[]]$NewName,
+		[switch]$Force,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	begin {
+		# Create array list to hold the results
+		$collection = New-Object System.Collections.ArrayList
+
+		# Check if multiple categories are being changed
+		if ($Category.Count -gt 1 -and $NewName.Count -eq 1) {
+			Stop-Function -Message "You cannot rename multiple jobs to the same name" -Target $instance
+		}
+	}
+
+	process {
+
+		foreach ($instance in $sqlinstance) {
+			# Try connecting to the instance
+			Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			# Loop through each of the categories
+			foreach ($cat in $Category) {
+				# Check if the category exists 
+				if ($cat -notin $server.JobServer.JobCategories.Name) {
+					Stop-Function -Message "Job category $cat doesn't exist on $instance" -Target $instance -Continue
+				}
+
+				# Check if the category already exists
+				if ($NewName -and ($NewName -in $server.JobServer.JobCategories.Name)) {
+					Stop-Function -Message "Job category $NewName already exists on $instance" -Target $instance -Continue
+				}
+
+				if ($PSCmdlet.ShouldProcess($instance, "Changing the job category $Category")) {
+					try {
+						# Get the job category object
+						$currentCategory = $server.JobServer.JobCategories[$cat]
+
+						Write-Message -Message "Changing job category $cat" -Level Verbose
+
+						# Get and set the original and new values
+						$originalCategoryName = $currentCategory.Name
+						$newCategoryName = $null
+
+						# Check if the job category needs to be renamed
+						if ($NewName) {
+							$currentCategory.Rename($NewName[$Category.IndexOf($cat)])
+							$newCategoryName = $currentCategory.Name
+						}
+					
+						# Set up the custom object
+						$null = $collection.Add([PSCustomObject]@{
+								ComputerName    = $server.NetName
+								InstanceName    = $server.ServiceName
+								SqlInstance     = $server.DomainInstanceName
+								CategoryName    = $originalCategoryName
+								NewCategoryName = $newCategoryName
+							})
+
+					}
+					catch {
+						Stop-Function -Message "Something went wrong changing the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
+					} 
+
+				} # if should process
+
+			} # for each category
+
+		} # foreach instance
+
+		# Return result
+		return $collection
+
+	} # end process
+
+	end {
+		if (Test-FunctionInterrupt) { return }
+		Write-Message -Message "Finished changing job category." -Level Verbose
+	}
+
+}

--- a/tests/New-DbaAgentJobCategory.Tests.ps1
+++ b/tests/New-DbaAgentJobCategory.Tests.ps1
@@ -1,0 +1,36 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "New Agent Job Category is added properly" {
+
+		It "Should have the right name and category type" {
+			$results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 
+			$results.Name | Should Be "CategoryTest1"
+			$results.CategoryType | Should Be "LocalJob"
+		}
+
+		It "Should have the right name and category type" {
+			$results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 -CategoryType MultiServerJob
+			$results.Name | Should Be "CategoryTest2"
+			$results.CategoryType | Should Be "MultiServerJob"
+		}
+
+		It "Should actually for sure exist" {
+			$newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
+			$newresults[0].Name | Should Be "CategoryTest1"
+			$results[0].CategoryType | Should Be "LocalJob"
+			$newresults[1].Name | Should Be "CategoryTest2"
+			$results[1].CategoryType | Should Be "MultiServerJob"
+		}
+
+		It "Should not write over existing job categories" {
+			$results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -WarningAction SilentlyContinue -WarningVariable warn
+			$warn -match "already exists" | Should Be $true
+		}
+
+		# Cleanup and ignore all output
+		Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 *> $null
+	}
+}

--- a/tests/New-DbaAgentJobCategory.Tests.ps1
+++ b/tests/New-DbaAgentJobCategory.Tests.ps1
@@ -20,9 +20,9 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		It "Should actually for sure exist" {
 			$newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
 			$newresults[0].Name | Should Be "CategoryTest1"
-			$results[0].CategoryType | Should Be "LocalJob"
+			$newresults[0].CategoryType | Should Be "LocalJob"
 			$newresults[1].Name | Should Be "CategoryTest2"
-			$results[1].CategoryType | Should Be "MultiServerJob"
+			$newresults[1].CategoryType | Should Be "MultiServerJob"
 		}
 
 		It "Should not write over existing job categories" {

--- a/tests/Remove-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentJobCategory.Tests.ps1
@@ -1,0 +1,31 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "New Agent Job Category is changed properly" {
+
+		It "Should have the right name and category type" {
+			$results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+			$results[0].Name | Should Be "CategoryTest1"
+			$results[0].CategoryType | Should Be "LocalJob"
+			$results[1].Name | Should Be "CategoryTest2"
+			$results[1].CategoryType | Should Be "LocalJob"
+			$results[2].Name | Should Be "CategoryTest3"
+			$results[2].CategoryType | Should Be "LocalJob"
+		}
+
+		It "Should actually for sure exist" {
+			$newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+			$newresults.Count | Should Be 3
+		}
+
+		It "Remove the job categories" {
+			Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3
+
+			$newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+
+			$newresults.Count | Should Be 0
+		}
+	}
+}

--- a/tests/Set-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Set-DbaAgentJobCategory.Tests.ps1
@@ -18,11 +18,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		}
 
 		It "Change the name of the job category" {
-			$results = Set-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -NewName -CategoryTest2 
-			$results.Name | Should Be "CategoryTest2"
+			$results = Set-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -NewName CategoryTest2 
+			$results.NewCategoryName | Should Be "CategoryTest2"
 		}
 
 		# Cleanup and ignore all output
-		Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 *> $null
+		Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 *> $null
 	}
 }

--- a/tests/Set-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Set-DbaAgentJobCategory.Tests.ps1
@@ -1,0 +1,28 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	Context "New Agent Job Category is changed properly" {
+
+		It "Should have the right name and category type" {
+			$results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 
+			$results.Name | Should Be "CategoryTest1"
+			$results.CategoryType | Should Be "LocalJob"
+		}
+
+		It "Should actually for sure exist" {
+			$newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1
+			$newresults.Name | Should Be "CategoryTest1"
+			$newresults.CategoryType | Should Be "LocalJob"
+		}
+
+		It "Change the name of the job category" {
+			$results = Set-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -NewName -CategoryTest2 
+			$results.Name | Should Be "CategoryTest2"
+		}
+
+		# Cleanup and ignore all output
+		Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 *> $null
+	}
+}


### PR DESCRIPTION
New functions to manage the job categories in SQL Sever. Commands added:
- Get-DbaAgentJobCategory
- New-DbaAgentJobCategory
- Set-DbaAgentJobCategory
- Remove-DbaAgentJobCategory

Changed the following functions to support the job categories:
- New-DbaAgentJob
- Set-DbaAgentJob

Added tests for the new functions

Cleaned up the existing functions.