### PR TITLE
Get-DbaUpTime - added tests, cleaned up a couple of things in function

### DIFF
--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -20,6 +20,9 @@ function Get-DbaUptime {
 
             To connect to SQL Server as a different Windows user, run PowerShell as that user.
 
+        .PARAMETER Credential
+            Allows you to login to the computer (not SQL Server instance) using alternative Windows credentials.
+
         .PARAMETER WindowsCredential
             Allows you to authenticate to Windows servers using alternate credentials.
 
@@ -62,9 +65,8 @@ function Get-DbaUptime {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Alias("Credential")]
         [PSCredential]$SqlCredential,
-        [PSCredential]$WindowsCredential,
+        [PSCredential]$Credential,
         [switch][Alias('Silent')]$EnableException
     )
 
@@ -73,7 +75,6 @@ function Get-DbaUptime {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            $SqlOnly = $false;
             if ($instance.Gettype().FullName -eq [System.Management.Automation.PSCustomObject] ) {
                 $servername = $instance.SqlInstance
             }
@@ -93,15 +94,15 @@ function Get-DbaUptime {
             }
             Write-Message -Level Verbose -Message "Getting start times for $servername"
             #Get tempdb creation date
-            $SQLStartTime = $server.Databases["tempdb"].CreateDate
+            [dbadatetime]$SQLStartTime = $server.Databases["tempdb"].CreateDate
             $SQLUptime = New-TimeSpan -Start $SQLStartTime.ToUniversalTime() -End $nowutc
             $SQLUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($SQLUptime.Days), $($SQLUptime.Hours), $($SQLUptime.Minutes), $($SQLUptime.Seconds)
 
-            $WindowsServerName = (Resolve-DbaNetworkName $servername -Credential $WindowsCredential).FullComputerName
+            $WindowsServerName = (Resolve-DbaNetworkName $servername -Credential $Credential).FullComputerName
 
             try {
                 Write-Message -Level Verbose -Message "Getting WinBootTime via CimInstance for $servername"
-                $WinBootTime = (Get-DbaOperatingSystem -ComputerName $windowsServerName -Credential $WindowsCredential -ErrorAction SilentlyContinue).LastBootTime
+                $WinBootTime = (Get-DbaOperatingSystem -ComputerName $windowsServerName -Credential $Credential -ErrorAction SilentlyContinue).LastBootTime
                 $WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end $nowutc
                 $WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
             }
@@ -109,8 +110,8 @@ function Get-DbaUptime {
                 try {
                     Write-Message -Level Verbose -Message "Getting WinBootTime via CimInstance DCOM"
                     $CimOption = New-CimSessionOption -Protocol DCOM
-                    $CimSession = New-CimSession -Credential:$WindowsCredential -ComputerName $WindowsServerName -SessionOption $CimOption
-                    $WinBootTime = ($CimSession | Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime
+                    $CimSession = New-CimSession -Credential:$Credential -ComputerName $WindowsServerName -SessionOption $CimOption
+                    [dbadatetime]$WinBootTime = ($CimSession | Get-CimInstance -ClassName Win32_OperatingSystem).LastBootUpTime
                     $WindowsUptime = New-TimeSpan -start $WinBootTime.ToUniversalTime() -end $nowutc
                     $WindowsUptimeString = "{0} days {1} hours {2} minutes {3} seconds" -f $($WindowsUptime.Days), $($WindowsUptime.Hours), $($WindowsUptime.Minutes), $($WindowsUptime.Seconds)
                 }

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -23,11 +23,6 @@ function Get-DbaUptime {
         .PARAMETER Credential
             Allows you to login to the computer (not SQL Server instance) using alternative Windows credentials.
 
-        .PARAMETER WindowsCredential
-            Allows you to authenticate to Windows servers using alternate credentials.
-
-            $wincred = Get-Credential, then pass $wincred object to the -WindowsCredential parameter.
-
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/tests/Get-DbaUpTime.Tests.ps1
+++ b/tests/Get-DbaUpTime.Tests.ps1
@@ -20,14 +20,14 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {
         $results = Get-DbaUptime -SqlInstance $script:instance1
-        It "should have correct properties" {
+        It "Should have correct properties" {
             $ExpectedProps = 'ComputerName,InstanceName,SqlServer,SqlUptime,WindowsUptime,SqlStartTime,WindowsBootTime,SinceSqlStart,SinceWindowsBoot'.Split(',')
             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
         }
     }
     Context "Command can handle multiple SqlInstances" {
         $results = Get-DbaUptime -SqlInstance $script:instance1,$script:instance2
-            It "command resultset could contain 2 results" {
+            It "Command resultset could contain 2 results" {
                 $results.count | Should Be 2
             }
         foreach ($result in $results) {

--- a/tests/Get-DbaUpTime.Tests.ps1
+++ b/tests/Get-DbaUpTime.Tests.ps1
@@ -32,7 +32,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
         foreach ($result in $results) {
             It "Windows up time should be more than SQL Uptime" {
-                $result.SqlUptime | Should BeLessThan $result.WindowsUpTime 
+                $result.SqlUptime | Should BeLessThan $result.WindowsUpTime
             }
         }
     }

--- a/tests/Get-DbaUpTime.Tests.ps1
+++ b/tests/Get-DbaUpTime.Tests.ps1
@@ -1,0 +1,50 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = 4
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaUptime).Parameters.Keys
+        $knownParameters = 'Computer', 'SqlInstance', 'SqlCredential', 'Credential', 'EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        $results = Get-DbaUptime -SqlInstance $script:instance1
+        It "should have correct properties" {
+            $ExpectedProps = 'ComputerName,InstanceName,SqlServer,SqlUptime,WindowsUptime,SqlStartTime,WindowsBootTime,SinceSqlStart,SinceWindowsBoot'.Split(',')
+            ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+        }
+    }
+    Context "Command can handle multiple SqlInstances" {
+        $results = Get-DbaUptime -SqlInstance $script:instance1,$script:instance2
+            It "command resultset could contain 2 results" {
+                $results.count | Should Be 2
+            }
+        foreach ($result in $results) {
+            It "Windows up time should be more than SQL Uptime" {
+                $result.SqlUptime | Should BeLessThan $result.WindowsUpTime 
+            }
+        }
+    }
+    Context "Properties should return expected types" {
+        $results = Get-DbaUptime -SqlInstance $script:instance1
+        foreach ($result in $results) {
+            It "SqlStartTime should be a DbaDateTime" {
+                $result.SqlStartTime  | Should BeOfType DbaDateTime
+            }
+            It "WindowsBootTime should be a DbaDateTime" {
+                $result.WindowsBootTime  | Should BeOfType DbaDateTime
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
- Added tests for the function.
- Changed parameter from 'WindowsCredential' to 'Credential' in help and function to match standard params
- forced use of dbadatetime for variables, previously two variables that I think should be the same type were coming back one as datetime and one as dbadatetime.
- removed $SqlOnly variable as it was never used.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
![image](https://user-images.githubusercontent.com/981370/35073064-45c39472-fbb5-11e7-90a3-b6b4d569d222.png)

![image](https://user-images.githubusercontent.com/981370/35073156-acab7790-fbb5-11e7-98a6-d923ea74bad0.png)