### PR TITLE
Test-DbaSqlPath, add extra infos

### DIFF
--- a/tests/Test-DbaSqlPath.Tests.ps1
+++ b/tests/Test-DbaSqlPath.Tests.ps1
@@ -39,6 +39,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
         }
         $falseTest = 'B:\FloppyDiskAreAwesome'
+        $trueTestPath = [System.IO.Path]::GetDirectoryName($trueTest)
     }
     Context "Command actually works" {
         $result = Test-DbaSqlPath -SqlInstance $script:instance2 -Path $trueTest
@@ -61,6 +62,17 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 $result.FileExists | Should Be $false
             }
             ($results.SqlInstance | Sort-Object -Unique).Count | Should Be 2
+        }
+        $results = Test-DbaSqlPath -SqlInstance $script:instance2 -Path @($trueTest)
+        It "Should return pscustomobject results when passed an array (even with one path)" {
+            ($results | Where-Object FilePath -eq $trueTest).FileExists | Should Be $true
+        }
+        $results = Test-DbaSqlPath -SqlInstance $script:instance2 -Path @($trueTest, $trueTestPath)
+        It "Should return pscustomobject results indicating if the path is a file or a directory" {
+            ($results | Where-Object FilePath -eq $trueTest).FileExists | Should Be $true
+            ($results | Where-Object FilePath -eq $trueTestPath).FileExists | Should Be $true
+            ($results | Where-Object FilePath -eq $trueTest).IsContainer | Should Be $false
+            ($results | Where-Object FilePath -eq $trueTestPath).IsContainer | Should Be $true
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Add info about the passed path (is it a folder or a file?). Also, make sure if we pass an array (even if it's composed by a single string) we get back detailed infos.

### Approach
Typecast `$Path` later.

### Screenshots
```
PS> Test-DbaSqlPath -SqlInstance foo -Path @('c:\temp')

SqlInstance  : foo
InstanceName : MSSQLSERVER
ComputerName : foo
FilePath     : c:\temp
FileExists   : True
IsContainer  : True

PS> Test-DbaSqlPath -SqlInstance localhost -Path @('c:\temp\constants.ps1')

SqlInstance  : foo
InstanceName : MSSQLSERVER
ComputerName : foo
FilePath     : c:\temp\constants.ps1
FileExists   : True
IsContainer  : False

PS> Test-DbaSqlPath -SqlInstance foo -Path 'c:\temp\constants.ps1'
True
```
