### PR TITLE
Removed unneccessary, hidden errors on import

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -68,7 +68,7 @@ if ($ImportLibrary) {
                 $start = Get-Date
                 try {
                     Write-Verbose -Message "Found library, trying to copy & import"
-                    Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $script:DllRoot -Force -ErrorAction Stop
+                    if ($libraryBase -ne $script:DllRoot) { Copy-Item -Path "$libraryBase\dbatools.dll" -Destination $script:DllRoot -Force -ErrorAction Stop }
                     Add-Type -Path "$script:DllRoot\dbatools.dll" -ErrorAction Stop
                 }
                 catch {

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -201,8 +201,10 @@ if ($script:serialImport) {
 }
 else {
     $script:dbatoolsConfigRunspace = [System.Management.Automation.PowerShell]::Create()
-    try { $script:dbatoolsConfigRunspace.Runspace.Name = "dbatools-import-config" }
-    catch { }
+    if ($script:dbatoolsConfigRunspace.Runspace.Name) {
+        try { $script:dbatoolsConfigRunspace.Runspace.Name = "dbatools-import-config" }
+        catch { }
+    }
     $script:dbatoolsConfigRunspace.AddScript($scriptBlock).AddArgument($global:dbatools_config)
     $script:dbatoolsConfigRunspace.BeginInvoke()
 }

--- a/internal/maintenance/PSSession-Cleanup.ps1
+++ b/internal/maintenance/PSSession-Cleanup.ps1
@@ -10,5 +10,5 @@ Register-DbaMaintenanceTask -Name "pssession_cleanup" -ScriptBlock $scriptBlock 
 # Cleans up local references in the current runspace. All actual termination logic is handled by the task above
 $script:pssession_cleanup_timer = New-Object System.Timers.TImer
 $script:pssession_cleanup_timer.Interval = 60000
-$null = Register-ObjectEvent -InputObject $script:pssession_cleanup_timer -EventName elapsed -SourceIdentifier Timer -Action { Get-PSSession | Where-Object State -Like Closed | Remove-PSSession }
+$null = Register-ObjectEvent -InputObject $script:pssession_cleanup_timer -EventName elapsed -SourceIdentifier dbatools_Timer -Action { Get-PSSession | Where-Object State -Like Closed | Remove-PSSession } -ErrorAction Ignore
 $script:pssession_cleanup_timer.Start()

--- a/internal/scripts/smoLibraryImport.ps1
+++ b/internal/scripts/smoLibraryImport.ps1
@@ -215,8 +215,10 @@ if ($script:serialImport) {
 }
 else {
     $script:smoRunspace = [System.Management.Automation.PowerShell]::Create()
-    try { $script:smoRunspace.Runspace.Name = "dbatools-import-smo" }
-    catch { }
+    if ($script:smoRunspace.Runspace.Name) {
+        try { $script:smoRunspace.Runspace.Name = "dbatools-import-smo" }
+        catch { }
+    }
     $script:smoRunspace.AddScript($scriptBlock).AddArgument($script:PSModuleRoot).AddArgument("$script:DllRoot\smo").AddArgument((-not $script:strictSecurityMode))
     $script:smoRunspace.BeginInvoke()
 }


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes
 - Only try to change the name of a runspace if it has a name to begin with, in order to avoid write errors
 - Do not try to copy library when source and destination folders are identical