### PR TITLE
Clean up of MaxMemory commands (Get, Set, and Test)

### DIFF
--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -60,17 +60,16 @@ function Get-DbaMaxMemory {
 				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
 			}
 
-			$totalmemory = $server.PhysicalMemory
+			$totalMemory = $server.PhysicalMemory
 
 			# Some servers under-report by 1MB.
-			if (($totalmemory % 1024) -ne 0) { $totalmemory = $totalmemory + 1 }
+			if (($totalMemory % 1024) -ne 0) { $totalMemory = $totalMemory + 1 }
 
 			[pscustomobject]@{
-				Server       = $server.name
 				ComputerName = $server.NetName
 				InstanceName = $server.ServiceName
 				SqlInstance  = $server.DomainInstanceName
-				TotalMB      = [int]$totalmemory
+				TotalMB      = [int]$totalMemory
 				SqlMaxMB     = [int]$server.Configuration.MaxServerMemory.ConfigValue
 			} | Select-DefaultView -ExcludeProperty Server
 		}

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaMaxMemory {
 	<#
         .SYNOPSIS

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -1,78 +1,78 @@
 function Get-DbaMaxMemory {
-    <#
-.SYNOPSIS
-Gets the 'Max Server Memory' configuration setting and the memory of the server.  Works on SQL Server 2000-2014.
+	<#
+        .SYNOPSIS
+            Gets the 'Max Server Memory' configuration setting and the memory of the server.  Works on SQL Server 2000-2014.
 
-.DESCRIPTION
-This command retrieves the SQL Server 'Max Server Memory' configuration setting as well as the total  physical installed on the server.
+        .DESCRIPTION
+            This command retrieves the SQL Server 'Max Server Memory' configuration setting as well as the total  physical installed on the server.
 
-.PARAMETER SqlInstance
-Allows you to specify a comma separated list of servers to query.
+        .PARAMETER SqlInstance
+            Allows you to specify a comma separated list of servers to query.
 
-.PARAMETER SqlCredential
-Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
+        .PARAMETER SqlCredential
+            Allows you to login to servers using SQL Logins as opposed to Windows Auth/Integrated/Trusted. To use:
 
-$cred = Get-Credential, then pass $cred variable to this parameter.
+            $cred = Get-Credential, then pass $cred variable to this parameter.
 
-Windows Authentication will be used when SqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.
+            Windows Authentication will be used when SqlCredential is not specified. To connect as a different Windows user, run PowerShell as that user.
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: Memory
-dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
-Copyright (C) 2016 Chrissy LeMaire
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+        .NOTES
+            Tags: MaxMemory, Memory
+            dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
+            Copyright (C) 2016 Chrissy LeMaire
+            License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Get-DbaMaxMemory
+        .LINK
+            https://dbatools.io/Get-DbaMaxMemory
 
-.EXAMPLE
-Get-DbaMaxMemory -SqlInstance sqlcluster,sqlserver2012
+        .EXAMPLE
+            Get-DbaMaxMemory -SqlInstance sqlcluster,sqlserver2012
 
-Get memory settings for all servers within the SQL Server Central Management Server "sqlcluster".
+            Get memory settings for all servers within the SQL Server Central Management Server "sqlcluster".
 
-.EXAMPLE
-Get-DbaMaxMemory -SqlInstance sqlcluster | Where-Object { $_.SqlMaxMB -gt $_.TotalMB }
+        .EXAMPLE
+            Get-DbaMaxMemory -SqlInstance sqlcluster | Where-Object { $_.SqlMaxMB -gt $_.TotalMB }
 
-Find all servers in Server Central Management Server that have 'Max Server Memory' set to higher than the total memory of the server (think 2147483647)
-
-#>
-    [CmdletBinding()]
-    Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-        [Alias("ServerInstance", "SqlServer", "SqlServers")]
-        [DbaInstanceParameter[]]$SqlInstance,
+            Find all servers in Server Central Management Server that have 'Max Server Memory' set to higher than the total memory of the server (think 2147483647)
+    #>
+	[CmdletBinding()]
+	param (
+		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+		[Alias("ServerInstance", "SqlServer", "SqlServers")]
+		[DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
-    )
+        [Alias('Silent')]
+		[switch]$EnableException
+	)
 
-    process {
-        foreach ($instance in $SqlInstance) {
-            try {
-                Write-Message -Level Verbose -Message "Connecting to $instance"
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-            }
-            catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
+	process {
+		foreach ($instance in $SqlInstance) {
+			try {
+				Write-Message -Level Verbose -Message "Connecting to $instance"
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
 
-            $totalmemory = $server.PhysicalMemory
+			$totalmemory = $server.PhysicalMemory
 
-            # Some servers under-report by 1MB.
-            if (($totalmemory % 1024) -ne 0) { $totalmemory = $totalmemory + 1 }
+			# Some servers under-report by 1MB.
+			if (($totalmemory % 1024) -ne 0) { $totalmemory = $totalmemory + 1 }
 
-            [pscustomobject]@{
-                Server       = $server.name
-                ComputerName = $server.NetName
-                InstanceName = $server.ServiceName
-                SqlInstance  = $server.DomainInstanceName
-                TotalMB      = [int]$totalmemory
-                SqlMaxMB     = [int]$server.Configuration.MaxServerMemory.ConfigValue
-            } | Select-DefaultView -ExcludeProperty Server
-        }
-    }
+			[pscustomobject]@{
+				Server       = $server.name
+				ComputerName = $server.NetName
+				InstanceName = $server.ServiceName
+				SqlInstance  = $server.DomainInstanceName
+				TotalMB      = [int]$totalmemory
+				SqlMaxMB     = [int]$server.Configuration.MaxServerMemory.ConfigValue
+			} | Select-DefaultView -ExcludeProperty Server
+		}
+	}
 }

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -63,7 +63,9 @@ function Get-DbaMaxMemory {
 			$totalMemory = $server.PhysicalMemory
 
 			# Some servers under-report by 1MB.
-			if (($totalMemory % 1024) -ne 0) { $totalMemory = $totalMemory + 1 }
+			if (($totalMemory % 1024) -ne 0) {
+                $totalMemory = $totalMemory + 1
+            }
 
 			[pscustomobject]@{
 				ComputerName = $server.NetName

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -1,6 +1,6 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaMaxMemory {
-	<#
+    <#
         .SYNOPSIS
             Gets the 'Max Server Memory' configuration setting and the memory of the server.  Works on SQL Server 2000-2014.
 
@@ -41,40 +41,40 @@ function Get-DbaMaxMemory {
 
             Find all servers in Server Central Management Server that have 'Max Server Memory' set to higher than the total memory of the server (think 2147483647)
     #>
-	[CmdletBinding()]
-	param (
-		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-		[Alias("ServerInstance", "SqlServer", "SqlServers")]
-		[DbaInstanceParameter[]]$SqlInstance,
+    [CmdletBinding()]
+    param (
+        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [Alias("ServerInstance", "SqlServer", "SqlServers")]
+        [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]
-		[switch]$EnableException
-	)
+        [switch]$EnableException
+    )
 
-	process {
-		foreach ($instance in $SqlInstance) {
-			try {
-				Write-Message -Level Verbose -Message "Connecting to $instance"
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-			$totalMemory = $server.PhysicalMemory
+            $totalMemory = $server.PhysicalMemory
 
-			# Some servers under-report by 1MB.
-			if (($totalMemory % 1024) -ne 0) {
+            # Some servers under-report by 1MB.
+            if (($totalMemory % 1024) -ne 0) {
                 $totalMemory = $totalMemory + 1
             }
 
-			[pscustomobject]@{
-				ComputerName = $server.NetName
-				InstanceName = $server.ServiceName
-				SqlInstance  = $server.DomainInstanceName
-				TotalMB      = [int]$totalMemory
-				SqlMaxMB     = [int]$server.Configuration.MaxServerMemory.ConfigValue
-			} | Select-DefaultView -ExcludeProperty Server
-		}
-	}
+            [pscustomobject]@{
+                ComputerName = $server.NetName
+                InstanceName = $server.ServiceName
+                SqlInstance  = $server.DomainInstanceName
+                TotalMB      = [int]$totalMemory
+                SqlMaxMB     = [int]$server.Configuration.MaxServerMemory.ConfigValue
+            } | Select-DefaultView -ExcludeProperty Server
+        }
+    }
 }

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -1,5 +1,5 @@
 function Set-DbaMaxMemory {
-    <#
+	<#
         .SYNOPSIS
             Sets SQL Server 'Max Server Memory' configuration setting to a new value then displays information this setting.
 
@@ -40,9 +40,8 @@ function Set-DbaMaxMemory {
         .PARAMETER Confirm
             Prompts you for confirmation before running the cmdlet.
 
-
         .NOTES
-            Tags: MaxMemory
+            Tags: MaxMemory, Memory
             dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
             Copyright (C) 2016 Chrissy LeMaire
             License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
@@ -66,91 +65,95 @@ function Set-DbaMaxMemory {
             Find all servers in SQL Server Central Management server that have Max SQL memory set to higher than the total memory
             of the server (think 2147483647), then pipe those to Set-DbaMaxMemory and use the default recommendation.
     #>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
-    param (
-        [Parameter(Position = 0)]
-        [Alias("ServerInstance", "SqlServer", "SqlServers", "ComputerName")]
-        [DbaInstance[]]$SqlInstance,
-        [Alias("Credential")]
-        [PSCredential]$SqlCredential,
-        [Parameter(Position = 1)]
-        [int]$MaxMB,
-        [Parameter(ValueFromPipeline = $True)]
-        [object]$Collection,
-        [switch][Alias('Silent')]$EnableException
-    )
-    process {
-        if ((Test-Bound -Not -Parameter SqlInstance) -and (Test-Bound -Not -Parameter Collection)) {
-            Stop-Function -Category InvalidArgument -Message "You must specify a server list source using -SqlInstance or you can pipe results from Test-DbaMaxMemory"
-            return
-        }
+	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+	param (
+		[Parameter(Position = 0)]
+		[Alias("ServerInstance", "SqlServer", "SqlServers", "ComputerName")]
+		[DbaInstance[]]$SqlInstance,
+		[Alias("Credential")]
+		[PSCredential]$SqlCredential,
+		[Parameter(Position = 1)]
+		[int]$MaxMB,
+		[Parameter(ValueFromPipeline = $True)]
+		[object]$Collection,
+        [Alias('Silent')]
+		[switch]$EnableException
+	)
+	begin {
+		if ((Test-Bound -Not -Parameter SqlInstance) -and (Test-Bound -Not -Parameter Collection)) {
+			Stop-Function -Category InvalidArgument -Message "You must specify a server list source using -SqlInstance or you can pipe results from Test-DbaMaxMemory"
+			return
+		}
 
-        if ($MaxMB -eq 0) {
-            $UseRecommended = $true
-        }
+		if ($MaxMB -eq 0) {
+			$UseRecommended = $true
+		}
+	}
+	process {
+		if (Test-FunctionInterrupt) { return }
 
-        if ((Test-Bound -Not -Parameter Collection)) {
-            $Collection = Test-DbaMaxMemory -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        }
+		if ((Test-Bound -Not -Parameter Collection)) {
+			$Collection = Test-DbaMaxMemory -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+		}
 
-        # We ignore errors, because this will error if we pass the same collection items twice.
-        # Given that it is an engine internal command, there is no other plausible error it could encounter.
-        $Collection | Add-Member -Force -NotePropertyName OldMaxValue -NotePropertyValue 0 -ErrorAction Ignore
+		# We ignore errors, because this will error if we pass the same collection items twice.
+		# Given that it is an engine internal command, there is no other plausible error it could encounter.
+		$Collection | Add-Member -Force -NotePropertyName OldMaxValue -NotePropertyValue 0 -ErrorAction Ignore
 
-        foreach ($currentServer in $Collection) {
-            $instance = $currentServer.SqlInstance
-            if ($instance -eq $null) {
-                $currentServer = Test-DbaMaxMemory -SqlInstance $instance
-                $currentServer | Add-Member -Force -NotePropertyName OldMaxValue -NotePropertyValue 0
-            }
+		foreach ($currentServer in $Collection) {
+			$instance = $currentServer.SqlInstance
+			if ($instance -eq $null) {
+				$currentServer = Test-DbaMaxMemory -SqlInstance $instance
+				$currentServer | Add-Member -Force -NotePropertyName OldMaxValue -NotePropertyValue 0
+			}
 
-            try {
-                Write-Message -Level Verbose -Message "Connecting to $instance"
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            }
-            catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
+			try {
+				Write-Message -Level Verbose -Message "Connecting to $instance"
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
 
-            if (!(Test-SqlSa -SqlInstance $server)) {
-                Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $currentServer -Continue
-            }
+			if (!(Test-SqlSa -SqlInstance $server)) {
+				Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $currentServer -Continue
+			}
 
-            $currentServer.OldMaxValue = $currentServer.SqlMaxMB
+			$currentServer.OldMaxValue = $currentServer.SqlMaxMB
 
-            try {
-                if ($UseRecommended) {
-                    Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
+			try {
+				if ($UseRecommended) {
+					Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
 
-                    if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
-                        $maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
-                        Write-Warning $maxMem
-                        $server.Configuration.MaxServerMemory.ConfigValue = $maxMem
-                    }
-                    else {
-                        $server.Configuration.MaxServerMemory.ConfigValue = $currentServer.RecommendedMB
-                    }
-                }
-                else {
-                    Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $MaxMB MB"
-                    $server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
-                }
-                if ($PSCmdlet.ShouldProcess($server, "Changing maximum memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
-                    try {
-                        $server.Configuration.Alter()
-                        $currentServer.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue
-                    }
-                    catch {
-                        Stop-Function -Message "Failed to apply configuration change for $server" -ErrorRecord $_ -Target $server -Continue
-                    }
-                }
-            }
-            catch {
-                Stop-Function -Message "Could not modify Max Server Memory for $server" -ErrorRecord $_ -Target $server -Continue
-            }
+					if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
+						$maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
+						Write-Warning $maxMem
+						$server.Configuration.MaxServerMemory.ConfigValue = $maxMem
+					}
+					else {
+						$server.Configuration.MaxServerMemory.ConfigValue = $currentServer.RecommendedMB
+					}
+				}
+				else {
+					Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $MaxMB MB"
+					$server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
+				}
+				if ($PSCmdlet.ShouldProcess($server, "Changing maximum memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
+					try {
+						$server.Configuration.Alter()
+						$currentServer.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue
+					}
+					catch {
+						Stop-Function -Message "Failed to apply configuration change for $server" -ErrorRecord $_ -Target $server -Continue
+					}
+				}
+			}
+			catch {
+				Stop-Function -Message "Could not modify Max Server Memory for $server" -ErrorRecord $_ -Target $server -Continue
+			}
 
-            Add-Member -InputObject $currentServer -Force -MemberType NoteProperty -Name CurrentMaxValue -Value $currentServer.SqlMaxMB
-            Select-DefaultView -InputObject $currentServer -Property ComputerName, InstanceName, SqlInstance, TotalMB, OldMaxValue, CurrentMaxValue
-        }
-    }
+			Add-Member -InputObject $currentServer -Force -MemberType NoteProperty -Name CurrentMaxValue -Value $currentServer.SqlMaxMB
+			Select-DefaultView -InputObject $currentServer -Property ComputerName, InstanceName, SqlInstance, TotalMB, OldMaxValue, CurrentMaxValue
+		}
+	}
 }

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -111,7 +111,7 @@ function Set-DbaMaxMemory {
 
 			try {
 				if ($UseRecommended) {
-					Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
+					Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
 
 					if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
 						$maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
@@ -123,10 +123,10 @@ function Set-DbaMaxMemory {
 					}
 				}
 				else {
-					Write-Message -Level Verbose -Message "Changing $server SQL Server max from $($currentServer.SqlMaxMB) to $MaxMB MB"
+					Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $MaxMB MB"
 					$server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
 				}
-				if ($PSCmdlet.ShouldProcess($server, "Changing maximum memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
+				if ($PSCmdlet.ShouldProcess($server, "Change Max Memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
 					try {
 						$server.Configuration.Alter()
 						$currentServer.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -1,7 +1,7 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 
 function Set-DbaMaxMemory {
-	<#
+    <#
         .SYNOPSIS
             Sets SQL Server 'Max Server Memory' configuration setting to a new value then displays information this setting.
 
@@ -64,86 +64,86 @@ function Set-DbaMaxMemory {
             Find all servers in SQL Server Central Management server that have Max SQL memory set to higher than the total memory
             of the server (think 2147483647), then pipe those to Set-DbaMaxMemory and use the default recommendation.
     #>
-	[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
-	param (
-		[Parameter(Position = 0)]
-		[Alias("ServerInstance", "SqlServer", "SqlServers", "ComputerName")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[Alias("Credential")]
-		[PSCredential]$SqlCredential,
-		[Parameter(Position = 1)]
-		[int]$MaxMB,
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Position = 0)]
+        [Alias("ServerInstance", "SqlServer", "SqlServers", "ComputerName")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [Alias("Credential")]
+        [PSCredential]$SqlCredential,
+        [Parameter(Position = 1)]
+        [int]$MaxMB,
         [Alias('Silent')]
-		[switch]$EnableException
-	)
-	begin {
-		if ((Test-Bound -Not -Parameter SqlInstance) -and (Test-Bound -Not -Parameter Collection)) {
-			Stop-Function -Category InvalidArgument -Message "You must specify a server list source using -SqlInstance or you can pipe results from Test-DbaMaxMemory"
-			return
-		}
+        [switch]$EnableException
+    )
+    begin {
+        if ((Test-Bound -Not -Parameter SqlInstance) -and (Test-Bound -Not -Parameter Collection)) {
+            Stop-Function -Category InvalidArgument -Message "You must specify a server list source using -SqlInstance or you can pipe results from Test-DbaMaxMemory"
+            return
+        }
 
-		if ($MaxMB -eq 0) {
-			$UseRecommended = $true
-		}
-	}
-	process {
-		if (Test-FunctionInterrupt) { return }
+        if ($MaxMB -eq 0) {
+            $UseRecommended = $true
+        }
+    }
+    process {
+        if (Test-FunctionInterrupt) { return }
 
-		foreach ($instance in $SqlInstance) {
-			try {
-				Write-Message -Level Verbose -Message "Connecting to $instance"
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-			if (!(Test-SqlSa -SqlInstance $server)) {
-				Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
-			}
+            if (!(Test-SqlSa -SqlInstance $server)) {
+                Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+            }
 
-			try {
-				$currentServer = Test-DbaMaxMemory -SqlInstance $server
-				Add-Member -Force -InputObject $currentServer -NotePropertyName OldMaxValue -NotePropertyValue 0
-				$currentServer.OldMaxValue = $currentServer.SqlMaxMB
-			}
-			catch {
-				Stop-Function -Mesage "Issue collecting memory information on $server" -Target $server -ErrorRecord $_ -InnerException $_.Exception -Continue
-			}
+            try {
+                $currentServer = Test-DbaMaxMemory -SqlInstance $server
+                Add-Member -Force -InputObject $currentServer -NotePropertyName OldMaxValue -NotePropertyValue 0
+                $currentServer.OldMaxValue = $currentServer.SqlMaxMB
+            }
+            catch {
+                Stop-Function -Mesage "Issue collecting memory information on $server" -Target $server -ErrorRecord $_ -InnerException $_.Exception -Continue
+            }
 
-			try {
-				if ($UseRecommended) {
-					Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
+            try {
+                if ($UseRecommended) {
+                    Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
 
-					if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
-						$maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
-						Write-Message -Level VeryVerbose -Message "Max memory recommended: $maxMem"
-						$server.Configuration.MaxServerMemory.ConfigValue = $maxMem
-					}
-					else {
-						$server.Configuration.MaxServerMemory.ConfigValue = $currentServer.RecommendedMB
-					}
-				}
-				else {
-					Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $MaxMB MB"
-					$server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
-				}
-				if ($PSCmdlet.ShouldProcess($server, "Change Max Memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
-					try {
-						$server.Configuration.Alter()
-						$currentServer.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue
-					}
-					catch {
-						Stop-Function -Message "Failed to apply configuration change for $server" -ErrorRecord $_ -Target $server -Continue
-					}
-				}
-			}
-			catch {
-				Stop-Function -Message "Could not modify Max Server Memory for $server" -ErrorRecord $_ -Target $server -Continue
-			}
+                    if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
+                        $maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
+                        Write-Message -Level VeryVerbose -Message "Max memory recommended: $maxMem"
+                        $server.Configuration.MaxServerMemory.ConfigValue = $maxMem
+                    }
+                    else {
+                        $server.Configuration.MaxServerMemory.ConfigValue = $currentServer.RecommendedMB
+                    }
+                }
+                else {
+                    Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $MaxMB MB"
+                    $server.Configuration.MaxServerMemory.ConfigValue = $MaxMB
+                }
+                if ($PSCmdlet.ShouldProcess($server, "Change Max Memory from $($currentServer.OldMaxValue) to $($server.Configuration.MaxServerMemory.ConfigValue)")) {
+                    try {
+                        $server.Configuration.Alter()
+                        $currentServer.SqlMaxMB = $server.Configuration.MaxServerMemory.ConfigValue
+                    }
+                    catch {
+                        Stop-Function -Message "Failed to apply configuration change for $server" -ErrorRecord $_ -Target $server -Continue
+                    }
+                }
+            }
+            catch {
+                Stop-Function -Message "Could not modify Max Server Memory for $server" -ErrorRecord $_ -Target $server -Continue
+            }
 
-			Add-Member -InputObject $currentServer -Force -MemberType NoteProperty -Name CurrentMaxValue -Value $currentServer.SqlMaxMB
-			Select-DefaultView -InputObject $currentServer -Property ComputerName, InstanceName, SqlInstance, TotalMB, OldMaxValue, CurrentMaxValue
-		}
-	}
+            Add-Member -InputObject $currentServer -Force -MemberType NoteProperty -Name CurrentMaxValue -Value $currentServer.SqlMaxMB
+            Select-DefaultView -InputObject $currentServer -Property ComputerName, InstanceName, SqlInstance, TotalMB, OldMaxValue, CurrentMaxValue
+        }
+    }
 }

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -1,3 +1,5 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+
 function Set-DbaMaxMemory {
 	<#
         .SYNOPSIS

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -69,7 +69,7 @@ function Set-DbaMaxMemory {
 	param (
 		[Parameter(Position = 0)]
 		[Alias("ServerInstance", "SqlServer", "SqlServers", "ComputerName")]
-		[DbaInstance[]]$SqlInstance,
+		[DbaInstanceParameter[]]$SqlInstance,
 		[Alias("Credential")]
 		[PSCredential]$SqlCredential,
 		[Parameter(Position = 1)]

--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Test-DbaMaxMemory {
 	<#
         .SYNOPSIS

--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -1,6 +1,6 @@
 #ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Test-DbaMaxMemory {
-	<#
+    <#
         .SYNOPSIS
             Calculates the recommended value for SQL Server 'Max Server Memory' configuration setting. Works on SQL Server 2000-2014.
 
@@ -42,82 +42,82 @@ function Test-DbaMaxMemory {
 
             Find all servers in CMS that have Max SQL memory set to higher than the total memory of the server (think 2147483647) and set it to recommended value.
     #>
-	[CmdletBinding()]
-	param (
-		[parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-		[Alias("ServerInstance", "SqlServer", "SqlServers")]
-		[DbaInstanceParameter[]]$SqlInstance,
-		[PSCredential]$SqlCredential,
-		[PSCredential]$Credential,
+    [CmdletBinding()]
+    param (
+        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [Alias("ServerInstance", "SqlServer", "SqlServers")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [PSCredential]$Credential,
         [Alias('Silent')]
-		[switch]$EnableException
-	)
+        [switch]$EnableException
+    )
 
-	process {
-		foreach ($instance in $SqlInstance) {
-			Write-Message -Level VeryVerbose -Message "Processing $instance" -Target $instance
+    process {
+        foreach ($instance in $SqlInstance) {
+            Write-Message -Level VeryVerbose -Message "Processing $instance" -Target $instance
 
-			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-			Write-Message -Level Verbose -Target $instance -Message "Retrieving maximum memory statistics from $instance"
-			$serverMemory = Get-DbaMaxMemory -SqlInstance $server
-			try {
-				Write-Message -Level Verbose -Target $instance -Message "Retrieving number of instances from $($instance.ComputerName)"
-				if ($Credential) {
-					$serverService = Get-DbaSqlService -ComputerName $instance -Credential $Credential -EnableException
-				}
-				else {
-					$serverService = Get-DbaSqlService -ComputerName $instance -EnableException
-				}
-				$instanceCount = ($serverService | Where-Object State -Like Running | Where-Object InstanceName | Group-Object InstanceName | Measure-Object Count).Count
-			}
-			catch {
-				Write-Message -Level Warning -Message "Couldn't get accurate SQL Server instance count on $instance. Defaulting to 1." -Target $instance -ErrorRecord $_
-				$instanceCount = 1
-			}
+            Write-Message -Level Verbose -Target $instance -Message "Retrieving maximum memory statistics from $instance"
+            $serverMemory = Get-DbaMaxMemory -SqlInstance $server
+            try {
+                Write-Message -Level Verbose -Target $instance -Message "Retrieving number of instances from $($instance.ComputerName)"
+                if ($Credential) {
+                    $serverService = Get-DbaSqlService -ComputerName $instance -Credential $Credential -EnableException
+                }
+                else {
+                    $serverService = Get-DbaSqlService -ComputerName $instance -EnableException
+                }
+                $instanceCount = ($serverService | Where-Object State -Like Running | Where-Object InstanceName | Group-Object InstanceName | Measure-Object Count).Count
+            }
+            catch {
+                Write-Message -Level Warning -Message "Couldn't get accurate SQL Server instance count on $instance. Defaulting to 1." -Target $instance -ErrorRecord $_
+                $instanceCount = 1
+            }
 
-			if ($null -eq $serverMemory) {
-				continue
-			}
-			$reserve = 1
+            if ($null -eq $serverMemory) {
+                continue
+            }
+            $reserve = 1
 
-			$maxMemory = $serverMemory.SqlMaxMB
-			$totalMemory = $serverMemory.TotalMB
+            $maxMemory = $serverMemory.SqlMaxMB
+            $totalMemory = $serverMemory.TotalMB
 
-			if ($totalMemory -ge 4096) {
-				$currentCount = $totalMemory
-				while ($currentCount / 4096 -gt 0) {
-					if ($currentCount -gt 16384) {
-						$reserve += 1
-						$currentCount += -8192
-					}
-					else {
-						$reserve += 1
-						$currentCount += -4096
-					}
-				}
-				$recommendedMax = [int]($totalMemory - ($reserve * 1024))
-			}
-			else {
-				$recommendedMax = $totalMemory * .5
-			}
+            if ($totalMemory -ge 4096) {
+                $currentCount = $totalMemory
+                while ($currentCount / 4096 -gt 0) {
+                    if ($currentCount -gt 16384) {
+                        $reserve += 1
+                        $currentCount += -8192
+                    }
+                    else {
+                        $reserve += 1
+                        $currentCount += -4096
+                    }
+                }
+                $recommendedMax = [int]($totalMemory - ($reserve * 1024))
+            }
+            else {
+                $recommendedMax = $totalMemory * .5
+            }
 
-			$recommendedMax = $recommendedMax / $instanceCount
+            $recommendedMax = $recommendedMax / $instanceCount
 
-			[pscustomobject]@{
-				ComputerName  = $server.NetName
-				InstanceName  = $server.ServiceName
-				SqlInstance   = $server.DomainInstanceName
-				InstanceCount = $instanceCount
-				TotalMB       = [int]$totalMemory
-				SqlMaxMB      = [int]$maxMemory
-				RecommendedMB = [int]$recommendedMax
-			} | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, InstanceCount, TotalMB, SqlMaxMB, RecommendedMB
-		}
-	}
+            [pscustomobject]@{
+                ComputerName  = $server.NetName
+                InstanceName  = $server.ServiceName
+                SqlInstance   = $server.DomainInstanceName
+                InstanceCount = $instanceCount
+                TotalMB       = [int]$totalMemory
+                SqlMaxMB      = [int]$maxMemory
+                RecommendedMB = [int]$recommendedMax
+            } | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, InstanceCount, TotalMB, SqlMaxMB, RecommendedMB
+        }
+    }
 }

--- a/tests/Get-DbaMaxMemory.Tests.ps1
+++ b/tests/Get-DbaMaxMemory.Tests.ps1
@@ -31,14 +31,14 @@ Describe "$commandname Unit Test" -Tags Unittest {
         }
 
         Context 'Validate functionality ' {
-            It 'Server name reported correctly the installed memory' {
+            It 'Server SqlInstance reported correctly' {
                 Mock Connect-SqlInstance {
                     return @{
-                        Name = 'ABC'
+                        DomainInstanceName = 'ABC'
                     }
                 }
 
-                (Get-DbaMaxMemory -SqlInstance 'ABC').Server | Should be 'ABC'
+                (Get-DbaMaxMemory -SqlInstance 'ABC').SqlInstance | Should be 'ABC'
             }
 
             It 'Server under-report by 1MB the memory installed on the host' {

--- a/tests/Set-DbaMaxMemory.Tests.ps1
+++ b/tests/Set-DbaMaxMemory.Tests.ps1
@@ -1,13 +1,31 @@
-﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-    Context "Connects to multiple instances" {
-        $results = Set-DbaMaxMemory -SqlInstance $script:instance1, $script:instance2 -MaxMB 1024
-        foreach ($result in $results) {
-            It 'Returns 1024 MB for each instance' {
-                $result.CurrentMaxValue | Should Be 1024
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $inst1CurrentSqlMax = (Get-DbaMaxMemory -SqlInstance $script:instance1).SqlMaxMB
+        $inst2CurrentSqlMax = (Get-DbaMaxMemory -SqlInstance $script:instance2).SqlMaxMB
+    }
+    AfterAll {
+       $null = Set-DbaMaxMemory -SqlInstance $script:instance1 -MaxMB $inst1CurrentSqlMax
+       $null = Set-DbaMaxMemory -SqlInstance $script:instance2 -MaxMB $inst2CurrentSqlMax
+    }
+	Context "Connects to multiple instances" {
+		$results = Set-DbaMaxMemory -SqlInstance $script:instance1, $script:instance2 -MaxMB 1024
+		foreach ($result in $results) {
+			It 'Returns 1024 MB for each instance' {
+				$result.CurrentMaxValue | Should Be 1024
+			}
+		}
+	}
+}
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    InModuleScope dbatools {
+        Context 'Validate input arguments' {
+            It 'SqlInstance parameter host cannot be found' {
+                Set-DbaMaxMemory -SqlInstance 'ABC' 3> $null | Should be $null
             }
         }
     }

--- a/tests/Set-DbaMaxMemory.Tests.ps1
+++ b/tests/Set-DbaMaxMemory.Tests.ps1
@@ -11,14 +11,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
        $null = Set-DbaMaxMemory -SqlInstance $script:instance1 -MaxMB $inst1CurrentSqlMax
        $null = Set-DbaMaxMemory -SqlInstance $script:instance2 -MaxMB $inst2CurrentSqlMax
     }
-	Context "Connects to multiple instances" {
-		$results = Set-DbaMaxMemory -SqlInstance $script:instance1, $script:instance2 -MaxMB 1024
-		foreach ($result in $results) {
-			It 'Returns 1024 MB for each instance' {
-				$result.CurrentMaxValue | Should Be 1024
-			}
-		}
-	}
+    Context "Connects to multiple instances" {
+        $results = Set-DbaMaxMemory -SqlInstance $script:instance1, $script:instance2 -MaxMB 1024
+        foreach ($result in $results) {
+            It 'Returns 1024 MB for each instance' {
+                $result.CurrentMaxValue | Should Be 1024
+            }
+        }
+    }
 }
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
A bit of a bug found in Set-DbaMaxMemory in how connections were managed. However, in the end, this required touching all three commands to clean up things.

Conversation in Slack but overall the commands were not following the standard we use for making connections to a given instance, and then use that connection in any sub call we have. This PR address that among other things.

The test for `Set-DbaMaxMemory` I also added a revert with BeforeAll and AfterAll so if you run this against your local instance it will put the values back the way they were found.