### PR TITLE
Test-DbaTempDbConfiguration Fixes #3006

### DIFF
--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -134,7 +134,7 @@ function Test-DbaTempDbConfiguration {
 
             #get files and log files
             $tempdbFiles = Get-DbaDatabaseFile -SqlInstance $server -Database tempdb
-            $dataFiles = $tempdbFiles | Where-Object Type -ne 1
+            [array]$dataFiles = $tempdbFiles | Where-Object Type -ne 1
             $logFiles = $tempdbFiles | Where-Object Type -eq 1
             Write-Message -Level Verbose -Message "TempDB file objects gathered"
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes issue #3006 - instances with only 1 core and 1 tempdb datafile showed as not meeting best practice. Count didn't work on object so to fix I specified it should be an array no matter how many objects. Now returns true as meeting the best practice for servers with 1 core and 1 tempdb data file.

### Approach
<!-- How does this change solve that purpose -->
Specified the type of $dataFiles
`[array]$dataFiles = $tempdbFiles | Where-Object Type -ne 1`

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Test-DbaTempDbConfiguration -SqlInstance Server1 `
- where Server1 has 1 core and 1 tempdb data file

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/34908157-7a0c5426-f859-11e7-868b-8fdadae24a89.png)
