### PR TITLE
Remove Distribution from list of excluded DBs

### DIFF
--- a/functions/Set-DbaDbRecoveryModel.ps1
+++ b/functions/Set-DbaDbRecoveryModel.ps1
@@ -119,7 +119,7 @@ function Set-DbaDbRecoveryModel {
             }
 
             # We need to be able to change the RecoveryModel for model database
-            $systemdbs = @("master", "msdb", "tempdb", "SSIS", "distribution")
+            $systemdbs = @("master", "msdb", "tempdb", "SSIS")
             $databases = $server.Databases | Where-Object { $systemdbs -notcontains $_.Name -and $_.IsAccessible }
 
             # filter collection based on -Database/-Exclude parameters

--- a/functions/Set-DbaDbRecoveryModel.ps1
+++ b/functions/Set-DbaDbRecoveryModel.ps1
@@ -119,7 +119,7 @@ function Set-DbaDbRecoveryModel {
             }
 
             # We need to be able to change the RecoveryModel for model database
-            $systemdbs = @("master", "msdb", "tempdb", "SSIS")
+            $systemdbs = @("master", "msdb", "tempdb")
             $databases = $server.Databases | Where-Object { $systemdbs -notcontains $_.Name -and $_.IsAccessible }
 
             # filter collection based on -Database/-Exclude parameters

--- a/functions/Set-DbaDbRecoveryModel.ps1
+++ b/functions/Set-DbaDbRecoveryModel.ps1
@@ -119,7 +119,7 @@ function Set-DbaDbRecoveryModel {
             }
 
             # We need to be able to change the RecoveryModel for model database
-            $systemdbs = @("master", "msdb", "tempdb")
+            $systemdbs = @("tempdb")
             $databases = $server.Databases | Where-Object { $systemdbs -notcontains $_.Name -and $_.IsAccessible }
 
             # filter collection based on -Database/-Exclude parameters


### PR DESCRIPTION
Line 122 lists system databases which are to be excluded from process. I have removed distribution as it is perfectly valid to set this to any recovery model, replication is not affected by this. Also, distribution is a valid name for a user database, it is not reserved for replication.

I believe this could also be done for SSIS but I wasn't sure the reason this was listed so have left it for now.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ x ] Bug fix (non-breaking change, fixes #<No bug listed>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Remove Distribution from list of excluded DBs

### Approach
<!-- How does this change solve that purpose -->
Distribution is no longer added to $systemdbs

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Set-DbaDbRecoveryModel -SqlInstance SQL2016 -RecoveryModel Simple -Database Distribution