### PR TITLE
Improve notification when no files available for Restore - #3026 

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -209,10 +209,16 @@ function Get-DbaBackupInformation {
                         if ((Test-DbaSqlPath -Path $f.fullname -SqlInstance $server)) {
                             $files += $f
                         }
+                        else {
+                            Write-Message -Level Verbose -Message "$server cannot 'see' file $($f.FullName)"
+                        }
                     }
                     else {
                         Write-Message -Message "Testing a folder $f" -Level Verbose
-                        $Files += Get-XpDirTreeRestoreFile -Path $f -SqlInstance $server
+                        $Files += $Check = Get-XpDirTreeRestoreFile -Path $f -SqlInstance $server
+                        if  ($null -eq $check) {
+                            Write-Message -Message "Nothing returned from $f" -Level Verbose
+                        }
                     }
                 }
             }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -592,6 +592,10 @@ function Restore-DbaDatabase {
     end {
         if (Test-FunctionInterrupt) { return }
         if ($PSCmdlet.ParameterSetName -like "Restore*") {
+            if ($BackupHistory.Count -eq 0) {
+                Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
+                return
+            }
             Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
             $FilteredBackupHistory = @()
             if (Test-Bound -ParameterName GetBackupInformation) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #3026 )
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing #3026 by raising some information when no files make it through to  restore, and when Get-DbaBackupInformation can't read files.

Raising a warning for no files rather than a 'sea of blood' error

GBI returns via verbose

### Approach
<!-- How does this change solve that purpose -->
