### PR TITLE
Get/Set-DbaDbQueryStoreOptions, reuse connection

### DIFF
--- a/functions/Get-DbaDbQueryStoreOptions.ps1
+++ b/functions/Get-DbaDbQueryStoreOptions.ps1
@@ -83,7 +83,7 @@ function Get-DbaDbQueryStoreOptions {
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"

--- a/functions/Get-DbaDbQueryStoreOptions.ps1
+++ b/functions/Get-DbaDbQueryStoreOptions.ps1
@@ -1,57 +1,58 @@
+#ValidationTags#CodeStyle,Messaging,FlowControl,Pipeline#
 function Get-DbaDbQueryStoreOptions {
     <#
-.SYNOPSIS
-Get the Query Store configuration for Query Store enabled databases.
+        .SYNOPSIS
+        Get the Query Store configuration for Query Store enabled databases.
 
-.DESCRIPTION
-Retrieves and returns the Query Store configuration for every database that has the Query Store feature enabled.
+        .DESCRIPTION
+        Retrieves and returns the Query Store configuration for every database that has the Query Store feature enabled.
 
-.OUTPUTS
-Microsoft.SqlServer.Management.Smo.QueryStoreOptions
+        .OUTPUTS
+        Microsoft.SqlServer.Management.Smo.QueryStoreOptions
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+        .PARAMETER SqlInstance
+        The SQL Server that you're connecting to.
 
-.PARAMETER SqlCredential
-SqlCredential object used to connect to the SQL Server as a different user.
+        .PARAMETER SqlCredential
+        SqlCredential object used to connect to the SQL Server as a different user.
 
-.PARAMETER Database
-The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
+        .PARAMETER Database
+        The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
 
-.PARAMETER ExcludeDatabase
-The database(s) to exclude - this list is auto-populated from the server
+        .PARAMETER ExcludeDatabase
+        The database(s) to exclude - this list is auto-populated from the server
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER EnableException
+                By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+                This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+                Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: QueryStore
-Author: Enrico van de Laar ( @evdlaar )
-Author: Klaas Vandenberghe ( @PowerDBAKlaas )
+        .NOTES
+        Tags: QueryStore
+        Author: Enrico van de Laar ( @evdlaar )
+        Author: Klaas Vandenberghe ( @PowerDBAKlaas )
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: GNU GPL v3 https://opensource.org/licenses/GPL-3.0
 
-.LINK
-https://dbatools.io/Get-DbaQueryStoreOptions
+        .LINK
+        https://dbatools.io/Get-DbaQueryStoreOptions
 
-.EXAMPLE
-Get-DbaDbQueryStoreOptions -SqlInstance ServerA\sql
+        .EXAMPLE
+        Get-DbaDbQueryStoreOptions -SqlInstance ServerA\sql
 
-Returns Query Store configuration settings for every database on the ServerA\sql instance.
+        Returns Query Store configuration settings for every database on the ServerA\sql instance.
 
-.EXAMPLE
-Get-DbaDbQueryStoreOptions -SqlInstance ServerA\sql | Where-Object {$_.ActualState -eq "ReadWrite"}
+        .EXAMPLE
+        Get-DbaDbQueryStoreOptions -SqlInstance ServerA\sql | Where-Object {$_.ActualState -eq "ReadWrite"}
 
-Returns the Query Store configuration for all databases on ServerA\sql where the Query Store feature is in Read/Write mode.
+        Returns the Query Store configuration for all databases on ServerA\sql where the Query Store feature is in Read/Write mode.
 
-.EXAMPLE
-Get-DbaDbQueryStoreOptions -SqlInstance localhost | format-table -AutoSize -Wrap
+        .EXAMPLE
+        Get-DbaDbQueryStoreOptions -SqlInstance localhost | format-table -AutoSize -Wrap
 
-Returns Query Store configuration settings for every database on the ServerA\sql instance inside a table format.
+        Returns Query Store configuration settings for every database on the ServerA\sql instance inside a table format.
 
 #>
     [CmdletBinding()]
@@ -74,20 +75,15 @@ Returns Query Store configuration settings for every database on the ServerA\sql
         foreach ($instance in $SqlInstance) {
             Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 13
             }
             catch {
                 Write-Message -Level Warning -Message "Can't connect to $instance. Moving on."
                 continue
             }
 
-            if ($server.VersionMajor -lt 13) {
-                Write-Message -Level Warning -Message "The SQL Server Instance ($instance) has a lower SQL Server version than SQL Server 2016. Skipping server."
-                continue
-            }
-
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"

--- a/functions/Set-DbaDbQueryStoreOptions.ps1
+++ b/functions/Set-DbaDbQueryStoreOptions.ps1
@@ -139,7 +139,7 @@ function Set-DbaDbQueryStoreOptions {
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            $dbs = Get-DbaDatabase -SqlInstance $server -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $instance"

--- a/functions/Set-DbaDbQueryStoreOptions.ps1
+++ b/functions/Set-DbaDbQueryStoreOptions.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#CodeStyle,Messaging,FlowControl,Pipeline#
 function Set-DbaDbQueryStoreOptions {
     <#
         .SYNOPSIS
@@ -138,14 +139,14 @@ function Set-DbaDbQueryStoreOptions {
             }
 
             # We have to exclude all the system databases since they cannot have the Query Store feature enabled
-            $dbs = Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
+            $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -ExcludeDatabase $ExcludeDatabase -Database $Database | Where-Object IsAccessible
 
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $instance"
 
                 if ($db.IsAccessible -eq $false) {
                     Write-Message -Level Warning -Message "The database $db on server $instance is not accessible. Skipping database."
-                    Continue
+                    continue
                 }
 
                 if ($State) {
@@ -158,7 +159,7 @@ function Set-DbaDbQueryStoreOptions {
 
                 if ($db.QueryStoreOptions.DesiredState -eq "Off" -and (Test-Bound -Parameter State -Not)) {
                     Write-Message -Level Warning -Message "State is set to Off; cannot change values. Please update State to ReadOnly or ReadWrite."
-                    Continue
+                    continue
                 }
 
                 if ($FlushInterval) {


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Those functions didn't reuse properly the already opened connection. Formatting and signing off everything 'cause functions are in good shape.
