### PR TITLE
Get-DbaBackupHistory lastFull works with multiple dbs

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -292,7 +292,7 @@ function Get-DbaBackupHistory {
                 if ($LastLog) {
                     $first = 'L'; $second = 'L'
                 }
-                $databases = $databases | Select-Object -Unique
+                $databases = $databases | Select-Object -Unique -Property Name
                 foreach ($db in $databases) {
                     Write-Message -Level Verbose -Message "Processing $($db.name)" -Target $db
                     $wherecopyonly = $null

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaLastBackup {
     <#
         .SYNOPSIS
@@ -66,14 +67,22 @@ function Get-DbaLastBackup {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
-        [PSCredential]$SqlCredential,
+        [PSCredential]
+        $SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]
-        $EnableException
+        [switch][Alias('Silent')]$EnableException
     )
-    
+    begin {
+        function Get-DbaDateOrNull ($TimeSpan) {
+            if ($TimeSpan -eq 0) {
+                return $null
+            }
+            return $TimeSpan
+        }
+        $StartOfTime = [DbaTimeSpan](New-TimeSpan -Start ([datetime]0))
+    }
     process {
         foreach ($instance in $SqlInstance) {
             Write-Message -Level Verbose -Message "Connecting to $instance"
@@ -84,96 +93,81 @@ function Get-DbaLastBackup {
                 Write-Message -Level Warning -Message "Can't connect to $instance"
                 Continue
             }
-            
+
             $dbs = $server.Databases | Where-Object { $_.name -ne 'tempdb' }
-            
+
             if ($Database) {
                 $dbs = $dbs | Where-Object Name -In $Database
             }
-            
+
             if ($ExcludeDatabase) {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
-            
+            # Get-DbaBackupHistory -Last would make the job in one query but SMO's (and this) report the last backup of this type irregardless of the chain
+            $FullHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastFull -IncludeCopyOnly -Raw
+            $DiffHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastDiff -IncludeCopyOnly -Raw
+            $IncrHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastLog -IncludeCopyOnly -Raw
             foreach ($db in $dbs) {
-                $result = $null
                 Write-Message -Level Verbose -Message "Processing $db on $instance"
-                
+
                 if ($db.IsAccessible -eq $false) {
                     Write-Message -Level Warning -Message "The database $db on server $instance is not accessible. Skipping database."
                     Continue
                 }
-                # To avoid complicated manipulations on datetimes depending on locale settings and culture,
-                # dates are compared to 0, which represents 1/01/0001 0:00:00
-                $SinceFull = if ($db.LastBackupdate -eq 0) {
-                    [String]::Empty
+                $LastFullBackup = ($FullHistory | Where-Object Database -eq $db.Name).End
+                if ($null -ne $LastFullBackup) {
+                    $SinceFull_ = [DbaTimeSpan](New-TimeSpan -Start $LastFullBackup)
                 }
                 else {
-                    (New-TimeSpan -Start $db.LastBackupdate).Tostring()
+                    $SinceFull_ = $StartOfTime
                 }
-                $SinceFull = if ($db.LastBackupdate -eq 0) {
-                    [String]::Empty
-                }
-                else {
-                    $SinceFull.split('.')[0 .. ($SinceFull.split('.').count - 2)] -join ' days '
-                }
-                
-                $SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {
-                    [String]::Empty
+
+                $LastDiffBackup = ($DiffHistory | Where-Object Database -eq $db.Name).End
+                if ($null -ne $LastDiffBackup) {
+                    $SinceDiff_ = [DbaTimeSpan](New-TimeSpan -Start $LastDiffBackup)
                 }
                 else {
-                    (New-TimeSpan -Start $db.LastDifferentialBackupDate).Tostring()
+                    $SinceDiff_ = $StartOfTime
                 }
-                $SinceDiff = if ($db.LastDifferentialBackupDate -eq 0) {
-                    [String]::Empty
-                }
-                else {
-                    $SinceDiff.split('.')[0 .. ($SinceDiff.split('.').count - 2)] -join ' days '
-                }
-                
-                $SinceLog = if ($db.LastLogBackupDate -eq 0) {
-                    [String]::Empty
+
+                $LastIncrBackup = ($IncrHistory | Where-Object Database -eq $db.Name).End
+                if ($null -ne $LastIncrBackup) {
+                    $SinceLog_ = [DbaTimeSpan](New-TimeSpan -Start $LastIncrBackup)
                 }
                 else {
-                    (New-TimeSpan -Start $db.LastLogBackupDate).Tostring()
+                    $SinceLog_ = $StartOfTime
                 }
-                $SinceLog = if ($db.LastLogBackupDate -eq 0) {
-                    [String]::Empty
-                }
-                else {
-                    $SinceLog.split('.')[0 .. ($SinceLog.split('.').count - 2)] -join ' days '
-                }
-                
+
                 $daysSinceDbCreated = (New-TimeSpan -Start $db.createDate).Days
-                
-                if ($daysSinceDbCreated -lt 1 -and $db.LastBackupDate -eq 0) {
+
+                if ($daysSinceDbCreated -lt 1 -and $SinceFull_ -eq 0) {
                     $Status = 'New database, not backed up yet'
                 }
-                elseif ((New-TimeSpan -Start $db.LastBackupDate).Days -gt 0 -and (New-TimeSpan -Start $db.LastDifferentialBackupDate).Days -gt 0) {
+                elseif ($SinceFull_.Days -gt 0 -and $SinceDiff_.Days -gt 0) {
                     $Status = 'No Full or Diff Back Up in the last day'
                 }
-                elseif ($db.RecoveryModel -eq "Full" -and (New-TimeSpan -Start $db.LastLogBackupDate).Hours -gt 0) {
+                elseif ($db.RecoveryModel -eq "Full" -and $SinceLog_.Hours -gt 0) {
                     $Status = 'No Log Back Up in the last hour'
                 }
                 else {
                     $Status = 'OK'
                 }
-                
+
                 $result = [PSCustomObject]@{
-                    ComputerName        = $server.NetName
-                    InstanceName        = $server.ServiceName
-                    SqlInstance         = $server.DomainInstanceName
-                    Database            = $db.name
-                    RecoveryModel       = $db.recoverymodel
-                    LastFullBackup      = if ($db.LastBackupdate -eq 0) { $null } else { [DbaDateTime]$db.LastBackupdate }
-                    LastDiffBackup      = if ($db.LastDifferentialBackupDate -eq 0) { $null } else { [DbaDateTime]$db.LastDifferentialBackupDate }
-                    LastLogBackup       = if ($db.LastLogBackupDate -eq 0) { $null } else { [DbaDateTime]$db.LastLogBackupDate }
-                    SinceFull           = $SinceFull
-                    SinceDiff           = $SinceDiff
-                    SinceLog            = $SinceLog
-                    DatabaseCreated     = $db.createDate
-                    DaysSinceDbCreated  = $daysSinceDbCreated
-                    Status              = $status
+                    ComputerName       = $server.NetName
+                    InstanceName       = $server.ServiceName
+                    SqlInstance        = $server.DomainInstanceName
+                    Database           = $db.Name
+                    RecoveryModel      = $db.RecoveryModel
+                    LastFullBackup     = [DbaDateTime]$LastFullBackup
+                    LastDiffBackup     = [DbaDateTime]$LastDiffBackup
+                    LastLogBackup      = [DbaDateTime]$LastIncrBackup
+                    SinceFull          = Get-DbaDateOrNull -TimeSpan $SinceFull_
+                    SinceDiff          = Get-DbaDateOrNull -TimeSpan $SinceDiff_
+                    SinceLog           = Get-DbaDateOrNull -TimeSpan $SinceLog_
+                    DatabaseCreated    = $db.createDate
+                    DaysSinceDbCreated = $daysSinceDbCreated
+                    Status             = $status
                 }
                 Select-DefaultView -InputObject $result -Property ComputerName, InstanceName, SqlInstance, Database, LastFullBackup, LastDiffBackup, LastLogBackup
             }

--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -46,6 +46,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
     }
 
+    Context "LastFull should work with multiple databases" {
+        $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -Database $dbname, master -lastfull
+        It "Should return 2 records" {
+            $results.count | Should Be 2
+        }
+    }
+
     Context "Testing IncludeCopyOnly with LastFull" {
         $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -LastFull -Database $dbname
         $resultsCo = Get-DbaBackupHistory -SqlInstance $script:instance1 -LastFull -IncludeCopyOnly -Database $dbname


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3158)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose

#3158 is caused by Get-DbaBackuphistory not returning all specified databases when used with -LastFull, LastLog or LogDiff.

Changed the filtering on L295 so we have multiple dbs passed through rather than just the first.

Added a integration test as well for future