### PR TITLE
reformatting EnableException param, fixes #3354

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -142,7 +142,8 @@ function Backup-DbaDatabase {
         [string]$AzureBaseUrl,
         [string]$AzureCredential,
         [switch]$NoRecovery,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Backup-DbaDatabaseMasterKey.ps1
+++ b/functions/Backup-DbaDatabaseMasterKey.ps1
@@ -70,7 +70,8 @@ Logs into sql2016 with Windows credentials then backs up db1's keys to the \\nas
         [object[]]$ExcludeDatabase,
         [Security.SecureString]$Password,
         [string]$Path,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -119,7 +119,8 @@ function Backup-DbaDbCertificate {
         [string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
         [parameter(ValueFromPipeline, ParameterSetName = "collection")]
         [Microsoft.SqlServer.Management.Smo.Certificate[]]$CertificateCollection,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -49,7 +49,8 @@ function Clear-DbaWaitStatistics {
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/ConvertTo-DbaDataTable.ps1
+++ b/functions/ConvertTo-DbaDataTable.ps1
@@ -86,7 +86,8 @@ function ConvertTo-DbaDataTable {
         [string]$SizeType = "Int64",
         [switch]$IgnoreNull,
         [switch]$Raw,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -96,7 +96,8 @@ function Copy-DbaAgentAlert {
         [object[]]$ExcludeAlert,
         [switch]$IncludeDefaults,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -99,7 +99,8 @@ function Copy-DbaAgentJob {
         [switch]$DisableOnSource,
         [switch]$DisableOnDestination,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaAgentOperator.ps1
+++ b/functions/Copy-DbaAgentOperator.ps1
@@ -92,7 +92,8 @@ function Copy-DbaAgentOperator {
         [object[]]$Operator,
         [object[]]$ExcludeOperator,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -84,7 +84,8 @@ function Copy-DbaAgentProxyAccount {
         [PSCredential]
         $DestinationSqlCredential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaAgentSharedSchedule.ps1
+++ b/functions/Copy-DbaAgentSharedSchedule.ps1
@@ -79,7 +79,8 @@ function Copy-DbaAgentSharedSchedule {
         [PSCredential]
         $DestinationSqlCredential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -86,7 +86,8 @@ function Copy-DbaBackupDevice {
         [PSCredential]$DestinationSqlCredential,
         [object[]]$BackupDevice,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaCentralManagementServer.ps1
+++ b/functions/Copy-DbaCentralManagementServer.ps1
@@ -96,7 +96,8 @@ function Copy-DbaCentralManagementServer {
         [object[]]$CMSGroup,
         [switch]$SwitchServerName,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         function Invoke-ParseServerGroup {

--- a/functions/Copy-DbaCredential.ps1
+++ b/functions/Copy-DbaCredential.ps1
@@ -98,7 +98,8 @@ function Copy-DbaCredential {
         [object[]]$CredentialIdentity,
         [object[]]$ExcludeCredentialIdentity,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -97,7 +97,8 @@ function Copy-DbaCustomError {
         [object[]]$CustomError,
         [object[]]$ExcludeCustomError,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaDatabaseAssembly.ps1
+++ b/functions/Copy-DbaDatabaseAssembly.ps1
@@ -94,7 +94,8 @@ function Copy-DbaDatabaseAssembly {
         [object[]]$Assembly,
         [object[]]$ExcludeAssembly,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
 

--- a/functions/Copy-DbaDatabaseMail.ps1
+++ b/functions/Copy-DbaDatabaseMail.ps1
@@ -91,7 +91,8 @@ function Copy-DbaDatabaseMail {
         [PSCredential]$SourceSqlCredential,
         [PSCredential]$DestinationSqlCredential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaEndpoint.ps1
+++ b/functions/Copy-DbaEndpoint.ps1
@@ -92,7 +92,8 @@ function Copy-DbaEndpoint {
         [object[]]$Endpoint,
         [object[]]$ExcludeEndpoint,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -97,7 +97,8 @@ function Copy-DbaExtendedEvent {
         [object[]]$XeSession,
         [object[]]$ExcludeXeSession,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
 

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -89,7 +89,8 @@ function Copy-DbaLinkedServer {
         [object[]]$ExcludeLinkedServer,
         [switch]$UpgradeSqlClient,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $null = Test-ElevationRequirement -ComputerName $Source.ComputerName

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -150,7 +150,8 @@ function Copy-DbaLogin {
         [hashtable]$LoginRenameHashtable,
         [switch]$KillActiveConnection,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -87,7 +87,8 @@ function Copy-DbaQueryStoreConfig {
         [object[]]$DestinationDatabase,
         [object[]]$Exclude,
         [switch]$AllDatabases,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     BEGIN {

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -92,7 +92,8 @@ function Copy-DbaResourceGovernor {
         [object[]]$ResourcePool,
         [object[]]$ExcludeResourcePool,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -92,7 +92,8 @@ function Copy-DbaServerAudit {
         [object[]]$Audit,
         [object[]]$ExcludeAudit,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -90,7 +90,8 @@ function Copy-DbaServerAuditSpecification {
         [object[]]$AuditSpecification,
         [object[]]$ExcludeAuditSpecification,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -90,7 +90,8 @@ function Copy-DbaServerTrigger {
         [object[]]$ServerTrigger,
         [object[]]$ExcludeServerTrigger,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaSpConfigure.ps1
+++ b/functions/Copy-DbaSpConfigure.ps1
@@ -91,7 +91,8 @@ function Copy-DbaSpConfigure {
         $DestinationSqlCredential,
         [object[]]$ConfigName,
         [object[]]$ExcludeConfigName,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaSqlDataCollector.ps1
+++ b/functions/Copy-DbaSqlDataCollector.ps1
@@ -99,7 +99,8 @@ function Copy-DbaSqlDataCollector {
         [object[]]$ExcludeCollectionSet,
         [switch]$NoServerReconfig,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaSqlPolicyManagement.ps1
+++ b/functions/Copy-DbaSqlPolicyManagement.ps1
@@ -103,7 +103,8 @@ function Copy-DbaSqlPolicyManagement {
         [object[]]$Condition,
         [object[]]$ExcludeCondition,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaSqlServerAgent.ps1
+++ b/functions/Copy-DbaSqlServerAgent.ps1
@@ -90,7 +90,8 @@ function Copy-DbaSqlServerAgent {
         [Switch]$DisableJobsOnDestination,
         [Switch]$DisableJobsOnSource,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Copy-DbaSysDbUserObject.ps1
+++ b/functions/Copy-DbaSysDbUserObject.ps1
@@ -68,7 +68,8 @@ function Copy-DbaSysDbUserObject {
         [ValidateNotNullOrEmpty()]
         [DbaInstanceParameter]$Destination,
         [PSCredential]$DestinationSqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -56,7 +56,8 @@ function Disable-DbaAgHadr {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         $Enabled = 0

--- a/functions/Disable-DbaForceNetworkEncryption.ps1
+++ b/functions/Disable-DbaForceNetworkEncryption.ps1
@@ -55,7 +55,8 @@ function Disable-DbaForceNetworkEncryption {
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]$SqlInstance = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
 

--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -46,7 +46,8 @@ function Disable-DbaTraceFlag {
         [PSCredential]$SqlCredential,
         [parameter(Mandatory)]
         [int[]]$TraceFlag,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Dismount-DbaDatabase.ps1
+++ b/functions/Dismount-DbaDatabase.ps1
@@ -83,7 +83,8 @@ function Dismount-DbaDatabase {
         [Microsoft.SqlServer.Management.Smo.Database[]]$DatabaseCollection,
         [Switch]$UpdateStatistics,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -56,7 +56,8 @@ function Enable-DbaAgHadr {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         $Enabled = 1

--- a/functions/Enable-DbaForceNetworkEncryption.ps1
+++ b/functions/Enable-DbaForceNetworkEncryption.ps1
@@ -55,7 +55,8 @@ function Enable-DbaForceNetworkEncryption {
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
 

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -49,7 +49,8 @@ function Enable-DbaTraceFlag {
         [PSCredential]$SqlCredential,
         [parameter(Mandatory)]
         [int[]]$TraceFlag,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -63,7 +63,8 @@ function Export-DbaDiagnosticQuery {
         [string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",
         [switch]$NoPlanExport,
         [switch]$NoQueryExport,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -118,7 +118,8 @@ function Export-DbaLogin {
         [switch]$Append,
         [switch]$NoDatabases,
         [switch]$NoJobs,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$ExcludeGoBatchSeparator,
         [ValidateSet('SQLServer2000', 'SQLServer2005', 'SQLServer2008/2008R2', 'SQLServer2012', 'SQLServer2014', 'SQLServer2016', 'SQLServer2017')]
         [string]$DestinationVersion

--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -98,7 +98,8 @@ function Export-DbaScript {
         [switch]$Passthru,
         [switch]$NoClobber,
         [switch]$Append,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -127,7 +127,8 @@ function Export-DbaUser {
         [Alias("NoOverwrite")]
         [switch]$NoClobber,
         [switch]$Append,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [Microsoft.SqlServer.Management.Smo.ScriptingOptions]$ScriptingOptionsObject = $null,
         [switch]$ExcludeGoBatchSeparator
     )

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -131,7 +131,8 @@ function Find-DbaAgentJob {
         [string[]]$Category,
         [string]$Owner,
         [datetime]$Since,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         if ($IsFailed, [boolean]$JobName, [boolean]$StepName, [boolean]$LastUsed.ToString(), $IsDisabled, $IsNotScheduled, $IsNoEmailNotification, [boolean]$Category, [boolean]$Owner, [boolean]$ExcludeJobName -notcontains $true) {

--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -73,7 +73,8 @@ function Find-DbaBackup {
         [string]$RetentionPeriod ,
         [parameter(Mandatory = $false)]
         [switch]$CheckArchiveBit = $false ,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaDisabledIndex.ps1
+++ b/functions/Find-DbaDisabledIndex.ps1
@@ -85,7 +85,8 @@
         [object[]]$ExcludeDatabase,
         [switch]$NoClobber,
         [switch]$Append,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -97,7 +97,8 @@ function Find-DbaOrphanedFile {
         [string[]]$FileType,
         [switch]$LocalOnly,
         [switch]$RemoteOnly,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaSimilarTable.ps1
+++ b/functions/Find-DbaSimilarTable.ps1
@@ -98,7 +98,8 @@ Searches AdventureWorks database and lists all tables/views with its correspondi
         [switch]$ExcludeViews,
         [switch]$IncludeSystemDatabases,
         [int]$MatchPercentThreshold,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -78,7 +78,8 @@ Searches in "mydb" database stored procedures for "runtime" in the textbody
         [string]$Pattern,
         [switch]$IncludeSystemObjects,
         [switch]$IncludeSystemDatabases,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaTrigger.ps1
+++ b/functions/Find-DbaTrigger.ps1
@@ -84,7 +84,8 @@ Searches in "mydb" database triggers for "runtime" in the textbody
         [string]$TriggerLevel = 'All',
         [switch]$IncludeSystemObjects,
         [switch]$IncludeSystemDatabases,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Find-DbaView.ps1
+++ b/functions/Find-DbaView.ps1
@@ -78,7 +78,8 @@ Searches in "mydb" database views for "runtime" in the textbody
         [string]$Pattern,
         [switch]$IncludeSystemObjects,
         [switch]$IncludeSystemDatabases,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -63,7 +63,8 @@ function Get-DbaAgDatabase {
         [parameter(ValueFromPipeline = $true)]
         [object[]]$AvailabilityGroup,
         [object[]]$Database,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -39,7 +39,8 @@ function Get-DbaAgHadr {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaAgListener.ps1
+++ b/functions/Get-DbaAgListener.ps1
@@ -59,7 +59,8 @@ function Get-DbaAgListener {
         [parameter(ValueFromPipeline = $true)]
         [object[]]$AvailabilityGroup,
         [object[]]$Listener,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -59,7 +59,8 @@ function Get-DbaAgReplica {
         [parameter(ValueFromPipeline = $true)]
         [object[]]$AvailabilityGroup,
         [object[]]$Replica,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -68,7 +68,8 @@ function Get-DbaAvailabilityGroup {
         [PSCredential]$SqlCredential,
         [object[]]$AvailabilityGroup,
         [switch]$IsPrimary,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaAvailableCollation.ps1
+++ b/functions/Get-DbaAvailableCollation.ps1
@@ -40,7 +40,8 @@ function Get-DbaAvailableCollation {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaClientAlias.ps1
+++ b/functions/Get-DbaClientAlias.ps1
@@ -39,7 +39,8 @@ function Get-DbaClientAlias {
     Param (
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaClientProtocol.ps1
+++ b/functions/Get-DbaClientProtocol.ps1
@@ -58,7 +58,8 @@ function Get-DbaClientProtocol {
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential] $Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -174,7 +174,8 @@ function Get-DbaDatabase {
         [datetime]$NoFullBackupSince,
         [switch]$NoLogBackup,
         [datetime]$NoLogBackupSince,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$IncludeLastUsed,
         [switch]$OnlyAccessible
     )

--- a/functions/Get-DbaDatabaseEncryption.ps1
+++ b/functions/Get-DbaDatabaseEncryption.ps1
@@ -66,7 +66,8 @@ function Get-DbaDatabaseEncryption {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$IncludeSystemDBs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabaseMasterKey.ps1
+++ b/functions/Get-DbaDatabaseMasterKey.ps1
@@ -55,7 +55,8 @@ Gets the master key for the db1 database
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabasePartitionFunction.ps1
+++ b/functions/Get-DbaDatabasePartitionFunction.ps1
@@ -60,7 +60,8 @@ Gets the Partition Functions for the databases on Sql1 and Sql2/sqlexpress
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabasePartitionScheme.ps1
+++ b/functions/Get-DbaDatabasePartitionScheme.ps1
@@ -60,7 +60,8 @@ Gets the Partition Schemes for the databases on Sql1 and Sql2/sqlexpress
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabaseSnapshot.ps1
+++ b/functions/Get-DbaDatabaseSnapshot.ps1
@@ -71,7 +71,8 @@ Returns information for database snapshots HR_snapshot and Accounting_snapshot
         [object[]]$ExcludeDatabase,
         [object[]]$Snapshot,
         [object[]]$ExcludeSnapshot,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabaseSpace.ps1
+++ b/functions/Get-DbaDatabaseSpace.ps1
@@ -72,7 +72,8 @@ function Get-DbaDatabaseSpace {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$IncludeSystemDBs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaDatabaseState.ps1
+++ b/functions/Get-DbaDatabaseState.ps1
@@ -72,7 +72,8 @@ Gets options for all databases of sqlserver2014a and sqlserver2014b instances
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaDatabaseUdf.ps1
+++ b/functions/Get-DbaDatabaseUdf.ps1
@@ -69,7 +69,8 @@ Gets the User Defined Functions for the databases on Sql1 and Sql2/sqlexpress
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemUdf,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabaseUser.ps1
+++ b/functions/Get-DbaDatabaseUser.ps1
@@ -69,7 +69,8 @@ Gets the users for the databases on Sql1 and Sql2/sqlexpress
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemUser,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDatabaseView.ps1
+++ b/functions/Get-DbaDatabaseView.ps1
@@ -69,7 +69,8 @@ Gets the views for the databases on Sql1 and Sql2/sqlexpress
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemView,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDbCertificate.ps1
+++ b/functions/Get-DbaDbCertificate.ps1
@@ -57,7 +57,8 @@ Gets the cert1 certificate within the db1 database
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [object[]]$Certificate,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Get-DbaDatabaseCertificate

--- a/functions/Get-DbaDbMailHistory.ps1
+++ b/functions/Get-DbaDbMailHistory.ps1
@@ -60,7 +60,8 @@ function Get-DbaDbMailHistory {
         [DateTime]$Since,
         [ValidateSet('Unsent', 'Sent', 'Failed', 'Retrying')]
         [string]$Status,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaDbMailLog.ps1
+++ b/functions/Get-DbaDbMailLog.ps1
@@ -60,7 +60,8 @@ function Get-DbaDbMailLog {
         [DateTime]$Since,
         [ValidateSet('Error', 'Warning', 'Success', 'Information', 'Internal')]
         [string[]]$Type,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaDbQueryStoreOptions.ps1
+++ b/functions/Get-DbaDbQueryStoreOptions.ps1
@@ -66,7 +66,8 @@ function Get-DbaDbQueryStoreOptions {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $ExcludeDatabase += 'master', 'tempdb'

--- a/functions/Get-DbaDbRole.ps1
+++ b/functions/Get-DbaDbRole.ps1
@@ -87,7 +87,8 @@ Returns SQLServer, Database, Role for DatabaseRoles on sql instance ServerB\sql1
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeFixedRole,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -68,7 +68,8 @@ function Get-DbaDbStoredProcedure {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemSp,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDbVirtualLogFile.ps1
+++ b/functions/Get-DbaDbVirtualLogFile.ps1
@@ -81,7 +81,8 @@ function Get-DbaDbVirtualLogFile {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$IncludeSystemDBs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaDefaultPath.ps1
+++ b/functions/Get-DbaDefaultPath.ps1
@@ -46,7 +46,8 @@ function Get-DbaDefaultPath {
         [Alias("Credential")]
         [PSCredential]
         $SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaDistributor.ps1
+++ b/functions/Get-DbaDistributor.ps1
@@ -40,7 +40,8 @@ function Get-DbaDistributor {
         [DbaInstanceParameter[]]$SqlInstance,
         [parameter(Position = 1)]
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         if ($null -eq [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.RMO")) {

--- a/functions/Get-DbaEstimatedCompletionTime.ps1
+++ b/functions/Get-DbaEstimatedCompletionTime.ps1
@@ -80,7 +80,8 @@ Gets estimated completion times for queries performed against the Northwind, pub
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -75,7 +75,8 @@ Finds files in E:\Dir1 ending with ".fsf" and ".mld" for both the servers sql201
         [string[]]$Path,
         [string[]]$FileType,
         [int]$Depth = 1,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $sql = ""

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -120,7 +120,8 @@ function Get-DbaHelpIndex {
         [switch]$IncludeStats,
         [switch]$IncludeDataTypes,
         [switch]$Raw,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -72,7 +72,8 @@ function Get-DbaLastBackup {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         function Get-DbaDateOrNull ($TimeSpan) {

--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -79,7 +79,8 @@ function Get-DbaLastGoodCheckDb {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaLinkedServer.ps1
+++ b/functions/Get-DbaLinkedServer.ps1
@@ -47,7 +47,8 @@ function Get-DbaLinkedServer {
         [PSCredential]$SqlCredential,
         [object[]]$LinkedServer,
         [object[]]$ExcludeLinkedServer,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     foreach ($Instance in $SqlInstance) {
         try {

--- a/functions/Get-DbaLocaleSetting.ps1
+++ b/functions/Get-DbaLocaleSetting.ps1
@@ -51,7 +51,8 @@ function Get-DbaLocaleSetting {
         [Alias("cn", "host", "Server")]
         [string[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential] $Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     BEGIN {

--- a/functions/Get-DbaLogShippingError.ps1
+++ b/functions/Get-DbaLogShippingError.ps1
@@ -98,7 +98,8 @@ function Get-DbaLogShippingError {
         [datetime]$DateTimeTo,
         [switch]$Primary,
         [switch]$Secondary,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -81,7 +81,8 @@ Gets the outcome of the IndexOptimize job on sqlserver2014a, the other options a
         [string[]]$LogType = 'IndexOptimize',
         [datetime]$Since,
         [string]$Path,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         function process-block ($block) {

--- a/functions/Get-DbaNetworkActivity.ps1
+++ b/functions/Get-DbaNetworkActivity.ps1
@@ -52,7 +52,8 @@ function Get-DbaNetworkActivity {
         [Alias("cn", "host", "Server")]
         [string[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential] $Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     BEGIN {

--- a/functions/Get-DbaNetworkCertificate.ps1
+++ b/functions/Get-DbaNetworkCertificate.ps1
@@ -40,7 +40,8 @@ Gets computer certificates on sql2016 that are being used for SQL Server network
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -45,7 +45,8 @@ function Get-DbaOperatingSystem {
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($computer in $ComputerName) {

--- a/functions/Get-DbaOrphanUser.ps1
+++ b/functions/Get-DbaOrphanUser.ps1
@@ -48,7 +48,8 @@ function Get-DbaOrphanUser {
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -49,7 +49,8 @@ function Get-DbaPageFileSetting {
         [Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
         [DbaInstance]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($computer in $ComputerName) {

--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -85,7 +85,8 @@ function Get-DbaPermission {
         [object[]]$ExcludeDatabase,
         [switch]$IncludeServerLevel,
         [switch]$NoSystemObjects,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         if ($NoSystemObjects) {

--- a/functions/Get-DbaPolicy.ps1
+++ b/functions/Get-DbaPolicy.ps1
@@ -63,7 +63,8 @@ function Get-DbaPolicy {
         [string[]]$Policy,
         [string[]]$Category,
         [switch]$IncludeSystemObject,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaProcess.ps1
+++ b/functions/Get-DbaProcess.ps1
@@ -91,7 +91,8 @@ function Get-DbaProcess {
         [string[]]$Hostname,
         [string[]]$Program,
         [switch]$NoSystemSpid,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaQueryExecutionTime.ps1
+++ b/functions/Get-DbaQueryExecutionTime.ps1
@@ -84,7 +84,8 @@ limiting results to queries with more than 200 total executions and an execution
         [int]$MinExecMs = 500,
         [parameter(Position = 4, Mandatory = $false)]
         [switch]$NoSystemDb,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaRegisteredServer.ps1
+++ b/functions/Get-DbaRegisteredServer.ps1
@@ -88,7 +88,8 @@ function Get-DbaRegisteredServer {
         [switch]$IncludeSelf,
         [switch]$ExcludeCmsServer,
         [switch]$ResolveNetworkName,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         function Find-CmsGroup {

--- a/functions/Get-DbaRegisteredServersStore.ps1
+++ b/functions/Get-DbaRegisteredServersStore.ps1
@@ -43,7 +43,8 @@ function Get-DbaRegisteredServersStore {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($Instance in $SqlInstance) {

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -55,7 +55,8 @@ function Get-DbaRunningJob {
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaSchemaChangeHistory.ps1
+++ b/functions/Get-DbaSchemaChangeHistory.ps1
@@ -77,7 +77,8 @@ function Get-DbaSchemaChangeHistory {
         [object[]]$ExcludeDatabase,
         [DbaDateTime]$Since,
         [string[]]$Object,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaServerAudit.ps1
+++ b/functions/Get-DbaServerAudit.ps1
@@ -43,7 +43,8 @@ Returns all Security Audits for the local and sql2016 SQL Server instances
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaServerAuditSpecification.ps1
+++ b/functions/Get-DbaServerAuditSpecification.ps1
@@ -42,7 +42,8 @@ Returns all Security Audit Specifications for the local and sql2016 SQL Server i
         [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaServerInstallDate.ps1
+++ b/functions/Get-DbaServerInstallDate.ps1
@@ -72,7 +72,8 @@ Returns an object with SQL Instance install date as a string for every server li
         [PSCredential]
         $Credential,
         [Switch]$IncludeWindows,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaServerProtocol.ps1
+++ b/functions/Get-DbaServerProtocol.ps1
@@ -58,7 +58,8 @@ function Get-DbaServerProtocol {
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -56,7 +56,8 @@ Returns a custom object with SearchTerm (ServerName) and the SPNs that were foun
         [string[]]$AccountName,
         [Parameter(Mandatory = $false)]
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         Function Process-Account ($AccountName) {

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -55,7 +55,8 @@ function Get-DbaSqlInstanceProperty {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaSqlInstanceUserOption.ps1
+++ b/functions/Get-DbaSqlInstanceUserOption.ps1
@@ -46,7 +46,8 @@ Returns SQL Instance user options on sql2 and sql4
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaSqlLog.ps1
+++ b/functions/Get-DbaSqlLog.ps1
@@ -93,7 +93,8 @@ function Get-DbaSqlLog {
         [string]$Text,
         [datetime]$After,
         [datetime]$Before,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Get-DbaSqlManagementObject.ps1
+++ b/functions/Get-DbaSqlManagementObject.ps1
@@ -52,7 +52,8 @@ function Get-DbaSqlManagementObject {
         [PSCredential]
         $Credential,
         [int]$VersionNumber,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaSqlModule.ps1
+++ b/functions/Get-DbaSqlModule.ps1
@@ -80,7 +80,8 @@ function Get-DbaSqlModule {
         [string[]]$Type,
         [switch]$NoSystemDb,
         [switch]$NoSystemObjects,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaSqlRegistryRoot.ps1
+++ b/functions/Get-DbaSqlRegistryRoot.ps1
@@ -39,7 +39,8 @@ Gets the registry root for all instances on server1
         [parameter(ValueFromPipeline)]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaSqlService.ps1
+++ b/functions/Get-DbaSqlService.ps1
@@ -85,7 +85,8 @@ function Get-DbaSqlService {
         [string[]]$Type,
         [Parameter(ParameterSetName = "ServiceName")]
         [string[]]$ServiceName,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     BEGIN {

--- a/functions/Get-DbaSsisEnvironmentVariable.ps1
+++ b/functions/Get-DbaSsisEnvironmentVariable.ps1
@@ -109,7 +109,8 @@ License: MIT https://opensource.org/licenses/MIT
         [object[]]$Folder,
         [parameter(Mandatory = $false)]
         [object[]]$FolderExclude,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaSuspectPage.ps1
+++ b/functions/Get-DbaSuspectPage.ps1
@@ -46,7 +46,8 @@ function Get-DbaSuspectPage {
         [DbaInstanceParameter[]]$SqlInstance,
         [object]$Database,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -71,7 +71,8 @@ function Get-DbaTcpPort {
         [switch]$Detailed,
         [Alias("Ipv4")]
         [switch]$ExcludeIpv6,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -41,7 +41,8 @@ function Get-DbaTempdbUsage {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaTopResourceUsage.ps1
+++ b/functions/Get-DbaTopResourceUsage.ps1
@@ -81,7 +81,8 @@ function Get-DbaTopResourceUsage {
         [ValidateSet("All", "Duration", "Frequency", "IO", "CPU")]
         [string[]]$Type = "All",
         [int]$Limit = 20,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$ExcludeSystem
     )
 

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -56,7 +56,8 @@ function Get-DbaTraceFlag {
         [PSCredential]
         $SqlCredential,
         [int[]]$TraceFlag,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -62,7 +62,8 @@ function Get-DbaUptime {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaUserLevelPermission.ps1
+++ b/functions/Get-DbaUserLevelPermission.ps1
@@ -76,7 +76,8 @@ function Get-DbaUserLevelPermission {
         [switch]$ExcludeSystemDatabase,
         [switch]$IncludePublicGuest,
         [switch]$IncludeSystemObjects,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     BEGIN {

--- a/functions/Get-DbaWaitStatistic.ps1
+++ b/functions/Get-DbaWaitStatistic.ps1
@@ -89,7 +89,8 @@
         [PSCredential]$SqlCredential,
         [int]$Threshold = 95,
         [switch]$IncludeIgnorable,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -60,7 +60,8 @@ function Get-DbaWaitingTask {
         [parameter(ValueFromPipelineByPropertyName = $true)]
         [object[]]$Spid,
         [switch]$IncludeSystemSpid,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Get-DbaXESession.ps1
+++ b/functions/Get-DbaXESession.ps1
@@ -60,7 +60,8 @@ function Get-DbaXESession {
         [PSCredential]$SqlCredential,
         [Alias("Sessions")]
         [object[]]$Session,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -78,7 +78,8 @@ function Install-DbaFirstResponderKit {
         [PSCredential]$SqlCredential,
         [string]$Branch = "master",
         [object]$Database = "master",
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -114,7 +114,8 @@ function Install-DbaMaintenanceSolution {
         [ValidateSet('All', 'Backup', 'IntegrityCheck', 'IndexOptimize')]
         [string]$Solution = 'All',
         [switch]$InstallJobs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Invoke-DbaCycleErrorLog.ps1
+++ b/functions/Invoke-DbaCycleErrorLog.ps1
@@ -66,7 +66,8 @@ function Invoke-DbaCycleErrorLog {
         [PSCredential]$SqlCredential,
         [ValidateSet('instance', 'agent')]
         [string]$Type,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Invoke-DbaDatabaseClone.ps1
+++ b/functions/Invoke-DbaDatabaseClone.ps1
@@ -63,7 +63,8 @@ function Invoke-DbaDatabaseClone {
         [object]$Database,
         [string[]]$CloneDatabase,
         [switch]$UpdateStatistics,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Invoke-DbaDatabaseShrink.ps1
+++ b/functions/Invoke-DbaDatabaseShrink.ps1
@@ -136,7 +136,8 @@ Shrinks all databases on SQL2012 (not ideal for production)
         [switch]$LogsOnly,
         [switch]$ExcludeIndexStats,
         [switch]$ExcludeUpdateUsage,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Invoke-DbaDatabaseUpgrade.ps1
+++ b/functions/Invoke-DbaDatabaseUpgrade.ps1
@@ -107,7 +107,8 @@ function Invoke-DbaDatabaseUpgrade {
         [switch]$Force,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$DatabaseCollection,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
 

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -628,7 +628,8 @@ The script will show a message that the copy destination has not been supplied a
 
         [switch]$Force,
 
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Invoke-DbaLogShippingRecovery.ps1
+++ b/functions/Invoke-DbaLogShippingRecovery.ps1
@@ -101,7 +101,8 @@ function Invoke-DbaLogShippingRecovery {
         [object[]]$Database,
         [PSCredential]$SqlCredential,
         [switch]$NoRecovery,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$Force,
         [int]$Delay = 5
     )

--- a/functions/Invoke-DbaWhoisActive.ps1
+++ b/functions/Invoke-DbaWhoisActive.ps1
@@ -241,7 +241,8 @@ Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 
         [switch]$ReturnSchema,
         [string]$Schema,
         [switch]$Help,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Measure-DbaBackupThroughput.ps1
+++ b/functions/Measure-DbaBackupThroughput.ps1
@@ -109,7 +109,8 @@ function Measure-DbaBackupThroughput {
         [ValidateSet("Full", "Log", "Differential", "File", "Differential File", "Partial Full", "Partial Differential")]
         [string]$Type = "Full",
         [string[]]$DeviceType,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Mount-DbaDatabase.ps1
+++ b/functions/Mount-DbaDatabase.ps1
@@ -82,7 +82,8 @@ function Mount-DbaDatabase {
         [string]$DatabaseOwner,
         [ValidateSet('None', 'RebuildLog', 'EnableBroker', 'NewBroker', 'ErrorBrokerConversations')]
         [string]$AttachOption = "None",
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -158,7 +158,8 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$DeleteLevel,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -71,7 +71,8 @@ Creates a new job category with the name 'Category 2' and assign the category ty
         [ValidateSet("LocalJob", "MultiServerJob", "None")]
         [string]$CategoryType,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -177,7 +177,8 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
         [string]$ProxyName,
         [Parameter(Mandatory = $false)]
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -114,7 +114,8 @@ function New-DbaAgentProxy {
         [string[]]$MsdbRole,
         [switch]$Disabled,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -150,7 +150,8 @@ function New-DbaAgentSchedule {
         [string]$StartTime,
         [string]$EndTime,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaClientAlias.ps1
+++ b/functions/New-DbaClientAlias.ps1
@@ -60,7 +60,8 @@ function New-DbaClientAlias {
         [string]$Alias,
         [ValidateSet("TCPIP", "NamedPipes")]
         [string]$Protocol = "TCPIP",
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -87,7 +87,8 @@ Password needs to be passed the Shared Access Token (SAS Key).
         [string]$MappedClassType = "None",
         [string]$ProviderName,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaDatabaseMasterKey.ps1
+++ b/functions/New-DbaDatabaseMasterKey.ps1
@@ -57,7 +57,8 @@ Suppresses all prompts to install but prompts to securely enter your password an
         [object[]]$Database = "master",
         [parameter(Mandatory)]
         [Security.SecureString]$Password = (Read-Host "Password" -AsSecureString),
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -100,7 +100,8 @@ Creates snapshots for HR and Accounting databases, storing files under the F:\sn
         [string]$NameSuffix,
         [string]$Path,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaDbCertificate.ps1
+++ b/functions/New-DbaDbCertificate.ps1
@@ -74,7 +74,8 @@ Suppresses all prompts to install but prompts to securely enter your password an
         [datetime]$ExpirationDate = $StartDate.AddYears(5),
         [switch]$ActiveForServiceBrokerDialog,
         [Security.SecureString]$Password,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias New-DbaDatabaseCertificate

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -152,7 +152,8 @@ function New-DbaLogin {
         [switch]$Disabled,
         [switch]$NewSid,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/New-DbaServiceMasterKey.ps1
+++ b/functions/New-DbaServiceMasterKey.ps1
@@ -46,7 +46,8 @@ You will be prompted to securely enter your Service Key Password twice, then a m
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Security.SecureString]$Password,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/New-DbaSsisCatalog.ps1
+++ b/functions/New-DbaSsisCatalog.ps1
@@ -61,7 +61,8 @@ Creates the SSIS Catalog on server DEV01 with the specified password.
         [parameter(Mandatory = $true)]
         [Security.SecureString]$Password,
         [string]$SsisCatalog = "SSISDB",
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -100,7 +100,8 @@ function Read-DbaBackupHeader {
         [switch]$Simple,
         [switch]$FileList,
         [string]$AzureCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Read-DbaTraceFile.ps1
+++ b/functions/Read-DbaTraceFile.ps1
@@ -171,7 +171,8 @@ function Read-DbaTraceFile {
         [string[]]$ApplicationName,
         [string[]]$ObjectName,
         [string]$Where,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -57,7 +57,8 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
         [parameter(Mandatory = $true)]
         [object]$Database,
         [Switch]$IgnoreLimit,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     try {

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -70,7 +70,8 @@ Remove multiple job categories from the multiple instances.
         [ValidateNotNullOrEmpty()]
         [string[]]$Category,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -88,8 +88,8 @@ Remove the schedules using a pipeline
         [object[]]$Schedule,
         [Parameter(ValueFromPipeline, Mandatory, ParameterSetName = "schedules")]
         [Microsoft.SqlServer.Management.Smo.Agent.ScheduleBase[]]$ScheduleCollection,
-        [switch][Alias('Silent')]$EnableException,
-
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$Force
     )
 

--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -95,7 +95,8 @@ function Remove-DbaBackup {
         [switch]$CheckArchiveBit = $false ,
         [parameter(Mandatory = $false)]
         [switch]$RemoveEmptyBackupFolder = $false,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         # Ensure BackupFileExtension does not begin with a .

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -47,7 +47,8 @@ function Remove-DbaClientAlias {
         [parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias('AliasName')]
         [string]$Alias,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Remove-DbaComputerCertificate.ps1
+++ b/functions/Remove-DbaComputerCertificate.ps1
@@ -63,7 +63,8 @@ function Remove-DbaComputerCertificate {
         [string[]]$Thumbprint,
         [string]$Store = "LocalMachine",
         [string]$Folder = "My",
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -86,7 +86,8 @@ Removes all the user databases from server\instance without any confirmation
         [Parameter(ValueFromPipeline, Mandatory, ParameterSetName = "databases")]
         [Microsoft.SqlServer.Management.Smo.Database[]]$DatabaseCollection,
         [switch]$IncludeSystemDb,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -149,7 +149,8 @@ function Remove-DbaDatabaseSafely {
         [string]$BackupCompression = 'Default',
         [switch]$ReuseSourceFolderStructure,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Remove-DbaDatabaseSnapshot.ps1
+++ b/functions/Remove-DbaDatabaseSnapshot.ps1
@@ -95,7 +95,8 @@ Removes all snapshots associated with databases that have dumpsterfire in the na
         [object]$PipelineSnapshot,
         [switch]$AllSnapshots,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Remove-DbaDbCertificate.ps1
+++ b/functions/Remove-DbaDbCertificate.ps1
@@ -62,7 +62,8 @@ Suppresses all prompts to remove the certificate in the 'db1' database and drops
         [object[]]$Certificate,
         [parameter(ValueFromPipeline, ParameterSetName = "collection")]
         [Microsoft.SqlServer.Management.Smo.Certificate[]]$CertificateCollection,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
 

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -101,7 +101,8 @@ function Remove-DbaDbUser {
         [parameter(ParameterSetName = 'Object')]
         [switch]$Force,
 
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -105,7 +105,8 @@ function Remove-DbaOrphanUser {
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [object[]]$User,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Remove-DbaSpn.ps1
+++ b/functions/Remove-DbaSpn.ps1
@@ -79,7 +79,8 @@ Removes all set SPNs for sql2005 and the relative delegations
         [string]$ServiceAccount,
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Rename-DbaDatabase.ps1
+++ b/functions/Rename-DbaDatabase.ps1
@@ -216,7 +216,8 @@ function Rename-DbaDatabase {
         [switch]$Preview,
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Pipe")]
         [Microsoft.SqlServer.Management.Smo.Database[]]$DatabaseCollection,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -97,7 +97,8 @@ function Repair-DbaOrphanUser {
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [object[]]$Users,
         [switch]$RemoveNotExisting,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -87,7 +87,8 @@ function Reset-DbaAdmin {
         $SqlInstance,
         [string]$Login = "sa",
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -91,7 +91,8 @@ function Resolve-DbaNetworkName {
         [PSCredential] $Credential,
         [Alias('FastParrot')]
         [switch]$Turbo,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Restart-DbaSqlService.ps1
+++ b/functions/Restart-DbaSqlService.ps1
@@ -90,7 +90,8 @@ function Restart-DbaSqlService {
         [int]$Timeout = 30,
         [PSCredential]$Credential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $processArray = @()

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -60,7 +60,8 @@ Imports all the certificates in the specified path.
         [object[]]$Path,
         [object]$Database = "master",
         [Security.SecureString]$Password = (Read-Host "Password" -AsSecureString),
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Restore-DbaFromDatabaseSnapshot.ps1
+++ b/functions/Restore-DbaFromDatabaseSnapshot.ps1
@@ -78,7 +78,8 @@ function Restore-DbaFromDatabaseSnapshot {
         [object[]]$ExcludeDatabase,
         [object[]]$Snapshot,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Save-DbaDiagnosticQueryScript.ps1
+++ b/functions/Save-DbaDiagnosticQueryScript.ps1
@@ -38,7 +38,8 @@ If Path is not specified, the "My Documents" location will be used.
     [CmdletBinding()]
     param (
         [System.IO.FileInfo]$Path = [Environment]::GetFolderPath("mydocuments"),
-        [Switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     function Get-WebData {
         param ($uri)

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -68,7 +68,8 @@ Rename multiple jobs in one go on multiple servers.
         [string[]]$Category,
         [string[]]$NewName,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Set-DbaAgentJobOutputFile.ps1
+++ b/functions/Set-DbaAgentJobOutputFile.ps1
@@ -76,7 +76,8 @@ function Set-DbaAgentJobOutputFile {
         [ValidateNotNull()]
         [ValidateNotNullOrEmpty()]
         [string]$OutputFile,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     foreach ($instance in $sqlinstance) {

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -179,7 +179,8 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
         [Parameter(Mandatory = $false)]
         [string]$ProxyName,
         [Parameter(Mandatory = $false)]
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [Parameter(Mandatory = $false)]
         [switch]$Force
     )

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -165,7 +165,8 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
         [Parameter(Mandatory = $false)]
         [string]$EndTime,
         [Parameter(Mandatory = $false)]
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [Parameter(Mandatory = $false)]
         [switch]$Force
     )

--- a/functions/Set-DbaDatabaseOwner.ps1
+++ b/functions/Set-DbaDatabaseOwner.ps1
@@ -78,7 +78,8 @@ function Set-DbaDatabaseOwner {
         [object[]]$ExcludeDatabase,
         [Alias("Login")]
         [string]$TargetLogin,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Set-DbaDatabaseState.ps1
+++ b/functions/Set-DbaDatabaseState.ps1
@@ -138,7 +138,8 @@ Gets the databases from Get-DbaDatabase, and sets them as SINGLE_USER, dropping 
         [switch]$RestrictedUser,
         [switch]$MultiUser,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [parameter(Mandatory = $true, ValueFromPipeline, ParameterSetName = "Database")]
         [PsCustomObject[]]$DatabaseCollection
     )

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -83,7 +83,8 @@ function Set-DbaDbCompression {
         [int]$MaxRunTime,
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [int]$PercentCompression,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Set-DbaDbQueryStoreOptions.ps1
+++ b/functions/Set-DbaDbQueryStoreOptions.ps1
@@ -111,7 +111,8 @@ function Set-DbaDbQueryStoreOptions {
         [ValidateSet('Auto', 'Off')]
         [string[]]$CleanupMode,
         [int64]$StaleQueryThreshold,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $ExcludeDatabase += 'master', 'tempdb'

--- a/functions/Set-DbaJobOwner.ps1
+++ b/functions/Set-DbaJobOwner.ps1
@@ -83,7 +83,8 @@ function Set-DbaJobOwner {
         [object[]]$ExcludeJob,
         [Alias("TargetLogin")]
         [string]$Login,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -154,7 +154,8 @@ function Set-DbaLogin {
         [string[]]$AddRole,
         [ValidateSet("bulkadmin", "dbcreator", "diskadmin", "processadmin", "public", "securityadmin", "serveradmin", "setupadmin", "sysadmin")]
         [string[]]$RemoveRole,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -99,7 +99,8 @@ function Set-DbaMaxDop {
         [object]$Collection,
         [Alias("All")]
         [switch]$AllDatabases,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Set-DbaSpn.ps1
+++ b/functions/Set-DbaSpn.ps1
@@ -86,7 +86,8 @@ Displays what would happen trying to set all missing SPNs for sql2016
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
         [PSCredential]$Credential,
         [switch]$NoDelegation,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -193,7 +193,8 @@ After the work has been completed, we can push the original startup parameters b
         [object]$StartUpConfig,
         [switch]$Offline,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
 

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -70,7 +70,8 @@ function Set-DbaTcpPort {
         [ValidateRange(1, 65535)]
         [int]$Port,
         [IpAddress[]]$IpAddress,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Set-DbaTempDbConfiguration.ps1
+++ b/functions/Set-DbaTempDbConfiguration.ps1
@@ -113,7 +113,8 @@ function Set-DbaTempDbConfiguration {
         [string]$OutFile,
         [switch]$OutputScriptOnly,
         [switch]$DisableGrowth,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $sql = @()

--- a/functions/Start-DbaAgentJob.ps1
+++ b/functions/Start-DbaAgentJob.ps1
@@ -76,7 +76,8 @@ function Start-DbaAgentJob {
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Object")]
         [Microsoft.SqlServer.Management.Smo.Agent.Job[]]$JobCollection,
         [switch]$Wait,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Start-DbaSqlService.ps1
+++ b/functions/Start-DbaSqlService.ps1
@@ -82,7 +82,8 @@ function Start-DbaSqlService {
         [object[]]$ServiceCollection,
         [int]$Timeout = 30,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $processArray = @()

--- a/functions/Stop-DbaAgentJob.ps1
+++ b/functions/Stop-DbaAgentJob.ps1
@@ -71,7 +71,8 @@ function Stop-DbaAgentJob {
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Object")]
         [Microsoft.SqlServer.Management.Smo.Agent.Job[]]$JobCollection,
         [switch]$Wait,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Stop-DbaProcess.ps1
+++ b/functions/Stop-DbaProcess.ps1
@@ -111,7 +111,8 @@ function Stop-DbaProcess {
         [string[]]$Program,
         [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "Process")]
         [object[]]$ProcessCollection,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Stop-DbaSqlService.ps1
+++ b/functions/Stop-DbaSqlService.ps1
@@ -94,7 +94,8 @@ function Stop-DbaSqlService {
         [int]$Timeout = 30,
         [PSCredential]$Credential,
         [switch]$Force,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $processArray = @()

--- a/functions/Sync-DbaSqlLoginPermission.ps1
+++ b/functions/Sync-DbaSqlLoginPermission.ps1
@@ -87,7 +87,8 @@ function Sync-DbaSqlLoginPermission {
         $DestinationSqlCredential,
         [object[]]$Login,
         [object[]]$ExcludeLogin,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         function Sync-Only {

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -65,7 +65,8 @@ function Test-DbaConnection {
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$Credential,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Test-DbaConnectionAuthScheme.ps1
+++ b/functions/Test-DbaConnectionAuthScheme.ps1
@@ -71,7 +71,8 @@ function Test-DbaConnectionAuthScheme {
         [switch]$Kerberos,
         [switch]$Ntlm,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -93,7 +93,8 @@ function Test-DbaDbCompression {
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaDbVirtualLogFile.ps1
+++ b/functions/Test-DbaDbVirtualLogFile.ps1
@@ -81,7 +81,8 @@ function Test-DbaDbVirtualLogFile {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$IncludeSystemDBs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Test-DbaDiskAlignment.ps1
+++ b/functions/Test-DbaDiskAlignment.ps1
@@ -93,7 +93,8 @@ function Test-DbaDiskAlignment {
         [System.Management.Automation.PSCredential]$Credential,
         [System.Management.Automation.PSCredential]$SqlCredential,
         [switch]$NoSqlCheck,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Parameter 'Detailed'

--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -77,7 +77,8 @@ function Test-DbaDiskAllocation {
         [switch]$NoSqlCheck,
         [object]$SqlCredential,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -72,7 +72,8 @@ function Test-DbaIdentityUsage {
         [parameter(Position = 2, Mandatory = $false)]
         [Alias("NoSystemDb")]
         [switch]$ExcludeSystemDb,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaJobOwner.ps1
+++ b/functions/Test-DbaJobOwner.ps1
@@ -81,7 +81,8 @@ function Test-DbaJobOwner {
         [Alias("TargetLogin")]
         [string]$Login,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -161,7 +161,8 @@ function Test-DbaLastBackup {
         [switch]$IncludeCopyOnly,
         [switch]$IgnoreLogBackup,
         [string]$AzureCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Test-DbaLinkedServerConnection.ps1
+++ b/functions/Test-DbaLinkedServerConnection.ps1
@@ -61,7 +61,8 @@ function Test-DbaLinkedServerConnection {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -92,7 +92,8 @@ function Test-DbaLogShippingStatus {
         [switch]$Simple,
         [switch]$Primary,
         [switch]$Secondary,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaMigrationConstraint.ps1
+++ b/functions/Test-DbaMigrationConstraint.ps1
@@ -92,7 +92,8 @@ function Test-DbaMigrationConstraint {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -75,7 +75,8 @@ function Test-DbaNetworkLatency {
         [PSCredential]$SqlCredential,
         [string]$Query = "select top 100 * from INFORMATION_SCHEMA.TABLES",
         [int]$Count = 3,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Test-DbaOptimizeForAdHoc.ps1
+++ b/functions/Test-DbaOptimizeForAdHoc.ps1
@@ -46,7 +46,8 @@ function Test-DbaOptimizeForAdHoc {
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -55,7 +55,8 @@ function Test-DbaPowerPlan {
         [PSCredential]$Credential,
         [string]$CustomPowerPlan,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -77,7 +77,8 @@ function Test-DbaServerName {
         [switch]$Detailed,
         [Alias("NoWarning")]
         [switch]$ExcludeSsrs,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -65,7 +65,8 @@ function Test-DbaSpn {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [DbaInstance[]]$ComputerName,
         [PSCredential]$Credential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         # spare the cmdlet to search for the same account over and over

--- a/functions/Test-DbaSqlManagementObject.ps1
+++ b/functions/Test-DbaSqlManagementObject.ps1
@@ -44,7 +44,8 @@ function Test-DbaSqlManagementObject {
         [PSCredential]$Credential,
         [Parameter(Mandatory)]
         [int[]]$VersionNumber,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Test-DbaSqlPath.ps1
+++ b/functions/Test-DbaSqlPath.ps1
@@ -61,7 +61,8 @@ function Test-DbaSqlPath {
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory = $true)]
         [string[]]$Path,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         foreach ($instance in $SqlInstance) {

--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -63,7 +63,8 @@ function Test-DbaTempDbConfiguration {
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed

--- a/functions/Test-DbaValidLogin.ps1
+++ b/functions/Test-DbaValidLogin.ps1
@@ -77,7 +77,8 @@ function Test-DbaValidLogin {
         [string]$FilterBy = "None",
         [string[]]$IgnoreDomains,
         [switch]$Detailed,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     begin {

--- a/functions/Update-DbaSqlServiceAccount.ps1
+++ b/functions/Update-DbaSqlServiceAccount.ps1
@@ -94,7 +94,8 @@ function Update-DbaSqlServiceAccount {
         [securestring]$OldPassword = (New-Object System.Security.SecureString),
         [Alias("Password")]
         [securestring]$NewPassword = (New-Object System.Security.SecureString),
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         $svcCollection = @()

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -80,7 +80,8 @@ function Watch-DbaDbLogin {
 
         # File with one server per line
         [string]$ServersFromFile,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -184,7 +184,8 @@ function Write-DbaDataTable {
         [ValidateNotNull()]
         [int]$bulkCopyTimeOut = 5000,
         [switch]$RegularUser,
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
         [switch]$UseDynamicStringLength
     )
     

--- a/internal/functions/Get-DbaADObject.ps1
+++ b/internal/functions/Get-DbaADObject.ps1
@@ -90,7 +90,8 @@ function Get-DbaADObject {
 
         [PSCredential]$Credential,
         [switch]$SearchAllDomains,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     begin {
         try {

--- a/internal/functions/Get-DirectoryRestoreFile.ps1
+++ b/internal/functions/Get-DirectoryRestoreFile.ps1
@@ -11,7 +11,8 @@ Takes path, checks for validity. Scans for usual backup file
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Path,
         [switch]$Recurse,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     Write-Message -Level Verbose -Message "Starting"

--- a/internal/functions/Get-JobList.ps1
+++ b/internal/functions/Get-JobList.ps1
@@ -62,7 +62,8 @@ function Get-JobList {
         [string[]]$JobFilter,
         [string[]]$StepFilter,
         [switch]$Not,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     process {
         $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential

--- a/internal/functions/Get-RestoreContinuableDatabase.ps1
+++ b/internal/functions/Get-RestoreContinuableDatabase.ps1
@@ -13,7 +13,8 @@ function Get-RestoreContinuableDatabase {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     try {

--- a/internal/functions/Invoke-DbaDatabaseCorruption.ps1
+++ b/internal/functions/Invoke-DbaDatabaseCorruption.ps1
@@ -65,7 +65,8 @@ function Invoke-DbaDatabaseCorruption {
         [parameter(Mandatory)]
         [string]$Database,
         [string]$Table,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
     # For later if we want to do bit flipping.
     # function Dbcc-ReadPage {

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -141,7 +141,8 @@ function New-DbaLogShippingPrimaryDatabase {
 
         [switch]$ThresholdAlertEnabled,
 
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
 
         [switch]$Force
     )

--- a/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
+++ b/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
@@ -81,7 +81,8 @@ New-DbaLogShippingPrimarySecondary -SqlInstance sql1 -PrimaryDatabase DB1 -Secon
         [System.Management.Automation.PSCredential]
         $SecondarySqlCredential,
 
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     # Try connecting to the instance

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -144,7 +144,8 @@ New-DbaLogShippingSecondaryDatabase -SqlInstance sql2 -SecondaryDatabase DB1_DR 
 
         [switch]$ThresholdAlertEnabled,
 
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
 
         [switch]$Force
     )

--- a/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -129,7 +129,8 @@ function New-DbaLogShippingSecondaryPrimary {
         [ValidateNotNullOrEmpty()]
         [string]$RestoreJob,
 
-        [switch][Alias('Silent')]$EnableException,
+        [Alias('Silent')]
+        [switch]$EnableException,
 
         [switch]$Force
     )

--- a/internal/functions/Test-PSRemoting.ps1
+++ b/internal/functions/Test-PSRemoting.ps1
@@ -11,7 +11,8 @@ function Test-PSRemoting {
         [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstance]$ComputerName,
         $Credential = [System.Management.Automation.PSCredential]::Empty,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     process {

--- a/internal/functions/Update-SqlPermissions.ps1
+++ b/internal/functions/Update-SqlPermissions.ps1
@@ -29,7 +29,8 @@ function Update-SqlPermissions {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object]$DestLogin,
-        [switch][Alias('Silent')]$EnableException
+        [Alias('Silent')]
+        [switch]$EnableException
     )
 
     $destination = $DestServer.DomainInstanceName


### PR DESCRIPTION
## Type of Change
 - cosmetic 

### Purpose
Be kind one another. 
No need to waste time in PR review on this point anymore (both for experienced users and newbies)

In addition to https://github.com/sqlcollaborative/dbatools/pull/3352 this wipes out of existence `[switch][Alias('Silent')]$EnableException` . Merge soon.