### PR TITLE
Return object additions needed to be within the WhatIf section

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -485,6 +485,15 @@ function Backup-DbaDatabase {
                                 $Verified = $false
                             }
                         }
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name BackupComplete -Value $BackupComplete
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFile -Value (Split-Path $FinalBackupPath -leaf)
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFilesCount -Value $FinalBackupPath.count
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFolder -Value (Split-Path $FinalBackupPath | Sort-Object -Unique)
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name BackupPath -Value ($FinalBackupPath | Sort-Object -Unique)
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name DatabaseName -Value $dbname
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name Notes -Value ($failures -join (','))
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name Script -Value $script
+                        $HeaderInfo | Add-Member -Type NoteProperty -Name Verified -Value $Verified
                     }
                 }
                 catch {
@@ -502,17 +511,6 @@ function Backup-DbaDatabase {
             if ($failures.count -eq 0) {
                 $OutputExclude += ('Notes', 'FirstLsn', 'DatabaseBackupLsn', 'CheckpointLsn', 'LastLsn', 'BackupSetId', 'LastRecoveryForkGuid')
             }
-
-            $HeaderInfo | Add-Member -Type NoteProperty -Name BackupComplete -Value $BackupComplete
-            $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFile -Value (Split-Path $FinalBackupPath -leaf)
-            $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFilesCount -Value $FinalBackupPath.count
-            $HeaderInfo | Add-Member -Type NoteProperty -Name BackupFolder -Value (Split-Path $FinalBackupPath | Sort-Object -Unique)
-            $HeaderInfo | Add-Member -Type NoteProperty -Name BackupPath -Value ($FinalBackupPath | Sort-Object -Unique)
-            $HeaderInfo | Add-Member -Type NoteProperty -Name DatabaseName -Value $dbname
-            $HeaderInfo | Add-Member -Type NoteProperty -Name Notes -Value ($failures -join (','))
-            $HeaderInfo | Add-Member -Type NoteProperty -Name Script -Value $script
-            $HeaderInfo | Add-Member -Type NoteProperty -Name Verified -Value $Verified
-
             $headerinfo | Select-DefaultView -ExcludeProperty $OutputExclude
             $BackupFileName = $null
         }

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -512,7 +512,7 @@ function Backup-DbaDatabase {
                 $OutputExclude += ('Notes', 'FirstLsn', 'DatabaseBackupLsn', 'CheckpointLsn', 'LastLsn', 'BackupSetId', 'LastRecoveryForkGuid')
             }
             $headerinfo | Select-DefaultView -ExcludeProperty $OutputExclude
-            $BackupFileName = $null
+            $BackupFileName  = $null
         }
     }
 }

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -512,7 +512,7 @@ function Backup-DbaDatabase {
                 $OutputExclude += ('Notes', 'FirstLsn', 'DatabaseBackupLsn', 'CheckpointLsn', 'LastLsn', 'BackupSetId', 'LastRecoveryForkGuid')
             }
             $headerinfo | Select-DefaultView -ExcludeProperty $OutputExclude
-            $BackupFileName  = $null
+            $BackupFileName = $null
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3020)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes issue #3020 by bring the Add-Property block within the WhatIf block (ie; don't add things to the output object it it hasn't been created).