### PR TITLE
Made Stop-Function vs Write-Message consistent with Stop-DbaSqlService

### DIFF
--- a/functions/Start-DbaSqlService.ps1
+++ b/functions/Start-DbaSqlService.ps1
@@ -104,6 +104,6 @@ function Start-DbaSqlService {
         if ($processArray) {
             Update-ServiceStatus -ServiceCollection $processArray -Action 'start' -Timeout $Timeout -EnableException $EnableException
         }
-        else { Write-Message -Level Warning -EnableException $EnableException -Message "No SQL Server services found with current parameters." }
+        else { Stop-Function -EnableException $EnableException -Message "No SQL Server services found with current parameters." -Category ObjectNotFound }
     }
 }

--- a/tests/Start-DbaSqlService.Tests.ps1
+++ b/tests/Start-DbaSqlService.Tests.ps1
@@ -47,5 +47,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                 $service.Status | Should Be 'Successful'
             }
         }
+
+        It "errors when passing an invalid InstanceName" {
+            { Start-DbaSqlService -ComputerName $script:instance2 -Type 'Agent' -InstanceName 'ThisIsInvalid' -EnableException } | Should Throw 'No SQL Server services found with current parameters.'
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
I was adding test coverage and came across bug where Start-DbaSqlService does not throw an exception when using the EnableException switch. 

### Approach
<!-- How does this change solve that purpose -->
I changed the error from Write-Message to Stop-Function, which is consistent with Stop-DbaSqlService.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See test.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
N/A

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
N/A