### PR TITLE
Restore FileStream data in a better way

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -25,7 +25,7 @@ Function Format-DbaBackupInformation{
     .PARAMETER LogFileDirectory
         This will move all log files to this location, overriding DataFileDirectory 
     
-    .PARAMETER FileStreamDirectory
+    .PARAMETER DestinationFileStreamDirectory
         This move the FileStream folder and contents to the new location, overriding DataFileDirectory 
     
     .PARAMETER FileNamePrefix
@@ -100,7 +100,7 @@ Function Format-DbaBackupInformation{
         [switch]$ReplaceDbNameInFile,
         [string]$DataFileDirectory,
         [string]$LogFileDirectory,
-        [string]$FileStreamDirectory,
+        [string]$DestinationFileStreamDirectory,
         [string]$DatabaseNamePrefix,
         [string]$DatabaseFilePrefix,
         [string]$DatabaseFileSuffix,
@@ -127,8 +127,8 @@ Function Format-DbaBackupInformation{
         if ((Test-Bound -Parameter DataFileDirectory) -and $DataFileDirectory[-1] -eq '\' ){
             $DataFileDirectory = $DataFileDirectory.substring(0,$DataFileDirectory.length-1)
         }
-        if ((Test-Bound -Parameter FileStreamDirectory) -and $FileStreamDirectory[-1] -eq '\' ){
-            $FileStreamDirectory = $FileStreamDirectory.substring(0,$FileStreamDirectory.length-1)
+        if ((Test-Bound -Parameter DestinationFileStreamDirectory) -and $DestinationFileStreamDirectory[-1] -eq '\' ){
+            $DestinationFileStreamDirectory = $DestinationFileStreamDirectory.substring(0,$DestinationFileStreamDirectory.length-1)
         }
         if ((Test-Bound -Parameter LogFileDirectory) -and $LogFileDirectory[-1] -eq '\' ){
             $LogFileDirectory = $LogFileDirectory.substring(0,$LogFileDirectory.length-1)
@@ -203,8 +203,8 @@ Function Format-DbaBackupInformation{
                             }
                         }
                         elseif ($_.Type -eq 'S' -or $_.FileType -eq 'S'){
-                            if ('' -ne $FileStreamDirectory){
-                                $RestoreDir = $FileStreamDirectory
+                            if ('' -ne $DestinationFileStreamDirectory){
+                                $RestoreDir = $DestinationFileStreamDirectory
                             }
                             elseif ('' -ne $DataFileDirectory){
                                 $RestoreDir = $DataFileDirectory

--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -23,7 +23,10 @@ Function Format-DbaBackupInformation{
         This will move ALL restored files to this location during the restore
 
     .PARAMETER LogFileDirectory
-        This will move all log files to this location. 
+        This will move all log files to this location, overriding DataFileDirectory 
+    
+    .PARAMETER FileStreamDirectory
+        This move the FileStream folder and contents to the new location, overriding DataFileDirectory 
     
     .PARAMETER FileNamePrefix
         This string will  be prefixed to all restored files (Data and Log)
@@ -97,6 +100,7 @@ Function Format-DbaBackupInformation{
         [switch]$ReplaceDbNameInFile,
         [string]$DataFileDirectory,
         [string]$LogFileDirectory,
+        [string]$FileStreamDirectory,
         [string]$DatabaseNamePrefix,
         [string]$DatabaseFilePrefix,
         [string]$DatabaseFileSuffix,
@@ -122,6 +126,9 @@ Function Format-DbaBackupInformation{
         }
         if ((Test-Bound -Parameter DataFileDirectory) -and $DataFileDirectory[-1] -eq '\' ){
             $DataFileDirectory = $DataFileDirectory.substring(0,$DataFileDirectory.length-1)
+        }
+        if ((Test-Bound -Parameter FileStreamDirectory) -and $FileStreamDirectory[-1] -eq '\' ){
+            $FileStreamDirectory = $FileStreamDirectory.substring(0,$FileStreamDirectory.length-1)
         }
         if ((Test-Bound -Parameter LogFileDirectory) -and $LogFileDirectory[-1] -eq '\' ){
             $LogFileDirectory = $LogFileDirectory.substring(0,$LogFileDirectory.length-1)
@@ -186,9 +193,18 @@ Function Format-DbaBackupInformation{
                             if ('' -ne $DataFileDirectory){
                                 $RestoreDir = $DataFileDirectory
                             }
-                        }elseif ($_.Type -eq 'L' -or $_.FileType -eq 'L'){
+                        }
+                        elseif ($_.Type -eq 'L' -or $_.FileType -eq 'L'){
                             if ('' -ne $LogFileDirectory){
                                 $RestoreDir = $LogFileDirectory
+                            }
+                            elseif ('' -ne $DataFileDirectory){
+                                $RestoreDir = $DataFileDirectory
+                            }
+                        }
+                        elseif ($_.Type -eq 'S' -or $_.FileType -eq 'S'){
+                            if ('' -ne $FileStreamDirectory){
+                                $RestoreDir = $FileStreamDirectory
                             }
                             elseif ('' -ne $DataFileDirectory){
                                 $RestoreDir = $DataFileDirectory

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -41,6 +41,10 @@ function Restore-DbaDatabase {
     .PARAMETER DestinationLogDirectory
         Path to restore the database log files to.
         This parameter can only be specified alongside DestinationDataDirectory.
+
+    .PARAMETER DestinationFileStreamDirectory
+        Path to restore FileStream data to
+        This parameter can only be specified alongside DestinationDataDirectory
     
     .PARAMETER RestoreTime
         Specify a DateTime object to which you want the database restored to. Default is to the latest point  available in the specified backups
@@ -306,6 +310,8 @@ function Restore-DbaDatabase {
         [parameter(ParameterSetName="Restore")]
         [String]$DestinationLogDirectory,
         [parameter(ParameterSetName="Restore")]
+        [String]$DestinationFileStreamDirectory,
+        [parameter(ParameterSetName="Restore")]
         [DateTime]$RestoreTime = (Get-Date).AddYears(1),
         [parameter(ParameterSetName="Restore")]
         [switch]$NoRecovery,
@@ -417,6 +423,14 @@ function Restore-DbaDatabase {
             }
             if ((Test-Bound "DestinationLogDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
                 Stop-Function -Category InvalidArgument -Message "The parameter DestinationLogDirectory can only be specified together with DestinationDataDirectory"
+                return
+            }
+            if ((Test-Bound "DestinationFileStreamDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
+                Stop-Function -Category InvalidArgument -Message "The parameters DestinationFileStreamDirectory and UseDestinationDefaultDirectories are mutually exclusive"
+                return
+            }
+            if ((Test-Bound "DestinationFileStreamDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
+                Stop-Function -Category InvalidArgument -Message "The parameter DestinationFileStreamDirectory can only be specified together with DestinationDataDirectory"
                 return
             }
             if (($null -ne $FileMapping) -or $ReuseSourceFolderStructure -or ($DestinationDataDirectory -ne '')) {
@@ -598,7 +612,7 @@ function Restore-DbaDatabase {
                 return
             }
             
-            $null = $FilteredBackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatababaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping
+            $null = $FilteredBackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatababaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping
             
             if ( Test-Bound -ParameterName FormatBackupInformation){
                 Set-Variable -Name $FormatBackupInformation -Value $FilteredBackupHistory -Scope Global

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -167,7 +167,7 @@ Function Test-DbaBackupInformation {
 								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data on $RestoreInstance and WithReplace not specified, cannot restore"	
 								$VerificationErrors++
 							}
-							$OtherOwners = $ExistingFs | Where-Object {$_.FileStreamFolder -eq $FileStreamFolder}
+							$OtherOwners = $ExistingFs | Where-Object {$_.FileStreamFolder -eq $FileStreamFolder -and $_.Database -ne $Database}
 							if ($null -ne $OtherOwners){
 								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data by $($OtherOwners.Database) on $RestoreInstance, cannot restore"
 								$VerificationErrors++	

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -157,19 +157,19 @@ Function Test-DbaBackupInformation {
 
 					$ExistingFS = Get-DbaFileStreamFolder -SqlInstance $RestoreInstance
 					#$ExistingFS = ((Get-DbaDatabase -SqlInstance $RestoreInstance).FileGroups | ?{$_.FileGroupType -eq 'FileStreamDataFileGroup'}).Files.FileName
-					Foreach ($FileStreamFolder in ($DbHistory | Select-Object -ExpandProperty filelist | Where-Object {$_.Type -eq 's'} | Select-Object PhysicalName -unique).PhysicalName){
+					Foreach ($FileStreamFolder in ($DbHistory | Select-Object -ExpandProperty filelist | Where-Object {$_.FileType -eq 's'} | Select-Object PhysicalName -unique).PhysicalName){
 						If ((Get-ChildItem $FileStreamFolder -ErrorAction SilentlyContinue).count -gt 0){
-							Write-Message -Level Warning -Message "Folder $FileStreamFolder already exists and contains data. Cannot use to restore $Database on $RestoreInstance"
+							Write-Message -Level Warning -Message "Folder $FileStreamFolder already exists and contains data. Cannot use to restore $Database on $SqlInstance"
 							$VerificationErrors++
 						}
 						if ($null -ne $ExistingFS){
 							if ($null -ne ($ExistingFs | Where-Object {$_.Database -eq $Database}) -and $Withreplace -ne $True){
-								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data on $RestoreInstance and WithReplace not specified, cannot restore"	
+								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data on $SqlInstance and WithReplace not specified, cannot restore"	
 								$VerificationErrors++
 							}
 							$OtherOwners = $ExistingFs | Where-Object {$_.FileStreamFolder -eq $FileStreamFolder -and $_.Database -ne $Database}
 							if ($null -ne $OtherOwners){
-								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data by $($OtherOwners.Database) on $RestoreInstance, cannot restore"
+								Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data by $($OtherOwners.Database) on $SqlInstance, cannot restore"
 								$VerificationErrors++	
 							}				
 						}

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -149,7 +149,7 @@ Function Test-DbaBackupInformation {
 					}
 				}
 				#Easier to do FileStream checks out of the loop:
-				if ('s' -in ($DbHistory | Select-Object -ExpandProperty filelist | Select-Object Type -Unique).Type) {
+				if ('s' -in ($DbHistory | Select-Object -ExpandProperty filelist | Select-Object FileType -Unique).FileType) {
 					if ((Get-DbaSpConfigure -SqlInstance $RestoreInstance -ConfigName FilestreamAccessLevel).RunningValue -eq 0){
 						Write-Message -Level Warning -Message "Database $Database contains FileStream data, and FileStream is not enable on the destination server"
 						$VerificationErrors++

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -155,7 +155,7 @@ Function Test-DbaBackupInformation {
 						$VerificationErrors++
 					}
 
-					$ExistingFS = Get-DbaFileStreamFolder -SqlInstance $RestoreInstance
+					$ExistingFS = Get-DbaFileStreamFolder -SqlInstance $SqlInstance
 					#$ExistingFS = ((Get-DbaDatabase -SqlInstance $RestoreInstance).FileGroups | ?{$_.FileGroupType -eq 'FileStreamDataFileGroup'}).Files.FileName
 					Foreach ($FileStreamFolder in ($DbHistory | Select-Object -ExpandProperty filelist | Where-Object {$_.FileType -eq 's'} | Select-Object PhysicalName -unique).PhysicalName){
 						If ((Get-ChildItem $FileStreamFolder -ErrorAction SilentlyContinue).count -gt 0){

--- a/internal/Get-DbaFileStreamFolder.ps1
+++ b/internal/Get-DbaFileStreamFolder.ps1
@@ -1,0 +1,84 @@
+Function Get-DbaFileStreamFolder {
+    <#
+
+    .SYNOPSIS
+        Returns basic information about Filestream folders from a Sql Instance
+
+    .DESCRIPTION
+        Given a SQL Instance, and an optional list of databases returns the FileStream containing folders on that Instance. Without the Database parameter, all dbs with FileStream are returned
+
+	.PARAMETER SqlInstance
+		The Sql Server instance to be queries
+
+	.PARAMETER SqlCredential
+		A Sql Credential to connect to $SqlInstance
+
+    .PARAMETER Database
+        Database to be tested, multiple databases may be specified as a comma seperated list.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .EXAMPLE
+        Get-DbaFileStreamFolder -SqlInstance server1\instance2
+        
+        Returns all FileStream folders from server1\instance2
+
+    .EXAMPLE
+        Get-DbaFileStreamFolder -SqlInstance server1\instance2 -Database Archive
+        
+        Returns any FileStream folders from the Archive database on server1\instance2
+    
+    .NOTES
+	Author:Stuart Moore (@napalmgram stuart-moore.com )
+
+
+	Website: https://dbatools.io
+	Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+	License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+    #>
+	param (
+		[Alias("ServerInstance", "SqlServer")]
+		[DbaInstanceParameter]$SqlInstance,
+		[PSCredential]$SqlCredential,
+		[string[]]$Database,
+		[switch]$EnableException
+    )
+    
+    BEGIN {
+        try {
+            Write-Message -Level VeryVerbose -Message "Connecting to $SqlInstance." -Target $SqlInstance
+            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        }
+        catch {
+            Stop-Function -Message "Failed to process Instance $SqlInstance." -InnerErrorRecord $_ -Target $SqlInstance -Continue
+        }
+    }
+
+    PROCESS {
+        $sql = "select d.name as 'dbname', mf.Physical_Name from sys.master_files mf inner join sys.databases d on mf.database_id = d.database_id 
+        where mf.type=2"
+        $databases = @()
+        if ($null -ne $Database) {
+            ForEach ($db in $Database) {
+                $databases += "'$db'"
+            }
+            $sql = $sql + " and d.name in ( $($databases -join ',') )"
+        }
+
+        $results = $server.ConnectionContext.ExecuteWithResults($sql).Tables.Rows | Select-Object * -ExcludeProperty  RowError, Rowstate, table, itemarray, haserrors
+        foreach ($result in $results){
+                [PsCustomObject]@{
+                    ServerInstance = $SqlInstance
+                    Database = $result.dbname
+                    FileStreamFolder = $result.Physical_Name
+                }
+        }
+
+        
+    }
+
+    END {}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2859)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
# DO NOT MERGE TILL CLAUDIO HAS SIGNED OFF!

sorry for shouting, but we can't do any meaningful automated testing for this until we have the filestream control commands sorted so we'll have to rely on wetware :)

### Purpose
Move FileStream data on restores. Follows the same logic as other files now, if DestinationDataDirectory specified, it'll end up in there. Specify DestinationFileStreamDirectory and it'll go there

### Approach
Testing is a little ad-hoc as we don't have a Get-FileStreamFiles, so:

It won't restore into an existing FileGroup folder owned by the target instance
It won't restore into a existing non empty folder.
Both of those can be overriedden with the usual AllowContinue options, but errors at your own risk

### Commands to test
Restore-DbaDatabase -SqlInstance localhost\developer2016 -DatabaseName arch4 -Path C:\dbatools\fs.bak -WithReplace -DestinationDataDirectory c:\temp\fs1ab -DestinationFileStreamDirectory c:\temp\fs2a


