### PR TITLE
Remove-DbaBackup, fixes #638

### DIFF
--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -1,0 +1,171 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+function Find-DbaBackup {
+	<#
+		.SYNOPSIS
+			Finds SQL Server backups on disk.
+
+		.DESCRIPTION
+			Provides all of the same functionality for finding SQL backups to remove from disk as a standard maintenance plan would.
+
+			As an addition you have the ability to check the Archive bit on files before deletion. This will allow you to ensure backups have been archived to your archive location before removal.
+
+		.PARAMETER Path
+			Specifies the name of the base level folder to search for backup files.
+
+		.PARAMETER BackupFileExtension
+			Specifies the filename extension of the backup files you wish to find (typically 'bak', 'trn' or 'log'). Do not include the period.
+
+		.PARAMETER RetentionPeriod
+			Specifies the retention period for backup files. Correct format is ##U.
+
+			## is the retention value and must be an integer value
+			U signifies the units where the valid units are:
+			h = hours
+			d = days
+			w = weeks
+			m = months
+
+			Formatting Examples:
+			'48h' = 48 hours
+			'7d' = 7 days
+			'4w' = 4 weeks
+			'1m' = 1 month
+
+		.PARAMETER CheckArchiveBit
+            If this switch is enabled, the filesystem Archive bit is checked.
+            If this bit is set (which translates to "it has not been backed up to another location yet"), the file won't be included.
+
+		.PARAMETER EnableException
+			By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+			This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+			Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+		.NOTES
+			Tags: Storage, DisasterRecovery, Backup
+			Author: Chris Sommer, @cjsommer, www.cjsommer.com
+
+			dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+			Copyright (C) 2016 Chrissy LeMaire
+			License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+		.LINK
+			https://dbatools.io/Find-DbaBackup
+
+		.EXAMPLE
+			Find-DbaBackup -Path 'C:\MSSQL\SQL Backup\' -BackupFileExtension trn -RetentionPeriod 48h
+
+			'*.trn' files in 'C:\MSSQL\SQL Backup\' and all subdirectories that are more than 48 hours old will be included.
+
+		.EXAMPLE
+			Find-DbaBackup -Path 'C:\MSSQL\Backup\' -BackupFileExtension bak -RetentionPeriod 7d -CheckArchiveBit
+
+			'*.bak' files in 'C:\MSSQL\Backup\' and all subdirectories that are more than 7 days old will be included, but only if the files have been backed up to another location as verified by checking the Archive bit.
+
+	#>
+	[CmdletBinding()]
+	param (
+		[parameter(Mandatory = $true, HelpMessage = "Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
+		[Alias("BackupFolder")]
+		[string]$Path,
+		[parameter(Mandatory = $true, HelpMessage = "Backup File extension to remove (ex. bak, trn, dif)")]
+		[string]$BackupFileExtension ,
+		[parameter(Mandatory = $true, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
+		[string]$RetentionPeriod ,
+		[parameter(Mandatory = $false)]
+		[switch]$CheckArchiveBit = $false ,
+		[switch][Alias('Silent')]$EnableException
+	)
+
+	begin {
+		### Local Functions
+		function Convert-UserFriendlyRetentionToDatetime {
+			[cmdletbinding()]
+			param (
+				[string]$UserFriendlyRetention
+			)
+
+			<#
+			Convert a user friendly retention value into a datetime.
+			The last character of the string will indicate units (validated)
+			Valid units are: (h = hours, d = days, w = weeks, m = months)
+
+			The preceeding characters are the value and must be an integer (validated)
+
+			Examples:
+				'48h' = 48 hours
+				'7d' = 7 days
+				'4w' = 4 weeks
+				'1m' = 1 month
+			#>
+
+			[int]$Length = ($UserFriendlyRetention).Length
+			$Value = ($UserFriendlyRetention).Substring(0, $Length - 1)
+			$Units = ($UserFriendlyRetention).Substring($Length - 1, 1)
+
+			# Validate that $Units is an accepted unit of measure
+			if ( $Units -notin @('h', 'd', 'w', 'm') ) {
+				throw "RetentionPeriod '$UserFriendlyRetention' units invalid! See Get-Help for correct formatting and examples."
+			}
+
+			# Validate that $Value is an INT
+			if ( ![int]::TryParse($Value, [ref]"") ) {
+				throw "RetentionPeriod '$UserFriendlyRetention' format invalid! See Get-Help for correct formatting and examples."
+			}
+
+			switch ($Units) {
+				'h' { $UnitString = 'Hours'; [datetime]$ReturnDatetime = (Get-Date).AddHours(-$Value)  }
+				'd' { $UnitString = 'Days'; [datetime]$ReturnDatetime = (Get-Date).AddDays(-$Value)   }
+				'w' { $UnitString = 'Weeks'; [datetime]$ReturnDatetime = (Get-Date).AddDays(-$Value * 7) }
+				'm' { $UnitString = 'Months'; [datetime]$ReturnDatetime = (Get-Date).AddMonths(-$Value) }
+			}
+			$ReturnDatetime
+		}
+
+		# Validations
+		# Ensure BackupFileExtension does not begin with a .
+		if ($BackupFileExtension -match "^[.]") {
+			Write-Message -Level Warning -Message "Parameter -BackupFileExtension begins with a period '$BackupFileExtension'. A period is automatically prepended to -BackupFileExtension and need not be passed in."
+        }
+        # Ensure Path is a proper path
+        if (!(Test-Path $Path -PathType 'Container')) {
+            Stop-Function -Message "$Path not found"
+        }
+
+	}
+	process {
+        if (Test-FunctionInterrupt) { return }
+		# Process stuff
+		Write-Message -Message "Finding backups on $Path" -Level Verbose
+		# Convert Retention Value to an actual DateTime
+		try {
+			$RetentionDate = Convert-UserFriendlyRetentionToDatetime -UserFriendlyRetention $RetentionPeriod
+			Write-Message -Message "Backup Retention Date set to $RetentionDate" -Level Verbose
+		}
+		catch {
+			Stop-Function -Message "Failed to interpret retention time!" -ErrorRecord $_
+		}
+
+		# Filter out unarchived files if -CheckArchiveBit parameter is used
+		if ($CheckArchiveBit) {
+			Write-Message -Message "Removing only archived files." -Level Verbose
+			filter DbaArchiveBitFilter {
+				if ($_.Attributes -notmatch "Archive") {
+					$_
+				}
+			}
+		}
+		else {
+			filter DbaArchiveBitFilter {
+				$_
+			}
+		}
+		# Enumeration may take a while. Without resorting to "esoteric" file listing facilities
+		# and given we need to fetch at least the LastWriteTime, let's just use "streaming" processing
+		# here to avoid issues like described in #970
+		Get-ChildItem $Path -Filter "*.$BackupFileExtension" -File -Recurse -ErrorAction SilentlyContinue -ErrorVariable EnumErrors |
+			Where-Object LastWriteTime -lt $RetentionDate | DbaArchiveBitFilter
+		if ($EnumErrors) {
+			Write-Message "Errors encountered enumerating files." -Level Warning -ErrorRecord $EnumErrors
+		}
+	}
+}

--- a/tests/Find-DbaBackup.Tests.ps1
+++ b/tests/Find-DbaBackup.Tests.ps1
@@ -1,0 +1,127 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1","")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		$paramCount = 5
+		$defaultParamCount = 11
+		[object[]]$params = (Get-ChildItem function:\Find-DbaBackup).Parameters.Keys
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	$testPath = "TestDrive:\sqlbackups"
+	if (!(Test-Path $testPath)) {
+		New-Item -Path $testPath -ItemType Container
+	}
+	Context "Path validation" {
+		{ Find-DbaBackup -Path 'funnypath' -BackupFileExtension 'bak' -RetentionPeriod '0d' -EnableException } | Should Throw "not found"
+	}
+	Context "RetentionPeriod validation" {
+		{ Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod 'ad' -EnableException } | Should Throw "format invalid"
+		{ Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '11y' -EnableException } | Should Throw "units invalid"
+	}
+	Context "BackupFileExtension validation" {
+		{ Find-DbaBackup -Path $testPath -BackupFileExtension '.bak' -RetentionPeriod '0d' -EnableException } | Should Not Throw
+	}
+	Context "BackupFileExtension message validation" {
+		$warnmessage = Find-DbaBackup -Path $testPath -BackupFileExtension '.bak' -RetentionPeriod '0d' 3>&1
+		$warnmessage | Should BeLike '*period*'
+	}
+	Context "Files found match the proper retention" {
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_hours.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddHours(-10)
+		}
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_days.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
+		}
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_weeks.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5*7)
+		}
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_months.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5*30)
+		}
+		It "Should find all files with retention 0d" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			$results.Length | Should Be 20
+		}
+		It "Should find no files '*hours*' with retention 11h" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '11h'
+			$results.Length | Should Be 15
+			($results | Where-Object FullName -Like '*hours*').Count | Should Be 0
+		}
+		It "Should find no files '*days*' with retention 6d" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '6d'
+			$results.Length | Should Be 10
+			($results | Where-Object FullName -Like '*hours*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*days*').Count | Should Be 0
+		}
+		It "Should find no files '*weeks*' with retention 6w" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '6w'
+			$results.Length | Should Be 5
+			($results | Where-Object FullName -Like '*hours*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*days*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*weeks*').Count | Should Be 0
+		}
+		It "Should find no files '*months*' with retention 6m" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '6m'
+			$results.Length | Should Be 0
+			($results | Where-Object FullName -Like '*hours*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*days*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*weeks*').Count | Should Be 0
+			($results | Where-Object FullName -Like '*weeks*').Count | Should Be 0
+		}
+	}
+	Context "Files found match the proper archive bit" {
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_notarchive.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).Attributes = "Normal"
+		}
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_archive.bak"
+			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).Attributes = "Archive"
+		}
+		It "Should find all files with retention 0d" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			$results.Length | Should Be 10
+		}
+		It "Should find only files with the archive bit not set" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d' -CheckArchiveBit
+			$results.Length | Should Be 5
+			($results | Where-Object FullName -Like '*_notarchive*').Count | Should Be 5
+			($results | Where-Object FullName -Like '*_archive*').Count | Should Be 0
+		}
+	}
+	Context "Files found match the proper extension" {
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.trn"
+			Set-Content $filepath -value "."
+		}
+		for ($i=1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
+			Set-Content $filepath -value "."
+		}
+		It "Should find 5 files with extension trn" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'trn' -RetentionPeriod '0d'
+			$results.Length | Should Be 5
+		}
+		It "Should find 5 files with extension bak" {
+			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			$results.Length | Should Be 5
+		}
+	}
+}

