### PR TITLE
Bugfix get dbadatabasefile

### DIFF
--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -195,7 +195,6 @@ function Get-DbaDatabaseFile {
                     }
                     else {
                         # if the server has one drive xp_fixeddrives returns one row, but we still need $disks to be an array.
-                        # $disks = $server.Query("xp_fixeddrives", $db.Name)
                         $disks = @($server.Query("xp_fixeddrives", $db.Name))
                         $MbFreeColName = $disks[0].psobject.Properties.Name[1]
                         $free = $disks | Where-Object { $_.drive -eq $result.PhysicalName.Substring(0, 1) } | Select-Object $MbFreeColName -ExpandProperty $MbFreeColName

--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -194,7 +194,9 @@ function Get-DbaDatabaseFile {
                         $VolumeFreeSpace = [dbasize]$result.VolumeFreeSpace
                     }
                     else {
-                        $disks = $server.Query("xp_fixeddrives", $db.Name)
+                        # if the server has one drive xp_fixeddrives returns one row, but we still need $disks to be an array.
+                        # $disks = $server.Query("xp_fixeddrives", $db.Name)
+                        $disks = @($server.Query("xp_fixeddrives", $db.Name))
                         $MbFreeColName = $disks[0].psobject.Properties.Name[1]
                         $free = $disks | Where-Object { $_.drive -eq $result.PhysicalName.Substring(0, 1) } | Select-Object $MbFreeColName -ExpandProperty $MbFreeColName
                         $VolumeFreeSpace = [dbasize]($free * 1024 * 1024)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3420)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
A one line change to prevent Get-DbaDatabaseFile from erroring on single-drive servers.

### Approach
Wrap the existing line with @() to ensure an array variable is created, rather than a non-array variable.

### Commands to test
You can only test this for failure against a single-drive server. I don't think that appveyor is set up for that, and it doesn't seem to fit into the existing Pester tests either.  Which is probably why this wasn't caught by someone else. 

I tested with (essentially) this:

    Get-DbaDatabase -SqlInstance <instance> -Database master -EnableException

I used 'master' just to cut down on the amount of output to look through and EnableException to get the 'real' error. 

(I actually used a small Pester snippet. I am not including that Pester snippet because it's specific to my homelab.)

You can test it against your own workstation, if you have SQLExpress or Developer edition installed. I tested it against my homelab environment, where I have multi-drive and single-drive instances.

### Learning
This is my first PR, ever. I learned how to do this and all the steps up to this by reading too many blogs (and watching too many YouTube videos) to list here...