### PR TITLE
Improvements Export-DbaUser

### DIFF
--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -47,7 +47,7 @@ function Export-DbaUser {
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.NOTES
 			Tags: User, Export
 			Author: Claudio Silva (@ClaudioESSilva)
@@ -190,6 +190,7 @@ function Export-DbaUser {
 				$scriptingOptions.IncludeDatabaseRoleMemberships = $true
 				$scriptingOptions.ContinueScriptingOnError = $false
 				$scriptingOptions.IncludeDatabaseContext = $false
+				$scriptingOptions.IncludeIfNotExists = $true
 
 				Write-Message -Level Output -Message "Validating users on database $db"
 

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -112,7 +112,7 @@ function Export-DbaUser {
 		[object[]]$Database,
 		[object[]]$ExcludeDatabase,
 		[object[]]$User,
-		[ValidateSet('SQLServer2000', 'SQLServer2005', 'SQLServer2008/2008R2', 'SQLServer2012', 'SQLServer2014', 'SQLServer2016')]
+		[ValidateSet('SQLServer2000', 'SQLServer2005', 'SQLServer2008/2008R2', 'SQLServer2012', 'SQLServer2014', 'SQLServer2016', 'SQLServer2017')]
 		[string]$DestinationVersion,
 		[Alias("OutFile", "Path", "FileName")]
 		[string]$FilePath,
@@ -146,6 +146,7 @@ function Export-DbaUser {
 			'SQLServer2012'        = 'Version110'
 			'SQLServer2014'        = 'Version120'
 			'SQLServer2016'        = 'Version130'
+			'SQLServer2017'        = 'Version140'
 		}
 
 		$versionName = @{
@@ -155,6 +156,7 @@ function Export-DbaUser {
 			'Version110' = 'SQLServer2012'
 			'Version120' = 'SQLServer2014'
 			'Version130' = 'SQLServer2016'
+			'Version140' = 'SQLServer2017'
 		}
 
 	}

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -1,0 +1,41 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+$outputFile = "$env:temp\dbatoolsci_user.sql"
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        try {
+            $dbname = "dbatoolsci_exportdbauser"
+            $login = "dbatoolsci_exportdbauser_login"
+            $user = "dbatoolsci_exportdbauser_user"
+            $server = Connect-DbaInstance -SqlInstance $script:instance1
+            $null = $server.Query("CREATE DATABASE [$dbname]")
+
+            $securePassword = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
+            $null = New-DbaLogin -SqlInstance $script:instance1 -Login $login -Password $securePassword
+
+            $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
+            $null = $db.Query("CREATE USER [$user] FOR LOGIN [$login]")
+        }
+        catch { } # No idea why appveyor can't handle this
+    }
+    AfterAll {
+        Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
+        Remove-DbaLogin -SqlInstance $script:instance1 -Login $login
+        (Get-ChildItem $outputFile) | Remove-Item
+    }
+
+    Context "Check if output file was created" {
+        if (Get-DbaDatabaseUser -SqlInstance $script:instance1 -Database $dbname | Where-Object Name -eq $user) {
+            $results = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -User $user -FilePath $outputFile
+            It "Exports results to one sql file" {
+                (Get-ChildItem $outputFile).Count | Should Be 1
+            }
+            It "Exported file is bigger than 0" {
+                (Get-ChildItem $outputFile).Length | Should BeGreaterThan 0
+            }
+        }
+	}
+}


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Improve the command with the following items:
 - By default include the `IF NOT EXISTS`
 - New `-ScriptingOptions` parameter that allows using your options and not the command defaults.
 - New `-ExcludeGoBatchsSparator` parameter. Some people have asked for this parameter to not include the `GO` batch separator.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/19521315/34115467-a3d57388-e40d-11e7-91ba-c4942c83670c.png)

#### Note
To make it trackable, I will submit a new PR with the same improvements for `Export-DbaLogin`. 