### PR TITLE
Get-DbaRegisteredServer, fixes #3529

### DIFF
--- a/functions/Get-DbaRegisteredServer.ps1
+++ b/functions/Get-DbaRegisteredServer.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaRegisteredServer {
     <#
         .SYNOPSIS
@@ -153,6 +154,10 @@ function Get-DbaRegisteredServer {
             else {
                 $cms = $cmsStore.DatabaseEngineServerGroup
                 $servers += ($cms.GetDescendantRegisteredServers())
+            }
+            if ($Group -and (Test-Bound -ParameterName Group -Not)) {
+                #add root ones
+                $servers += ($cmsstore.DatabaseEngineServerGroup.RegisteredServers)
             }
 
             # Close the connection, otherwise using it with the ServersStore will keep it open

--- a/tests/Get-DbaRegisteredServer.Tests.ps1
+++ b/tests/Get-DbaRegisteredServer.Tests.ps1
@@ -40,10 +40,20 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $newServer2.ServerName = $srvName2
             $newServer2.Description = $regSrvDesc2
             $newServer2.Create()
+
+            $regSrvName3 = "dbatoolsci-server3"
+            $srvName3 = "dbatoolsci-server3"
+            $regSrvDesc3 = "dbatoolsci-server3desc"
+            $newServer3 = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer($dbStore, $regSrvName3)
+            $newServer3.ServerName = $srvName3
+            $newServer3.Description = $regSrvDesc3
+            $newServer3.Create()
         }
         AfterAll {
             <# The top level group is all that is needed to be dropped #>
             $newGroup.Drop()
+            # plus the root one
+            $newServer3.Drop()
         }
 
         It "Should return multiple objects" {
@@ -53,6 +63,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should allow searching subgroups" {
             $results = Get-DbaRegisteredServer -SqlInstance $script:instance1 -Group "$group\$group2"
             $results.Count | Should Be 1
+        }
+        It "Should return the root server when excluding (see #3529)" {
+            $results = Get-DbaRegisteredServer -SqlInstance $script:instance1 -ExcludeGroup "$group\$group2"
+            @($results | Where-Object Name -eq $srvName3).Count | Should -Be 1
         }
 
         # Property Comparisons will come later when we have the commands


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #3529)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fix the bug. A sidecase in how the logic works never considered passing an -ExcludeGroup without an -IncludeGroup, and root servers were left out. Slapped in a regr test to make it never happen again
