### PR TITLE
Improve Export-DbaLogin - Allow username different from login name

### DIFF
--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -392,19 +392,19 @@ function Export-DbaLogin {
 
                     # Database Roles: db_owner, db_datareader, etc
                     foreach ($role in $sourceDb.Roles) {
-                        if ($role.EnumMembers() -contains $userName) {
+                        if ($role.EnumMembers() -contains $dbUserName) {
                             $roleName = $role.Name
                             if (($server.VersionMajor -lt 11 -and [string]::IsNullOrEmpty($destinationVersion)) -or ($DestinationVersion -in "SQLServer2000", "SQLServer2005", "SQLServer2008/2008R2")) {
-                                $outsql += "EXEC sys.sp_addrolemember @rolename = N'$roleName', @membername = N'$userName'"
+                                $outsql += "EXEC sys.sp_addrolemember @rolename = N'$roleName', @membername = N'$dbUserName'"
                             }
                             else {
-                                $outsql += "ALTER ROLE [$roleName] ADD MEMBER [$userName]"
+                                $outsql += "ALTER ROLE [$roleName] ADD MEMBER [$dbUserName]"
                             }
                         }
                     }
 
                     # Connect, Alter Any Assembly, etc
-                    $perms = $sourceDb.EnumDatabasePermissions($userName)
+                    $perms = $sourceDb.EnumDatabasePermissions($dbUserName)
                     foreach ($perm in $perms) {
                         $permState = $perm.PermissionState
                         $permType = $perm.PermissionType

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -320,7 +320,7 @@ function Export-DbaLogin {
 
                 if ($roleMembers -contains $userName) {
                     if (($server.VersionMajor -lt 11 -and [string]::IsNullOrEmpty($destinationVersion)) -or ($DestinationVersion -in "SQLServer2000", "SQLServer2005", "SQLServer2008/2008R2")) {
-                        $outsql += "EXEC sys.sp_addrolemember @rolename = N'$roleName', @membername = N'$userName'"
+                        $outsql += "EXEC sys.sp_addsrvrolemember @rolename=N'$roleName', @loginame=N'$userName'"
                     }
                     else {
                         $outsql += "ALTER SERVER ROLE [$roleName] ADD MEMBER [$userName]"
@@ -395,7 +395,7 @@ function Export-DbaLogin {
                         if ($role.EnumMembers() -contains $dbUserName) {
                             $roleName = $role.Name
                             if (($server.VersionMajor -lt 11 -and [string]::IsNullOrEmpty($destinationVersion)) -or ($DestinationVersion -in "SQLServer2000", "SQLServer2005", "SQLServer2008/2008R2")) {
-                                $outsql += "EXEC sys.sp_addrolemember @rolename = N'$roleName', @membername = N'$dbUserName'"
+                                $outsql += "EXEC sys.sp_addrolemember @rolename=N'$roleName', @membername=N'$dbUserName'"
                             }
                             else {
                                 $outsql += "ALTER ROLE [$roleName] ADD MEMBER [$dbUserName]"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2995 #2680)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For #2995:
 - Change from `sys.sp_addrolemember` to `sp_addsrvrolemember` and `@membername` for `@loginame`

For #2680, replace the `$userName` by `$dbUserName` at database level
