### PR TITLE
Fix/coverage

### DIFF
--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -80,7 +80,7 @@ function Get-CoverageIndications($Path, $ModuleBase) {
         }
     }
     $testpaths = @()
-    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal", "$ModuleBase\functions" -Filter '*.ps1'
+    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal\functions", "$ModuleBase\functions" -Filter '*.ps1'
     foreach ($f in $funcs) {
         # exclude always used functions ?!
         if ($f -in ('Connect-SqlInstance', 'Select-DefaultView', 'Stop-Function', 'Write-Message')) { continue }
@@ -99,7 +99,7 @@ function Get-CodecovReport($Results, $ModuleBase) {
     #needs correct casing to do the replace
     $ModuleBase = (Resolve-Path $ModuleBase).Path
     # things we wanna a report for (and later backfill if not tested)
-    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal", "$ModuleBase\functions" -Filter '*.ps1'
+    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal\functions", "$ModuleBase\functions" -Filter '*.ps1'
 
     $missed = $results.CodeCoverage | Select-Object -ExpandProperty MissedCommands | Sort-Object -Property File, Line -Unique
     $hits = $results.CodeCoverage | Select-Object -ExpandProperty HitCommands | Sort-Object -Property File, Line -Unique
@@ -191,8 +191,6 @@ if (-not $Finalize) {
         $TestsToRun = "*.Tests.*"
     }
 
-
-    # do we have a scenario ?
     # do we have a scenario ?
     if ($env:SCENARIO) {
         # if so, do we have a group with tests to run ?

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen
 choco install codecov | Out-Null
 
 Write-Host -Object "appveyor.prep: Install PSScriptAnalyzer" -ForegroundColor DarkGreen
-Install-PackageProvider Nuget –Force -Verbose | Out-Null
+Install-PackageProvider Nuget –Force | Out-Null
 Install-Module -Name PSScriptAnalyzer | Out-Null
 
 

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -3,10 +3,11 @@ git clone -q --branch=master --depth=1 https://github.com/sqlcollaborative/appve
 #Install codecov to upload results
 Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen
 choco install codecov | Out-Null
-# "Installing nuget and PSScriptAnalyzer"
-#Install-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
-#Import-PackageProvider NuGet -MinimumVersion '2.8.5.201' -Force | Out-Null
-#Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.6.0 -Repository PSGallery -Force | Out-Null
+
+Write-Host -Object "appveyor.prep: Install PSScriptAnalyzer" -ForegroundColor DarkGreen
+Install-PackageProvider Nuget –Force -Verbose | Out-Null
+Install-Module -Name PSScriptAnalyzer | Out-Null
+
 
 # "Get Pester manually"
 Write-Host -Object "appveyor.prep: Install Pester" -ForegroundColor DarkGreen

--- a/tests/manual.pester.ps1
+++ b/tests/manual.pester.ps1
@@ -153,7 +153,7 @@ function Get-CoverageIndications($Path, $ModuleBase) {
         }
     }
     $testpaths = @()
-    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal", "$ModuleBase\functions" -Filter '*.ps1'
+    $allfiles = Get-ChildItem -File -Path "$ModuleBase\internal\functions", "$ModuleBase\functions" -Filter '*.ps1'
     foreach ($f in $funcs) {
         # exclude always used functions ?!
         if ($f -in ('Connect-SqlInstance', 'Select-DefaultView', 'Stop-Function', 'Write-Message')) { continue }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [x] Build system
 
### Purpose
recalculating coverage for internal functions, plus warning if errors are found to avoid the gallery notify errors (see https://github.com/sqlcollaborative/dbatools/pull/3205)