### PR TITLE
Find-SqlInstance: Fixed interpretation of SPNs that point at named instances

### DIFF
--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -315,9 +315,19 @@ function Find-DbaInstance {
                         if ($portResult.IsOpen) { $portsDetected += $portResult.Port }
                     }
                     foreach ($sPN in $sPNs) {
-                        [int]$portNumber = $sPN.Split(':')[1]
-                        if ($portNumber -and ($portsDetected -notcontains $portNumber)) {
-                            $portsDetected += $portNumber
+                        try { $inst = $sPN.Split(':')[1] }
+                        catch { continue }
+                        
+                        try {
+                            [int]$portNumber = $inst
+                            if ($portNumber -and ($portsDetected -notcontains $portNumber)) {
+                                $portsDetected += $portNumber
+                            }
+                        }
+                        catch {
+                            if ($inst -and ($instanceNames -notcontains $inst)) {
+                                $instanceNames += $inst
+                            }
                         }
                     }
                     #endregion Gather list of found instance indicators


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

 - Added error handling for bad SPNs
 - Added logic to deal with named instances as SPNs