### PR TITLE
Get-DbaLastBackup, fix issues with striped backups

### DIFF
--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -114,7 +114,7 @@ function Get-DbaLastBackup {
                     Write-Message -Level Warning -Message "The database $db on server $instance is not accessible. Skipping database."
                     Continue
                 }
-                $LastFullBackup = ($FullHistory | Where-Object Database -eq $db.Name).End
+                $LastFullBackup = ($FullHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
                 if ($null -ne $LastFullBackup) {
                     $SinceFull_ = [DbaTimeSpan](New-TimeSpan -Start $LastFullBackup)
                 }
@@ -122,7 +122,7 @@ function Get-DbaLastBackup {
                     $SinceFull_ = $StartOfTime
                 }
 
-                $LastDiffBackup = ($DiffHistory | Where-Object Database -eq $db.Name).End
+                $LastDiffBackup = ($DiffHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
                 if ($null -ne $LastDiffBackup) {
                     $SinceDiff_ = [DbaTimeSpan](New-TimeSpan -Start $LastDiffBackup)
                 }
@@ -130,7 +130,7 @@ function Get-DbaLastBackup {
                     $SinceDiff_ = $StartOfTime
                 }
 
-                $LastIncrBackup = ($IncrHistory | Where-Object Database -eq $db.Name).End
+                $LastIncrBackup = ($IncrHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
                 if ($null -ne $LastIncrBackup) {
                     $SinceLog_ = [DbaTimeSpan](New-TimeSpan -Start $LastIncrBackup)
                 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3207)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Chooses the last possible end date in case of striped backup

### TODO
Can anyone slip in a regr-test based on the super-helpful example reported in #3207 ? Even a 
```
##FIXME : add regr tests for 3207 
```
will do if you don't want to spend time on it, at least it gets tracked