### PR TITLE
Fixes ScriptAnalyser PSPossibleIncorrectComparisonWithNull rule

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -279,7 +279,7 @@ function Connect-DbaInstance {
                 }
 
                 try {
-                    if ($Credential.username -ne $null) {
+                    if ($null -ne $Credential.username) {
                         $username = ($Credential.username).TrimStart("\")
 
                         if ($username -like "*\*") {

--- a/functions/ConvertTo-DbaDataTable.ps1
+++ b/functions/ConvertTo-DbaDataTable.ps1
@@ -288,7 +288,7 @@ function ConvertTo-DbaDataTable {
     
     process {
         #region Handle null objects
-        if ($InputObject -eq $null) {
+        if ($null -eq $InputObject) {
             if (-not $IgnoreNull) {
                 $datarow = $datatable.NewRow()
                 $datatable.Rows.Add($datarow)
@@ -301,7 +301,7 @@ function ConvertTo-DbaDataTable {
         
         foreach ($object in $InputObject) {
             #region Handle null objects
-            if ($object -eq $null) {
+            if ($null -eq $object) {
                 if (-not $IgnoreNull) {
                     $datarow = $datatable.NewRow()
                     $datatable.Rows.Add($datarow)

--- a/functions/Copy-DbaCredential.ps1
+++ b/functions/Copy-DbaCredential.ps1
@@ -321,7 +321,7 @@ function Copy-DbaCredential {
                     DateTime          = [DbaDateTime](Get-Date)
                 }
 
-                if ($destServer.Credentials[$credentialName] -ne $null) {
+                if ($null -ne $destServer.Credentials[$credentialName]) {
                     if (!$force) {
                         $copyCredentialStatus.Status = "Skipping"
                         $copyCredentialStatus.Notes = "Already exists"
@@ -369,7 +369,7 @@ function Copy-DbaCredential {
         $source = $sourceServer.DomainInstanceName
         $destination = $destServer.DomainInstanceName
 
-        if ($SourceSqlCredential.Username -ne $null) {
+        if ($null -ne $SourceSqlCredential.Username) {
             Write-Message -Level Verbose -Message "You are using SQL credentials and this script requires Windows admin access to the $Source server. Trying anyway."
         }
 

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -506,7 +506,7 @@ function Copy-DbaDatabase {
                 $dbOwner
             )
 
-            if ($server.Logins.Item($dbOwner) -eq $null) {
+            if ($null -eq $server.Logins.Item($dbOwner)) {
                 try {
                     $dbOwner = ($destServer.logins | Where-Object { $_.id -eq 1 }).Name
                 }
@@ -615,7 +615,7 @@ function Copy-DbaDatabase {
             $sourceFileStructure = New-Object System.Collections.Specialized.StringCollection
             $dbOwner = $sourceServer.databases[$dbName].owner
 
-            if ($dbOwner -eq $null) {
+            if ($null -eq $dbOwner) {
                 try {
                     $dbOwner = ($destServer.logins | Where-Object { $_.id -eq 1 }).Name
                 }
@@ -997,7 +997,7 @@ function Copy-DbaDatabase {
                     continue
                 }
 
-                if (($destServer.Databases[$dbName] -ne $null) -and !$force -and !$WithReplace) {
+                if (($null -ne $destServer.Databases[$dbName]) -and !$force -and !$WithReplace) {
                     Write-Message -Level Verbose -Message "Database exists at destination. Use -Force to drop and migrate. Aborting routine for this database."
 
                     $copyDatabaseStatus.Status = "Skipped"
@@ -1005,7 +1005,7 @@ function Copy-DbaDatabase {
                     $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                     continue
                 }
-                elseif ($destServer.Databases[$dbName] -ne $null -and $force) {
+                elseif ($null -ne $destServer.Databases[$dbName] -and $force) {
                     if ($Pscmdlet.ShouldProcess($destination, "DROP DATABASE $dbName")) {
                         Write-Message -Level Verbose -Message "$dbName already exists. -Force was specified. Dropping $dbName on $destination."
                         $dropResult = Remove-SqlDatabase $destServer $dbName

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -139,7 +139,7 @@ function Copy-DbaExtendedEvent {
                 DateTime          = [DbaDateTime](Get-Date)
             }
 
-            if ($destStore.Sessions[$sessionName] -ne $null) {
+            if ($null -ne $destStore.Sessions[$sessionName]) {
                 if ($force -eq $false) {
                     $copyXeSessionStatus.Status = "Skipped"
                     $copyXeSessionStatus.Notes = "Already exists"

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -313,7 +313,7 @@ function Copy-DbaLinkedServer {
                     }
                 }
 
-                if ($destServer.LinkedServers[$linkedServerName] -ne $null) {
+                if ($null -ne $destServer.LinkedServers[$linkedServerName]) {
                     if (!$force) {
                         $copyLinkedServer.Status = "Skipped"
                         $copyLinkedServer | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
@@ -395,7 +395,7 @@ function Copy-DbaLinkedServer {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        if ($SourceSqlCredential.username -ne $null) {
+        if ($null -ne $SourceSqlCredential.username) {
             Write-Message -Level Verbose -Message "You are using a SQL Credential. Note that this script requires Windows Administrator access on the source server. Attempting with $($SourceSqlCredential.Username)."
         }
 

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -215,7 +215,7 @@ function Copy-DbaLogin {
                     }
                 }
 
-                if ($destServer.Logins.Item($userName) -ne $null -and !$force) {
+                if ($null -ne $destServer.Logins.Item($userName) -and !$force) {
                     if ($Pscmdlet.ShouldProcess("console", "Stating $userName is skipped because it exists at destination.")) {
                         Write-Message -Level Verbose -Message "$userName already exists in destination. Use -Force to drop and recreate."
                     }
@@ -226,7 +226,7 @@ function Copy-DbaLogin {
                     continue
                 }
 
-                if ($destServer.Logins.Item($userName) -ne $null -and $force) {
+                if ($null -ne $destServer.Logins.Item($userName) -and $force) {
                     if ($userName -eq $destServer.ServiceAccount) {
                         Write-Message -Level Verbose -Message "$userName is the destination service account. Skipping drop."
 
@@ -302,7 +302,7 @@ function Copy-DbaLogin {
                     Write-Message -Level Verbose -Message "Setting login language to $($sourceLogin.Language)."
                     $destLogin.Language = $sourceLogin.Language
 
-                    if ($destServer.databases[$defaultDb] -eq $null) {
+                    if ($null -eq $destServer.databases[$defaultDb]) {
                         # we end up here when the default database on source doesn't exist on dest
                         # if source login is a sysadmin, then set the default database to master
                         # if not, set it to tempdb (see #303)

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -170,7 +170,7 @@ function Copy-DbaResourceGovernor {
                 DateTime          = [DbaDateTime](Get-Date)
             }
 
-            if ($destServer.ResourceGovernor.ResourcePools[$poolName] -ne $null) {
+            if ($null -ne $destServer.ResourceGovernor.ResourcePools[$poolName]) {
                 if ($force -eq $false) {
                     Write-Message -Level Verbose -Message "Pool '$poolName' was skipped because it already exists on $destination. Use -Force to drop and recreate."
 

--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -164,7 +164,7 @@ function Copy-DbaServerAudit {
                 }
             }
 
-            if (($currentAudit.Filepath) -ne $null -AND (Test-DbaSqlPath -SqlInstance $destServer -Path $currentAudit.Filepath) -eq $false) {
+            if ($null -ne ($currentAudit.Filepath) -AND (Test-DbaSqlPath -SqlInstance $destServer -Path $currentAudit.Filepath) -eq $false) {
                 if ($Force -eq $false) {
                     Write-Message -Level Verbose -Message "$($currentAudit.Filepath) does not exist on $destination. Skipping $auditName. Specify -Force to create the directory."
 

--- a/functions/Copy-DbaSqlDataCollector.ps1
+++ b/functions/Copy-DbaSqlDataCollector.ps1
@@ -186,7 +186,7 @@ function Copy-DbaSqlDataCollector {
                 DateTime          = [DbaDateTime](Get-Date)
             }
 
-            if ($destStore.CollectionSets[$collectionName] -ne $null) {
+            if ($null -ne $destStore.CollectionSets[$collectionName]) {
                 if ($force -eq $false) {
                     Write-Message -Level Verbose -Message "Collection Set '$collectionName' was skipped because it already exists on $destination. Use -Force to drop and recreate"
 

--- a/functions/Copy-DbaSqlPolicyManagement.ps1
+++ b/functions/Copy-DbaSqlPolicyManagement.ps1
@@ -164,7 +164,7 @@ function Copy-DbaSqlPolicyManagement {
                 DateTime          = [DbaDateTime](Get-Date)
             }
 
-            if ($destStore.Conditions[$conditionName] -ne $null) {
+            if ($null -ne $destStore.Conditions[$conditionName]) {
                 if ($force -eq $false) {
                     Write-Message -Level Verbose -Message "condition '$conditionName' was skipped because it already exists on $destination. Use -Force to drop and recreate"
 
@@ -234,7 +234,7 @@ function Copy-DbaSqlPolicyManagement {
                 DateTime          = [DbaDateTime](Get-Date)
             }
 
-            if ($destStore.Policies[$policyName] -ne $null) {
+            if ($null -ne $destStore.Policies[$policyName]) {
                 if ($force -eq $false) {
                     Write-Message -Level Verbose -Message "Policy '$policyName' was skipped because it already exists on $destination. Use -Force to drop and recreate"
 

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -150,7 +150,7 @@ function Copy-DbaSsisCatalog {
                 $cmd.Parameters.Add("@folder_name", $Folder) | out-null;
                 $cmd.Parameters.Add("@project_name", $Project) | out-null;
                 [byte[]]$results = $cmd.ExecuteScalar();
-                if ($results -ne $null) {
+                if ($null -ne $results) {
                     $destFolder = $destinationFolders | Where-Object { $_.Name -eq $Folder }
                     $deployedProject = $destFolder.DeployProject($Project, $results)
                     if ($deployedProject.Status -ne "Success") {

--- a/functions/Export-DbaExecutionPlan.ps1
+++ b/functions/Export-DbaExecutionPlan.ps1
@@ -183,12 +183,12 @@ Exports all execution plans for databases db1 and db2 on sqlserver2014a since Ju
                     $wherearray += " DB_NAME(deqp.dbid) in ('$dblist') "
                 }
 
-                if ($SinceCreation -ne $null) {
+                if ($null -ne $SinceCreation) {
                     Write-Verbose "Adding creation time"
                     $wherearray += " creation_time >= '$SinceCreation' "
                 }
 
-                if ($SinceLastExecution -ne $null) {
+                if ($null -ne $SinceLastExecution) {
                     Write-Verbose "Adding last execution time"
                     $wherearray += " last_execution_time >= '$SinceLastExecution' "
                 }

--- a/functions/Get-DbaDistributor.ps1
+++ b/functions/Get-DbaDistributor.ps1
@@ -43,7 +43,7 @@ function Get-DbaDistributor {
         [switch][Alias('Silent')]$EnableException
     )
     begin {
-        if ([System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.RMO") -eq $null) {
+        if ($null -eq [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.RMO")) {
             Stop-Function -Message "Replication management objects not available. Please install SQL Server Management Studio."
         }
     }

--- a/functions/Get-DbaExecutionPlan.ps1
+++ b/functions/Get-DbaExecutionPlan.ps1
@@ -142,12 +142,12 @@ Gets super detailed information for execution plans on only for AdventureWorks20
                     $wherearray += " DB_NAME(deqp.dbid) in ('$dblist') "
                 }
 
-                if ($SinceCreation -ne $null) {
+                if ($null -ne $SinceCreation) {
                     Write-Message -Level Verbose -Message "Adding creation time"
                     $wherearray += " creation_time >= '$SinceCreation' "
                 }
 
-                if ($SinceLastExecution -ne $null) {
+                if ($null -ne $SinceLastExecution) {
                     Write-Message -Level Verbose -Message "Adding last exectuion time"
                     $wherearray += " last_execution_time >= '$SinceLastExecution' "
                 }

--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -167,7 +167,7 @@ function Get-DbaRestoreHistory {
                     $wherearray += "destination_database_name in ('$dblist')"
                 }
 
-                if ($Since -ne $null) {
+                if ($null -ne $Since) {
                     $wherearray += "rsh.restore_date >= '$since'"
                 }
 

--- a/functions/Get-DbaSqlProductKey.ps1
+++ b/functions/Get-DbaSqlProductKey.ps1
@@ -97,7 +97,7 @@ Gets SQL Server versions, editions and product keys for all instances listed wit
     PROCESS {
 
         if ($SqlCms) {
-            if ([Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.RegisteredServers") -eq $null)
+            if ($null -eq [Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Management.RegisteredServers"))
             { throw "Can't load CMS assemblies. You must have SQL Server Management Studio installed to use the -SqlCms switch." }
 
             Write-Verbose "Gathering SQL Servers names from Central Management Server"
@@ -153,7 +153,7 @@ Gets SQL Server versions, editions and product keys for all instances listed wit
 
                 $subkeys = $reg.OpenSubKey("$basepath", $false)
                 $instancekey = $subkeys.GetSubKeynames() | Where-Object { $_ -like "*.$instance" }
-                if ($instancekey -eq $null) { $instancekey = $instance } # SQL 2k5
+                if ($null -eq $instancekey) { $instancekey = $instance } # SQL 2k5
 
                 # Cluster instance hostnames are required for SMO connection
                 $cluster = $reg.OpenSubKey("$basepath\$instancekey\Cluster", $false)

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -123,25 +123,25 @@ function Get-DbaStartupParameter {
                         $minimalstart = $noeventlogs = $instancestart = $disablemonitoring = $false
                         $increasedextents = $commandprompt = $singleuser = $false
 
-                        if ($commandpromptparm -ne $null) {
+                        if ($null -ne $commandpromptparm) {
                             $commandprompt = $true
                         }
-                        if ($minimalstartparm -ne $null) {
+                        if ($null -ne $minimalstartparm) {
                             $minimalstart = $true
                         }
-                        if ($memorytoreserve -eq $null) {
+                        if ($null -eq $memorytoreserve) {
                             $memorytoreserve = 0
                         }
-                        if ($noeventlogsparm -ne $null) {
+                        if ($null -ne $noeventlogsparm) {
                             $noeventlogs = $true
                         }
-                        if ($instancestartparm -ne $null) {
+                        if ($null -ne $instancestartparm) {
                             $instancestart = $true
                         }
-                        if ($disablemonitoringparm -ne $null) {
+                        if ($null -ne $disablemonitoringparm) {
                             $disablemonitoring = $true
                         }
-                        if ($increasedextentsparm -ne $null) {
+                        if ($null -ne $increasedextentsparm) {
                             $increasedextents = $true
                         }
 

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -174,7 +174,7 @@ function Get-DbaTcpPort {
                 $cleanedUp
             }
 
-            if ($Detailed -eq $false -or ($Detailed -eq $true -and $someIps -eq $null)) {
+            if ($Detailed -eq $false -or ($Detailed -eq $true -and $null -eq $someIps)) {
                 try {
                     $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
                 }

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -225,7 +225,7 @@ function Import-DbaCsvToSql {
                 $SqlCredential = Import-CliXml $SqlCredentialPath
             }
 
-            if ($SqlCredential.count -eq 0 -or $SqlCredential -eq $null) {
+            if ($SqlCredential.count -eq 0 -or $null -eq $SqlCredential) {
                 $paramconn.ConnectionString = "Data Source=$SqlInstance;Integrated Security=True;"
             }
             else {
@@ -605,7 +605,7 @@ function Import-DbaCsvToSql {
         # UniqueIdentifier kills OLE DB / SqlBulkCopy imports. Check to see if destination table contains this datatype.
         if ($safe -eq $true) {
             $sqlcheckconn = New-Object System.Data.SqlClient.SqlConnection
-            if ($SqlCredential.count -eq 0 -or $SqlCredential -eq $null) {
+            if ($SqlCredential.count -eq 0 -or $null -eq $SqlCredential) {
                 $sqlcheckconn.ConnectionString = "Data Source=$SqlInstance;Integrated Security=True;Connection Timeout=3; Initial Catalog=master"
             }
             else {
@@ -657,13 +657,13 @@ function Import-DbaCsvToSql {
                 $provider = (New-Object System.Data.OleDb.OleDbEnumerator).GetElements() | Where-Object { $_.SOURCES_NAME -like "Microsoft.ACE.OLEDB.*" }
             }
 
-            if ($provider -eq $null) {
+            if ($null -eq $provider) {
                 $provider = (New-Object System.Data.OleDb.OleDbEnumerator).GetElements() | Where-Object { $_.SOURCES_NAME -like "Microsoft.Jet.OLEDB.*" }
             }
 
             # If a suitable provider cannot be found (If x64 and Access hasn't been installed)
             # switch to x86, because it natively supports JET
-            if ($provider -ne $null) {
+            if ($null -ne $provider) {
                 if ($provider -is [system.array]) {
                     $provider = $provider[$provider.GetUpperBound(0)].SOURCES_NAME
                 }
@@ -673,7 +673,7 @@ function Import-DbaCsvToSql {
             }
 
             # If a provider doesn't exist, it is necessary to switch to x86 which natively supports JET.
-            if ($provider -eq $null) {
+            if ($null -eq $provider) {
                 # While Install-Module takes care of installing modules to x86 and x64, Import-Module doesn't.
                 # Because of this, the Module must be exported, written to file, and imported in the x86 shell.
                 $definition = (Get-Command Import-DbaCsvToSql).Definition
@@ -908,7 +908,7 @@ function Import-DbaCsvToSql {
         }
 
         # Get columns for column mapping
-        if ($columnMappings -eq $null) {
+        if ($null -eq $columnMappings) {
             $olecolumns = ($columns | ForEach-Object { $_ -Replace "\[|\]" })
             $sql = "select name from sys.columns where object_id = object_id('$schema.$table') order by column_id"
             $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
@@ -1124,7 +1124,7 @@ function Import-DbaCsvToSql {
                         $pattern = "((?<=`")[^`"]*(?=`"($InternalDelimiter|$)+)|(?<=$InternalDelimiter|^)[^$InternalDelimiter`"]*(?=$InternalDelimiter|$))"
                     }
                     if ($turbo -eq $true -and $first -eq 0) {
-                        while (($line = $reader.ReadLine()) -ne $null) {
+                        while ($null -ne ($line = $reader.ReadLine())) {
                             $i++
                             if ($quoted -eq $true) {
                                 $null = $datatable.Rows.Add(($line.TrimStart('"').TrimEnd('"')) -Split "`"$InternalDelimiter`"")
@@ -1143,7 +1143,7 @@ function Import-DbaCsvToSql {
                     else {
                         if ($turbo -eq $true -and $first -gt 0) { Write-Warning -Message "Using -First makes turbo a little slower." }
                         # Start import!
-                        while (($line = $reader.ReadLine()) -ne $null) {
+                        while ($null -ne ($line = $reader.ReadLine())) {
                             $i++
                             try {
                                 if ($quoted -eq $true) {

--- a/functions/Import-DbaSpConfigure.ps1
+++ b/functions/Import-DbaSpConfigure.ps1
@@ -139,7 +139,7 @@ function Import-DbaSpConfigure {
                     $displayname = $sourceprop.DisplayName
 
                     $destprop = $destprops | where-object { $_.Displayname -eq $displayname }
-                    if ($destprop -ne $null) {
+                    if ($null -ne $destprop) {
                         try {
                             $destprop.configvalue = $sourceprop.configvalue
                             $destserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -652,11 +652,11 @@ The script will show a message that the copy destination has not been supplied a
         $SourceServerName, $SourceInstanceName = $SourceSqlInstance.Split("\")
         $DestinationServerName, $DestinationInstanceName = $DestinationSqlInstance.Split("\")
 
-        if ($SourceInstanceName -eq $null) {
+        if ($null -eq $SourceInstanceName) {
             $SourceInstanceName = "MSSQLSERVER"
         }
 
-        if ($DestinationInstanceName -eq $null) {
+        if ($null -eq $DestinationInstanceName) {
             $DestinationInstanceName = "MSSQLSERVER"
         }
 
@@ -1356,7 +1356,7 @@ The script will show a message that the copy destination has not been supplied a
                     $LastBackup = Get-DbaBackupHistory -SqlServer $SourceSqlInstance -Databases $($db.Name) -LastFull -Credential $SourceSqlCredential
 
                     # Check if there was a last backup
-                    if ($LastBackup -ne $null) {
+                    if ($null -ne $LastBackup) {
                         # Test the path to the backup
                         Write-Message -Message "Testing last backup path $(($LastBackup[-1]).Path[-1])" -Level Verbose
                         if ((Test-DbaSqlPath -Path ($LastBackup[-1]).Path[-1] -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true) {
@@ -1472,7 +1472,7 @@ The script will show a message that the copy destination has not been supplied a
             }
 
             # Check the primary monitor server
-            if ($Force -and (-not$PrimaryMonitorServer -or [string]$PrimaryMonitorServer -eq '' -or $PrimaryMonitorServer -eq $null)) {
+            if ($Force -and (-not$PrimaryMonitorServer -or [string]$PrimaryMonitorServer -eq '' -or $null -eq $PrimaryMonitorServer)) {
                 Write-Message -Message "Setting monitor server for primary server to $SourceSqlInstance." -Level Output
                 $PrimaryMonitorServer = $SourceSqlInstance
             }
@@ -1496,7 +1496,7 @@ The script will show a message that the copy destination has not been supplied a
             }
 
             # Check the secondary monitor server
-            if ($Force -and (-not $SecondaryMonitorServer -or [string]$SecondaryMonitorServer -eq '' -or $SecondaryMonitorServer -eq $null)) {
+            if ($Force -and (-not $SecondaryMonitorServer -or [string]$SecondaryMonitorServer -eq '' -or $null -eq $SecondaryMonitorServer)) {
                 Write-Message -Message "Setting secondary monitor server for $DestinationSqlInstance to $SourceSqlInstance." -Level Verbose
                 $SecondaryMonitorServer = $SourceSqlInstance
             }

--- a/functions/Invoke-DbaLogShippingRecovery.ps1
+++ b/functions/Invoke-DbaLogShippingRecovery.ps1
@@ -117,7 +117,7 @@ function Invoke-DbaLogShippingRecovery {
             # Check the instance if it is a named instance
             $servername, $instancename = $sqlinstance.Split("\")
 
-            if ($instancename -eq $null) {
+            if ($null -eq $instancename) {
                 $instancename = "MSSQLSERVER"
             }
 
@@ -231,7 +231,7 @@ function Invoke-DbaLogShippingRecovery {
             }
 
             # Check if there are any databases to recover
-            if ($logshipping_details -eq $null) {
+            if ($null -eq $logshipping_details) {
                 Stop-Function -Message "The database $db is not configured as a secondary database for log shipping." -Continue
             }
             else {
@@ -324,7 +324,7 @@ function Invoke-DbaLogShippingRecovery {
                         $latestrestore = $server.Query($query)
 
                         # Check if the last copied file is newer than the last restored file
-                        if ((([string]$latestcopy.last_copied_file).Split('\')[-1] -ne ([string]$latestrestore.last_restored_file).Split('\')[-1]) -or (([string]$latestcopy.last_copied_file).Split('\')[-1]) -eq $null) {
+                        if ((([string]$latestcopy.last_copied_file).Split('\')[-1] -ne ([string]$latestrestore.last_restored_file).Split('\')[-1]) -or ($null -eq ([string]$latestcopy.last_copied_file).Split('\')[-1])) {
                             Write-Message -Message "Restore is not up-to-date" -Level Verbose
 
                             # Start the restore job

--- a/functions/Invoke-DbaPfRelog.ps1
+++ b/functions/Invoke-DbaPfRelog.ps1
@@ -255,7 +255,7 @@
             }
             $item = Get-ChildItem -Path $file -ErrorAction SilentlyContinue
 
-            if ($item -eq $null) {
+            if ($null -eq $item) {
                 Stop-Function -Message "$file does not exist" -Target $file -Continue
                 return
             }

--- a/functions/Invoke-DbaSqlCmd.ps1
+++ b/functions/Invoke-DbaSqlCmd.ps1
@@ -125,7 +125,7 @@ function Invoke-DbaSqlCmd {
             $temporaryFilesPrefix = (97 .. 122 | Get-Random -Count 10 | ForEach-Object { [char]$_ }) -join ''
             
             foreach ($item in $File) {
-                if ($item -eq $null) { continue }
+                if ($null -eq $item) { continue }
                 
                 $type = $item.GetType().FullName
                 

--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -417,10 +417,10 @@ function Invoke-Sqlcmd2 {
             $cmd = New-Object system.Data.SqlClient.SqlCommand($Query, $conn)
             $cmd.CommandTimeout = $QueryTimeout
 
-            if ($SqlParameters -ne $null) {
+            if ($null -ne $SqlParameters) {
                 $SqlParameters.GetEnumerator() |
                     ForEach-Object {
-                    if ($_.Value -ne $null) {
+                    if ($null -ne $_.Value) {
                         $cmd.Parameters.AddWithValue($_.Key, $_.Value)
                     }
                     else {

--- a/functions/New-DbaSqlConnectionString.ps1
+++ b/functions/New-DbaSqlConnectionString.ps1
@@ -231,7 +231,7 @@ Creates a connection string with ReadOnly ApplicantionIntent.
                     if ($connstring -ne $server.ConnectionContext.ConnectionString) {
                         $server.ConnectionContext.ConnectionString = $connstring
                     }
-                    if ($Credential.username -ne $null) {
+                    if ($null -ne $Credential.username) {
                         $username = ($Credential.username).TrimStart("\")
 
                         if ($username -like "*\*") {

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -654,7 +654,7 @@ function Remove-DbaDatabaseSafely {
 
             $refreshRetries = 1
 
-            while (($destserver.databases[$dbname] -eq $null) -and $refreshRetries -lt 6) {
+            while ($null -eq ($destserver.databases[$dbname]) -and $refreshRetries -lt 6) {
                 Write-Message -Level verbose -Message "Database $dbname not found! Refreshing collection."
 
                 #refresh database list, otherwise the next step (DBCC) can fail

--- a/functions/Repair-DbaServerName.ps1
+++ b/functions/Repair-DbaServerName.ps1
@@ -243,7 +243,7 @@ function Repair-DbaServerName {
                 $renamed = $true
             }
 
-            if ($allsqlservices -eq $null) {
+            if ($null -eq $allsqlservices) {
                 Write-Warning "Could not contact $($server.ComputerNamePhysicalNetBIOS) using Get-Service. You must manually restart the SQL Server instance."
                 $needsrestart = $true
             }

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -197,7 +197,7 @@ function Reset-DbaAdmin {
                 Write-Message -Level Verbose -Message "Resolving NetBIOS name."
                 try {
                     $hostname = (Get-WmiObject -Class Win32_NetworkAdapterConfiguration -Filter IPEnabled=TRUE -ComputerName $ipaddr).PSComputerName
-                    if ($hostname -eq $null) {
+                    if ($null -eq $hostname) {
                         $hostname = (nbtstat -A $ipaddr | Where-Object { $_ -match '\<00\>  UNIQUE' } | ForEach-Object { $_.SubString(4, 14) }).Trim()
                     }
                 }
@@ -287,7 +287,7 @@ function Reset-DbaAdmin {
                 return
             }
 
-            if ($checkcluster -ne $null) {
+            if ($null -ne $checkcluster) {
                 $clusterResource = Get-DbaCmObject -ClassName "MSCluster_Resource" -Namespace "root\mscluster" -ComputerName $hostname |
                     Where-Object { $_.Name.StartsWith("SQL Server") -and $_.OwnerGroup -eq "SQL Server ($instance)" }
             }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -178,27 +178,27 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
 
     begin {
         # Check of the event log level is of type string and set the integer value
-        if (($EventLogLevel -notin 0, 1, 2, 3) -and ($EventLogLevel -ne $null)) {
+        if (($EventLogLevel -notin 0, 1, 2, 3) -and ($null -ne $EventLogLevel)) {
             $EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
 
         # Check of the email level is of type string and set the integer value
-        if (($EmailLevel -notin 0, 1, 2, 3) -and ($EmailLevel -ne $null)) {
+        if (($EmailLevel -notin 0, 1, 2, 3) -and ($null -ne $EmailLevel)) {
             $EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
 
         # Check of the net send level is of type string and set the integer value
-        if (($NetsendLevel -notin 0, 1, 2, 3) -and ($NetsendLevel -ne $null)) {
+        if (($NetsendLevel -notin 0, 1, 2, 3) -and ($null -ne $NetsendLevel)) {
             $NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
 
         # Check of the page level is of type string and set the integer value
-        if (($PageLevel -notin 0, 1, 2, 3) -and ($PageLevel -ne $null)) {
+        if (($PageLevel -notin 0, 1, 2, 3) -and ($null -ne $PageLevel)) {
             $PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
 
         # Check of the delete level is of type string and set the integer value
-        if (($DeleteLevel -notin 0, 1, 2, 3) -and ($DeleteLevel -ne $null)) {
+        if (($DeleteLevel -notin 0, 1, 2, 3) -and ($null -ne $DeleteLevel)) {
             $DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
 

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -211,7 +211,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
         }
 
         # Check of the FrequencyInterval value is of type string and set the integer value
-        if (($FrequencyType -ne $null)) {
+        if (($null -ne $FrequencyType)) {
             # Create the interval to hold the value(s)
             [int]$Interval = 0
 
@@ -275,7 +275,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
         }
 
         # Check of the relative FrequencyInterval value is of type string and set the integer value
-        if (($FrequencyRelativeInterval -notin 1, 2, 4, 8, 16) -and $FrequencyRelativeInterval -ne $null) {
+        if (($FrequencyRelativeInterval -notin 1, 2, 4, 8, 16) -and $null -ne $FrequencyRelativeInterval) {
             [int]$FrequencyRelativeInterval = switch ($FrequencyRelativeInterval) { "First" { 1 } "Second" { 2 } "Third" { 4 } "Fourth" { 8 } "Last" { 16 } "Unused" { 0 } default { 0 }}
         }
 

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -308,7 +308,7 @@ function Set-DbaLogin {
                 $l.Alter()
 
                 # Retrieve the server roles for the login
-                $roles = Get-DbaRoleMember -SqlInstance $instance -IncludeServerLevel | Where-Object {$_.Database -eq $null -and $_.Member -eq $l.Name}
+                $roles = Get-DbaRoleMember -SqlInstance $instance -IncludeServerLevel | Where-Object {$null -eq $_.Database -and $_.Member -eq $l.Name}
 
                 # Check if there were any notes to include in the results
                 if ($notes) {

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -121,7 +121,7 @@ function Set-DbaMaxDop {
         if ((Test-Bound -Not -Parameter Collection)) {
             $collection = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
         }
-        elseif ($collection.SqlInstance -eq $null) {
+        elseif ($null -eq $collection.SqlInstance) {
             $collection = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
         }
 

--- a/functions/Set-DbaMaxMemory.ps1
+++ b/functions/Set-DbaMaxMemory.ps1
@@ -115,7 +115,7 @@ function Set-DbaMaxMemory {
                 if ($UseRecommended) {
                     Write-Message -Level Verbose -Message "Change $server SQL Server Max Memory from $($currentServer.SqlMaxMB) to $($currentServer.RecommendedMB) MB"
 
-                    if ($currentServer.RecommendedMB -eq 0 -or $currentServer.RecommendedMB -eq $null) {
+                    if ($currentServer.RecommendedMB -eq 0 -or $null -eq $currentServer.RecommendedMB) {
                         $maxMem = (Test-DbaMaxMemory -SqlInstance $server).RecommendedMB
                         Write-Message -Level VeryVerbose -Message "Max memory recommended: $maxMem"
                         $server.Configuration.MaxServerMemory.ConfigValue = $maxMem

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -85,7 +85,7 @@ function Set-DbaPowerPlan {
                 return
             }
 
-            if ($currentplan -eq $null) {
+            if ($null -eq $currentplan) {
                 # the try/catch above isn't working, so make it silent and handle it here.
                 Write-Warning "Cannot get Power Plan for $server."
                 return

--- a/functions/Sync-DbaSqlLoginPermission.ps1
+++ b/functions/Sync-DbaSqlLoginPermission.ps1
@@ -118,7 +118,7 @@ function Sync-DbaSqlLoginPermission {
                     continue
                 }
 
-                if ($Logins -ne $null -and $Logins -notcontains $username) {
+                if ($null -ne $Logins -and $Logins -notcontains $username) {
                     continue
                 }
 
@@ -131,7 +131,7 @@ function Sync-DbaSqlLoginPermission {
                 if ($serverName -eq $userBase -or $username.StartsWith("NT ")) {
                     continue
                 }
-                if (($destLogin = $destServer.Logins.Item($username)) -eq $null) {
+                if ($null -eq ($destLogin = $destServer.Logins.Item($username))) {
                     continue
                 }
 

--- a/functions/Test-DbaDiskAlignment.ps1
+++ b/functions/Test-DbaDiskAlignment.ps1
@@ -188,7 +188,7 @@ function Test-DbaDiskAlignment {
                         foreach ($SqlInstance in $SqlInstances) {
                             Write-Message -Level Verbose -Message "Connecting to SQL instance ($SqlInstance)." -FunctionName $FunctionName
                             try {
-                                if ($SqlCredential -ne $null) {
+                                if ($null -ne $SqlCredential) {
                                     $smoserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
                                 }
                                 else {
@@ -336,7 +336,7 @@ function Test-DbaDiskAlignment {
                 Stop-Function -Message "Failed to process $($Computer): $($_.Exception.Message)" -Continue -InnerErrorRecord $_ -Target $Computer
             }
 
-            if ($data.Server -eq $null) {
+            if ($null -eq $data.Server) {
                 Stop-Function -Message "CIM query to $Computer failed." -Continue -Target $computer
             }
 

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -228,7 +228,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                         }
                         elseif (-not $result.IsPrimary) {
                             # Check the restore
-                            if ($result.TimeSinceLastRestore -eq $null) {
+                            if ($null -eq $result.TimeSinceLastRestore) {
                                 $statusDetails += "The restore has never been executed."
                             }
                             elseif ($result.TimeSinceLastRestore -ge $result.RestoreThresshold) {

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -136,7 +136,7 @@ function Test-DbaServerName {
                 }
             }
 
-            if ($rs -ne $null -or $rs.Count -gt 0) {
+            if ($null -ne $rs -or $rs.Count -gt 0) {
                 if ($rs.State -eq 'Running') {
                     $rstext = "$ssrsService must be stopped and updated."
                 }

--- a/functions/Test-DbaVirtualLogFile.ps1
+++ b/functions/Test-DbaVirtualLogFile.ps1
@@ -120,8 +120,8 @@ function Test-DbaVirtualLogFile {
                         Database          = $db.name
                         Total             = $data.Count
                         TotalCount        = $data.Count
-                        Inactive          = if ($inactive -and $inactive.Count -eq $null) {1} else {$inactive.Count}
-                        Active            = if ($active -and $active.Count -eq $null) {1} else {$active.Count}
+                        Inactive          = if ($inactive -and $null -eq $inactive.Count) {1} else {$inactive.Count}
+                        Active            = if ($active -and $null -eq $active.Count) {1} else {$active.Count}
                         LogFileName       = $logFile.LogicalName -join ","
                         LogFileGrowth     = $logFile.Growth -join ","
                         LogFileGrowthType = $logFile.GrowthType -join ","

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -283,7 +283,7 @@ function Write-DbaDataTable {
             $sqlDataTypes = @();
             $columns = $DataTable.Columns
             
-            if ($columns -eq $null) {
+            if ($null -eq $columns) {
                 $columns = $DataTable.Table.Columns
             }
             
@@ -297,7 +297,7 @@ function Write-DbaDataTable {
                     $columnValue = $DataTable.$sqlColumnName
                 }
                 
-                if ($columnValue -eq $null) {
+                if ($null -eq $columnValue) {
                     $columnValue = $DataTable.$sqlColumnName
                 }
                 
@@ -365,7 +365,7 @@ function Write-DbaDataTable {
         #region Resolve Full Qualified Table Name
         $dotCount = ([regex]::Matches($Table, "\.")).count
 
-        if ($dotCount -lt 2 -and $Database -eq $null) {
+        if ($dotCount -lt 2 -and $null -eq $Database) {
             Stop-Function -Message "You must specify a database or fully qualified table name."
             return
         }
@@ -432,7 +432,7 @@ function Write-DbaDataTable {
         #endregion Connect to server and get database
 
         #region Prepare database and bulk operations
-        if ($databaseObject -eq $null) {
+        if ($null -eq $databaseObject) {
             Stop-Function -Message "$databaseName does not exist." -Target $SqlInstance
             return
         }
@@ -555,7 +555,7 @@ function Write-DbaDataTable {
     process {
         if (Test-FunctionInterrupt) { return }
         
-        if ($InputObject -ne $null) { $inputType = $InputObject.GetType() }
+        if ($null -ne $InputObject) { $inputType = $InputObject.GetType() }
         else { $inputType = $null }
         
         if ($inputType -eq [System.Data.DataSet]) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Correct all `PSPossibleIncorrectComparisonWithNull` ScriptAnalyzer rule violations

### Approach
<!-- How does this change solve that purpose -->
Flips each comparrison so that `$null` is on the left side of the equality operators.
