### PR TITLE
Install-DbaFirstResponderKit - Included TLS protocol override

### DIFF
--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -102,6 +102,8 @@ function Install-DbaFirstResponderKit {
         Write-Message -Level Verbose -Message "Downloading and unzipping the First Responder Kit zip file."
 
         try {
+            $oldSslSettings = [System.Net.ServicePointManager]::SecurityProtocol
+            [System.Net.ServicePointManager]::SecurityProtocol = "Tls12"
             try {
                 Invoke-WebRequest $url -OutFile $zipfile
             }
@@ -110,6 +112,7 @@ function Install-DbaFirstResponderKit {
                 (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
                 Invoke-WebRequest $url -OutFile $zipfile
             }
+            [System.Net.ServicePointManager]::SecurityProtocol = $oldSslSettings
 
             # Unblock if there's a block
             Unblock-File $zipfile -ErrorAction SilentlyContinue


### PR DESCRIPTION

## Type of Change

 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

Temporarily overrides the default TLS protocol settings to be able to access github.