### PR TITLE
ConvertTo-DbaDataTable - Performance and adding missing columns

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -166,7 +166,6 @@
         'Test-DbaValidLogin',
         'Get-DbaMemoryUsage',
         'Export-DbaAvailabilityGroup',
-        'Out-DbaDataTable',
         'Write-DbaDataTable',
         'New-DbaDatabaseSnapshot',
         'Restore-DbaFromDatabaseSnapshot',
@@ -433,7 +432,8 @@
         'Find-DbaDisabledIndex',
         'Set-DbaLogin',
         'Copy-DbaXESessionTemplate',
-        'Get-DbaXEObject'
+        'Get-DbaXEObject',
+        'ConvertTo-DbaDataTable'
     )
 
     # Cmdlets to export from this module
@@ -527,7 +527,8 @@
     'Remove-DbaDatabaseCertificate',
     'Restore-DbaDatabaseCertificate',
     'Find-DbaDatabaseGrowthEvent',
-    'Get-DbaTraceFile'
+    'Get-DbaTraceFile',
+    'Out-DbaDataTable'
 
     # List of all modules packaged with this module
     ModuleList              = @()

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -524,6 +524,10 @@ Write-ImportTime -Text "Script: Maintenance"
     @{
         "AliasName"   = "Get-DbaTraceFile"
         "Definition"  = "Get-DbaTrace"
+    },
+    @{
+        "AliasName"  = "Out-DbaDataTable"
+        "Definition" = "ConvertTo-DbaDataTable"
     }
 ) | ForEach-Object {
     if (-not (Test-Path Alias:$($_.AliasName))) { Set-Alias -Scope Global -Name $($_.AliasName) -Value $($_.Definition) }

--- a/functions/ConvertTo-DbaDataTable.ps1
+++ b/functions/ConvertTo-DbaDataTable.ps1
@@ -203,7 +203,7 @@ function ConvertTo-DbaDataTable {
         #>
             [CmdletBinding()]
             Param (
-                $Value,                
+                $Value,
                 [ValidateSet('Timespan','Size')] [string]$Type,
                 [string]$SizeType,
                 [string]$TimeSpanType
@@ -282,6 +282,8 @@ function ConvertTo-DbaDataTable {
         $columns = @()
         $specialColumns = @()
         $specialColumnsType = @{ }
+        
+        $ShouldCreateColumns = $true
     }
     
     process {
@@ -367,7 +369,7 @@ function ConvertTo-DbaDataTable {
                                         $specialColumnsType[$property.Name] = $newColumn.SpecialType
                                     }
                                     
-                                    $datarow.Item($property.Name) = $value
+                                    $datarow.Item($property.Name) = $newColumn.Value
                                 }
                                 catch {
                                     Write-Message -Level Warning -Message "Failed to add property $($property.Name) from $object" -ErrorRecord $_ -Target $object

--- a/functions/ConvertTo-DbaDataTable.ps1
+++ b/functions/ConvertTo-DbaDataTable.ps1
@@ -1,5 +1,5 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
-function Out-DbaDataTable {
+function ConvertTo-DbaDataTable {
     <#
         .SYNOPSIS
             Creates a DataTable for an object.
@@ -32,22 +32,22 @@ function Out-DbaDataTable {
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
         .EXAMPLE
-            Get-Service | Out-DbaDataTable
+            Get-Service | ConvertTo-DbaDataTable
 
             Creates a DataTable from the output of Get-Service.
 
         .EXAMPLE
-            Out-DbaDataTable -InputObject $csv.cheesetypes
+            ConvertTo-DbaDataTable -InputObject $csv.cheesetypes
 
             Creates a DataTable from the CSV object $csv.cheesetypes.
 
         .EXAMPLE
-            $dblist | Out-DbaDataTable
+            $dblist | ConvertTo-DbaDataTable
 
             Creates a DataTable from the $dblist object passed in via pipeline.
 
         .EXAMPLE
-            Get-Process | Out-DbaDataTable -TimeSpanType TotalSeconds
+            Get-Process | ConvertTo-DbaDataTable -TimeSpanType TotalSeconds
 
             Creates a DataTable with the running processes and converts any TimeSpan property to TotalSeconds.
 
@@ -62,7 +62,7 @@ function Out-DbaDataTable {
             License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
         .LINK
-            https://dbatools.io/Out-DbaDataTable
+            https://dbatools.io/ConvertTo-DbaDataTable
     #>
     [CmdletBinding()]
     [OutputType([System.Object[]])]
@@ -90,15 +90,16 @@ function Out-DbaDataTable {
     )
 
     begin {
-        Write-Message -Level InternalComment -Message "Starting."
         Write-Message -Level Debug -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
         Write-Message -Level Debug -Message "TimeSpanType = $TimeSpanType | SizeType = $SizeType"
+        Test-DbaDeprecation -DeprecatedOn 1.0.0 -Alias Out-DbaDataTable
 
         function Convert-Type {
             # This function will check so that the type is an accepted type which could be used when inserting into a table.
             # If a type is accepted (included in the $type array) then it will be passed on, otherwise it will first change type before passing it on.
             # Special types will have both their types converted as well as the value.
             # TimeSpan is a special type and will be converted into the $timespantype. (default: TotalMilliseconds) so that the timespan can be stored in a database further down the line.
+            [CmdletBinding()]
             param (
                 $type,
 

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -160,7 +160,7 @@ function Watch-DbaDbLogin {
             $procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program }
 
             if ($procs.Count -gt 0) {
-                $procs | Select-Object @{Label = "ComputerName"; Expression = {$server.NetName}}, @{Label = "InstanceName"; Expression = {$server.ServiceName}}, @{Label = "SqlInstance"; Expression = {$server.DomainInstanceName}}, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | Out-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
+                $procs | Select-Object @{Label = "ComputerName"; Expression = {$server.NetName}}, @{Label = "InstanceName"; Expression = {$server.ServiceName}}, @{Label = "SqlInstance"; Expression = {$server.DomainInstanceName}}, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
 
                 Write-Output "Added process information for $instance to datatable."
             }

--- a/tests/ConvertTo-DbaDataTable.Tests.ps1
+++ b/tests/ConvertTo-DbaDataTable.Tests.ps1
@@ -188,16 +188,6 @@ Describe "Testing input parameters" {
             $null
         }
 
-        It "Returns message if Null value in pipeline when IgnoreNull is set" {
-            $null = returnnull | ConvertTo-DbaDataTable -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
-            $warn.message | Should Match 'The InputObject from the pipe is null'
-        }
-
-        It "Returns warning if Null value in array when IgnoreNull is set" {
-            $null = ConvertTo-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
-            $warn.message | Should Match 'Object in array is null'
-        }
-
         It "Does not create row if null is in array when IgnoreNull is set" {
             $result = ConvertTo-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningAction SilentlyContinue
             $result.Rows.Count | Should Be 2

--- a/tests/ConvertTo-DbaDataTable.Tests.ps1
+++ b/tests/ConvertTo-DbaDataTable.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Testing data table output when using a complex object" {
     }
 
     Add-Member -Force -InputObject $obj -MemberType NoteProperty -Name myobject -Value $innedobj
-    $result = Out-DbaDataTable -InputObject $obj
+    $result = ConvertTo-DbaDataTable -InputObject $obj
 
     Context "Property: guid" {
         It 'Has a column called "guid"' {
@@ -150,25 +150,25 @@ Describe "Testing input parameters" {
 
     Context "Verifying TimeSpanType" {
         It "Should return '1.00:00:00' when String is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType String).Timespan | Should Be '1.00:00:00'
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType String).Timespan | Should Be '1.00:00:00'
         }
         It "Should return 864000000000 when Ticks is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType Ticks).Timespan | Should Be 864000000000
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType Ticks).Timespan | Should Be 864000000000
         }
         It "Should return 1 when TotalDays is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalDays).Timespan | Should Be 1
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType TotalDays).Timespan | Should Be 1
         }
         It "Should return 24 when TotalHours is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalHours).Timespan | Should Be 24
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType TotalHours).Timespan | Should Be 24
         }
         It "Should return 86400000 when TotalMilliseconds is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalMilliseconds).Timespan | Should Be 86400000
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType TotalMilliseconds).Timespan | Should Be 86400000
         }
         It "Should return 1440 when TotalMinutes is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalMinutes).Timespan | Should Be 1440
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType TotalMinutes).Timespan | Should Be 1440
         }
         It "Should return 86400 when TotalSeconds is used" {
-            (Out-DbaDataTable -InputObject $obj -TimeSpanType TotalSeconds).Timespan | Should Be 86400
+            (ConvertTo-DbaDataTable -InputObject $obj -TimeSpanType TotalSeconds).Timespan | Should Be 86400
         }
     }
 
@@ -189,34 +189,34 @@ Describe "Testing input parameters" {
         }
 
         It "Returns message if Null value in pipeline when IgnoreNull is set" {
-            $null = returnnull | Out-DbaDataTable -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
+            $null = returnnull | ConvertTo-DbaDataTable -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
             $warn.message | Should Match 'The InputObject from the pipe is null'
         }
 
         It "Returns warning if Null value in array when IgnoreNull is set" {
-            $null = Out-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
+            $null = ConvertTo-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningVariable warn -WarningAction SilentlyContinue
             $warn.message | Should Match 'Object in array is null'
         }
 
         It "Does not create row if null is in array when IgnoreNull is set" {
-            $result = Out-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningAction SilentlyContinue
+            $result = ConvertTo-DbaDataTable -InputObject (returnnull) -IgnoreNull -WarningAction SilentlyContinue
             $result.Rows.Count | Should Be 2
         }
 
         It "Does not create row if null is in pipeline when IgnoreNull is set" {
-            $result = returnnull | Out-DbaDataTable -IgnoreNull -WarningAction SilentlyContinue
+            $result = returnnull | ConvertTo-DbaDataTable -IgnoreNull -WarningAction SilentlyContinue
             $result.Rows.Count | Should Be 2
         }
 
         It "Returns empty row when null value is provided (without IgnoreNull)" {
-            $result = Out-DbaDataTable -InputObject (returnnull)
+            $result = ConvertTo-DbaDataTable -InputObject (returnnull)
             $result.Name[0] | Should Be 1
             $result.Name[1].GetType().FullName | Should Be 'System.DBNull'
             $result.Name[2] | Should Be 3
         }
 
         It "Returns empty row when null value is passed in pipe (without IgnoreNull)" {
-            $result = returnnull | Out-DbaDataTable
+            $result = returnnull | ConvertTo-DbaDataTable
             $result.Name[0] | Should Be 1
             $result.Name[1].GetType().FullName | Should Be 'System.DBNull'
             $result.Name[2] | Should Be 3
@@ -232,7 +232,7 @@ Describe "Testing input parameters" {
         }
 
         It "Suppresses warning messages when Silent is used" {
-            $null = Out-DbaDataTable -InputObject (returnnull) -IgnoreNull -EnableException -WarningVariable warn -WarningAction SilentlyContinue
+            $null = ConvertTo-DbaDataTable -InputObject (returnnull) -IgnoreNull -EnableException -WarningVariable warn -WarningAction SilentlyContinue
             $warn.message -eq $null | Should Be $true
         }
     }
@@ -242,7 +242,7 @@ Describe "Testing input parameters" {
         It "Returns string column if a script property returns null" {
             $myobj = New-Object -TypeName psobject -Property @{ Name = 'Test' }
             $myobj | Add-Member -Force -MemberType ScriptProperty -Name ScriptNothing -Value { $null }
-            $r = Out-DbaDataTable -InputObject $myobj
+            $r = ConvertTo-DbaDataTable -InputObject $myobj
             ($r.Columns | Where-Object ColumnName -eq ScriptNothing | Select-Object -ExpandProperty DataType).ToString() | Should Be 'System.String'
 
         }


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Changes

 - Renamed `Out-DbaDataTable` to `ConvertTo-DbaDataTable` (added alias for compatibility)
 - Streamlined code in order to optimize performance
 - Added automatism to add a new column when an object with an unknown property shows up, rather than erroring out
 - Included property-level error handling, preventing seas of blood