### PR TITLE
Find-DbaDatabaseGrowth - hot fix and rename

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -231,7 +231,7 @@
         'Remove-DbaDatabase',
         'Get-DbaQueryExecutionTime',
         'Get-DbaTempdbUsage',
-        'Find-DbaDatabaseGrowthEvent',
+        'Find-DbaDbGrowthEvent',
         'Get-DbaNetworkActivity',
         'Get-DbaAgentJobOutputFile',
         'Set-DbaAgentJobOutputFile',
@@ -432,7 +432,7 @@
     # Aliases to export from this module
     # Aliases are stored in dbatools.psm1
     # KEEP Detach-DbaDatabase, Dismount-DbaDatabase and Start-SqlMigration FOREVER
-    AliasesToExport         = 'Detach-DbaDatabase', 'Attach-DbaDatabase',
+    AliasesToExport        = 'Detach-DbaDatabase', 'Attach-DbaDatabase',
     'Reset-SqlSaPassword',
     'Copy-SqlUserDefinedMessage',
     'Copy-SqlJobServer',
@@ -512,7 +512,8 @@
     'Get-DbaDatabaseCertificate',
     'New-DbaDatabaseCertificate',
     'Remove-DbaDatabaseCertificate',
-    'Restore-DbaDatabaseCertificate'
+    'Restore-DbaDatabaseCertificate',
+    'Find-DbaDatabaseGrowthEvent'
 
     # List of all modules packaged with this module
     ModuleList              = @()

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -516,6 +516,10 @@ Write-ImportTime -Text "Script: Maintenance"
     @{
         "AliasName"  = "Backup-DbaDatabaseCertificate"
         "Definition" = "Backup-DbaDbCertificate"
+    },
+    @{
+        "AliasName"  = "Find-DbaDatabaseGrowthEvent"
+        "Definition" = "Find-DbaDbGrowthEvent"
     }
 ) | ForEach-Object {
     if (-not (Test-Path Alias:$($_.AliasName))) { Set-Alias -Scope Global -Name $($_.AliasName) -Value $($_.Definition) }

--- a/functions/Find-DbaDatabaseGrowthEvent.ps1
+++ b/functions/Find-DbaDatabaseGrowthEvent.ps1
@@ -41,6 +41,9 @@ function Find-DbaDatabaseGrowthEvent {
 
             Allowed vaules: Data, Log
 
+        .PARAMETER UseLocalTime
+            Return the local time of the instance instead of converting to UTC.
+
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -61,7 +64,12 @@ function Find-DbaDatabaseGrowthEvent {
         .EXAMPLE
             Find-DbaDatabaseGrowthEvent -SqlInstance localhost
 
-            Returns any database AutoGrow events in the Default Trace for every database on the localhost instance.
+            Returns any database AutoGrow events in the Default Trace with UTC time for the instance for every database on the localhost instance.
+
+        .EXAMPLE
+            Find-DbaDatabaseGrowthEvent -SqlInstance localhost -UseLocalTime
+
+            Returns any database AutoGrow events in the Default Trace with the local time of the instance for every database on the localhost instance.
 
         .EXAMPLE
             Find-DbaDatabaseGrowthEvent -SqlInstance ServerA\SQL2016, ServerA\SQL2014
@@ -96,6 +104,7 @@ function Find-DbaDatabaseGrowthEvent {
         [string]$EventType,
         [ValidateSet('Data', 'Log')]
         [string]$FileType,
+        [switch]$UseLocalTime,
         [Alias('Silent')]
         [switch]$EnableException
     )
@@ -159,10 +168,14 @@ function Find-DbaDatabaseGrowthEvent {
                             [DatabaseName],
                             [Filename],
                             CONVERT(INT,(Duration/1000)) AS Duration,
-                            DATEADD (MINUTE, DATEDIFF(MINUTE, GETDATE(), GETUTCDATE()), [StartTime]) AS StartTimeUTC,  -- Convert to UTC time
-                            DATEADD (MINUTE, DATEDIFF(MINUTE, GETDATE(), GETUTCDATE()), [EndTime]) AS EndTimeUTC,  -- Convert to UTC time
+                            $(if (-not $UseLocalTime) { "
+                            DATEADD (MINUTE, DATEDIFF(MINUTE, GETDATE(), GETUTCDATE()), [StartTime]) AS StartTime,  -- Convert to UTC time
+                            DATEADD (MINUTE, DATEDIFF(MINUTE, GETDATE(), GETUTCDATE()), [EndTime]) AS EndTime,  -- Convert to UTC time"
+                            }
+                            else { "
                             [StartTime] AS StartTime,
-                            [EndTime] AS EndTime,
+                            [EndTime] AS EndTime,"
+                            })
                             ([IntegerData]*8.0/1024) AS ChangeInSize,
                             ApplicationName,
                             HostName,
@@ -186,14 +199,12 @@ function Find-DbaDatabaseGrowthEvent {
                         0 [DatabaseName],
                         0 AS [Filename],
                         0 AS [Duration],
-                        0 AS [StartTimeUTC],
-                        0 AS [EndTimeUTC],
                         0 AS [StartTime],
                         0 AS [EndTime],
-                        0 AS ChangeInSize
+                        0 AS ChangeInSize,
                         0 AS [ApplicationName],
                         0 AS [HostName],
-                        0 AS [SessionLoginName]
+                        0 AS [SessionLoginName],
                         0 AS [SPID]
             END	TRY
             BEGIN CATCH
@@ -207,14 +218,12 @@ function Find-DbaDatabaseGrowthEvent {
                     ERROR_SEVERITY() AS [DatabaseName],
                     ERROR_STATE() AS [Filename],
                     ERROR_MESSAGE() AS [Duration],
-                    1 AS [StartTimeUTC],
-                    1 AS [EndTimeUTC],
                     1 AS [StartTime],
                     1 AS [EndTime],
-                    1 AS [ChangeInSize]
+                    1 AS [ChangeInSize],
                     1 AS [ApplicationName],
                     1 AS [HostName],
-                    1 AS [SessionLoginName]
+                    1 AS [SessionLoginName],
                     1 AS [SPID]
             END CATCH"
     }
@@ -245,9 +254,14 @@ function Find-DbaDatabaseGrowthEvent {
             $sql = $sql -replace '_DatabaseList_', $dbsList
             Write-Message -Level Debug -Message "Executing SQL Statement:`n $sql"
 
-            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTimeUTC', 'EndTimeUTC', 'ChangeInSize', 'ApplicationName', 'HostName'
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTime', 'EndTime', 'ChangeInSize', 'ApplicationName', 'HostName'
 
-            Select-DefaultView -InputObject $server.Query($sql) -Property $defaults
+            try {
+                Select-DefaultView -InputObject $server.Query($sql) -Property $defaults
+            }
+            catch {
+                Stop-Function -Message "Issue collecting data on $server" -Target $server -ErrorRecord $_ -Exception $_.Exception.InnerException.InnerException.InnerException -Continue
+            }
         }
     }
 }

--- a/functions/Find-DbaDbGrowthEvent.ps1
+++ b/functions/Find-DbaDbGrowthEvent.ps1
@@ -1,5 +1,5 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
-function Find-DbaDatabaseGrowthEvent {
+function Find-DbaDbGrowthEvent {
     <#
         .SYNOPSIS
             Finds any database AutoGrow events in the Default Trace.
@@ -226,6 +226,8 @@ function Find-DbaDatabaseGrowthEvent {
                     1 AS [SessionLoginName],
                     1 AS [SPID]
             END CATCH"
+
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Find-DbaDatabaseGrowthEvent
     }
     process {
         foreach ($instance in $SqlInstance) {


### PR DESCRIPTION
- Rename `Find-DbaDatabaseGrowthEvent` to `Find-DbaDbGrowthEvent`
- Adjust local and UTC time output to be via parameter `-UseLocalTime`, the default will be UTC time as it was but if the parameter is passed it will output the time as-is in default trace (which is local time of the instance).

Updated psd1 and psm1 for rename of the command.