### PR TITLE
Set length of nvarchar column in Write-DbaDataTable

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -87,6 +87,10 @@ function Write-DbaDataTable {
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+        .PARAMETER UseDynamicStringLength
+            By default, all string columns will be NVARCHAR(MAX). 
+            If this switch is enabled, all columns will get the length specified by the column's MaxLength property (if specified)
+            
         .NOTES
             Tags: DataTable, Insert
             Website: https://dbatools.io
@@ -180,7 +184,8 @@ function Write-DbaDataTable {
         [ValidateNotNull()]
         [int]$bulkCopyTimeOut = 5000,
         [switch]$RegularUser,
-        [switch][Alias('Silent')]$EnableException
+        [switch][Alias('Silent')]$EnableException,
+        [switch]$UseDynamicStringLength
     )
     
     begin {
@@ -257,6 +262,9 @@ function Write-DbaDataTable {
                 By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
                 This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
                 Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+            .PARAMETER UseDynamicStringLength
+                Automatically inherits from parent.
         #>
             [CmdletBinding()]
             Param (
@@ -300,7 +308,8 @@ function Write-DbaDataTable {
             #>
                 if ($PStoSQLTypes.Keys -contains $column.DataType) {
                     $sqlDataType = $PStoSQLTypes[$($column.DataType.toString())]
-                    if($column.MaxLength -gt 0 -and ($column.DataType -in ("String", "System.String"))) {
+                    #Global parameter Write-DbaDataTable. Couldn't get Test-Bound to work
+                    if($UseDynamicStringLength -and $column.MaxLength -gt 0 -and ($column.DataType -in ("String", "System.String"))) {
                         $sqlDataType = $sqlDataType.Replace("(MAX)", "($($column.MaxLength))")
                     }
                 }

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -300,6 +300,9 @@ function Write-DbaDataTable {
             #>
                 if ($PStoSQLTypes.Keys -contains $column.DataType) {
                     $sqlDataType = $PStoSQLTypes[$($column.DataType.toString())]
+                    if($column.MaxLength -gt 0 -and ($column.DataType -in ("String", "System.String"))) {
+                        $sqlDataType = $sqlDataType.Replace("(MAX)", "($($column.MaxLength))")
+                    }
                 }
                 else {
                     $sqlDataType = "nvarchar(MAX)"

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -88,9 +88,9 @@ function Write-DbaDataTable {
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
         .PARAMETER UseDynamicStringLength
-            By default, all string columns will be NVARCHAR(MAX). 
+            By default, all string columns will be NVARCHAR(MAX).
             If this switch is enabled, all columns will get the length specified by the column's MaxLength property (if specified)
-            
+
         .NOTES
             Tags: DataTable, Insert
             Website: https://dbatools.io
@@ -304,11 +304,11 @@ function Write-DbaDataTable {
             <#
                 PS to SQL type conversion
                 If data type exists in hash table, use the corresponding SQL type
-                Else, fallback to nvarchar
+                Else, fallback to nvarchar.
+                If UseDynamicStringLength is specified, the DataColumn MaxLength is used if specified
             #>
                 if ($PStoSQLTypes.Keys -contains $column.DataType) {
                     $sqlDataType = $PStoSQLTypes[$($column.DataType.toString())]
-                    #Global parameter Write-DbaDataTable. Couldn't get Test-Bound to work
                     if($UseDynamicStringLength -and $column.MaxLength -gt 0 -and ($column.DataType -in ("String", "System.String"))) {
                         $sqlDataType = $sqlDataType.Replace("(MAX)", "($($column.MaxLength))")
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
More flexibility to set column length of nvarchar on table creation

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
