### PR TITLE
appveyor timings and speedups

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,14 @@
 build: false
 version: 0.9.{build}
 
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+  - C:\Program Files\WindowsPowerShell\Modules\PSScriptAnalyzer -> appveyor.yml
+  - C:\Program Files\WindowsPowerShell\Modules\Pester -> appveyor.yml
+
+shallow_clone: true
+
 # Set build info
 environment: 
   environment: development

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -307,7 +307,11 @@ if (-not $Finalize) {
         }
         # Pester 4.0 outputs already what file is being ran. If we remove write-host from every test, we can time
         # executions for each test script (i.e. Executing Get-DbaFoo .... Done (40 seconds))
+        Add-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Running
+        $sw = [system.diagnostics.stopwatch]::startNew()
         Invoke-Pester @PesterSplat | Export-Clixml -Path "$ModuleBase\PesterResults$PSVersion$Counter.xml"
+        $sw.Stop()
+        Update-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Passed -Duration $sw.ElapsedMilliseconds
     }
 }
 else {

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -266,8 +266,7 @@ if (-not $Finalize) {
             foreach ($k in $validScenarios) {
                 $AllTestsToExclude += Get-TestsForScenario -scenario $k -AllTest $AllTests
             }
-            $AllTests = $AllTests | Where-Object { $_ -notin $AllTestsToExclude }
-            $AllScenarioTests = $AllTests
+            $AllScenarioTests = $AllTests | Where-Object { $_ -notin $AllTestsToExclude }
         }
     }
     else {
@@ -308,10 +307,9 @@ if (-not $Finalize) {
         # Pester 4.0 outputs already what file is being ran. If we remove write-host from every test, we can time
         # executions for each test script (i.e. Executing Get-DbaFoo .... Done (40 seconds))
         Add-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Running
-        $sw = [system.diagnostics.stopwatch]::startNew()
-        Invoke-Pester @PesterSplat | Export-Clixml -Path "$ModuleBase\PesterResults$PSVersion$Counter.xml"
-        $sw.Stop()
-        Update-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Passed -Duration $sw.ElapsedMilliseconds
+        $PesterRun = Invoke-Pester @PesterSplat
+        $PesterRun | Export-Clixml -Path "$ModuleBase\PesterResults$PSVersion$Counter.xml"
+        Update-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Passed -Duration $PesterRun.Time.TotalMilliseconds
     }
 }
 else {

--- a/tests/appveyor.post.ps1
+++ b/tests/appveyor.post.ps1
@@ -1,10 +1,11 @@
-﻿Write-Host -Object "appveyor.post: Sending coverage data" -ForeGroundColor DarkGreen
+﻿Add-AppveyorTest -Name "appveyor.post" -Framework NUnit -FileName "appveyor.post.ps1" -Outcome Running
+$sw = [system.diagnostics.stopwatch]::startNew()
+Write-Host -Object "appveyor.post: Sending coverage data" -ForeGroundColor DarkGreen
 Push-AppveyorArtifact PesterResultsCoverage.json -FileName "PesterResultsCoverage"
 codecov -f PesterResultsCoverage.json --flag "ps,$($env:SCENARIO.toLower())" | Out-Null
 # DLL unittests only in default scenario
 if($env:SCENARIO -eq 'default') {
   Write-Host -Object "appveyor.post: DLL unittests"  -ForeGroundColor DarkGreen
-  choco install opencover.portable | Out-Null
   OpenCover.Console.exe `
     -register:user `
     -target:"vstest.console.exe" `
@@ -15,3 +16,5 @@ if($env:SCENARIO -eq 'default') {
   Push-AppveyorArtifact coverage.xml -FileName "OpenCover c# report"
   codecov -f "coverage.xml" --flag "dll,$($env:SCENARIO.toLower())" | Out-Null
 }
+$sw.Stop()
+Update-AppveyorTest -Name "appveyor.post" -Framework NUnit -FileName "appveyor.post.ps1" -Outcome Passed -Duration $sw.ElapsedMilliseconds

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -1,14 +1,28 @@
-﻿Write-Host -Object "appveyor.prep: Cloning lab materials"  -ForegroundColor DarkGreen
+﻿Add-AppveyorTest -Name "appveyor.prep" -Framework NUnit -FileName "appveyor.prep.ps1" -Outcome Running
+$sw = [system.diagnostics.stopwatch]::startNew()
+Write-Host -Object "appveyor.prep: Cloning lab materials"  -ForegroundColor DarkGreen
 git clone -q --branch=master --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
-#Install codecov to upload results
+
+#Get codecov (to upload coverage results)
 Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen
 choco install codecov | Out-Null
 
+#Write-Host -Object "appveyor.prep: Install Nuget" -ForegroundColor DarkGreen
+## appveyor has 2.8.5.208 installed, so no need to nuget over and over just to fetch scriptanalyzer
+#Install-PackageProvider Nuget –Force | Out-Null
+
+#Get PSScriptAnalyzer (to check warnings)
 Write-Host -Object "appveyor.prep: Install PSScriptAnalyzer" -ForegroundColor DarkGreen
-Install-PackageProvider Nuget –Force | Out-Null
 Install-Module -Name PSScriptAnalyzer | Out-Null
 
-
-# "Get Pester manually"
+#Get Pester (to run tests)
 Write-Host -Object "appveyor.prep: Install Pester" -ForegroundColor DarkGreen
-Install-Module -Name Pester -Repository PSGallery -Force | Out-Null
+choco install pester | Out-Null
+
+#Get opencover.portable (to run DLL tests)
+Write-Host -Object "appveyor.prep: Install opencover.portable" -ForegroundColor DarkGreen
+choco install opencover.portable | Out-Null
+
+$sw.Stop()
+Update-AppveyorTest -Name "appveyor.prep" -Framework NUnit -FileName "appveyor.prep.ps1" -Outcome Passed -Duration $sw.ElapsedMilliseconds
+

--- a/tests/appveyor.sqlserver.ps1
+++ b/tests/appveyor.sqlserver.ps1
@@ -11,10 +11,10 @@ if ($env:SCENARIO) {
     $Setup_Scripts = $env:SETUP_SCRIPTS.split(',').Trim()
     foreach ($Setup_Script in $Setup_Scripts) {
         $SetupScriptPath = Join-Path $env:APPVEYOR_BUILD_FOLDER $Setup_Script
-        Add-AppveyorTest -Name "Setup" -Framework NUnit -FileName $Setup_Script -Outcome Running
+        Add-AppveyorTest -Name $Setup_Script -Framework NUnit -FileName $Setup_Script -Outcome Running
         $sw = [system.diagnostics.stopwatch]::startNew()
         . $SetupScriptPath
         $sw.Stop()
-        Update-AppveyorTest -Name "Setup" -Framework NUnit -FileName $Setup_Script -Outcome Passed -Duration $sw.ElapsedMilliseconds
+        Update-AppveyorTest -Name $Setup_Script -Framework NUnit -FileName $Setup_Script -Outcome Passed -Duration $sw.ElapsedMilliseconds
     }
 }

--- a/tests/appveyor.sqlserver.ps1
+++ b/tests/appveyor.sqlserver.ps1
@@ -11,6 +11,10 @@ if ($env:SCENARIO) {
     $Setup_Scripts = $env:SETUP_SCRIPTS.split(',').Trim()
     foreach ($Setup_Script in $Setup_Scripts) {
         $SetupScriptPath = Join-Path $env:APPVEYOR_BUILD_FOLDER $Setup_Script
+        Add-AppveyorTest -Name "Setup" -Framework NUnit -FileName $Setup_Script -Outcome Running
+        $sw = [system.diagnostics.stopwatch]::startNew()
         . $SetupScriptPath
+        $sw.Stop()
+        Update-AppveyorTest -Name "Setup" -Framework NUnit -FileName $Setup_Script -Outcome Passed -Duration $sw.ElapsedMilliseconds
     }
 }


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [x] Build system
 

### Purpose
Since we're on the verge/in the middle of testing spree, having a way to "monitor" timings regains some value. As everyone can watch times explicitely for each step, most of the time is spent on setting up the needed services. 
I'll tackle startup scripts in the future (todolist: remove specific actions that make tests go nuclear on "private" testing setups and port them over inside specific tests that need those preparation, see if we can avoid loading dbatools that takes some time too, etc)

Main deal for now is shaving off precious time by:
- fetching the repo via zip rather than by git (we ship DLLs in source control and cloning the repo is a PITA) 
- install early all deps for every scenario to enable caching deps when possible 

NB: cache will not be preserved on PRs by default, looking at Appveyor's docs, and for a good reason

NB2: once in a while we may want to touch appveyor.yml which will trigger cache invalidation (e.g. when dependencies needed for tests get updated)

Future deals: 
- incorporating DLL tests in the main runner so it if fails (as it is for some time now) build fails too
- avoid setting up services when no tests need to be ran (e.g. `(do something)`)

### Approach
Pester is able to generate full blown Nunit blorbs that appveyor happily accepts, although with the zillions test we have it makes it not useful at all. 
We just use Appveyor's facility to store times for main steps of each scenario run, so we all get a specific idea on what takes time and what doesn't.
As for the cache, we use choco to install, and cache choco dirs. Also, we cache directories used to store PS modules needed which are not available via choco.
Choco dir on appveyor is kinda big, but for the time being I could not find an easier and succint method to install "manually" and be able to cache our dependencies.

