### PR TITLE
Column Name Fix for new Glenn Berry query

### DIFF
--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -126,11 +126,11 @@ function Export-DbaDiagnosticQuery {
 			$csvdbfilename = "$Path\$SqlInstance-$dbname-DQ-$number-$queryname-$Suffix.csv"
 			$csvfilename = "$Path\$SqlInstance-DQ-$number-$queryname-$Suffix.csv"
 
-            $columnnameoptions = "Query Plan", "QueryPlan", "Query_Plan"
+            $columnnameoptions = "Query Plan", "QueryPlan", "Query_Plan", "query_plan_xml"
             if (($result | Get-Member | Where-Object Name -in $columnnameoptions).Count -gt 0) {
                 $plannr = 0
                 $columnname = ($result | Get-Member | Where-Object Name -In $columnnameoptions).Name
-                   foreach ($plan in $result."$columname") {
+                   foreach ($plan in $result."$columnname") {
                     $plannr += 1
                     if ($row.DatabaseSpecific) {
                         $planfilename = "$Path\$SqlInstance-$dbname-DQ-$number-$queryname-$plannr-$Suffix.sqlplan"
@@ -142,14 +142,14 @@ function Export-DbaDiagnosticQuery {
                     if (!$NoPlanExport)
                     {
 					    Write-Message -Level Output -Message "Exporting $planfilename"
-                        $plan | Out-File -FilePath $planfilename
+                        if ($plan) {$plan | Out-File -FilePath $planfilename}
                     }
                 }
 
                 $result = $result | Select-Object * -ExcludeProperty "$columnname"
             }
 
-            $columnnameoptions = "Complete Query Text", "QueryText", "Query Text", "Query_Text"
+            $columnnameoptions = "Complete Query Text", "QueryText", "Query Text", "Query_Text", "query_sql_text"
             if (($result | Get-Member | Where-Object Name -In $columnnameoptions ).Count -gt 0) {
                 $sqlnr = 0
                 $columnname = ($result | Get-Member | Where-Object Name -In $columnnameoptions).Name
@@ -165,7 +165,7 @@ function Export-DbaDiagnosticQuery {
                     if (!$NoQueryExport)
                     {
 					    Write-Message -Level Output -Message "Exporting $sqlfilename"
-                        $sql | Out-File -FilePath $sqlfilename
+                        if ($sql) {$sql | Out-File -FilePath $sqlfilename}
                     }
                 }
 


### PR DESCRIPTION
There was a new query with yet another way to name the plan and sql text column. This breaks the excel export. High Aggregate Duration Queries should now work again (this is a Query Store specific query, which must be enabled for it to give a result)

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [* ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Glenn Berry released a new version of his dmv scripts, it contained a new query with new column names for query text and query plans which breaks the excel export. I added the column names to filter on to the code.

### Approach
Export-DbaDiagnosticQuery has an array for sql query text en plan text column name variations, I added the new ones

### Commands to test
Invoke-DbaDiagnosticQuery -SqlInstance localhost\sql2016 -QueryName "High Aggregate Duration Queries" | Export-DbaDiagnosticQuery -ConvertTo Excel -Path C:\temp\

This should export .sql and .sqlplan files (on SQL Server 2016 with Query Store enabled)

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
