### PR TITLE
Get-DbaDatabase, speedups

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -265,8 +265,10 @@ function Get-DbaDatabase {
                 $true { @($true) }
                 default { @($true, $false, $null) }
             }
-
-            $backed_info = $server.Query("SELECT *, SUSER_NAME(owner_sid) AS [Owner] FROM sys.databases")
+            function Invoke-QueryRawDatabases {
+                $server.Query("SELECT *, SUSER_NAME(owner_sid) AS [Owner] FROM sys.databases")
+            }
+            $backed_info = Invoke-QueryRawDatabases
             $backed_info = $backed_info | Where-Object {
                 ($_.name -in $Database -or !$Database) -and
                 ($_.name -notin $ExcludeDatabase -or !$ExcludeDatabase) -and
@@ -278,7 +280,6 @@ function Get-DbaDatabase {
             foreach($dt in $backed_info) {
                 $inputObject += $server.Databases[$dt.name]
             }
-
             $inputobject = $inputObject |
                 Where-Object {
                 ($_.Name -in $Database -or !$Database) -and
@@ -291,7 +292,6 @@ function Get-DbaDatabase {
                 $_.RecoveryModel -in $RecoveryModel -and
                 $_.EncryptionEnabled -in $Encrypt
             }
-
             if ($NoFullBackup -or $NoFullBackupSince) {
                 $dabs = (Get-DbaBackupHistory -SqlInstance $server -LastFull )
                 if ($null -ne $NoFullBackupSince) {

--- a/tests/Get-DbaDatabase.Tests.ps1
+++ b/tests/Get-DbaDatabase.Tests.ps1
@@ -38,14 +38,38 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
             Mock Stop-Function { } -ModuleName dbatools
             Mock Test-FunctionInterrupt { } -ModuleName dbatools
         }
+        Mock Connect-SQLInstance -MockWith {
+            [object]@{
+                Name      = 'SQLServerName';
+                Databases = [object]@(
+                    @{
+                        Name           = 'db1'
+                        Status         = 'Normal'
+                        ReadOnly       = 'false'
+                        IsSystemObject = 'false'
+                        RecoveryModel  = 'Full'
+                        Owner          = 'sa'
+                    }
+                ); #databases
+            } #object
+        } -ModuleName dbatools #mock connect-sqlserver
+        function Invoke-QueryRawDatabases { }
+        Mock Invoke-QueryRawDatabases -MockWith {
+            [object]@(
+                @{
+                    name     = 'db1'
+                    state = 0
+                    Owner = 'sa'
+                }
+            )
+        } -ModuleName dbatools
         It "Should Call Stop-Function if NoUserDbs and NoSystemDbs are specified" {
             Get-DbaDatabase -SqlInstance Dummy -ExcludeAllSystemDb -ExcludeAllUserDb -ErrorAction SilentlyContinue | Should Be
         }
         It "Validates that Stop Function Mock has been called" {
-            ## Nope I have no idea why it's two either - RMS
             $assertMockParams = @{
                 'CommandName' = 'Stop-Function'
-                'Times'       = 2
+                'Times'       = 1
                 'Exactly'     = $true
                 'Module'      = 'dbatools'
             }
@@ -65,27 +89,38 @@ Describe "$commandname Unit Tests" -Tags "UnitTests", Get-DBADatabase {
         It "Should have Last Read and Last Write Property when IncludeLastUsed switch is added" {
             Mock Connect-SQLInstance -MockWith {
                 [object]@{
-                    Name      = 'SQLServerName';
-                    Databases = [object]@(
-                        @{
-                            Name           = 'db1';
-                            Status         = 'Normal';
-                            ReadOnly       = 'false';
-                            IsSystemObject = 'false';
-                            RecoveryModel  = 'Full';
-                            Owner          = 'sa'
-                        }
-                    ); #databases
+                    Name      = 'SQLServerName'
+                    Databases = [object]@{
+                            'db1' = @{
+                                Name           = 'db1'
+                                Status         = 'Normal'
+                                ReadOnly       = 'false'
+                                IsSystemObject = 'false'
+                                RecoveryModel  = 'Full'
+                                Owner          = 'sa'
+                                IsAccessible   = $true
+                            }
+                    }
                 } #object
             } -ModuleName dbatools #mock connect-sqlserver
             function Invoke-QueryDBlastUsed { }
             Mock Invoke-QueryDBlastUsed -MockWith {
                 [object]
                 @{
-                    dbname     = 'db1';
-                    last_read  = (Get-Date).AddHours(-1);
+                    dbname     = 'db1'
+                    last_read  = (Get-Date).AddHours(-1)
                     last_write = (Get-Date).AddHours(-1)
                 }
+            } -ModuleName dbatools
+            function Invoke-QueryRawDatabases { }
+            Mock Invoke-QueryRawDatabases -MockWith {
+                [object]@(
+                    @{
+                        name  = 'db1'
+                        state = 0
+                        Owner = 'sa'
+                    }
+                )
             } -ModuleName dbatools
             (Get-DbaDatabase -SqlInstance SQLServerName -IncludeLastUsed).LastRead -ne $null | Should Be $true
             (Get-DbaDatabase -SqlInstance SQLServerName -IncludeLastUsed).LastWrite -ne $null | Should Be $true


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Speeding up enumeration for some usecases. The "framework" is there if anyone wants to fiddle with additional properties. The "game" is discerning from a raw sys.databases query the filtered properties, in order to use a pre-filtered collection to be passed down to additional filters.
Added here a new switch (I'm sure someone will come up with better naming) to pre-filter on isaccessible databases. Doing so down the line in most of the commands is ... non-optimal, so we'd better do it here.

### Approach
See the code

----

Hopefully nothing breaks, this is just a "rapid poc".

PS: the databases.refresh() at the end was chewing up resources as well. After a bit of discussion with @potatoqualitee, it seems that the only impacted usecase would be the one reported on piping to Remove-DbaDatabase, in which case .... it'd better fail than slowdown any other function.