### PR TITLE
Measure-DbaBackupThroughput, fetch only needed

### DIFF
--- a/functions/Measure-DbaBackupThroughput.ps1
+++ b/functions/Measure-DbaBackupThroughput.ps1
@@ -139,10 +139,10 @@ function Measure-DbaBackupThroughput {
 
                 # Splatting didn't work
                 if ($since) {
-                    $histories = Get-DbaBackupHistory -SqlInstance $server -Database $db.name -Since $since -DeviceType $DeviceType | Where-Object Type -eq $Type
+                    $histories = Get-DbaBackupHistory -SqlInstance $server -Database $db.name -Since $since -DeviceType $DeviceType -Type $Type
                 }
                 else {
-                    $histories = Get-DbaBackupHistory -SqlInstance $server -Database $db.name -Last:$last -DeviceType $DeviceType | Where-Object Type -eq $Type
+                    $histories = Get-DbaBackupHistory -SqlInstance $server -Database $db.name -Last:$last -DeviceType $DeviceType -Type $Type
                 }
 
                 foreach ($history in $histories) {


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Be speedier. No need to fetch every backup type and then filter... just fetch what is needed and go from there

