### PR TITLE
Invoke-DbaSqlCmd to Invoke-DbaSqlQuery

### DIFF
--- a/functions/Invoke-DbaXEReplay.ps1
+++ b/functions/Invoke-DbaXEReplay.ps1
@@ -35,17 +35,17 @@ function Invoke-DbaXeReplay {
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
         .EXAMPLE
-            Read-DbaXEFile -Path C:\temp\sample.xel | Invoke-DbaSqlCmd -SqlInstance sql2017 -Database tempdb
+            Read-DbaXEFile -Path C:\temp\sample.xel | Invoke-DbaSqlQuery -SqlInstance sql2017 -Database tempdb
 
             Runs all batch_text for sql_batch_completed against tempdb on sql2017.
 
         .EXAMPLE
-            Read-DbaXEFile -Path C:\temp\sample.xel | Invoke-DbaSqlCmd -SqlInstance sql2017, sql2016 -Database tempdb, db1
+            Read-DbaXEFile -Path C:\temp\sample.xel | Invoke-DbaSqlQuery -SqlInstance sql2017, sql2016 -Database tempdb, db1
 
             Runs all batch_text for sql_batch_completed against tempdb and db1 on servers sql2017 and sql2016.
 
         .EXAMPLE
-            Watch-DbaXESession -SqlInstance sql2017 -Session 'Profile New App' | Invoke-DbaSqlCmd -SqlInstance sql2017, sql2016 -Database tempdb, db1
+            Watch-DbaXESession -SqlInstance sql2017 -Session 'Profile New App' | Invoke-DbaSqlQuery -SqlInstance sql2017, sql2016 -Database tempdb, db1
 
             Runs all batch_text for sql_batch_completed against tempdb and db1 on servers sql2017 and sql2016.
     #>

--- a/tests/Invoke-DbaSqlQuery.Tests.ps1
+++ b/tests/Invoke-DbaSqlQuery.Tests.ps1
@@ -4,7 +4,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     It "supports pipable instances" {
-        $results = $script:instance1, $script:instance2 | Invoke-DbaSqlcmd -Database tempdb -Query "Select 'hello' as TestColumn"
+        $results = $script:instance1, $script:instance2 | Invoke-DbaSqlQuery -Database tempdb -Query "Select 'hello' as TestColumn"
         foreach ($result in $results) {
             $result.TestColumn -eq 'hello'
         }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
As discussed over in slack and on invoke-sqlcmd2 repo, a better name separates better the expected features. This wrapper ultimately isn't (and won't ever be) "SQLCMD mode compatible", hence the rename.

I'm unsure on the process of editing the psm1 to add the alias, prolly some tests are going to fail till that's solved.