### PR TITLE
Created a Parameterset for destination parameter.

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -131,7 +131,7 @@ function Copy-DbaLogin {
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(ParameterSetName = "Destination", Mandatory = $true)]
         [DbaInstanceParameter]$Destination,
         [PSCredential]
         $DestinationSqlCredential,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #2939 )
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When sending the output to a file the function no longer prompts for a destination.

### Approach
<!-- How does this change solve that purpose -->
By creating a ParameterSet for the destination it is now mutually exclusive of the OutFile parameter which was already configured as a ParameterSet. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
Get-Command Copy-DbaLogin -syntax
Copy-DbaLogin -Source myserver -OutFile c:\temp\myserver_logins.sql

```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
[](https://blogs.msdn.microsoft.com/powershell/2008/12/23/powershell-v2-parametersets/)
[](http://blog.simonw.se/powershell-functions-and-parameter-sets/)