### PR TITLE
Read-DbaBackupHeader: now multi-threaded

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -271,7 +271,8 @@ function Get-DbaBackupInformation {
                 $Files = $Files | Where-Object {$_.FullName -notlike '*\LOG\*'}
             }
 
-            $FileDetails = $Files | Read-DbaBackupHeader -SqlInstance $server
+            Write-Message -Level Verbose -Message "Reading backup headers of $($Files.Count) files"
+            $FileDetails = Read-DbaBackupHeader -SqlInstance $server -Path $Files
 
             $groupdetails = $FileDetails | group-object -Property BackupSetGUID
 

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -236,7 +236,7 @@ function Read-DbaBackupHeader {
         #receive runspaces
         while ($threads | Where-Object { $_.isRetrieved -eq $false }) {
             $totalThreads = ($threads | Measure-Object).Count
-            $totalRetrievedThreads = ($threads | Where-Object { $_.isRetrieved -eq $false } | Measure-Object).Count
+            $totalRetrievedThreads = ($threads | Where-Object { $_.isRetrieved -eq $true } | Measure-Object).Count
             Write-Progress -Id 1 -Activity Updating -Status 'Progress' -CurrentOperation "Scanning Restore headers: $totalRetrievedThreads/$totalThreads" -PercentComplete ($totalRetrievedThreads / $totalThreads * 100)
             foreach ($thread in ($threads | Where-Object { $_.isRetrieved -eq $false })) {
                 if ($thread.Handle.IsCompleted) {

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -101,6 +101,7 @@ function Read-DbaBackupHeader {
 	)
 
 	begin {
+		Write-Message -Level InternalComment -Message "Starting reading headers"
 		try {
 			$server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 		}

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -528,8 +528,17 @@ function Restore-DbaDatabase {
                 }
             }
             else {
-                Write-Message -Level Verbose -Message "Unverified input, full scans - $($path -join ';')"
-                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $path -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup
+                $files = @()
+                foreach ($f in $Path) {
+                    if ($f -is [System.IO.FileSystemInfo]) {
+                        $files += $f.fullname
+                    }
+                    else {
+                        $files += $f
+                    }
+                }
+                Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
+                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if (-not (Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -496,7 +496,7 @@ function Restore-DbaDatabase {
         if ($PSCmdlet.ParameterSetName -like "Restore*") {
             if ($PipeDatabaseName -eq $true) {$DatabaseName = ''}
             Write-Message -message "ParameterSet  = Restore" -Level Verbose
-            if ($TrustDbBackupHistory -or $path.GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
+            if ($TrustDbBackupHistory -or $path[0].GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
                 foreach ($f in $path) {
                     Write-Message -Level Verbose -Message "Trust Database Backup History Set"
                     if ("BackupPath" -notin $f.PSobject.Properties.name) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Got tired of restores running indefinitely for any folder that has >100 files (read: any production backup folder) reading every single header of every backup file one by one. This change enables the command to submit up to 10 tasks simultaneously using runspaces and run header checks in parallel.
With this approach, restores from folders can be sped up up to 6x, which I'm more than happy about.

### Approach
* Headers are now being read as a runspace task
* All the relevant commands are trying their best to send the files as an array instead of pipelining them one by one
* Runspace is configured to run max 10 threads due to SQL Server behavior: apparently it has an internal queue and allows only ~6 tasks to run simultaneously anyways (still researching on this one), no reason to bloat it up any higher
* File access is checked beforehand now - again, to pass all the files as an array
* Implemented grouping - to avoid scanning the same file twice

### Commands to test
I really hope everything would work as expected, as I had to revisit some parts in other commands to ensure that arrays are passed properly everywhere. My manual tests are throwing errors because apparently I have an outdated branch and materials from appveyor repo are returning different numbers now. Let's see if PR test succeeds.
List of modified commands:
Read-DbaBackupHeader
Restore-DbaDatabase
Get-DbaBackupInformation

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Before:
![2018-04-09_16-09-13](https://user-images.githubusercontent.com/30303784/38523221-7490108c-3c10-11e8-9eb9-273e6b5d6e8f.jpg)
After:
![2018-04-09_16-08-23](https://user-images.githubusercontent.com/30303784/38523252-8962af10-3c10-11e8-83e0-6b3f830d7a48.jpg)
Beautiful progress bar:
![2018-04-09_16-11-38](https://user-images.githubusercontent.com/30303784/38523326-bef78cea-3c10-11e8-9cf6-e9430f1908a8.jpg)


### Learning
Surprisingly, 50 threads ran more slowly than 10 threads due to Powershell overheads on top of internal SQL Server queuing of RESTORE HEADERONLY commands - sessions just sit there waiting on PARALLEL_BACKUP_QUEUE - that's the first time I personally see it. It allowed no more than 6 sessions running at the same time.
