### PR TITLE
Get-DbaBackupHistory, fix for compressionratio calc

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -514,8 +514,9 @@ function Get-DbaBackupHistory {
                     if ($CompressedBackupSize -eq [System.DBNull]::Value) {
                         $CompressedBackupSize = $null
                         $ratio = 1
-                    } else {
-                        $ratio = [Math]::Round(($historyObject.TotalSize.Byte)/($historyObject.CompressedBackupSize.Byte),2)
+                    }
+                    else {
+                        $ratio = [Math]::Round(($group.Group[0].TotalSize) / ($CompressedBackupSize), 2)
                     }
                     $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
                     $historyObject.ComputerName = $server.NetName

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -510,6 +510,13 @@ function Get-DbaBackupHistory {
                 Write-Message -Level Debug -Message "FileSQL: $fileAllSql"
                 $FileListResults = $server.Query($fileAllSql)
                 foreach ($group in $GroupedResults) {
+                    $CompressedBackupSize = $group.Group[0].CompressedBackupSize
+                    if ($CompressedBackupSize -eq [System.DBNull]::Value) {
+                        $CompressedBackupSize = $null
+                        $ratio = 1
+                    } else {
+                        $ratio = [Math]::Round(($historyObject.TotalSize.Byte)/($historyObject.CompressedBackupSize.Byte),2)
+                    }
                     $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
                     $historyObject.ComputerName = $server.NetName
                     $historyObject.InstanceName = $server.ServiceName
@@ -521,8 +528,8 @@ function Get-DbaBackupHistory {
                     $historyObject.Duration = New-TimeSpan -Seconds ($group.Group.Duration | Measure-Object -Maximum).Maximum
                     $historyObject.Path = $group.Group.Path
                     $historyObject.TotalSize = $group.Group[0].TotalSize
-                    $historyObject.CompressedBackupSize = $group.Group[0].CompressedBackupSize
-                    $HistoryObject.CompressionRatio = [Math]::Round(($historyObject.TotalSize.Byte)/($historyObject.CompressedBackupSize.Byte),2)
+                    $historyObject.CompressedBackupSize = $CompressedBackupSize
+                    $HistoryObject.CompressionRatio = $ratio
                     $historyObject.Type = $group.Group[0].Type
                     $historyObject.BackupSetId = $group.Group[0].BackupSetId
                     $historyObject.DeviceType = $group.Group[0].DeviceType


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3200)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fixing errors when no compression info is there

### Approach
scrub dbnull and do math only if needed

