### PR TITLE
Test-DbaSqlPath, fix #1004

### DIFF
--- a/tests/Test-DbaSqlPath.Tests.ps1
+++ b/tests/Test-DbaSqlPath.Tests.ps1
@@ -49,18 +49,18 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $result = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $falseTest
         It "Should only return false if the path IS NOT accessible to the instance" {
             $result | Should Be $false
-		}
-		$results = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $trueTest, $falseTest
-		It "Should return multiple results when passed multiple paths" {
-			($results | Where-Object FilePath -eq $trueTest).FileExists | Should Be $true
-			($results | Where-Object FilePath -eq $falseTest).FileExists | Should Be $false
-		}
-		$results = Test-DbaSqlPath -SqlInstance $script:instance2,$script:instance1 -Path $falseTest
-		It "Should return multiple results when passed multiple instances" {
-			foreach($result in $results) {
-				$result.FileExists | Should Be $false
-			}
-			($results.SqlInstance | Sort-Object -Unique).Count | Should Be 2
-		}
-	}
+        }
+        $results = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $trueTest, $falseTest
+        It "Should return multiple results when passed multiple paths" {
+            ($results | Where-Object FilePath -eq $trueTest).FileExists | Should Be $true
+            ($results | Where-Object FilePath -eq $falseTest).FileExists | Should Be $false
+        }
+        $results = Test-DbaSqlPath -SqlInstance $script:instance2,$script:instance1 -Path $falseTest
+        It "Should return multiple results when passed multiple instances" {
+            foreach($result in $results) {
+                $result.FileExists | Should Be $false
+            }
+            ($results.SqlInstance | Sort-Object -Unique).Count | Should Be 2
+        }
+    }
 }

--- a/tests/Test-DbaSqlPath.Tests.ps1
+++ b/tests/Test-DbaSqlPath.Tests.ps1
@@ -49,6 +49,18 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $result = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $falseTest
         It "Should only return false if the path IS NOT accessible to the instance" {
             $result | Should Be $false
-        }
-    }
+		}
+		$results = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $trueTest, $falseTest
+		It "Should return multiple results when passed multiple paths" {
+			($results | Where-Object FilePath -eq $trueTest).FileExists | Should Be $true
+			($results | Where-Object FilePath -eq $falseTest).FileExists | Should Be $false
+		}
+		$results = Test-DbaSqlPath -SqlInstance $script:instance2,$script:instance1 -Path $falseTest
+		It "Should return multiple results when passed multiple instances" {
+			foreach($result in $results) {
+				$result.FileExists | Should Be $false
+			}
+			($results.SqlInstance | Sort-Object -Unique).Count | Should Be 2
+		}
+	}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1004 )
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Perfectly described in #1004, which is to test one or multiple paths from one or multiple sqlinstances

### Approach
Adds the "usual suspects" properties to the already present non-bool output

### Commands to test
Everything in the test file, plus anything else you can think of

