### PR TITLE
manual.pester, do not consider utf-8 without bom

### DIFF
--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -266,8 +266,7 @@ if (-not $Finalize) {
             foreach ($k in $validScenarios) {
                 $AllTestsToExclude += Get-TestsForScenario -scenario $k -AllTest $AllTests
             }
-            $AllTests = $AllTests | Where-Object { $_ -notin $AllTestsToExclude }
-            $AllScenarioTests = $AllTests
+            $AllScenarioTests = $AllTests | Where-Object { $_ -notin $AllTestsToExclude }
         }
     }
     else {

--- a/tests/manual.pester.ps1
+++ b/tests/manual.pester.ps1
@@ -128,7 +128,7 @@ Import-Module "$ModuleBase\dbatools.psd1" -DisableNameChecking
 #imports the psm1 to be able to use internal functions in tests
 Import-Module "$ModuleBase\dbatools.psm1" -DisableNameChecking
 
-$ScriptAnalyzerRulesExclude = @('PSUseOutputTypeCorrectly', 'PSAvoidUsingPlainTextForPassword')
+$ScriptAnalyzerRulesExclude = @('PSUseOutputTypeCorrectly', 'PSAvoidUsingPlainTextForPassword', 'PSUseBOMForUnicodeEncodedFile')
 
 $testInt = $false
 if ($config_TestIntegration) {


### PR DESCRIPTION
(do state)

Since the rule has often incorrect checking, better to leave it out of the picture till gets properly fixed.