### PR TITLE
fixing copy database tests

### DIFF
--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -15,7 +15,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             if ($db.AutoClose) {
                 $db.AutoClose = $false
                 $db.Alter()
-                # Appv Trigger
             }
         }
         Stop-DbaProcess -SqlInstance $script:instance1 -Database model
@@ -49,7 +48,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Should say skipped" {
-            $results = Copy-DbaDatabase -Source $script:instance1 -Destination $script:instance2 -Database $detachattachdb -DetachAttach -Reattach 
+            $results = Copy-DbaDatabase -Source $script:instance1 -Destination $script:instance2 -Database $detachattachdb -DetachAttach -Reattach
             $results.Status | Should be "Skipped"
             $results.Notes | Should be "Already exists"
         }
@@ -60,7 +59,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             It "copies a database and retain its name, recovery model, and status." {
 
                 Set-DbaDatabaseOwner -SqlInstance $script:instance1 -Database $backuprestoredb -TargetLogin sa
-                Copy-DbaDatabase -Source $script:instance1 -Destination $script:instance2 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath 
+                Copy-DbaDatabase -Source $script:instance1 -Destination $script:instance2 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath
  
                 $db1 = Get-DbaDatabase -SqlInstance $script:instance1 -Database $backuprestoredb
                 $db2 = Get-DbaDatabase -SqlInstance $script:instance2 -Database $backuprestoredb

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -15,6 +15,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             if ($db.AutoClose) {
                 $db.AutoClose = $false
                 $db.Alter()
+                # Appv Trigger
             }
         }
         Stop-DbaProcess -SqlInstance $script:instance1 -Database model


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The alter() call on L17 appears to be tempremental. So as it's only use for the restore copy test which is non appveyor, let's skip it on appveyor 

Also made the tests work on all machines, not just @potatoqualitee 

Don't merge yet. Going to play with spaces to get multiple runs through av
