### PR TITLE
manual.pester.ps1 added PassThru parameter

### DIFF
--- a/tests/manual.pester.ps1
+++ b/tests/manual.pester.ps1
@@ -12,6 +12,9 @@
     .PARAMETER Show
         Gets passed down to Pester's -Show parameter (useful if you want to reduce verbosity)
 
+    .PARAMETER PassThru
+        Gets passed down to Pester's -PassThru parameter (useful if you want to return an object to analyze)
+
     .PARAMETER TestIntegration
         dbatools's suite has unittests and integrationtests. This switch enables IntegrationTests, which need live instances
         see constants.ps1 for customizations
@@ -25,7 +28,6 @@
     .PARAMETER ScriptAnalyzer
         Enables checking the called function's code with Invoke-ScriptAnalyzer, with dbatools's profile
 
-
     .EXAMPLE
         .\manual.pester.ps1 -Path Find-DbaOrphanedFile.Tests.ps1 -TestIntegration -Coverage -DependencyCovearge -ScriptAnalyzer
 
@@ -38,6 +40,11 @@
         .\manual.pester.ps1 -Path Find-DbaOrphanedFile.Tests.ps1
 
         Runs unittests stored in Find-DbaOrphanedFile.Tests.ps1
+
+    .EXAMPLE
+        .\manual.pester.ps1 -Path Find-DbaOrphanedFile.Tests.ps1 -PassThru
+
+        Runs unittests stored in Find-DbaOrphanedFile.Tests.ps1 and returns an object that can be analyzed
 
     .EXAMPLE
         .\manual.pester.ps1 -Path orphan
@@ -74,6 +81,9 @@ param (
     [ValidateSet('None', 'Default', 'Passed', 'Failed', 'Pending', 'Skipped', 'Inconclusive', 'Describe', 'Context', 'Summary', 'Header', 'All', 'Fails')]
     [string]
     $Show = "All",
+
+    [switch]
+    $PassThru,
 
     [switch]
     $TestIntegration,
@@ -189,6 +199,7 @@ foreach ($f in $AllTestsWithinScenario) {
     $PesterSplat = @{
         'Script' = $f.FullName
         'Show'   = $show
+        'PassThru' = $passThru
     }
     #opt-in
     $HeadFunctionPath = $f.FullName


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Allows access to the -PassThru parameter of pester through the manual.pester script. 

### Approach
<!-- How does this change solve that purpose -->
Added a parameter
```
    [switch]
    $PassThru,
```
Added to the pester splat
```
    $PesterSplat = @{
        'Script' = $f.FullName
        'Show'   = $show
        'PassThru' = $passThru
    }
```

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`.\tests\manual.pester.ps1 -Path .\tests\Test-DbaIdentityUsage.Tests.ps1 -TestIntegration -Coverage -PassThru`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/37611932-20a1ba3a-2b7a-11e8-8261-3abf928cb42f.png)
