### PR TITLE
Get-DbaUserLevelPermission - Reset $serverDT for next Instance

### DIFF
--- a/functions/Get-DbaUserLevelPermission.ps1
+++ b/functions/Get-DbaUserLevelPermission.ps1
@@ -206,6 +206,9 @@ function Get-DbaUserLevelPermission {
                 $dbs = $dbs | Where-Object IsSystemObject -eq $false
             }
 
+            #reset $serverDT
+            $serverDT = $null
+
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $db on $instance"
 


### PR DESCRIPTION
Variable need reset for next instance, otherwise will just run on the 1st one.

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3392)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix for #3392

### Approach
By reset $serverDT variable for next instance.

### Commands to test
Execute `Get-DbaUserLevelPermission` for more than one instance and see that logins from all instances are available.

Example:
```
$SQLList = "localhost\SQL2012","localhost\SQL2014", "localhost\SQL2016"
Get-DbaUserLevelPermission -SqlInstance $SQLList | Where-Object RoleSecurableClass -eq "sysadmin"
```
Assuming there one login with `sysadmin` previleges, need to appear one row per instance.