### PR TITLE
Removing an ambiguity about Backup-DbaDatabases instance support

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -1,10 +1,10 @@
 function Backup-DbaDatabase {
 	<#
 			.SYNOPSIS
-				Backup one or more SQL Sever databases from a SQL Server SqlInstance.
+				Backup one or more SQL Sever databases from a single SQL Server SqlInstance.
 	
 			.DESCRIPTION
-				Performs a backup of a specified type of 1 or more databases on a SQL Server Instance. These backups may be Full, Differential or Transaction log backups.
+				Performs a backup of a specified type of 1 or more databases on a single SQL Server Instance. These backups may be Full, Differential or Transaction log backups.
 	
 			.PARAMETER SqlInstance
 				The SQL Server instance hosting the databases to be backed up.
@@ -119,7 +119,7 @@ function Backup-DbaDatabase {
 		[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 		param (
 			[parameter(ParameterSetName = "Pipe", Mandatory = $true)]
-			[DbaInstanceParameter[]]$SqlInstance,
+			[DbaInstanceParameter$SqlInstance,
 			[PSCredential]$SqlCredential,
 			[Alias("Databases")]
 			[object[]]$Database,

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -119,7 +119,7 @@ function Backup-DbaDatabase {
 		[CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 		param (
 			[parameter(ParameterSetName = "Pipe", Mandatory = $true)]
-			[DbaInstanceParameter$SqlInstance,
+			[DbaInstanceParameter]$SqlInstance,
 			[PSCredential]$SqlCredential,
 			[Alias("Databases")]
 			[object[]]$Database,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2921)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Just making it clear that Backup-DbaDatabase takes multiple databases, but only one instance for the time  being

### Approach
Think an array of instances parameter snuck in during one of the refactors/renames over time, so doesn't error on multiple instance. Removed that and made CBH explicist.
