### PR TITLE
Development

### DIFF
--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -2,14 +2,14 @@ function Install-DbaWhoIsActive {
 	<#
 		.SYNOPSIS
 			Automatically installs or updates sp_WhoisActive by Adam Machanic.
-		
+
 		.DESCRIPTION
 			This command downloads, extracts and installs sp_WhoisActive with Adam's permission. To read more about sp_WhoisActive, please visit http://whoisactive.com and http://sqlblog.com/blogs/adam_machanic/archive/tags/who+is+active/default.aspx
-			
+
 			Please consider donating to Adam if you find this stored procedure helpful: http://tinyurl.com/WhoIsActiveDonate
-			
-			Note that you will be prompted a bunch of times to confirm an action. 
-	
+
+			Note that you will be prompted a bunch of times to confirm an action.
+
  		.PARAMETER SqlInstance
 			The SQL Server instance. Server version must be SQL Server version 2005 or higher.
 
@@ -21,13 +21,13 @@ function Install-DbaWhoIsActive {
 			Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
 
 			To connect as a different Windows user, run PowerShell as that user.
-	
+
 		.PARAMETER Database
 			The database to install sp_WhoisActive into. This parameter is mandatory when executing this command unattended.
-		
-		.PARAMETER LocalFile 
+
+		.PARAMETER LocalFile
 			Specifies the path to a local file to install sp_WhoisActive from. This can be either the zipfile as distributed by the website or the expanded SQL script. If this parameter is not specified, the latest version will be downloaded and installed from https://whoisactive.com/
-		
+
 		.PARAMETER WhatIf
 			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
@@ -38,38 +38,38 @@ function Install-DbaWhoIsActive {
 			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
 			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
 			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-			
+
 		.PARAMETER Force
 			If this switch is enabled, the sp_WhoisActive will be downloaded from the internet even if previously cached.
 
 		.EXAMPLE
 			Install-DbaWhoIsActive -SqlInstance sqlserver2014a -Database master
-			
+
 			Downloads sp_WhoisActive from the internet and installs to sqlserver2014a's master database. Connects to SQL Server using Windows Authentication.
-		
+
 		.EXAMPLE
 			Install-DbaWhoIsActive -SqlInstance sqlserver2014a -SqlCredential $cred
-			
+
 			Pops up a dialog box asking which database on sqlserver2014a you want to install the procedure into. Connects to SQL Server using SQL Authentication.
-		
+
 		.EXAMPLE
 			Install-DbaWhoIsActive -SqlInstance sqlserver2014a -Database master -LocalFile c:\SQLAdmin\whoisactive_install.sql
-			
+
 			Installs sp_WhoisActive to sqlserver2014a's master database from the local file whoisactive_install.sql
-		
+
 		.EXAMPLE
 			$instances = Get-DbaRegisteredServer sqlserver
 			Install-DbaWhoIsActive -SqlInstance $instances -Database master
-			
+
 		.NOTES
 			Website: https://dbatools.io
 			Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
-		
+
 		.LINK
 			https://dbatools.io/Install-DbaWhoIsActive
 	#>
-	
+
 	[CmdletBinding(SupportsShouldProcess)]
 	param (
 		[parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
@@ -84,17 +84,17 @@ function Install-DbaWhoIsActive {
 		$EnableException,
 		[switch]$Force
 	)
-	
+
 	begin {
 		$DbatoolsData = Get-DbaConfigValue -FullName "Path.DbatoolsData"
 		$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
 		$zipfile = "$temp\spwhoisactive.zip"
-		
+
 		if ($LocalFile -eq $null -or $LocalFile.Length -eq 0) {
 			$baseUrl = "http://whoisactive.com/downloads"
 			$latest = ((Invoke-WebRequest -UseBasicParsing -uri http://whoisactive.com/downloads).Links | where-object { $PSItem.href -match "who_is_active" } | Select-Object href -First 1).href
 			$LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath $latest;
-			
+
 			if ((Test-Path -Path $LocalCachedCopy -PathType Leaf) -and (-not $Force)) {
 				Write-Message -Level Verbose -Message "Locally-cached copy exists, skipping download."
 				if ($PSCmdlet.ShouldProcess($env:computername, "Copying sp_WhoisActive from local cache for installation")) {
@@ -126,7 +126,7 @@ function Install-DbaWhoIsActive {
 		else {
 			# Look local
 			if ($PSCmdlet.ShouldProcess($env:computername, "Copying local file to temp directory")) {
-				
+
 				if ($LocalFile.EndsWith("zip")) {
 					Copy-Item -Path $LocalFile -Destination $zipfile -Force
 				}
@@ -139,9 +139,9 @@ function Install-DbaWhoIsActive {
 			# Unpack
 			# Unblock if there's a block
 			if ($PSCmdlet.ShouldProcess($env:computername, "Unpacking zipfile")) {
-				
+
 				Unblock-File $zipfile -ErrorAction SilentlyContinue
-				
+
 				if (Get-Command -ErrorAction SilentlyContinue -Name "Expand-Archive") {
 					try {
 						Expand-Archive -Path $zipfile -DestinationPath $temp -Force
@@ -166,19 +166,19 @@ function Install-DbaWhoIsActive {
 		else {
 			$sqlfile = $LocalFile
 		}
-		
+
 		if ($PSCmdlet.ShouldProcess($env:computername, "Reading SQL file into memory")) {
 			Write-Message -Level Verbose -Message "Using $sqlfile."
-			
+
 			$sql = [IO.File]::ReadAllText($sqlfile)
 			$sql = $sql -replace 'USE master', ''
 			$batches = $sql -split "GO\r\n"
 		}
 	}
-	
+
 	process {
 		if (Test-FunctionInterrupt) { return }
-		
+
 		foreach ($instance in $SqlInstance) {
 			try {
 				Write-Message -Level Verbose -Message "Connecting to $instance."
@@ -187,72 +187,60 @@ function Install-DbaWhoIsActive {
 			catch {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
-			
+
 			if (-not $Database) {
 				if ($PSCmdlet.ShouldProcess($instance, "Prompting with GUI list of databases")) {
 					$Database = Show-DbaDatabaseList -SqlInstance $server -Title "Install sp_WhoisActive" -Header "To deploy sp_WhoisActive, select a database or hit cancel to quit." -DefaultDb "master"
-					
+
 					if (-not $Database) {
 						Stop-Function -Message "You must select a database to install the procedure." -Target $Database
 						return
 					}
-					
+
 					if ($Database -ne 'master') {
 						Write-Message -Level Warning -Message "You have selected a database other than master. When you run Invoke-DbaWhoIsActive in the future, you must specify -Database $Database."
 					}
 				}
 			}
-			
 			if ($PSCmdlet.ShouldProcess($instance, "Installing sp_WhoisActive")) {
 				try {
-					$allprocedures_query = "select name from sys.procedures where is_ms_shipped = 0"
-					#Commenting out to avoid enumerating through all databases
-                    #$databases = $server.Databases | Where-Object Name -eq $Database
-					#I am not sure why I need to create a new SMO object?? Otherwise '$server.Databases[$Database]' does not work
-                    $server = new-object ("Microsoft.SqlServer.Management.Smo.Server") $sqlinstance
-                    IF ($server.Databases[$Database]) {
-                     }
-                     ELSE {
-                        Stop-Function -Message "Failed to find database $Database on $instance or $Database is not writeable." -ErrorRecord $_ -Continue -Target $instance
-                     }
+					$ProcedureExists_Query = "select COUNT(*) [proc_count] from sys.procedures where is_ms_shipped = 0 and name like '%sp_WhoisActive%'"
 
-                if ($databases.Count -eq 0) {
-						Stop-Function -Message "Failed to find database $Database on $instance." -ErrorRecord $_ -Continue -Target $instance
+					if ($server.Databases[$Database]) {
+						$ProcedureExists = ($server.Query($ProcedureExists_Query, $Database)).proc_count
+						foreach ($batch in $batches) {
+							try {
+								$null = $server.databases[$Database].ExecuteNonQuery($batch)
+							}
+							catch {
+								Stop-Function -Message "Failed to install stored procedure." -ErrorRecord $_ -Continue -Target $instance
+							}
+						}
+
+						if ($ProcedureExists -gt 0) {
+							$status = 'Updated'
+						}
+						else {
+							$status = 'Installed'
+						}
+						[PSCustomObject]@{
+							ComputerName = $server.NetName
+							InstanceName = $server.ServiceName
+							SqlInstance  = $server.DomainInstanceName
+							Database     = $Database
+							Name         = 'sp_WhoisActive'
+							Status	      = $status
+						}
 					}
-					$allprocedures = ($server.Query($allprocedures_query, $Database)).Name
+					else {
+						Stop-Function -Message "Failed to find database $Database on $instance or $Database is not writeable." -ErrorRecord $_ -Continue -Target $instance
+					}
+
 				}
 				catch {
 					Stop-Function -Message "Failed to install stored procedure." -ErrorRecord $_ -Continue -Target $instance
 				}
-				foreach ($batch in $batches) {
-					try {
-						$null = $server.databases[$Database].ExecuteNonQuery($batch)
-					}
-					catch {
-						Stop-Function -Message "Failed to install stored procedure." -ErrorRecord $_ -Continue -Target $instance
-					}
-				}
-				$baseres = @{
-					ComputerName = $server.NetName
-					InstanceName = $server.ServiceName
-					SqlInstance  = $server.DomainInstanceName
-					Database     = $Database
-					Name         = 'sp_WhoisActive'
-				}
-				if ('sp_WhoisActive' -in $allprocedures) {
-					$status = 'Updated'
-				}
-				else {
-					$status = 'Installed'
-				}
-				[PSCustomObject]@{
-					ComputerName = $server.NetName
-					InstanceName = $server.ServiceName
-					SqlInstance  = $server.DomainInstanceName
-					Database     = $Database
-					Name         = 'sp_WhoisActive'
-					Status	      = $status
-				}
+
 			}
 		}
 	}

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -206,8 +206,17 @@ function Install-DbaWhoIsActive {
 			if ($PSCmdlet.ShouldProcess($instance, "Installing sp_WhoisActive")) {
 				try {
 					$allprocedures_query = "select name from sys.procedures where is_ms_shipped = 0"
-					$databases = $server.Databases | Where-Object Name -eq $Database
-					if ($databases.Count -eq 0) {
+					#Commenting out to avoid enumerating through all databases
+                    #$databases = $server.Databases | Where-Object Name -eq $Database
+					#I am not sure why I need to create a new SMO object?? Otherwise '$server.Databases[$Database]' does not work
+                    $server = new-object ("Microsoft.SqlServer.Management.Smo.Server") $sqlinstance
+                    IF ($server.Databases[$Database]) {
+                     }
+                     ELSE {
+                        Stop-Function -Message "Failed to find database $Database on $instance or $Database is not writeable." -ErrorRecord $_ -Continue -Target $instance
+                     }
+
+                if ($databases.Count -eq 0) {
 						Stop-Function -Message "Failed to find database $Database on $instance." -ErrorRecord $_ -Continue -Target $instance
 					}
 					$allprocedures = ($server.Query($allprocedures_query, $Database)).Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
While install/update sp_whoisactive was iterating through every database and checking for all stored procedure to determine if sp_whoisactive exist.  Interacting through every database will fail for offline or Always On Availability Group secondary replica where secondary is set to `read-intent only`.

Example of error I got while deploying:

> WARNING: [Install-DbaWhoIsActive][09:47:15] Failed to install stored procedure. | The following exception occurred while trying to enumerate the coll
> ection: "The target database ('databaseinAG') is in an availability group and is currently accessible for connections when the application intent is set to r
> ead only. For more information about application intent, see SQL Server Books Online.".

### Approach
It will only check for database passed through -database parameter or the database chosen via GUI.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
@ck helped setting up git on my desktop and walked me through the whole process. Also helped my with the code.