### PR TITLE
Fix Test-DBADatabaseOwner -Detailed

### DIFF
--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -6,9 +6,7 @@ function Test-DbaDatabaseOwner {
         .DESCRIPTION
             This function will check all databases on an instance against a SQL login to validate if that
             login owns those databases or not. By default, the function will check against 'sa' for
-            ownership, but the user can pass a specific login if they use something else. Only databases
-            that do not match this ownership will be displayed, but if the -Detailed switch is set all
-            databases will be shown.
+            ownership, but the user can pass a specific login if they use something else. 
 
             Best Practice reference: http://weblogs.sqlteam.com/dang/archive/2008/01/13/Database-Owner-Troubles.aspx
 
@@ -41,7 +39,7 @@ function Test-DbaDatabaseOwner {
             Specifies the login that you wish check for ownership. This defaults to 'sa' or the sysadmin name if sa was renamed. This must be a valid security principal which exists on the target server.
 
         .PARAMETER Detailed
-            Deprecated
+            Will be deprecated in 1.0.0 release.
 
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -71,9 +69,9 @@ function Test-DbaDatabaseOwner {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [string]$TargetLogin = "sa",
+        [string]$TargetLogin ,
         [Switch]$Detailed,
-        [switch]$EnableException
+        [switch][Alias('Silent')]$EnableException
     )
 
     begin {
@@ -89,6 +87,10 @@ function Test-DbaDatabaseOwner {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            #Sets the default login to sa if -TargetLogin is not present
+            if(!($PSBoundParameters.ContainsKey('TargetLogin'))){
+                $TargetLogin = "sa"
+            }
             # dynamic sa name for orgs who have changed their sa name
             if (Test-Bound -ParameterName TargetLogin -Not) {
                 $TargetLogin = ($server.logins | Where-Object { $_.id -eq 1 }).Name

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -6,7 +6,7 @@ function Test-DbaDatabaseOwner {
         .DESCRIPTION
             This function will check all databases on an instance against a SQL login to validate if that
             login owns those databases or not. By default, the function will check against 'sa' for
-            ownership, but the user can pass a specific login if they use something else. 
+            ownership, but the user can pass a specific login if they use something else.
 
             Best Practice reference: http://weblogs.sqlteam.com/dang/archive/2008/01/13/Database-Owner-Troubles.aspx
 

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -71,7 +71,8 @@ function Test-DbaDatabaseOwner {
         [object[]]$ExcludeDatabase,
         [string]$TargetLogin ,
         [Switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [Switch]$EnableException
     )
 
     begin {
@@ -87,10 +88,6 @@ function Test-DbaDatabaseOwner {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            #Sets the default login to sa if -TargetLogin is not present
-            if(!($PSBoundParameters.ContainsKey('TargetLogin'))){
-                $TargetLogin = "sa"
-            }
             # dynamic sa name for orgs who have changed their sa name
             if (Test-Bound -ParameterName TargetLogin -Not) {
                 $TargetLogin = ($server.logins | Where-Object { $_.id -eq 1 }).Name

--- a/tests/Test-DbaDatabaseOwner.Tests.ps1
+++ b/tests/Test-DbaDatabaseOwner.Tests.ps1
@@ -2,7 +2,26 @@ $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$Name Tests" {
+Describe "$CommandName Unit Tests" -Tag "UnitTests" {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 7
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Test-DbaDatabaseOwner).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'TargetLogin', 'EnableException', 'Detailed'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
     InModuleScope 'dbatools' {
         Context "Connects to SQL Server" {
             It -Skip "Should not throw" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2217)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Update Description and Help to reflect Depreciated cmdlet
Adjust selection of default TargetLogin to test
Include alias for `-EnableException` as seen on other cmdlets
Include Parameter check in the existing test
### Approach
<!-- How does this change solve that purpose -->
Removed unnecessary reference to `-Detailed`
Removed Default assignment in the parameter block for lines 90-93
Aliased `-EnableException` as Silent
Added Parameter Check in the existing describe block and tagged that block as UnitTests
### Commands to test
<!-- if these are the examples in the help just note it as such -->
No Functionality change, so executing any of the examples should have the same result.
