### PR TITLE
Issue 3179 - Set-DbaLogin add PasswordPolicyEnforce parameter

### DIFF
--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -60,6 +60,18 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             $result.DenyLogin | Should -Be $false
         }
 
+        It "Enforces password policy on login" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced
+
+            $result.PasswordPolicyEnforced | Should Be $true
+        }
+
+        It "Disables enforcing password policy on login" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced:$false
+
+            $result.PasswordPolicyEnforced | Should Be $false
+        }
+
         It "Add roles to login" {
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -AddRole serveradmin, processadmin
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add PasswordPolicyEnforce parameter to Set-DbaLogin to allow enabling/disabling the password policy for a login.

### Approach
<!-- How does this change solve that purpose -->
Added parameter and if it is passed it is updated.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Enable Policy
`Set-DbaLogin -SqlInstance localhost\sql2016 -Login testlogin -PasswordPolicyEnforced`

Disable Policy
`Set-DbaLogin -SqlInstance localhost\sql2016 -Login testlogin -PasswordPolicyEnforced:$false`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
N/A

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
N/A