### PR TITLE
Invoke-DbaAdvancedRestore, progress info with percentages

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -5,10 +5,10 @@ function Invoke-DbaAdvancedRestore {
 		For 90% of users Restore-DbaDatabase should be your point of access to this function. The other 10% use it at their own risk
 
 	.DESCRIPTION
-		This is the final piece in the Restore-DbaDatabase Stack. Uusally a BackupHistory object will arrive here from Restore-DbaDatabse via the following pipeline:
+		This is the final piece in the Restore-DbaDatabase Stack. Usually a BackupHistory object will arrive here from Restore-DbaDatabse via the following pipeline:
 		Get-DbaBackupInformation  | Select-DbaBackupInformation | Format-DbaBackupInformation | Test-DbaBackupInformation | Invoke-DbaAdvancedRestore
 
-		We have exposed these functions publically to allow advanced users to perform operations that we don't support, or won't add as they would make things too complex for the majority of our users
+		We have exposed these functions publicly to allow advanced users to perform operations that we don't support, or won't add as they would make things too complex for the majority of our users
 
 		For example if you wanted to do some very complex redirection during a migration, then doing the rewrite of destinations may be better done with your own custom scripts rather than via Format-DbaBackupInformation
 
@@ -87,7 +87,7 @@ function Invoke-DbaAdvancedRestore {
 		$BackupHistory | Invoke-DbaAdvancedRestore -SqlInstance MyInstance -OutputScriptOnly
 		$BackupHistory | Invoke-DbaAdvancedRestore -SqlInstance MyInstance
 
-		First generates just the T-SQL restore scripts so they can be sanity checked, and then if they are good perform the full restore. By  reusing the BackupHistory object there is no need to rescan all the backup files again 
+		First generates just the T-SQL restore scripts so they can be sanity checked, and then if they are good perform the full restore. By reusing the BackupHistory object there is no need to rescan all the backup files again
 	#>
 	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
 	param (

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -331,9 +331,8 @@ function Invoke-DbaAdvancedRestore {
 						else {
 							$script
 						}
-						while ($Restore.Devices.count -gt 0) {
-							$Device = $Restore.Devices[0]
-							$null = $Restore.Devices.Remove($Device)
+						if ($Restore.Devices.Count -gt 0) {
+							$Restore.Devices.Clear()
 						}
 						Write-Message -Level Verbose -Message "Succeeded, Closing Server connection"
 						$server.ConnectionContext.Disconnect()

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -124,10 +124,10 @@ function Invoke-DbaAdvancedRestore {
 			return
 		}
 
-		If ($null -ne $PageRestore) {
+		if ($null -ne $PageRestore) {
 			Write-Message -Message "Doing Page Recovery" -Level Verbose
 			$tmpPages = @()
-			ForEach ($Page in $PageRestore) {
+			foreach ($Page in $PageRestore) {
 				$tmppages += "$($Page.FileId):$($Page.PageID)"
 			}
 			$NoRecovery = $True
@@ -137,7 +137,7 @@ function Invoke-DbaAdvancedRestore {
 		$InternalHistory = @()
 	}
 	process {
-		ForEach ($bh in $BackupHistory) {
+		foreach ($bh in $BackupHistory) {
 			$InternalHistory += $bh
 		}
 	}
@@ -232,7 +232,7 @@ function Invoke-DbaAdvancedRestore {
 						$Device.devicetype = "File"
 					}
 					$Restore.FileNumber = $backup.Position
-					$Restore.Devices.Add($device)
+					$Restore.Devices.Add($Device)
 				}
 				Write-Message -Level Verbose -Message "Performing restore action"
 				$ConfirmMessage = "`n Restore Database $Database on $SqlInstance `n from files: $RestoreFileNames `n with these file moves: `n $LogicalFileMovesString `n $ConfirmPointInTime `n"
@@ -268,7 +268,7 @@ function Invoke-DbaAdvancedRestore {
 						elseif ($VerifyOnly) {
 							Write-Message -Message "VerifyOnly restore" -Level Verbose
 							Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
-							$Verify = $Restore.sqlverify($server)
+							$Verify = $Restore.SqlVerify($server)
 							Write-Progress -id 2 -activity "Verifying $Database backup file on $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -status "Complete" -Completed
 							if ($verify -eq $true) {
 								Write-Message -Message "VerifyOnly restore Succeeded" -Level Verbose
@@ -291,7 +291,7 @@ function Invoke-DbaAdvancedRestore {
 							}
 							$Restore.add_PercentComplete($percentcomplete)
 							$Restore.PercentCompleteNotification = 1
-							$Restore.sqlrestore($Server)
+							$Restore.SqlRestore($Server)
 							Write-Progress -id 3 -ParentId 2 -Activity "Restore $($backup.FullName -Join ',')" -Completed
 							Write-Progress -id 2 -ParentId 1 -Activity "Restoring $Database to $sqlinstance `n Backup $BackupCnt of $($Backups.count)" -percentcomplete $outerProgress -status ([System.String]::Format("Progress: {0:N2} %", $outerProgress))
 						}
@@ -332,8 +332,8 @@ function Invoke-DbaAdvancedRestore {
 							$script
 						}
 						while ($Restore.Devices.count -gt 0) {
-							$device = $Restore.devices[0]
-							$null = $Restore.devices.remove($Device)
+							$Device = $Restore.Devices[0]
+							$null = $Restore.Devices.Remove($Device)
 						}
 						Write-Message -Level Verbose -Message "Succeeded, Closing Server connection"
 						$server.ConnectionContext.Disconnect()


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Not a new feature per se, rather a better functionality for an existing one. Write-Progress was used with no meaningful progress values, just to print out what step was the restore on. For long chains or huge backups having a progress info without the bar forced to go and inspect db_exec_requests to monitor the progress. Given we have a progress already, this just adds proper percentage info on it.
