### PR TITLE
Read-DbaBackupHeader, fixes #3510

### DIFF
--- a/internal/functions/Convert-DbVersionToSqlVersion.ps1
+++ b/internal/functions/Convert-DbVersionToSqlVersion.ps1
@@ -20,6 +20,7 @@ Returns "SQL Server vNext CTP1"
     )
 
     $dbversion = switch ($dbversion) {
+        869 { "SQL Server 2017"}
         856 { "SQL Server vNext CTP1" }
         852 { "SQL Server 2016" }
         829 { "SQL Server 2016 Prerelease" }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #3510)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fast validation for users not reading the included help. Slapped in also update to the internal "get me the human version of this database version number"

### Approach
We don't do a proper test (that is usually done at a higher level, see Get-DbaBackupInformation) but we duck-infere if it looks like a folder. and if it walks like a duck, it's a duck. (tl;dr: people may wanna stop using extensionless backups)

