### PR TITLE
Add last query to collection

### DIFF
--- a/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
+++ b/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
@@ -66,5 +66,8 @@
         }
     }
 
+    $properties = @{QueryNr = $querynr; QueryName = $queryname; DBSpecific = $DBSpecific; Description = $queryDescription; Text = $scriptpart}
+    $newscript = New-Object -TypeName PSObject -Property $properties
+    $ParsedScript += $newscript
     $ParsedScript
 }


### PR DESCRIPTION
Repeated a small section to make sure the last query in the script gets added as well.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
The parser for the diagnosticquery scripts had a bug, it didn't return the last query. The result was always one query short.
### Approach
Repeated a small section to make sure the last query is included
### Commands to test
Invoke-DbaDiagnosticQuery -SqlInstance localhost\sql2017 -UseSelectionHelper 
Should show 86 queries, the last one is called "Recent Full Backups"
Previously it would show "Automatic Tuning Options", which is wrong, that's not the last one in the script.