--- a/tests/Find-DbaBackup.Tests.ps1
+++ b/tests/Find-DbaBackup.Tests.ps1
@@ -88,11 +88,13 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		for ($i=1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_notarchive.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 			(Get-ChildItem $filepath).Attributes = "Normal"
 		}
 		for ($i=1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup_archive.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 			(Get-ChildItem $filepath).Attributes = "Archive"
 		}
 		It "Should find all files with retention 0d" {
@@ -110,10 +112,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		for ($i=1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.trn"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		for ($i=1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		It "Should find 5 files with extension trn" {
 			$results = Find-DbaBackup -Path $testPath -BackupFileExtension 'trn' -RetentionPeriod '0d'

--- a/tests/Remove-DbaBackup.Tests.ps1
+++ b/tests/Remove-DbaBackup.Tests.ps1
@@ -1,0 +1,93 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+	Context "Validate parameters" {
+		$paramCount = 6
+		$defaultParamCount = 13
+		[object[]]$params = (Get-ChildItem function:\Remove-DbaBackup).Parameters.Keys
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+	Context "It's Confirm impact should be medium" {
+		$command = Get-Command Remove-DbaBackup
+		$metadata = [System.Management.Automation.CommandMetadata]$command
+		$metadata.ConfirmImpact | Should Be 'Medium'
+	}
+}
+
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	$testPath = "TestDrive:\sqlbackups"
+	if (!(Test-Path $testPath)) {
+		New-Item -Path $testPath -ItemType Container
+	}
+	Context "Path validation" {
+		{ Remove-DbaBackup -Path 'funnypath' -BackupFileExtension 'bak' -RetentionPeriod '0d' -EnableException } | Should Throw "not found"
+	}
+	Context "RetentionPeriod validation" {
+		{ Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod 'ad' -EnableException } | Should Throw "format invalid"
+		{ Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '11y' -EnableException } | Should Throw "units invalid"
+	}
+	Context "BackupFileExtension validation" {
+		{ Remove-DbaBackup -Path $testPath -BackupFileExtension '.bak' -RetentionPeriod '0d' -EnableException } | Should Not Throw
+	}
+	Context "BackupFileExtension message validation" {
+		$warnmessage = Remove-DbaBackup -Path $testPath -BackupFileExtension '.bak' -RetentionPeriod '0d' 3>&1
+		$warnmessage | Should BeLike '*period*'
+	}
+	Context "Files are removed" {
+		for ($i = 1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
+			Set-Content $filepath -value "."
+		}
+		It "Should remove all files with retention 0d" {
+			$null = Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			(Get-ChildItem -Path $testPath -File -Recurse).Count | Should Be 0
+		}
+	}
+	Context "Files with matching extensions only are removed" {
+		for ($i = 1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
+			Set-Content $filepath -value "."
+		}
+		for ($i = 1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.trn"
+			Set-Content $filepath -value "."
+		}
+		It "Should remove all files but not the trn ones" {
+			$null = Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			(Get-ChildItem -Path $testPath -File -Recurse).Count | Should Be 5
+			(Get-ChildItem -Path $testPath -File -Recurse).Name | Should BeLike '*trn'
+		}
+	}
+	Context "Cleanup empty folders" {
+		$testPathinner_empty = "TestDrive:\sqlbackups\empty"
+		if (!(Test-Path $testPathinner_empty)) {
+			New-Item -Path $testPathinner_empty -ItemType Container
+		}
+		$testPathinner = "TestDrive:\sqlbackups\inner"
+		if (!(Test-Path $testPathinner)) {
+			New-Item -Path $testPathinner -ItemType Container
+		}
+		for ($i = 1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
+			Set-Content $filepath -value "."
+		}
+		for ($i = 1; $i -le 5; $i++) {
+			$filepath = Join-Path $testPathinner "dbatoolsci_$($i)_backup.bak"
+			Set-Content $filepath -value "."
+		}
+		It "Removes files but leaves empty dirs" {
+			Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
+			(Get-ChildItem -Path $testPath -Directory -Recurse).Count | Should Be 2
+		}
+		It "Removes files and removes empty dirs" {
+			Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d' -RemoveEmptyBackupFolder
+			(Get-ChildItem -Path $testPath -Directory -Recurse).Count | Should Be 0
+		}
+	}
+}

--- a/tests/Remove-DbaBackup.Tests.ps1
+++ b/tests/Remove-DbaBackup.Tests.ps1
@@ -43,6 +43,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		for ($i = 1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		It "Should remove all files with retention 0d" {
 			$null = Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
@@ -53,10 +54,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		for ($i = 1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		for ($i = 1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.trn"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		It "Should remove all files but not the trn ones" {
 			$null = Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'
@@ -76,10 +79,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 		for ($i = 1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPath "dbatoolsci_$($i)_backup.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		for ($i = 1; $i -le 5; $i++) {
 			$filepath = Join-Path $testPathinner "dbatoolsci_$($i)_backup.bak"
 			Set-Content $filepath -value "."
+			(Get-ChildItem $filepath).LastWriteTime = (Get-Date).AddDays(-5)
 		}
 		It "Removes files but leaves empty dirs" {
 			Remove-DbaBackup -Path $testPath -BackupFileExtension 'bak' -RetentionPeriod '0d'


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #638)
 - [x] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Spawn Find-DbaBackup from Remove-DbaBackup

### Approach
Copied most of the code and put into Find-DbaBackup.
Silenced Remove-DbaBackup (now it does not need to return anything, since people can use Find-DbaBackup for analysis)
Added the proper tags for 1.0 progress (IMHO it passes all manual signoffs needed)
Added tests for both.
