### PR TITLE
Get-DbaBackupHistory, fix for same-named databases

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -295,6 +295,17 @@ function Get-DbaBackupHistory {
                     if ($deviceTypeFilter) {
                         $devTypeFilterWhere = "AND mediafamily.device_type $deviceTypeFilterRight"
                     }
+                    # recap for future editors (as this has been discussed over and over):
+                    #   - original editors (from hereon referred as "we") rank over backupset.last_lsn desc, backupset.backup_finish_date desc for a good reason: DST
+                    #     all times are recorded with the timezone of the server
+                    #   - we thought about ranking over backupset.backup_set_id desc, backupset.last_lsn desc, backupset.backup_finish_date desc
+                    #     but there is no explicit documentation about "when" a row gets inserted into backupset. Theoretically it _could_
+                    #     happen that backup_set_id for the same database has not the same order of last_lsn.
+                    #   - given ultimately to restore something lsn IS the source of truth, we decided to trust that and only that
+                    #   - we know that sometimes it happens to drop a database without deleting the history. Assuming then to create a database with the same name,
+                    #     and given the lsn are composed in the first part by the VLF SeqID, it happens seldomly that for the same database_name backupset holds
+                    #     last_lsn out of order. To avoid this behaviour, we filter by database_guid choosing the guid that has MAX(backup_finish_date), as we know
+                    #     last_lsn cannot be out-of-order for the same database, and the same database cannot have different database_guid
                     $sql += "
                                 SELECT
                                     a.BackupSetRank,
@@ -311,16 +322,16 @@ function Get-DbaBackupHistory {
                                     a.MediaSetId,
                                     a.BackupSetID,
                                     a.Software,
-                                     a.position,
-                                     a.first_lsn,
-                                     a.database_backup_lsn,
-                                     a.checkpoint_lsn,
-                                     a.last_lsn,
+                                    a.position,
+                                    a.first_lsn,
+                                    a.database_backup_lsn,
+                                    a.checkpoint_lsn,
+                                    a.last_lsn,
                                     a.first_lsn as 'FirstLSN',
-                                     a.database_backup_lsn as 'DatabaseBackupLsn',
-                                     a.checkpoint_lsn as 'CheckpointLsn',
-                                     a.last_lsn as 'LastLsn',
-                                     a.software_major_version,
+                                    a.database_backup_lsn as 'DatabaseBackupLsn',
+                                    a.checkpoint_lsn as 'CheckpointLsn',
+                                    a.last_lsn as 'LastLsn',
+                                    a.software_major_version,
                                     a.DeviceType,
                                     a.is_copy_only,
                                     a.last_recovery_fork_guid
@@ -372,6 +383,19 @@ function Get-DbaBackupHistory {
                                   ON mediafamily.media_set_id = mediaset.media_set_id
                                 JOIN msdb..backupset AS backupset
                                   ON backupset.media_set_id = mediaset.media_set_id
+                                JOIN (
+                                    SELECT database_guid, database_name, backup_finish_date
+                                    FROM msdb..backupset
+                                ) dbguid
+                                  ON dbguid.database_name = backupset.database_name
+                                  AND dbguid.database_guid = backupset.database_guid
+                                JOIN (
+                                    SELECT database_name, MAX(backup_finish_date) max_finish_date
+                                    FROM msdb..backupset bs
+                                    GROUP BY database_name
+                                ) dbguid_support
+                                  ON dbguid_support.database_name = backupset.database_name
+                                  AND dbguid.backup_finish_date = dbguid_support.max_finish_date
                                 WHERE backupset.database_name = '$($db.Name)' $whereCopyOnly
                                 AND (type = '$first' OR type = '$second')
                                 $devTypeFilterWhere

--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -34,6 +34,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "First backup should be a Full Backup" {
             $results[0].Type | Should be "Full"
         }
+        It "Duration should be meaningful" {
+            ($results[0].end - $results[0].start).TotalSeconds | Should Be $results[0].Duration.TotalSeconds
+        }
         It "Last Backup Should be a log backup" {
             $results[-1].Type | Should Be "Log"
         }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Getting correct last backups in a recurring scenario when database with the same name get dropped and recreated. We continue to trust LSNs, which ultimately is what makes a restore possible.

### Approach
I slapped in the most annoying comment ever, because we revisited bits and pieces of the logic over and over without finding a proper fix (till now). 
Long story short (still long), LSNs are ordered correctly always. The whole point of LSNs is to be comparable and sortable to build a chain. Opposed to most of the scripts out there, we don't rely on backup_finish_date (even if that's what SMO does) because msdb holds dates with the timezone of the server. DST happens rarely, but they happen everywhere. That's why we go for last_lsn being "truthful" always. A small hiccup in this scenario happens when msdb holds the history for a database that has been backed up with the same name. LSNs are guaranteed to be ordered for the same database, but when you drop and recreate a database with the same name it's not the same database. 
database_guid, on the other end, changes. For the same database_guid, last_lsn is ordered correctly. So, to circumvent the hiccup, before trusting last_lsn, we filter out the history seeking the database that has the database_guid which has the last backup_finish_date (which translates to selecting the history that is relative to the last database backed up on the server with the same name).  

Short story: we trust last_lsn whenever possible. When it's not possible we filter out those rows whose database_guid has the oldest backup_finish_date. We don't go for backup_finish_date for DST. We don't go for backup_set_id because there's no explicit documentation stating that is ordered the same as LSNs.


