### PR TITLE
Invoke-Command2 - Fixed manual session manipulation interference

### DIFF
--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -48,7 +48,7 @@
         $sessionname = "dbatools_$runspaceid"
         
         # Retrieve a session from the session cache, if available (it's unique per runspace)
-        if (-not ($currentsession = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceid, $ComputerName.ComputerName))) {
+        if (-not ($currentsession = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceid, $ComputerName.ComputerName) | Where-Object State -EQ Opened)) {
             $timeout = New-PSSessionOption -IdleTimeout (New-TimeSpan -Minutes 10).TotalMilliSeconds
             if ($Credential) {
                 $InvokeCommandSplat["Session"] = (New-PSSession -ComputerName $ComputerName.ComputerName -Name $sessionname -SessionOption $timeout -Credential $Credential)

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -48,7 +48,7 @@
         $sessionname = "dbatools_$runspaceid"
         
         # Retrieve a session from the session cache, if available (it's unique per runspace)
-        if (-not ($currentsession = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceid, $ComputerName.ComputerName) | Where-Object State -EQ Opened)) {
+        if (-not ($currentsession = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceid, $ComputerName.ComputerName) | Where-Object State -Match "Opened|Disconnected")) {
             $timeout = New-PSSessionOption -IdleTimeout (New-TimeSpan -Minutes 10).TotalMilliSeconds
             if ($Credential) {
                 $InvokeCommandSplat["Session"] = (New-PSSession -ComputerName $ComputerName.ComputerName -Name $sessionname -SessionOption $timeout -Credential $Credential)
@@ -60,7 +60,7 @@
         }
         else {
             if ($currentsession.State -eq "Disconnected") {
-                $currentsession | Connect-PSSession
+                $null = $currentsession | Connect-PSSession
             }
             $InvokeCommandSplat["Session"] = $currentsession
             


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

PSSessions can be manipulated manually, using tools such as `Disconnect-PSSession` or `Remove-PSSession`. This update fixes our internal `Invoke-Commnad2` function to be able to handle those:

 - Do not try to reuse killed sessions
 - Properly reconnect to disconnected sessions
 - No longer return session object on reconnect