### PR TITLE
Adjusting default output and test for Get-DbaOperatingSystem

### DIFF
--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -117,6 +117,7 @@ function Get-DbaOperatingSystem {
                 Architecture             = $os.OSArchitecture
                 Version                  = $os.Version
                 Build                    = $os.BuildNumber
+                Caption                  = $os.Caption
                 InstallDate              = [DbaDateTime]$os.InstallDate
                 LastBootTime             = [DbaDateTime]$os.LastBootUpTime
                 LocalDateTime            = [DbaDateTime]$os.LocalDateTime
@@ -137,11 +138,10 @@ function Get-DbaOperatingSystem {
                 LanguageThreeLetter      = $language.ThreeLetterISOLanguageName
                 LanguageAlias            = $language.DisplayName
                 LanguageNative           = $language.NativeName
-
                 CodeSet                  = $os.CodeSet
                 CountryCode              = $os.CountryCode
                 Locale                   = $os.Locale
-            } | Select-DefaultView -ExcludeProperty CodeSet, CountryCode, Locale, LanguageAlias
+            } | Select-DefaultView -Property ComputerName, Manufacturer, Organization, Architecture, Version, Caption, LastBootTime, LocalDateTime, PowerShellVersion, TimeZone, TotalVisibleMemory, ActivePowerPlan, LanguageNative
         }
     }
 }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -37,11 +37,11 @@ Describe "Get-DbaOperatingSystem Integration Test" -Tag "IntegrationTests" {
     Context "Validate output" {
         foreach ($prop in $props) {
             $p = $result.PSObject.Properties[$prop]
-            it "Should return property: $prop" {
+            It "Should return property: $prop" {
                 $p.Name | Should Be $prop
             }
         }
-        it "Should return nothing if unable to connect to server" {
+        It "Should return nothing if unable to connect to server" {
             $result = Get-DbaOperatingSystem -ComputerName 'Melton5312' -WarningAction SilentlyContinue
             $result | Should Be $null
         }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -1,25 +1,23 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-Describe "Get-DbaOperatingSystem Unit Tests" -Tag "UnitTests" {
-    InModuleScope dbatools {
-        Context "Validate parameters" {
-            $params = (Get-ChildItem function:\Get-DbaOperatingSystem).Parameters
-            it "should have a parameter named ComputerName" {
-                $params.ContainsKey("ComputerName") | Should Be $true
-            }
-            it "should have a parameter named Credential" {
-                $params.ContainsKey("Credential") | Should Be $true
-            }
-            it "should have a parameter named Silent" {
-                $params.ContainsKey("EnableException") | Should Be $true
-            }
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = x
+        $commonParamCount = ([System.Management.Automation.PSCmdlet]::CommonParameters).Count
+        [object[]]$params = (Get-ChildItem function:\Get-DBaOperatingSystem).Parameters.Keys
+        $knownParameters = 'ComputerName', 'Credential', 'EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
-        Context "Validate input" {
-            it "Cannot resolve hostname of computer" {
-                mock Resolve-DbaNetworkName {$null}
-                {Get-DbaOperatingSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
-            }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $commonParamCount | Should Be $paramCount
+        }
+    }
+    Context "Validate input" {
+        It "Cannot resolve hostname of computer" {
+            mock Resolve-DbaNetworkName {$null}
+            {Get-DbaOperatingSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null} | Should Throw
         }
     }
 }

--- a/tests/Get-DbaOperatingSystem.Tests.ps1
+++ b/tests/Get-DbaOperatingSystem.Tests.ps1
@@ -3,9 +3,9 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = x
+        $paramCount = 3
         $commonParamCount = ([System.Management.Automation.PSCmdlet]::CommonParameters).Count
-        [object[]]$params = (Get-ChildItem function:\Get-DBaOperatingSystem).Parameters.Keys
+        [object[]]$params = (Get-ChildItem function:\Get-DbaOperatingSystem).Parameters.Keys
         $knownParameters = 'ComputerName', 'Credential', 'EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount


### PR DESCRIPTION
Just adjusting default output of Get-DbaOperatingSystem, and added the `Caption` property that gives you the full user-friendly OS Edition and Version (not sure why I didn't have this in there before).

Updating test to also include the standard unti testing on parameters and such.

Found cool way to get the common parameters based on commit on PowerShell repo:

```powershell
#this will output the "default" parameter that functions get with cmdletbinding()
[System.Management.Automation.PSCmdlet]::CommonParameters

#this outputs the additional parameters that come with ShouldProcess being set to true
[System.Management.Automation.PSCmdlet]::OptionalCommonParameters
```
![image](https://user-images.githubusercontent.com/11204251/38289199-b8b90e28-379a-11e8-85c0-37cdfd703969.png)
