### PR TITLE
Get-DbaSqlService - Used FullComputerName property

### DIFF
--- a/functions/Get-DbaSqlService.ps1
+++ b/functions/Get-DbaSqlService.ps1
@@ -130,8 +130,8 @@ function Get-DbaSqlService {
     PROCESS {
         foreach ($Computer in $ComputerName.ComputerName) {
             $Server = Resolve-DbaNetworkName -ComputerName $Computer -Credential $credential
-            if ($Server.ComputerName) {
-                $Computer = $server.ComputerName
+            if ($Server.FullComputerName) {
+                $Computer = $server.FullComputerName
                 Write-Message -Level VeryVerbose -Message "Getting SQL Server namespace on $Computer" -Target $Computer
                 try { $namespaces = Get-DbaCmObject -ComputerName $Computer -NameSpace root\Microsoft\SQLServer -Query "Select Name FROM __NAMESPACE WHERE Name Like 'ComputerManagement%'" -EnableException -Credential $credential | Sort-Object Name -Descending }
                 catch { }


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Fixes lost fqdn issue, by using the `FullComputerName` of the input resolution