### PR TITLE
Fix to TotalSize calculation.

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -511,7 +511,7 @@ function Get-DbaBackupHistory {
                     $historyObject.End = ($group.Group.End | Measure-Object -Maximum).Maximum
                     $historyObject.Duration = New-TimeSpan -Seconds ($group.Group.Duration | Measure-Object -Maximum).Maximum
                     $historyObject.Path = $group.Group.Path
-                    $historyObject.TotalSize = ($group.Group.TotalSize | Measure-Object -Sum).Sum
+                    $historyObject.TotalSize = $group.Group[0].TotalSize
                     $historyObject.Type = $group.Group[0].Type
                     $historyObject.BackupSetId = $group.Group[0].BackupSetId
                     $historyObject.DeviceType = $group.Group[0].DeviceType


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2981)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
To fix the TotalSize value returned by the function for striped backups.  

### Approach
<!-- How does this change solve that purpose -->
The Get-DbaBackupHistory function uses the backup_size column in msdb.dbo.backupset table to get the backup size.   Currently this value is summed for each file in a media set. If there's one file it's accurate but for striped backups the value is too high.   Since this value is already the total size of the backup there's no need to sum the values and returning the first value in the group returns the backup size. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Test:  Create two full backups, one a single file and one with multiple file. Then run the Get-DbaBackupHistory command and compare the file system size of the backup files to what's returned by the command.
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
