### PR TITLE
Get-DbaComputerSystem - Duplicate Continue parameter

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -151,7 +151,7 @@ function Get-DbaComputerSystem {
                 Select-DefaultView -InputObject $inputObject -ExcludeProperty $excludes
             }
             catch {
-                Stop-Function -Continue -Message "Failure" -ErrorRecord $_ -Target $computer -Continue
+                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $computer -Continue
             }
         }
     }


### PR DESCRIPTION
Found duplicate Continue in the call to `Stop-Function`...test file does not cover calling the catch block I guess.