### PR TITLE
#3414 added -force option Remove-DbaOrphanUser

### DIFF
--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -220,7 +220,7 @@ function Repair-DbaOrphanUser {
                                 }
                             }
                             }
-                        } # I match this line if ($UsersToWork.Count -gt 0) {
+                        }
                         else {
                             Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
                         }

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -189,7 +189,7 @@ function Repair-DbaOrphanUser {
                                     }
                                 }
                                 else {
-                                    if ($RemoveNotExisting -eq $true) {
+                                    if ($RemoveNotExisting) {
                                         #add user to collection
                                         $UsersToRemove += $User
                                     }
@@ -206,8 +206,8 @@ function Repair-DbaOrphanUser {
                             }
 
                             #With the collection complete invoke remove.
-                            if ($RemoveNotExisting -eq $true) {
-                                if ($Force -eq $true) {
+                            if ($RemoveNotExisting) {
+                                if ($Force) {
                                     if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
                                         Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser' with -Force."
                                         Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove -Force

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -97,6 +97,7 @@ function Repair-DbaOrphanUser {
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [object[]]$Users,
         [switch]$RemoveNotExisting,
+        [switch]$Force,
         [Alias('Silent')]
         [switch]$EnableException
     )
@@ -206,12 +207,20 @@ function Repair-DbaOrphanUser {
 
                             #With the collection complete invoke remove.
                             if ($RemoveNotExisting -eq $true) {
-                                if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
+                                if ($Force -eq $true) {
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
+                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser' with -Force."
+                                        Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove -Force
+                                    }
+                                }
+                                Else {
+                                    If ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
                                     Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser'."
                                     Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove
                                 }
                             }
-                        }
+                            }
+                        } # I match this line if ($UsersToWork.Count -gt 0) {
                         else {
                             Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
                         }

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -32,6 +32,9 @@ function Repair-DbaOrphanUser {
         .PARAMETER Users
             Specifies the list of usernames to repair.
 
+        .PARAMETER Force
+        Forces alter schema to dbo owner so users can be dropped.
+
         .PARAMETER RemoveNotExisting
             If this switch is enabled, all users that do not have a matching login will be dropped from the database.
 


### PR DESCRIPTION
## Type of Change
Bug fix (non-breaking change, fixes #3414)

### Approach
Added the param $Force
Added an If to check for the param being used and ran the command with -Force, Else If Force wasn't used, run the original command.

### Commands to test
Repair-DbaOrphanUser -SqlInstance ComputerName -RemoveNotExisting -Verbose
Repair-DbaOrphanUser -SqlInstance ComputerName -RemoveNotExisting -Force -Verbose

### Screenshots

![image](https://user-images.githubusercontent.com/31617434/37931639-401f0556-313e-11e8-8d2d-9f8d43b614e5.png)

