### PR TITLE
Allow overriding of the uptime check

### DIFF
--- a/functions/Find-DbaUnusedIndex.ps1
+++ b/functions/Find-DbaUnusedIndex.ps1
@@ -88,6 +88,13 @@ function Find-DbaUnusedIndex {
 			Find-DbaUnusedIndex -SqlInstance sqlserver2016
 
 			Generates the SQL statements to drop selected indexes on all user databases.
+
+		.EXAMPLE
+			Fine-DbaUnusedIndex -SqlInstance sqlserver2016 -IgnoreUptime
+			
+			Generates the SQL statements to drop selected indexes on all user databases even if the instance has been online for less than 7 days.
+			Note that results may not have enough detail for all indexes, so care should be taken when using them or the generated scripts. Best practice is to allow a full week to capture the mmajority of index use cases
+
 	#>
 	[CmdletBinding(SupportsShouldProcess = $true)]
 	Param (

--- a/functions/Find-DbaUnusedIndex.ps1
+++ b/functions/Find-DbaUnusedIndex.ps1
@@ -39,7 +39,10 @@ function Find-DbaUnusedIndex {
 		.PARAMETER Append
 			If this switch is enabled, content will be appended to the output file.
 
-		.PARAMETER WhatIf
+		.PARAMETER IgnoreUptime
+			Less than 7 days uptime can mean that analysis of unused indexes is unreliable, and normally no results will be returned. By setting this option results will be returned even if the Instance has been running for less that 7 days.		
+
+			.PARAMETER WhatIf
 			If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
 		.PARAMETER Confirm
@@ -100,6 +103,7 @@ function Find-DbaUnusedIndex {
 		[string]$FilePath,
 		[switch]$NoClobber,
 		[switch]$Append,
+		[switch]$IgnoreUptime,
 		[switch][Alias('Silent')]$EnableException
 	)
 
@@ -152,8 +156,13 @@ function Find-DbaUnusedIndex {
 		$diffDays = (New-TimeSpan -Start $endDate -End (Get-Date)).Days
 
 		if ($diffDays -le 6) {
+			if ($IgnoreUptime -ne $true ){
 			Stop-Function -Message "The SQL Service was restarted on $lastRestart, which is not long enough for a solid evaluation."
 			return
+			}
+			else {
+				Write-Message -Level Warning -Message "The SQL Service was restarted on $lastRestart, which is not long enough for a solid evaluation."
+			}
 		}
 
 		<#


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow Find-DbaUnusedIndex to be used on an instance that's been online for less than 7 days.

I needed to check that an index had been preferred  on an overnight run with an instance that had been restarted 2 days before, so scratching a personal need really

### Approach
Added IgnoreUptime switch. Default is as now and function will exit, set the switch and it'll return any data, though still printing a warning to remind the user that the output may not be completely useful

