### PR TITLE
Issue 3275 - Copy-DbaLinkedServer Providers Incorrect

### DIFF
--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -305,7 +305,7 @@ function Copy-DbaLinkedServer {
                 if ($destServer.Settings.OleDbProviderSettings.Name.Length -ne 0) {
                     if (!$destServer.Settings.OleDbProviderSettings.Name -contains $provider -and !$provider.StartsWith("SQLN")) {
                         $copyLinkedServer.Status = "Skipped"
-                        $copyLinkedServer.Notes = "Already exists"
+                        $copyLinkedServer.Notes = "Missing provider"
                         $copyLinkedServer | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
 
                         Write-Message -Level Verbose -Message "$($destServer.Name) does not support the $provider provider. Skipping $linkedServerName."
@@ -341,9 +341,11 @@ function Copy-DbaLinkedServer {
                         Write-Message -Level Debug -Message $sql
 
                         if ($UpgradeSqlClient -and $sql -match "sqlncli") {
-                            $newstring = "sqlncli$($destServer.VersionMajor)"
-                            Write-Message -Level Verbose -Message "Changing sqlncli to $newstring"
-                            $sql = $sql -replace ("sqlncli[0-9]+", $newstring)
+                            $destProviders = $destServer.Settings.OleDbProviderSettings | Where-Object { $_.Name -like 'SQLNCLI*' }
+                            $newProvider = $destProviders | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty Name
+
+                            Write-Message -Level Verbose -Message "Changing sqlncli to $newProvider"
+                            $sql = $sql -replace ("sqlncli[0-9]+", $newProvider)
                         }
 
                         $destServer.Query($sql)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix issue #3275. Linked servers for SQL Server 2014 are incorrect (using SQLNCLI12 instead of SQLNCLI11).

### Approach
<!-- How does this change solve that purpose -->
Pick the latest SQLNCLIXX registered instead of building it based on the SQL Server major version.

While I was in there I also changed the verbage for when a provider does not exist on the destinations erver from "Already exists" to "Provider missing." 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See test case.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
N/A

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
Funny enough, when I was looking for how to find the registered providers through SMO, I came across a bug that [Chrissy had a post about](https://blog.netnerds.net/2015/01/workaround-for-smo-bug-urn-could-not-be-resolved-at-level-oledbprovidersetting/).