### PR TITLE
Bug 3156 - Connect-DbaInstance set StatementTimeout when value of 0

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -250,29 +250,29 @@ function Connect-DbaInstance {
 
                 $server.ConnectionContext.ApplicationName = $ClientName
 
-                if ($AccessToken) { $server.ConnectionContext.AccessToken = $AccessToken }
-                if ($BatchSeparator) { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
-                if ($ConnectTimeout) { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
-                if ($Database) { $server.ConnectionContext.DatabaseName = $Database }
-                if ($EncryptConnection) { $server.ConnectionContext.EncryptConnection = $true }
-                if ($IsActiveDirectoryUniversalAuth) { $server.ConnectionContext.IsActiveDirectoryUniversalAuth = $true }
-                if ($LockTimeout) { $server.ConnectionContext.LockTimeout = $LockTimeout }
-                if ($MaxPoolSize) { $server.ConnectionContext.MaxPoolSize = $MaxPoolSize }
-                if ($MinPoolSize) { $server.ConnectionContext.MinPoolSize = $MinPoolSize }
-                if ($MultipleActiveResultSets) { $server.ConnectionContext.MultipleActiveResultSets = $true }
-                if ($NetworkProtocol) { $server.ConnectionContext.NetworkProtocol = $NetworkProtocol }
-                if ($NonPooledConnection) { $server.ConnectionContext.NonPooledConnection = $true }
-                if ($PacketSize) { $server.ConnectionContext.PacketSize = $PacketSize }
-                if ($PooledConnectionLifetime) { $server.ConnectionContext.PooledConnectionLifetime = $PooledConnectionLifetime }
-                if ($StatementTimeout) { $server.ConnectionContext.StatementTimeout = $StatementTimeout }
-                if ($SqlExecutionModes) { $server.ConnectionContext.SqlExecutionModes = $SqlExecutionModes }
-                if ($TrustServerCertificate) { $server.ConnectionContext.TrustServerCertificate = $true }
-                if ($WorkstationId) { $server.ConnectionContext.WorkstationId = $WorkstationId }
+                if (Test-Bound -ParameterName 'AccessToken') { $server.ConnectionContext.AccessToken = $AccessToken }
+                if (Test-Bound -ParameterName 'BatchSeparator') { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
+                if (Test-Bound -ParameterName 'ConnectTimeout') { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
+                if (Test-Bound -ParameterName 'Database') { $server.ConnectionContext.DatabaseName = $Database }
+                if (Test-Bound -ParameterName 'EncryptConnection') { $server.ConnectionContext.EncryptConnection = $true }
+                if (Test-Bound -ParameterName 'IsActiveDirectoryUniversalAuth') { $server.ConnectionContext.IsActiveDirectoryUniversalAuth = $true }
+                if (Test-Bound -ParameterName 'LockTimeout') { $server.ConnectionContext.LockTimeout = $LockTimeout }
+                if (Test-Bound -ParameterName 'MaxPoolSize') { $server.ConnectionContext.MaxPoolSize = $MaxPoolSize }
+                if (Test-Bound -ParameterName 'MinPoolSize') { $server.ConnectionContext.MinPoolSize = $MinPoolSize }
+                if (Test-Bound -ParameterName 'MultipleActiveResultSets') { $server.ConnectionContext.MultipleActiveResultSets = $true }
+                if (Test-Bound -ParameterName 'NetworkProtocol') { $server.ConnectionContext.NetworkProtocol = $NetworkProtocol }
+                if (Test-Bound -ParameterName 'NonPooledConnection') { $server.ConnectionContext.NonPooledConnection = $true }
+                if (Test-Bound -ParameterName 'PacketSize') { $server.ConnectionContext.PacketSize = $PacketSize }
+                if (Test-Bound -ParameterName 'PooledConnectionLifetime') { $server.ConnectionContext.PooledConnectionLifetime = $PooledConnectionLifetime }
+                if (Test-Bound -ParameterName 'StatementTimeout') { $server.ConnectionContext.StatementTimeout = $StatementTimeout }
+                if (Test-Bound -ParameterName 'SqlExecutionModes') { $server.ConnectionContext.SqlExecutionModes = $SqlExecutionModes }
+                if (Test-Bound -ParameterName 'TrustServerCertificate') { $server.ConnectionContext.TrustServerCertificate = $true }
+                if (Test-Bound -ParameterName 'WorkstationId') { $server.ConnectionContext.WorkstationId = $WorkstationId }
 
                 $connstring = $server.ConnectionContext.ConnectionString
-                if ($MultiSubnetFailover) { $connstring = "$connstring;MultiSubnetFailover=True" }
-                if ($FailoverPartner) { $connstring = "$connstring;Failover Partner=$FailoverPartner" }
-                if ($ApplicationIntent) { $connstring = "$connstring;ApplicationIntent=$ApplicationIntent" }
+                if (Test-Bound -ParameterName 'MultiSubnetFailover') { $connstring = "$connstring;MultiSubnetFailover=True" }
+                if (Test-Bound -ParameterName 'FailoverPartner') { $connstring = "$connstring;Failover Partner=$FailoverPartner" }
+                if (Test-Bound -ParameterName 'ApplicationIntent') { $connstring = "$connstring;ApplicationIntent=$ApplicationIntent" }
 
                 if ($connstring -ne $server.ConnectionContext.ConnectionString) {
                     $server.ConnectionContext.ConnectionString = $connstring
@@ -310,8 +310,6 @@ function Connect-DbaInstance {
                 }
 
             }
-
-
 
             if ($loadedSmoVersion -ge 11) {
                 if ($server.VersionMajor -eq 8) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -250,29 +250,29 @@ function Connect-DbaInstance {
 
                 $server.ConnectionContext.ApplicationName = $ClientName
 
-                if (Test-Bound -ParameterName 'AccessToken') { $server.ConnectionContext.AccessToken = $AccessToken }
-                if (Test-Bound -ParameterName 'BatchSeparator') { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
-                if (Test-Bound -ParameterName 'ConnectTimeout') { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
-                if (Test-Bound -ParameterName 'Database') { $server.ConnectionContext.DatabaseName = $Database }
-                if (Test-Bound -ParameterName 'EncryptConnection') { $server.ConnectionContext.EncryptConnection = $true }
-                if (Test-Bound -ParameterName 'IsActiveDirectoryUniversalAuth') { $server.ConnectionContext.IsActiveDirectoryUniversalAuth = $true }
-                if (Test-Bound -ParameterName 'LockTimeout') { $server.ConnectionContext.LockTimeout = $LockTimeout }
-                if (Test-Bound -ParameterName 'MaxPoolSize') { $server.ConnectionContext.MaxPoolSize = $MaxPoolSize }
-                if (Test-Bound -ParameterName 'MinPoolSize') { $server.ConnectionContext.MinPoolSize = $MinPoolSize }
-                if (Test-Bound -ParameterName 'MultipleActiveResultSets') { $server.ConnectionContext.MultipleActiveResultSets = $true }
-                if (Test-Bound -ParameterName 'NetworkProtocol') { $server.ConnectionContext.NetworkProtocol = $NetworkProtocol }
-                if (Test-Bound -ParameterName 'NonPooledConnection') { $server.ConnectionContext.NonPooledConnection = $true }
-                if (Test-Bound -ParameterName 'PacketSize') { $server.ConnectionContext.PacketSize = $PacketSize }
-                if (Test-Bound -ParameterName 'PooledConnectionLifetime') { $server.ConnectionContext.PooledConnectionLifetime = $PooledConnectionLifetime }
-                if (Test-Bound -ParameterName 'StatementTimeout') { $server.ConnectionContext.StatementTimeout = $StatementTimeout }
-                if (Test-Bound -ParameterName 'SqlExecutionModes') { $server.ConnectionContext.SqlExecutionModes = $SqlExecutionModes }
-                if (Test-Bound -ParameterName 'TrustServerCertificate') { $server.ConnectionContext.TrustServerCertificate = $true }
-                if (Test-Bound -ParameterName 'WorkstationId') { $server.ConnectionContext.WorkstationId = $WorkstationId }
+                if ($AccessToken) { $server.ConnectionContext.AccessToken = $AccessToken }
+                if ($BatchSeparator) { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
+                if ($ConnectTimeout) { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
+                if ($Database) { $server.ConnectionContext.DatabaseName = $Database }
+                if ($EncryptConnection) { $server.ConnectionContext.EncryptConnection = $true }
+                if ($IsActiveDirectoryUniversalAuth) { $server.ConnectionContext.IsActiveDirectoryUniversalAuth = $true }
+                if ($LockTimeout) { $server.ConnectionContext.LockTimeout = $LockTimeout }
+                if ($MaxPoolSize) { $server.ConnectionContext.MaxPoolSize = $MaxPoolSize }
+                if ($MinPoolSize) { $server.ConnectionContext.MinPoolSize = $MinPoolSize }
+                if ($MultipleActiveResultSets) { $server.ConnectionContext.MultipleActiveResultSets = $true }
+                if ($NetworkProtocol) { $server.ConnectionContext.NetworkProtocol = $NetworkProtocol }
+                if ($NonPooledConnection) { $server.ConnectionContext.NonPooledConnection = $true }
+                if ($PacketSize) { $server.ConnectionContext.PacketSize = $PacketSize }
+                if ($PooledConnectionLifetime) { $server.ConnectionContext.PooledConnectionLifetime = $PooledConnectionLifetime }
+                if ($StatementTimeout) { $server.ConnectionContext.StatementTimeout = $StatementTimeout }
+                if ($SqlExecutionModes) { $server.ConnectionContext.SqlExecutionModes = $SqlExecutionModes }
+                if ($TrustServerCertificate) { $server.ConnectionContext.TrustServerCertificate = $true }
+                if ($WorkstationId) { $server.ConnectionContext.WorkstationId = $WorkstationId }
 
                 $connstring = $server.ConnectionContext.ConnectionString
-                if (Test-Bound -ParameterName 'MultiSubnetFailover') { $connstring = "$connstring;MultiSubnetFailover=True" }
-                if (Test-Bound -ParameterName 'FailoverPartner') { $connstring = "$connstring;Failover Partner=$FailoverPartner" }
-                if (Test-Bound -ParameterName 'ApplicationIntent') { $connstring = "$connstring;ApplicationIntent=$ApplicationIntent" }
+                if ($MultiSubnetFailover) { $connstring = "$connstring;MultiSubnetFailover=True" }
+                if ($FailoverPartner) { $connstring = "$connstring;Failover Partner=$FailoverPartner" }
+                if ($ApplicationIntent) { $connstring = "$connstring;ApplicationIntent=$ApplicationIntent" }
 
                 if ($connstring -ne $server.ConnectionContext.ConnectionString) {
                     $server.ConnectionContext.ConnectionString = $connstring
@@ -310,6 +310,8 @@ function Connect-DbaInstance {
                 }
 
             }
+
+
 
             if ($loadedSmoVersion -ge 11) {
                 if ($server.VersionMajor -eq 8) {

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -43,7 +43,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server = Connect-DbaInstance -SqlInstance $script:instance1 @params
 
             foreach ($param in $params.GetEnumerator()) {
-                if ($param.Key -eq 'Database') { 
+                if ($param.Key -eq 'Database') {
                     $propName = 'DatabaseName'
                 } else {
                     $propName = $param.Key

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -2,6 +2,8 @@
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
+$instance1 = 'localhost'
+
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "connection is properly made" {
         $server = Connect-DbaInstance -SqlInstance $script:instance1 -ApplicationIntent ReadOnly
@@ -16,6 +18,41 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "returns the connection with ApplicationIntent of ReadOnly" {
             $server.ConnectionContext.ConnectionString -match "ApplicationIntent=ReadOnly" | Should Be $true
+        }
+
+        It "sets StatementTimeout to 0" {
+            $server = Connect-DbaInstance -SqlInstance $script:instance1 -StatementTimeout 0
+
+            $server.ConnectionContext.StatementTimeout | Should Be 0
+        }
+
+        It "sets connectioncontext parameters that are provided" {
+            $params = @{
+                'BatchSeparator' = 'GO'
+                'ConnectTimeout' = 1
+                'Database' = 'master'
+                'LockTimeout' = 1
+                'MaxPoolSize' = 20
+                'MinPoolSize' = 1
+                'NetworkProtocol' = 'TcpIp'
+                'PacketSize' = 4096
+                'PooledConnectionLifetime' = 600
+                'WorkstationId' = 'MadeUpServer'
+                'SqlExecutionModes' = 'ExecuteSql'
+                'StatementTimeout' = 0
+            }
+
+            $server = Connect-DbaInstance -SqlInstance $script:instance1 @params
+
+            foreach ($param in $params.GetEnumerator()) {
+                if ($param.Key -eq 'Database') { 
+                    $propName = 'DatabaseName'
+                } else {
+                    $propName = $param.Key
+                }
+
+                $server.ConnectionContext.$propName | Should Be $param.Value
+            }
         }
     }
 }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -17,5 +17,40 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "returns the connection with ApplicationIntent of ReadOnly" {
             $server.ConnectionContext.ConnectionString -match "ApplicationIntent=ReadOnly" | Should Be $true
         }
+
+        It "sets StatementTimeout to 0" {
+            $server = Connect-DbaInstance -SqlInstance $script:instance1 -StatementTimeout 0
+
+            $server.ConnectionContext.StatementTimeout | Should Be 0
+        }
+
+        It "sets connectioncontext parameters that are provided" {
+            $params = @{
+                'BatchSeparator' = 'GO'
+                'ConnectTimeout' = 1
+                'Database' = 'master'
+                'LockTimeout' = 1
+                'MaxPoolSize' = 20
+                'MinPoolSize' = 1
+                'NetworkProtocol' = 'TcpIp'
+                'PacketSize' = 4096
+                'PooledConnectionLifetime' = 600
+                'WorkstationId' = 'MadeUpServer'
+                'SqlExecutionModes' = 'ExecuteSql'
+                'StatementTimeout' = 0
+            }
+
+            $server = Connect-DbaInstance -SqlInstance $script:instance1 @params
+
+            foreach ($param in $params.GetEnumerator()) {
+                if ($param.Key -eq 'Database') { 
+                    $propName = 'DatabaseName'
+                } else {
+                    $propName = $param.Key
+                }
+
+                $server.ConnectionContext.$propName | Should Be $param.Value
+            }
+        }
     }
 }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -2,8 +2,6 @@
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-$instance1 = 'localhost'
-
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "connection is properly made" {
         $server = Connect-DbaInstance -SqlInstance $script:instance1 -ApplicationIntent ReadOnly
@@ -18,41 +16,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
         It "returns the connection with ApplicationIntent of ReadOnly" {
             $server.ConnectionContext.ConnectionString -match "ApplicationIntent=ReadOnly" | Should Be $true
-        }
-
-        It "sets StatementTimeout to 0" {
-            $server = Connect-DbaInstance -SqlInstance $script:instance1 -StatementTimeout 0
-
-            $server.ConnectionContext.StatementTimeout | Should Be 0
-        }
-
-        It "sets connectioncontext parameters that are provided" {
-            $params = @{
-                'BatchSeparator' = 'GO'
-                'ConnectTimeout' = 1
-                'Database' = 'master'
-                'LockTimeout' = 1
-                'MaxPoolSize' = 20
-                'MinPoolSize' = 1
-                'NetworkProtocol' = 'TcpIp'
-                'PacketSize' = 4096
-                'PooledConnectionLifetime' = 600
-                'WorkstationId' = 'MadeUpServer'
-                'SqlExecutionModes' = 'ExecuteSql'
-                'StatementTimeout' = 0
-            }
-
-            $server = Connect-DbaInstance -SqlInstance $script:instance1 @params
-
-            foreach ($param in $params.GetEnumerator()) {
-                if ($param.Key -eq 'Database') { 
-                    $propName = 'DatabaseName'
-                } else {
-                    $propName = $param.Key
-                }
-
-                $server.ConnectionContext.$propName | Should Be $param.Value
-            }
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3156)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Resolves bug #3156 and adds additional tests coverage for Connect-DbaInstance.

### Approach
<!-- How does this change solve that purpose -->
Any property on ConnectionContext that was set directly from a parameter was changed to use Test-Bound before setting the property. The reason this bug came up was because a 0 was being passed in, which was being evaluated as $false in the conditional before setting the property on ConnectionContext. By using Test-Bound it checks to see if the parameter was passed or not instead.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See test file.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
