### PR TITLE
Fixes issues 3210, 3211

### DIFF
--- a/internal/functions/Update-SqlPermissions.ps1
+++ b/internal/functions/Update-SqlPermissions.ps1
@@ -273,9 +273,9 @@ function Update-SqlPermissions {
         $dbUsername = $db.Username;
         $dbLogin = $db.LoginName
 
-        if ($null -eq $destDb) {
+        if ($null -ne $destDb) {
             if (!$destDb.IsAccessible) {
-                Write-Message -Level Verbose -Message "Database [$($destDb.Name)] is not accessible. Skipping."
+                Write-Message -Level Verbose -Message "Database [$dbName] is not accessible. Skipping."
                 continue
             }
             if ($null -eq $destDb.Users[$dbUsername]) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Purpose
Fixes 2 bugs in Update-SqlPermissions

<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3210, #3211)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolve 2 minor bugs with Update-SqlPermissions:
- Database permissions were not applied to the destination database.  Previous logic only applied permissions when $null -eq $dbName (meaning if source database did NOT exist on destination)
- When a source database does not exist on the destination, the error message used a variable that derived from the destination server object (thus blank or NULL) and reported a blank database name in the message.

### Approach
Corrects the condition for first #3210, corrects variable reference for #3211.

### Commands to test
Anything that calls Update-SqlPermissions
- Copy-DbaLogin
- Sync-DbaSqlLoginPermission
