### PR TITLE
Wrong database ist used for table searching

### DIFF
--- a/functions/Copy-DbaTableData.ps1
+++ b/functions/Copy-DbaTableData.ps1
@@ -275,7 +275,7 @@ function Copy-DbaTableData {
             }
 
             try {
-                $desttable = Get-DbaTable -SqlInstance $destServer -Table $DestinationTable -Database $Database -EnableException -Verbose:$false | Select-Object -First 1
+                $desttable = Get-DbaTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -EnableException -Verbose:$false | Select-Object -First 1
             }
             catch {
                 Stop-Function -Message "Unable to determine destination table: $DestinationTable"


### PR DESCRIPTION
$desttable = Get-DbaTable looks in $Database not in $DestinationDatabase on $destServer

When executing

`Copy-DbaTableData -SqlInstance instance1 -Destination instance2 -Database db1 -DestinationDatabase db2 -Table table1 -DestinationTable table2`

the table2 ist searched in instance1.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #3171)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Just fix a bug (without given issue)

### Commands to test
Copy-DbaTableData