### PR TITLE
Get/Set-DbaDatabaseState, performance improvements

### DIFF
--- a/tests/Get-DbaDatabaseState.Tests.ps1
+++ b/tests/Get-DbaDatabaseState.Tests.ps1
@@ -6,7 +6,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Reading db statuses" {
         BeforeAll {
-            $script:instance2 = $env:COMPUTERNAME
             $server = Connect-DbaInstance -SqlInstance $script:instance2
             $db1 = "dbatoolsci_dbstate_online"
             $db2 = "dbatoolsci_dbstate_offline"
@@ -26,7 +25,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server.Query("CREATE DATABASE $db7; ALTER DATABASE $db7 SET READ_WRITE WITH ROLLBACK IMMEDIATE")
             $server.Query("CREATE DATABASE $db8; ALTER DATABASE $db8 SET READ_ONLY WITH ROLLBACK IMMEDIATE")
             $setupright = $true
-            $needed = Get-DbaDatabase -SqlInstance $script:instance2 -Database $db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8
+            $needed_ = $server.Query("select name from sys.databases")
+            $needed = $needed_ | Where-Object name -in $db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8
             if ($needed.Count -ne 8) {
                 $setupright = $false
                 It "has failed setup" {
@@ -39,6 +39,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2 -Database $db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8
         }
         if ($setupright) {
+            # just to have a correct report on how much time BeforeAll takes
+            It "Waits for BeforeAll to finish" {
+                $true | Should Be $true
+            }
             It "Honors the Database parameter" {
                 $result = Get-DbaDatabaseState -SqlInstance $script:instance2 -Database $db2
                 $result.DatabaseName | Should be $db2
@@ -46,7 +50,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                 $results.Count | Should be 2
             }
             It "Honors the ExcludeDatabase parameter" {
-                $alldbs = (Get-DbaDatabase -SqlInstance $script:instance2 | Where-Object Name -notin @($db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8)).Name
+                $alldbs_ = $server.Query("select name from sys.databases")
+                $alldbs = ($alldbs_ | Where-Object Name -notin @($db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8)).name
                 $results = Get-DbaDatabaseState -SqlInstance $script:instance2 -ExcludeDatabase $alldbs
                 $comparison = Compare-Object -ReferenceObject ($results.DatabaseName) -DifferenceObject (@($db1, $db2, $db3, $db4, $db5, $db6, $db7, $db8))
                 $comparison.Count | Should Be 0

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -15,7 +15,6 @@ $TestsRunGroups = @{
     )
     # do not run on appveyor
     "appveyor_disabled" = @(
-        'Get-DbaDatabaseState',
         'Dismount-DbaDatabase'
     )
 


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Being able to use the commands. SMO ultra-wonky enumeration on not-so-accessible databases is .... suboptimal. Skipping over inaccessible made half of the features go away (damn mass-rewrites...) 
This has been a long-standing issue and I hated it, and hated it, and hated it, and tried to find out what property triggered whatever enumeration on each version... and came out empty/without a consistent root-cause. 
So.... I circumvented it. Granted, if SMO somehow fixes the bug we can revert to the "old way", but since dbatools exists *also* to avoid SMO nightmares, this is a good case for being smart the way SMO isn't.

### Approach
We had tests that did not work for some time. Part of the blame was on:
- typos 
- hurry
- get-dbadatabase being as wonky as SMO enumeration
- ...

Given we just need to traverse props which are in sys.databases .... the new function(s) ask there for data instead of db properties. Nonetheless, every previous feature has been kept, and it also works with Case Sensitive instances, with a little bit of added love. Tests have been rewritten to avoid wonky Get-DbaDatabase calls, and now it *just works &trade;*

### Commands to test
Included pester tests are pretty extensive


reissue of #3224