### PR TITLE
Fix $Query variable check issue.  Fixes #2987

### DIFF
--- a/functions/Copy-DbaTableData.ps1
+++ b/functions/Copy-DbaTableData.ps1
@@ -292,13 +292,13 @@ function Copy-DbaTableData {
             $fqtnfrom = "$($server.Databases[$Database]).$sqltable"
             $fqtndest = "$($destServer.Databases[$DestinationDatabase]).$desttable"
 
-            if (-not $Query) {
+            if (Test-Bound -ParameterName Query -Not) {
                 $Query = "SELECT * FROM $fqtnfrom"
             }
 
             if ($Truncate -eq $true) {
                 if ($Pscmdlet.ShouldProcess($destServer, "Truncating table $fqtndest")) {
-                    $null = $destServer.Databases[$DestinationDatabase].Query("TRUNCATE TABLE $fqtndest")
+                    $null = $destServer.Databases[$DestinationDatabase].ExecuteNonQuery("TRUNCATE TABLE $fqtndest")
                 }
             }
             $cmd = $server.ConnectionContext.SqlConnectionObject.CreateCommand()


### PR DESCRIPTION
Fix check issue with $Query parameter, as this variable is re-used in the event that multiple tables are copied the current check does not properly validate this scenario.  The $Query variable is written to in the first iteration of the loop and any subsequent iteration will result in the copy failing to run as expected.  Also corrected an issue with the truncation which resulted from the "Query" method being used which does not seem to exist, changed to "ExecuteNonQuery" method.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
