### PR TITLE
Test-DbaSqlBuild, fixes #2375

### DIFF
--- a/functions/Test-DbaSqlBuild.ps1
+++ b/functions/Test-DbaSqlBuild.ps1
@@ -1,0 +1,246 @@
+function Test-DbaSqlBuild {
+    <#
+    .SYNOPSIS
+        Returns SQL Server Build "compliance" level on a build
+
+    .DESCRIPTION
+        It answers the question "is this build up to date ?"
+        Returns info about the specific build of a SQL instance, including the SP, the CU and the reference KB, End Of Support, wherever possible.
+        It adds a Compliance property as true/false, and adds details about the "targeted compliance"
+
+    .PARAMETER Build
+        Instead of connecting to a real instance, pass a string identifying the build to get the info back.
+
+    .PARAMETER MinimumBuild
+        This is the build version to test "compliance" against. Anything below this is flagged as not compliant
+
+    .PARAMETER MaxBehind
+        Instead of using a specific MinimumBuild here you can pass "how many service packs and cu back" is the targeted compliance level
+        You can use xxSP or xxCU or both, where xx is a number. See Examples for more informations
+
+    .PARAMETER SqlInstance
+        Target any number of instances, in order to return their compliance state.
+
+    .PARAMETER SqlCredential
+        When connecting to an instance, use the credentials specified.
+
+    .PARAMETER Update
+        Looks online for the most up to date reference, replacing the local one.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.0.5540" -MinimumBuild "12.0.5557"
+
+        Returns information about a build identified by "12.0.5540" (which is SQL 2014 with SP2 and CU4), which is not compliant as the minimum required
+        build is "12.0.5557" (which is SQL 2014 with SP2 and CU8)
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.0.5540" -MaxBehind "1SP"
+
+        Returns information about a build identified by "12.0.5540", making sure it is AT MOST 1 Service Pack "behind". For that version,
+        that identifies an SP2, means accepting as the lowest compliance version as "12.0.4110", that identifies 2014 with SP1
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.0.5540" -MaxBehind "1SP 1CU"
+
+        Returns information about a build identified by "12.0.5540", making sure it is AT MOST 1 Service Pack "behind", plus 1 CU "behind". For that version,
+        that identifies an SP2 and CU, rolling back 1 SP brings you to "12.0.4110", but given the latest CU for SP1 is CU13, the target "compliant" build
+        will be "12.0.4511", which is 2014 with SP1 and CU12
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.0.5540" -MaxBehind "0CU"
+
+        Returns information about a build identified by "12.0.5540", making sure it is the latest CU release.
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.00.4502" -MinimumBuild "12.0.4511" -Update
+
+        Same as before, but tries to fetch the most up to date index online. When the online version is newer, the local one gets overwritten
+
+    .EXAMPLE
+        Test-DbaSqlBuild -Build "12.0.4502","10.50.4260" -MinimumBuild "12.0.4511"
+
+        Returns information builds identified by these versions strings
+
+    .EXAMPLE
+        Get-DbaRegisteredServer -SqlInstance sqlserver2014a | Test-DbaSqlBuild -MinimumBuild "12.0.4511"
+
+        Integrate with other commandlets to have builds checked for all your registered servers on sqlserver2014a
+
+    .NOTES
+        Author: niphlod
+        Editor: Fred
+        Tags: SqlBuild
+
+        dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+        Copyright (C) 2016 Chrissy LeMaire
+        License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+
+    .LINK
+        https://dbatools.io/Test-DbaSqlBuild
+#>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    [CmdletBinding()]
+    param (
+        [version[]]
+        $Build,
+
+        [version]
+        $MinimumBuild,
+
+        [string]
+        $MaxBehind,
+
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]
+        $SqlInstance,
+
+        [Alias("Credential")]
+        [PsCredential]
+        $SqlCredential,
+
+        [switch]
+        $Update,
+
+        [switch]
+        [Alias('Silent')]$EnableException
+    )
+
+    begin {
+        #region Helper functions
+        function Get-DbaSqlBuildReferenceIndex {
+            [CmdletBinding()]
+
+            $DbatoolsData = Get-DbaConfigValue -Name 'Path.DbatoolsData'
+            $writable_idxfile = Join-Path $DbatoolsData "dbatools-buildref-index.json"
+            $result = Get-Content $writable_idxfile -Raw | ConvertFrom-Json
+            $result.Data | Select-Object @{ Name = "VersionObject"; Expression = { [version]$_.Version } }, *
+        }
+        if ($MaxBehind) {
+            $MaxBehindValidator = [regex]'^(?<howmany>[\d]+)(?<what>SP|CU)$'
+            $pieces = $MaxBehind.Split(' ')	| Where-Object { $_ }
+            try {
+                $ParsedMaxBehind = @{}
+                foreach ($piece in $pieces) {
+                    $pieceMatch = $MaxBehindValidator.Match($piece)
+                    if ($pieceMatch.Success -ne $true) {
+                        Stop-Function -Message "MaxBehind has an invalid syntax ('$piece' could not be parsed correctly)" -ErrorRecord $_
+                        return
+                    }
+                    else {
+                        $howmany = [int]$pieceMatch.Groups['howmany'].Value
+                        $what = $pieceMatch.Groups['what'].Value
+                        if ($ParsedMaxBehind.ContainsKey($what)) {
+                            Stop-Function -Message "The specifier $what has been already passed" -ErrorRecord $_
+                            return
+                        }
+                        else {
+                            $ParsedMaxBehind[$what] = $howmany
+                        }
+                    }
+                }
+                if (-not $ParsedMaxBehind.ContainsKey('SP')) {
+                    $ParsedMaxBehind['SP'] = 0
+                }
+            }
+            catch {
+                Stop-Function -Message "Error parsing MaxBehind" -ErrorRecord $_
+                return
+            }
+        }
+    }
+    process {
+        if (Test-FunctionInterrupt) { return }
+        try {
+            $IdxRef = Get-DbaSqlBuildReferenceIndex -Moduledirectory $moduledirectory -Update $Update -EnableException $EnableException
+        }
+        catch {
+            Stop-Function -Message "Error loading SQL build reference" -ErrorRecord $_
+            return
+        }
+        $hiddenProps = @()
+        if (-not $SqlInstance) {
+            $hiddenProps += 'SqlInstance'
+        }
+        if ($MinimumBuild) {
+            $hiddenProps += 'MaxBehind', 'SPTarget', 'CUTarget', 'BuildTarget'
+        }
+        elseif ($MaxBehind) {
+            $hiddenProps += 'MinimumBuild'
+        }
+        $BuildVersions = Get-DbaSqlBuildReference -Build $Build -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Update:$Update -EnableException:$EnableException
+        foreach ($BuildVersion in $BuildVersions) {
+            $inputbuild = $BuildVersion.Build
+            $compliant = $false
+            if ($BuildVersion.MatchType -eq 'Approximate') {
+                Stop-Function -Message "$($BuildVersion.Build) is not recognized as a correct version" -ErrorRecord $_ -Continue
+            }
+            if ($MinimumBuild) {
+                Write-Message -Level verbose -Message "Comparing $MinimumBuild to $inputbuild"
+                if ($inputbuild -ge $MinimumBuild) {
+                    $compliant = $true
+                }
+            }
+            elseif ($MaxBehind) {
+                $IdxVersion = $IdxRef | Where-Object Version -like "$($inputbuild.Major).$($inputbuild.Minor).*"
+                $lastsp = ''
+                $SPsAndCUs = @()
+                foreach ($el in $IdxVersion) {
+                    if ($null -ne $el.SP) {
+                        $lastsp = $el.SP | Where-Object { $_ -ne 'LATEST' }
+                        $SPsAndCUs += @{
+                            VersionObject = $el.VersionObject
+                            SP            = $lastsp
+                        }
+                    }
+                    if ($null -ne $el.CU) {
+                        $SPsAndCUs += @{
+                            VersionObject = $el.VersionObject
+                            SP            = $lastsp
+                            CU            = $el.CU
+                        }
+                    }
+                }
+                $targetedBuild = $SPsAndCUs[0]
+                if ($ParsedMaxBehind.ContainsKey('SP')) {
+                    $AllSPs = $SPsAndCUs.SP | Select-Object -Unique
+                    $targetSP = $AllSPs.Length - $ParsedMaxBehind['SP'] - 1
+                    if ($targetSP -lt 0) {
+                        $targetSP = 0
+                    }
+                    $targetSPName = $AllSPs[$targetSP]
+                    Write-Message -Level verbose -Message "Target SP is $targetSPName - $targetSP on $($AllSPs.Length)"
+                    $targetedBuild = $SPsAndCUs | Where-Object SP -eq $targetSPName | Select-Object -First 1
+                }
+                if ($ParsedMaxBehind.ContainsKey('CU')) {
+                    $SPsAndCUs | Where-Object Version -gt $targetedBuild.Version | ConvertTo-Json
+                    $AllCUs = ($SPsAndCUs | Where-Object VersionObject -gt $targetedBuild.VersionObject).CU | Select-Object -Unique
+                    $targetCU = $AllCUs.Length - $ParsedMaxBehind['CU'] - 1
+                    if ($targetCU -lt 0) {
+                        $targetCU = 0
+                    }
+                    $targetCUName = $AllCUs[$targetCU]
+                    Write-Message -Level verbose -Message "Target CU is $targetCUName - $targetCU on $($AllCUs.Length)"
+                    $targetedBuild = $SPsAndCUs | Where-Object VersionObject -gt $targetedBuild.VersionObject | Where-Object CU -eq $targetCUName | Select-Object -First 1
+                }
+                if ($inputbuild -ge $targetedBuild.VersionObject) {
+                    $compliant = $true
+                }
+            }
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name Compliant -Value $compliant
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name MinimumBuild -Value $MinimumBuild
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name MaxBehind -Value $MaxBehind
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name SPTarget -Value $targetSPName
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name CUTarget -Value $targetCUName
+            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name BuildTarget -Value $targetedBuild.VersionObject
+
+            $BuildVersion | Select-Object * | Select-DefaultView -ExcludeProperty $hiddenProps
+        }
+    }
+}
+


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality, see #2375 and #2985)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
 see #2375 and #2985

### Approach
Builds up on Get-DbaSqlBuildReference and @FriedrichWeinmann speedy [version] type to compare versions. Granted, doing the same thing MinimumBuild does was only a matter of knowing that `[version]` existed, but the added logic for MaxBehind makes checking compliance really swift.
For #2985 all it takes is a nice blogpost with the MinimumBuild for each version ... or at most a wrapper around this one. 

### Commands to test
See ALL examples. Then show it to your compliance auditor. Then go take care of his/her goosebumps ^_^.

### Screenshots
![image](https://user-images.githubusercontent.com/122119/34588358-d99d21e4-f1ac-11e7-89a4-8b6574d078eb.png)


