### PR TITLE
add dacFxpath variable to publish-DbDacpac

### DIFF
--- a/functions/Publish-DbaDacpac.ps1
+++ b/functions/Publish-DbaDacpac.ps1
@@ -50,6 +50,9 @@ function Publish-DbaDacpac {
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+        .PARAMETER DacFxPath
+            Path to the dac dll. If this is ommited, then the version of dac dll which is packaged with dbatools is used. 
+
         .NOTES
             Tags: Migration, Database, Dacpac
             Author: Richie lee (@bzzzt_io)
@@ -92,7 +95,8 @@ function Publish-DbaDacpac {
         [Switch]$ScriptOnly,
         [string]$OutputPath = "$home\Documents",
         [switch]$IncludeSqlCmdVars,
-        [switch]$EnableException
+        [switch]$EnableException,
+        [String]$DacFxPath
     )
 
     begin {
@@ -120,8 +124,9 @@ function Publish-DbaDacpac {
 
             return $instance.ToString().Replace('\', '-')
         }
-
-        $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
+        if (Test-Bound -Not -ParameterName 'DacfxPath'){
+            $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
+        }
         if ((Test-Path $dacfxPath) -eq $false) {
             Stop-Function -Message 'No usable version of Dac Fx found.' -EnableException $EnableException
         }

--- a/functions/Publish-DbaDacpac.ps1
+++ b/functions/Publish-DbaDacpac.ps1
@@ -51,7 +51,7 @@ function Publish-DbaDacpac {
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
         .PARAMETER DacFxPath
-            Path to the dac dll. If this is ommited, then the version of dac dll which is packaged with dbatools is used. 
+            Path to the dac dll. If this is ommited, then the version of dac dll which is packaged with dbatools is used.
 
         .NOTES
             Tags: Migration, Database, Dacpac

--- a/functions/Publish-DbaDacpac.ps1
+++ b/functions/Publish-DbaDacpac.ps1
@@ -75,7 +75,10 @@ function Publish-DbaDacpac {
 
             Creates a publish profile at C:\temp\sql2016-db2-publish.xml, exports the .dacpac to $home\Documents\sql2016-db2.dacpac
             then publishes it to the sql2017 server database db2
-
+        
+        .EXAMPLE
+        $loc = "C:\Users\bob\source\repos\Microsoft.Data.Tools.Msbuild\lib\net46\Microsoft.SqlServer.Dac.dll"
+        Publish-DbaDacpac -SqlInstance "local" -Database WideWorldImporters -Path C:\temp\WideWorldImporters.dacpac -PublishXml C:\temp\WideWorldImporters.publish.xml -DacFxPath $loc
   #>
     [CmdletBinding()]
     param (
@@ -127,6 +130,8 @@ function Publish-DbaDacpac {
         if (Test-Bound -Not -ParameterName 'DacfxPath'){
             $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
         }
+
+        Write-Host $dacfxPath
         if ((Test-Path $dacfxPath) -eq $false) {
             Stop-Function -Message 'No usable version of Dac Fx found.' -EnableException $EnableException
         }

--- a/functions/Publish-DbaDacpac.ps1
+++ b/functions/Publish-DbaDacpac.ps1
@@ -131,7 +131,6 @@ function Publish-DbaDacpac {
             $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
         }
 
-        Write-Host $dacfxPath
         if ((Test-Path $dacfxPath) -eq $false) {
             Stop-Function -Message 'No usable version of Dac Fx found.' -EnableException $EnableException
         }


### PR DESCRIPTION
 - Allows a version of dacfx other than the one packaged with dbatools to be used.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow different versions of dacFx to be used other than the one packaged with dbatools.

### Approach
Adding variable and see if it is indluded by running Test-Bound, which is basically a wrapper for PSBoundParameters

### Commands to test
See 3rd example in help
