### PR TITLE
Get-DbaSqlInstanceProperty formatted help, fixed ScriptAnalyzer complaint

### DIFF
--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -1,4 +1,3 @@
-#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaSqlInstanceProperty {
     <#
         .SYNOPSIS

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,Pipeline#
 function Get-DbaSqlInstanceProperty {
     <#
         .SYNOPSIS

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -1,44 +1,53 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaSqlInstanceProperty {
     <#
-.SYNOPSIS
-Gets SQL Instance properties of one or more instance(s) of SQL Server.
+        .SYNOPSIS
+            Gets SQL Instance properties of one or more instance(s) of SQL Server.
 
-.DESCRIPTION
- The Get-DbaSqlInstanceProperty command gets SQL Instance properties from the SMO object sqlserver.
+        .DESCRIPTION
+            The Get-DbaSqlInstanceProperty command gets SQL Instance properties from the SMO object sqlserver.
 
-.PARAMETER SqlInstance
-SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function
-to be executed against multiple SQL Server instances.
+        .PARAMETER SqlInstance
+            SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
 
-.PARAMETER SqlCredential
-PSCredential object to connect as. If not specified, current Windows login will be used.
+        .PARAMETER SqlCredential
+            SqlCredential object to connect as. If not specified, current Windows login will be used.
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Author: Klaas Vandenberghe (@powerdbaklaas)
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+        .NOTES
+            Author: Klaas Vandenberghe (@powerdbaklaas)
 
-.LINK
-https://dbatools.io/Get-DbaSqlInstanceProperty
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.EXAMPLE
-Get-DbaSqlInstanceProperty -SqlInstance localhost
-Returns SQL Instance properties on the local default SQL Server instance
+        .LINK
+            https://dbatools.io/Get-DbaSqlInstanceProperty
 
-.EXAMPLE
-Get-DbaSqlInstanceProperty -SqlInstance sql2, sql4\sqlexpress
-Returns SQL Instance properties on default instance on sql2 and sqlexpress instance on sql4
+        .EXAMPLE
+            Get-DbaSqlInstanceProperty -SqlInstance localhost
 
-.EXAMPLE
-'sql2','sql4' | Get-DbaSqlInstanceProperty
-Returns SQL Instance properties on sql2 and sql4
+            Returns SQL Instance properties on the local default SQL Server instance
 
+        .EXAMPLE
+            Get-DbaSqlInstanceProperty -SqlInstance sql2, sql4\sqlexpress
+
+            Returns SQL Instance properties on default instance on sql2 and sqlexpress instance on sql4
+
+        .EXAMPLE
+            'sql2','sql4' | Get-DbaSqlInstanceProperty
+
+            Returns SQL Instance properties on sql2 and sql4
+
+        .EXAMPLE
+            $cred = Get-Credential sqladmin
+            Get-DbaSqlInstanceProperty -SqlInstance sql2 -SqlCredential $cred
+
+            Connects using sqladmin credential and returns SQL Instance properties from sql2
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
@@ -48,7 +57,6 @@ Returns SQL Instance properties on sql2 and sql4
         [PSCredential]$SqlCredential,
         [switch][Alias('Silent')]$EnableException
     )
-
     process {
         foreach ($instance in $SqlInstance) {
             try {
@@ -57,8 +65,9 @@ Returns SQL Instance properties on sql2 and sql4
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
+
             try {
-                $props = $server.information.properties
+                $props = $server.Information.Properties
                 foreach ($prop in $props) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
@@ -67,8 +76,11 @@ Returns SQL Instance properties on sql2 and sql4
                     Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value, PropertyType
                 }
             }
-            catch { } # SMO bug sometimes complains w/e
-            $props = $server.useroptions.properties
+            catch {
+                Write-Message -Level Warning -Message "Trouble getting SMO information properties"
+                continue
+            }
+            $props = $server.Useroptions.Properties
             foreach ($prop in $props) {
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
@@ -76,7 +88,7 @@ Returns SQL Instance properties on sql2 and sql4
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'UserOption'
                 Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value, PropertyType
             }
-            $props = $server.settings.properties
+            $props = $server.Settings.Properties
             foreach ($prop in $props) {
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes complaint from ScriptAnalyzer (empty catch block), cleans up help and capitalizes SMO properties.

### Approach
<!-- How does this change solve that purpose -->
- Added `Write-Message -Level Warning -Message "Trouble getting SMO information properties"` inside empty catch block 
- cleaned up help
- capital letters on SMO properties, e.g. `$server.Useroptions.Properties`