### PR TITLE
Snapshot commands, performance powerup

### DIFF
--- a/functions/Get-DbaDatabaseSnapshot.ps1
+++ b/functions/Get-DbaDatabaseSnapshot.ps1
@@ -116,11 +116,11 @@ WHERE sn.state <> 6
                     ComputerName    = $server.NetName
                     InstanceName    = $server.ServiceName
                     SqlInstance     = $server.DomainInstanceName
-                    Database        = $db.name
+                    Database        = $db.Name
                     SnapshotOf      = $db.DatabaseSnapshotBaseName
                     SizeMB          = [Math]::Round($db.Size, 2) ##FIXME, should use the stats for sparse files
                     DatabaseCreated = [dbadatetime]$db.createDate
-                    SnapshotDb      = $db
+                    SnapshotDb      = $server.Databases[$db.Name]
                 }
 
                 Select-DefaultView -InputObject $object -Property ComputerName, InstanceName, SqlInstance, Database, SnapshotOf, SizeMB, DatabaseCreated

--- a/functions/Get-DbaDatabaseSnapshot.ps1
+++ b/functions/Get-DbaDatabaseSnapshot.ps1
@@ -1,65 +1,65 @@
 #ValidationTags#FlowControl#
 function Get-DbaDatabaseSnapshot {
     <#
-.SYNOPSIS
-Get database snapshots with details
+    .SYNOPSIS
+        Get database snapshots with details
 
-.DESCRIPTION
-Retrieves the list of database snapshot available, along with their base (the db they are the snapshot of) and creation time
+    .DESCRIPTION
+        Retrieves the list of database snapshot available, along with their base (the db they are the snapshot of) and creation time
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+    .PARAMETER SqlInstance
+        The SQL Server that you're connecting to.
 
-.PARAMETER SqlCredential
-Credential object used to connect to the SQL Server as a different user
+    .PARAMETER SqlCredential
+        Credential object used to connect to the SQL Server as a different user
 
-.PARAMETER Database
-Return information for only specific databases
+    .PARAMETER Database
+        Return information for only specific databases
 
-.PARAMETER ExcludeDatabase
-The database(s) to exclude - this list is auto-populated from the server
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude - this list is auto-populated from the server
 
-.PARAMETER Snapshot
-Return information for only specific snapshots
+    .PARAMETER Snapshot
+        Return information for only specific snapshots
 
-.PARAMETER ExcludeSnapshot
-The snapshot(s) to exclude - this list is auto-populated from the server
+    .PARAMETER ExcludeSnapshot
+        The snapshot(s) to exclude - this list is auto-populated from the server
 
-.PARAMETER EnableException
+    .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: Snapshot
-Author: niphlod
+    .NOTES
+        Tags: Snapshot
+        Author: niphlod
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: MIT https://opensource.org/licenses/MIT
 
 
-.LINK
- https://dbatools.io/Get-DbaDatabaseSnapshot
+    .LINK
+         https://dbatools.io/Get-DbaDatabaseSnapshot
 
-.EXAMPLE
-Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a
+    .EXAMPLE
+        Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a
 
-Returns a custom object displaying Server, Database, DatabaseCreated, SnapshotOf, SizeMB, DatabaseCreated
+        Returns a custom object displaying Server, Database, DatabaseCreated, SnapshotOf, SizeMB, DatabaseCreated
 
-.EXAMPLE
-Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
+    .EXAMPLE
+        Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
 
-Returns information for database snapshots having HR and Accounting as base dbs
+        Returns information for database snapshots having HR and Accounting as base dbs
 
-.EXAMPLE
-Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snapshot, Accounting_snapshot
+    .EXAMPLE
+        Get-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snapshot, Accounting_snapshot
 
-Returns information for database snapshots HR_snapshot and Accounting_snapshot
+        Returns information for database snapshots HR_snapshot and Accounting_snapshot
 
 #>
     [CmdletBinding()]
-    Param (
+    param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -84,8 +84,16 @@ Returns information for database snapshots HR_snapshot and Accounting_snapshot
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-
-            $dbs = $server.Databases | Where-Object IsAccessible
+            $alldbq = @"
+SELECT sn.name as Name, dt.name as DatabaseSnapshotBaseName, sn.create_date as CreateDate,
+CASE WHEN sn.source_database_id IS NOT NULL THEN 1 ELSE 0 END as IsDatabaseSnapshot
+FROM sys.databases sn
+LEFT JOIN sys.databases dt
+ON sn.source_database_id = dt.database_id
+WHERE sn.state <> 6
+"@
+            $dbs = $server.Query($alldbq)
+            #$dbs = $server.Databases | Where-Object IsAccessible
 
             if ($Database) {
                 $dbs = $dbs | Where-Object { $Database -contains $_.DatabaseSnapshotBaseName }

--- a/functions/New-DbaDatabaseSnapshot.ps1
+++ b/functions/New-DbaDatabaseSnapshot.ps1
@@ -1,91 +1,91 @@
 #ValidationTags#FlowControl#
 function New-DbaDatabaseSnapshot {
     <#
-.SYNOPSIS
-Creates database snapshots
+    .SYNOPSIS
+        Creates database snapshots
 
-.DESCRIPTION
-Creates database snapshots without hassles
+    .DESCRIPTION
+        Creates database snapshots without hassles
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+    .PARAMETER SqlInstance
+        The SQL Server that you're connecting to.
 
-.PARAMETER SqlCredential
-Credential object used to connect to the SQL Server as a different user
+    .PARAMETER SqlCredential
+        Credential object used to connect to the SQL Server as a different user
 
-.PARAMETER AllDatabases
-Creates snapshot for all eligible databases
+    .PARAMETER AllDatabases
+        Creates snapshot for all eligible databases
 
-.PARAMETER Database
-The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
+    .PARAMETER Database
+        The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
 
-.PARAMETER ExcludeDatabase
-The database(s) to exclude - this list is auto-populated from the server
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude - this list is auto-populated from the server
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run
 
-.PARAMETER Confirm
-Prompts for confirmation of every step.
+    .PARAMETER Confirm
+        Prompts for confirmation of every step.
 
-.PARAMETER Name
-The specific snapshot name you want to create. Works only if you target a single database. If you need to create multiple snapshot,
-you must use the NameSuffix parameter
+    .PARAMETER Name
+        The specific snapshot name you want to create. Works only if you target a single database. If you need to create multiple snapshot,
+        you must use the NameSuffix parameter
 
-.PARAMETER NameSuffix
-When you pass a simple string, it'll be appended to use it to build the name of the snapshot. By default snapshots are created with yyyyMMdd_HHmmss suffix
-You can also pass a standard placeholder, in which case it'll be interpolated (e.g. '{0}' gets replaced with the database name)
+    .PARAMETER NameSuffix
+        When you pass a simple string, it'll be appended to use it to build the name of the snapshot. By default snapshots are created with yyyyMMdd_HHmmss suffix
+        You can also pass a standard placeholder, in which case it'll be interpolated (e.g. '{0}' gets replaced with the database name)
 
-.PARAMETER Path
-Snapshot files will be created here (by default the filestructure will be created in the same folder as the base db)
+    .PARAMETER Path
+        Snapshot files will be created here (by default the filestructure will be created in the same folder as the base db)
 
-.PARAMETER Force
-Databases with Filestream FG can be snapshotted, but the Filestream FG is marked offline
-in the snapshot. To create a "partial" snapshot, you need to pass -Force explicitely
+    .PARAMETER Force
+        Databases with Filestream FG can be snapshotted, but the Filestream FG is marked offline
+        in the snapshot. To create a "partial" snapshot, you need to pass -Force explicitely
 
-NB: You can't then restore the Database from the newly-created snapshot.
-For details, check https://msdn.microsoft.com/en-us/library/bb895334.aspx
+        NB: You can't then restore the Database from the newly-created snapshot.
+        For details, check https://msdn.microsoft.com/en-us/library/bb895334.aspx
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+    .PARAMETER EnableException
+                By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+                This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+                Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: DisasterRecovery, Snapshot, Restore, Databases
-Author: niphlod
+    .NOTES
+        Tags: DisasterRecovery, Snapshot, Restore, Databases
+        Author: niphlod
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: MIT https://opensource.org/licenses/MIT
 
-.LINK
- https://dbatools.io/New-DbaDatabaseSnapshot
+    .LINK
+         https://dbatools.io/New-DbaDatabaseSnapshot
 
-.EXAMPLE
-New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
+    .EXAMPLE
+        New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
 
-Creates snapshot for HR and Accounting, returning a custom object displaying Server, Database, DatabaseCreated, SnapshotOf, SizeMB, DatabaseCreated, PrimaryFilePath, Status, Notes
+        Creates snapshot for HR and Accounting, returning a custom object displaying Server, Database, DatabaseCreated, SnapshotOf, SizeMB, DatabaseCreated, PrimaryFilePath, Status, Notes
 
-.EXAMPLE
-New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -Name HR_snap
+    .EXAMPLE
+        New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -Name HR_snap
 
-Creates snapshot named "HR_snap" for HR
+        Creates snapshot named "HR_snap" for HR
 
-.EXAMPLE
-New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -NameSuffix 'fool_{0}_snap'
+    .EXAMPLE
+        New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -NameSuffix 'fool_{0}_snap'
 
-Creates snapshot named "fool_HR_snap" for HR
+        Creates snapshot named "fool_HR_snap" for HR
 
-.EXAMPLE
-New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting -Path F:\snapshotpath
+    .EXAMPLE
+        New-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting -Path F:\snapshotpath
 
-Creates snapshots for HR and Accounting databases, storing files under the F:\snapshotpath\ dir
+        Creates snapshots for HR and Accounting databases, storing files under the F:\snapshotpath\ dir
 
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param (
+    param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,

--- a/functions/Remove-DbaDatabaseSnapshot.ps1
+++ b/functions/Remove-DbaDatabaseSnapshot.ps1
@@ -1,86 +1,86 @@
 #ValidationTags#FlowControl#
 function Remove-DbaDatabaseSnapshot {
     <#
-.SYNOPSIS
-Removes database snapshots
+    .SYNOPSIS
+        Removes database snapshots
 
-.DESCRIPTION
-Removes (drops) database snapshots from the server
+    .DESCRIPTION
+        Removes (drops) database snapshots from the server
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to
+    .PARAMETER SqlInstance
+        The SQL Server that you're connecting to
 
-.PARAMETER SqlCredential
-Credential object used to connect to the SQL Server as a different user
+    .PARAMETER SqlCredential
+        Credential object used to connect to the SQL Server as a different user
 
-.PARAMETER Database
-Removes snapshots for only this specific base db
+    .PARAMETER Database
+        Removes snapshots for only this specific base db
 
-.PARAMETER ExcludeDatabase
-Removes snapshots excluding this specific base dbs
+    .PARAMETER ExcludeDatabase
+        Removes snapshots excluding this specific base dbs
 
-.PARAMETER Snapshot
-Restores databases from snapshot with this name only
+    .PARAMETER Snapshot
+        Restores databases from snapshot with this name only
 
-.PARAMETER AllSnapshots
-Specifies that you want to remove all snapshots from the server
+    .PARAMETER AllSnapshots
+        Specifies that you want to remove all snapshots from the server
 
-.PARAMETER Force
-Will forcibly kill all running queries that prevent the drop process.
+    .PARAMETER Force
+        Will forcibly kill all running queries that prevent the drop process.
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run
 
-.PARAMETER Confirm
-Prompts for confirmation of every step.
+    .PARAMETER Confirm
+        Prompts for confirmation of every step.
 
-.PARAMETER PipelineSnapshot
-Internal parameter
+    .PARAMETER PipelineSnapshot
+        Internal parameter
 
-.PARAMETER EnableException
+    .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: Snapshot, Database
-Author: niphlod
+    .NOTES
+        Tags: Snapshot, Database
+        Author: niphlod
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: MIT https://opensource.org/licenses/MIT
 
-.LINK
- https://dbatools.io/Remove-DbaDatabaseSnapshot
+    .LINK
+         https://dbatools.io/Remove-DbaDatabaseSnapshot
 
-.EXAMPLE
-Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a
+    .EXAMPLE
+        Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a
 
-Removes all database snapshots from sqlserver2014a
+        Removes all database snapshots from sqlserver2014a
 
-.EXAMPLE
-Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snap_20161201, HR_snap_20161101
+    .EXAMPLE
+        Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snap_20161201, HR_snap_20161101
 
-Removes database snapshots named HR_snap_20161201 and HR_snap_20161101
+        Removes database snapshots named HR_snap_20161201 and HR_snap_20161101
 
-.EXAMPLE
-Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
+    .EXAMPLE
+        Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
 
-Removes all database snapshots having HR and Accounting as base dbs
+        Removes all database snapshots having HR and Accounting as base dbs
 
-.EXAMPLE
-Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snapshot, Accounting_snapshot
+    .EXAMPLE
+        Remove-DbaDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snapshot, Accounting_snapshot
 
-Removes HR_snapshot and Accounting_snapshot
+        Removes HR_snapshot and Accounting_snapshot
 
-.EXAMPLE
-Get-DbaDatabaseSnapshot -SqlInstance sql2016 | Where SnapshotOf -like '*dumpsterfire*' | Remove-DbaDatabaseSnapshot
+    .EXAMPLE
+        Get-DbaDatabaseSnapshot -SqlInstance sql2016 | Where SnapshotOf -like '*dumpsterfire*' | Remove-DbaDatabaseSnapshot
 
-Removes all snapshots associated with databases that have dumpsterfire in the name
+        Removes all snapshots associated with databases that have dumpsterfire in the name
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param (
+    param (
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -149,7 +149,15 @@ Removes all snapshots associated with databases that have dumpsterfire in the na
             }
 
 
-            $dbs = $server.Databases
+            $alldbq = @"
+SELECT sn.name AS Name, dt.name AS DatabaseSnapshotBaseName, sn.create_date AS CreateDate,
+CASE WHEN sn.state = 6 THEN 0 ELSE 1 END AS IsAccessible,
+CASE WHEN sn.source_database_id IS NOT NULL THEN 1 ELSE 0 END AS IsDatabaseSnapshot
+FROM sys.databases sn
+LEFT JOIN sys.databases dt
+ON sn.source_database_id = dt.database_id
+"@
+            $dbs = $server.Query($alldbq)
             if ($Database) {
                 $dbs = $dbs | Where-Object { $Database -contains $_.DatabaseSnapshotBaseName }
             }
@@ -167,11 +175,12 @@ Removes all snapshots associated with databases that have dumpsterfire in the na
             }
 
 
-            foreach ($db in $dbs) {
-                if ($db.IsAccessible -eq $false) {
-                    Write-Message -Level Warning -Message "Database $db is not accessible."
+            foreach ($dbraw in $dbs) {
+                if ($dbraw.IsAccessible -eq $false) {
+                    Write-Message -Level Warning -Message "Database $dbraw is not accessible."
                     continue
                 }
+                $db = $server.Databases[$($dbraw.Name)]
                 if ($Pscmdlet.ShouldProcess($server.name, "Remove db snapshot $db")) {
                     $basedb = $db.DatabaseSnapshotBaseName
                     try {

--- a/functions/Restore-DbaFromDatabaseSnapshot.ps1
+++ b/functions/Restore-DbaFromDatabaseSnapshot.ps1
@@ -1,70 +1,70 @@
 #ValidationTags#FlowControl#
 function Restore-DbaFromDatabaseSnapshot {
     <#
-        .SYNOPSIS
-            Restores databases from snapshots
+    .SYNOPSIS
+        Restores databases from snapshots
 
-        .DESCRIPTION
-            Restores the database from the snapshot, discarding every modification made to the database
-            NB: Restoring to a snapshot will result in every other snapshot of the same database to be dropped
-            It also fixes some long-standing bugs in SQL Server when restoring from snapshots
+    .DESCRIPTION
+        Restores the database from the snapshot, discarding every modification made to the database
+        NB: Restoring to a snapshot will result in every other snapshot of the same database to be dropped
+        It also fixes some long-standing bugs in SQL Server when restoring from snapshots
 
-        .PARAMETER SqlInstance
-            The SQL Server that you're connecting to
+    .PARAMETER SqlInstance
+        The SQL Server that you're connecting to
 
-        .PARAMETER SqlCredential
-            Credential object used to connect to the SQL Server as a different user
+    .PARAMETER SqlCredential
+        Credential object used to connect to the SQL Server as a different user
 
-        .PARAMETER Database
-            Restores from the last snapshot databases with this names only. You can pass either Databases or Snapshots
+    .PARAMETER Database
+        Restores from the last snapshot databases with this names only. You can pass either Databases or Snapshots
 
-        .PARAMETER ExcludeDatabase
-            The database(s) to exclude - this list is auto-populated from the server
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude - this list is auto-populated from the server
 
-        .PARAMETER Snapshot
-            Restores databases from snapshots with this names only. You can pass either Databases or Snapshots
+    .PARAMETER Snapshot
+        Restores databases from snapshots with this names only. You can pass either Databases or Snapshots
 
-        .PARAMETER Force
-            If restoring from a snapshot involves dropping any other shapshot, you need to explicitly
-            use -Force to let this command delete the ones not involved in the restore process.
-            Also, -Force will forcibly kill all running queries that prevent the restore process.
+    .PARAMETER Force
+        If restoring from a snapshot involves dropping any other shapshot, you need to explicitly
+        use -Force to let this command delete the ones not involved in the restore process.
+        Also, -Force will forcibly kill all running queries that prevent the restore process.
 
-        .PARAMETER WhatIf
-            Shows what would happen if the command were to run
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run
 
-        .PARAMETER Confirm
-            Prompts for confirmation of every step.
+    .PARAMETER Confirm
+        Prompts for confirmation of every step.
 
-        .PARAMETER EnableException
-            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-        .NOTES
-            Tags: DisasterRecovery, Snapshot, Backup, Restore, Database
-            Author: niphlod
+    .NOTES
+        Tags: DisasterRecovery, Snapshot, Backup, Restore, Database
+        Author: niphlod
 
-            Website: https://dbatools.io
-            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-            License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: MIT https://opensource.org/licenses/MIT
 
-        .LINK
-             https://dbatools.io/Restore-DbaFromDatabaseSnapshot
+    .LINK
+        https://dbatools.io/Restore-DbaFromDatabaseSnapshoT
 
-        .EXAMPLE
-            Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
+    .EXAMPLE
+        Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR, Accounting
 
-            Restores HR and Accounting databases using the latest snapshot available
+        Restores HR and Accounting databases using the latest snapshot available
 
-        .EXAMPLE
-            Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -Force
+    .EXAMPLE
+        Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Database HR -Force
 
-            Restores HR database from latest snapshot and kills any active connections in the database on sqlserver2014a.
+        Restores HR database from latest snapshot and kills any active connections in the database on sqlserver2014a.
 
-        .EXAMPLE
-            Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snap_20161201, Accounting_snap_20161101
+    .EXAMPLE
+        Restore-DbaFromDatabaseSnapshot -SqlInstance sqlserver2014a -Snapshot HR_snap_20161201, Accounting_snap_20161101
 
-            Restores databases from snapshots named HR_snap_20161201 and Accounting_snap_20161101
+        Restores databases from snapshots named HR_snap_20161201 and Accounting_snap_20161101
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
@@ -96,8 +96,33 @@ function Restore-DbaFromDatabaseSnapshot {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $allDbs = $server.Databases
-
+            #$allDbs = $server.Databases
+            $alldbq = @"
+SELECT sn.name AS Name,
+       dt.name AS DatabaseSnapshotBaseName,
+       sn.create_date AS CreateDate,
+       CASE
+           WHEN sn.source_database_id IS NOT NULL
+           THEN CASE
+                    WHEN dt.state = 6
+                    THEN 0
+                    ELSE 1
+                END
+           ELSE CASE
+                    WHEN sn.state = 6
+                    THEN 0
+                    ELSE 1
+                END
+       END AS IsAccessible,
+       CASE
+           WHEN sn.source_database_id IS NOT NULL
+           THEN 1
+           ELSE 0
+       END AS IsDatabaseSnapshot
+FROM sys.databases sn
+     LEFT JOIN sys.databases dt ON sn.source_database_id = dt.database_id
+"@
+            $alldbs = $server.Query($alldbq)
             # vault to hold all programmed operations from --> to
             $operations = @()
 
@@ -129,10 +154,12 @@ function Restore-DbaFromDatabaseSnapshot {
                     continue
                 }
             }
-
             $opsHash = @{ }
-
             foreach ($db in $dbs) {
+                if (-not($db.IsAccessible)) {
+                    Write-Message -Level Warning -Message "Database $db is not accessible."
+                    continue
+                }
                 if ($db.DatabaseSnapshotBaseName -notin $opsHash.Keys) {
                     if ($snapshot.Count -gt 0) {
                         # just in the need to drop every other snapshot
@@ -170,7 +197,6 @@ function Restore-DbaFromDatabaseSnapshot {
                     'drop' = $drop
                 }
             }
-
             foreach ($op in $operations) {
                 # Check if there are FS, because then a restore is not possible
                 $all_FS = $server.Databases[$op['to']].FileGroups | Where-Object FileGroupType -EQ 'FileStreamDataFileGroup'
@@ -188,7 +214,7 @@ function Restore-DbaFromDatabaseSnapshot {
                     break
                 }
                 # Get log size and autogrowth
-                $orig_logproperties = $server.Databases[$op['to']].LogFiles | Select-Object Id, Size
+                $orig_logproperties = $server.Databases[$op['to']].LogFiles | Select-Object Id, Size, Growth, GrowthType
                 # Drop what needs to be dropped
                 $opError = $false
 
@@ -267,14 +293,21 @@ function Restore-DbaFromDatabaseSnapshot {
                     }
                     break
                 }
-                # Comparing sizes before and after, need to reconnect to see if size
-                # changed
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                # Comparing sizes before and after, need to refresh to see if size
+                foreach ($log in $server.Databases[$op['to']].LogFiles) {
+                    $log.Refresh()
+                }
                 foreach ($log in $server.Databases[$op['to']].LogFiles) {
                     $matching = $orig_logproperties | Where-Object ID -EQ $log.ID
-                    if ($matching.Size -ne $log.Size) {
-                        Write-Message -Level Verbose -Message "Resizing log to the original value"
-                        $log.Size = $matching.Size
+                    $changeflag = 0
+                    foreach ($prop in @('Size', 'Growth', 'Growth', 'GrowthType')) {
+                        if ($matching.$prop -ne $log.$prop) {
+                            $changeflag = 1
+                            $log.$prop = $matching.$prop
+                        }
+                    }
+                    if ($changeflag -ne 0) {
+                        Write-Message -Level Verbose -Message "Restoring original settings for log file"
                         $log.Alter()
                     }
                 }


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Avoid SMO enum. Seems that to access DatabaseSnapshotBaseName invokes a full enum. And it's recursive so for 10 databases, it's 10 enums for each, leading to hundreds of queries.

### Approach
Push SMO down the toilet whenever possible. Sorry, SMO.

### Commands to test
If the test suite runs, we're good to go

@potatoqualitee : give the user reporting performance nightmares a ping and let him try this version