### PR TITLE
appveyor autodetection, take care of new envs

### DIFF
--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -6,18 +6,7 @@ $TestsRunGroups = @{
     # run on scenario 2016
     "2016"                      = 'autodetect_$script:instance2'
     # run on scenario 2016_2017 - tests that need developer license
-    "2016_2017"                 = @(
-        'Copy-DbaCredential',
-        'Copy-DbaAgentJob',
-        'Copy-DbaLinkedServer',
-        'Copy-DbaAgentAlert',
-        'Copy-DbaAgentCategory',
-        'Copy-DbaAgentOperator',
-        'Copy-DbaDatabase',
-        'Dismount-DbaDatabase',
-        'Copy-DbaDatabaseAssembly',
-        'Copy-DbaCustomError'
-    )
+    "2016_2017"                 = 'autodetect_$script:instance2,$script:instance3'
     #run on scenario 2016_service - SQL Server service tests that might disrupt other tests
     "2016_service"              = @(
         'Start-DbaSqlService',
@@ -30,7 +19,6 @@ $TestsRunGroups = @{
     "appveyor_disabled"         = @(
         'Dismount-DbaDatabase'
     )
-    
     # do not run everywhere
     "disabled"                  = @()
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Have a new logic in place for pester autodetection (i.e. what tests to run in which scenario)

---

locally doesn't break. hopefully neither in appveyor.