### PR TITLE
Connect-FooInstance, try to improve enum times

### DIFF
--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -22,7 +22,7 @@ function Connect-SqlInstance {
 
         .PARAMETER AzureUnsupported
             Throw if Azure is detected but not supported
-    
+
         .PARAMETER RegularUser
             The connection doesn't require SA privileges.
             By default, the assumption is that SA is no longer required.
@@ -222,17 +222,24 @@ function Connect-SqlInstance {
             throw "SQL Server version $MinimumVersion required - $server not supported."
         }
     }
-    
-    
+
     if ($AzureUnsupported -and $server.DatabaseEngineType -eq "SqlAzureDatabase") {
         throw "SQL Azure DB not supported :("
     }
-    
+
     if (-not $RegularUser) {
         if ($server.ConnectionContext.FixedServerRoles -notmatch "SysAdmin") {
             throw "Not a sysadmin on $ConvertedSqlInstance. Quitting."
         }
     }
+    #'PrimaryFilePath' seems the culprit for slow SMO on databases
+    $Fields2000_Db = 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsSystemObject', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'ReadOnly', 'RecoveryModel', 'ReplicationOptions', 'Status', 'Version'
+    $Fields200x_Db = $Fields2000_Db + @('BrokerEnabled', 'IsMirroringEnabled', 'Trustworthy')
+    $Fields201x_Db = $Fields200x_Db + @('ActiveConnections', 'AvailabilityDatabaseSynchronizationState', 'AvailabilityGroupName', 'ContainmentType', 'EncryptionEnabled')
+
+    $Fields2000_Login = 'CreateDate' , 'DateLastModified' , 'DefaultDatabase' , 'DenyWindowsLogin' , 'IsSystemObject' , 'Language' , 'LanguageAlias' , 'LoginType' , 'Name' , 'Sid' , 'WindowsLoginAccessType'
+    $Fields200x_Login = $Fields2000_Login + @('AsymmetricKey', 'Certificate', 'Credential', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'MustChangePassword', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced')
+    $Fields201x_Login = $Fields200x_Login + @('PasswordHashAlgorithm')
 
     if ($loadedSmoVersion -ge 11) {
         try {
@@ -247,18 +254,30 @@ function Connect-SqlInstance {
 
                 if ($server.VersionMajor -eq 8) {
                     # 2000
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Version')
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'CreateDate', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'Name', 'Sid', 'WindowsLoginAccessType')
+                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsDb.AddRange($Fields2000_Db)
+                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsLogin.AddRange($Fields2000_Login)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
                 }
                 elseif ($server.VersionMajor -eq 9 -or $server.VersionMajor -eq 10) {
                     # 2005 and 2008
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'BrokerEnabled', 'Collation', 'CompatibilityLevel', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsMirroringEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Trustworthy', 'Version')
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'AsymmetricKey', 'Certificate', 'CreateDate', 'Credential', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'MustChangePassword', 'Name', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced', 'Sid', 'WindowsLoginAccessType')
+                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsDb.AddRange($Fields200x_Db)
+                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsLogin.AddRange($Fields200x_Login)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
                 }
                 else {
                     # 2012 and above
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], 'ReplicationOptions', 'ActiveConnections', 'AvailabilityDatabaseSynchronizationState', 'AvailabilityGroupName', 'BrokerEnabled', 'Collation', 'CompatibilityLevel', 'ContainmentType', 'CreateDate', 'ID', 'IsAccessible', 'IsFullTextEnabled', 'IsMirroringEnabled', 'IsUpdateable', 'LastBackupDate', 'LastDifferentialBackupDate', 'LastLogBackupDate', 'Name', 'Owner', 'PrimaryFilePath', 'ReadOnly', 'RecoveryModel', 'Status', 'Trustworthy', 'Version')
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], 'AsymmetricKey', 'Certificate', 'CreateDate', 'Credential', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'MustChangePassword', 'Name', 'PasswordExpirationEnabled', 'PasswordHashAlgorithm', 'PasswordPolicyEnforced', 'Sid', 'WindowsLoginAccessType')
+                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsDb.AddRange($Fields201x_Db)
+                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                    [void]$initFieldsLogin.AddRange($Fields201x_Login)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
                 }
             }
         }


### PR DESCRIPTION
## Type of Change
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 - [x] Speedup
 
### Purpose
Discussed briefly on slack with @potatoqualitee and partly confirmed by @wsuhoey... I'll try to recap here.
Topic is slooooow database enumeration on remote instances (read:  "with measurable latency as soon as you hit an instance with 100 dbs you'll get bored").
I created a script that enums every property we have as InitFields. Turns out that it *seems* that PrimaryFilePath is the culprit.
You can all confirm running with this branch something among the lines of
```
$x = connect-dbainstance -sqlinstance 'foo'
$stopwatch =  [system.diagnostics.stopwatch]::StartNew()
$y = $x.Databases.Name
$stopwatch.Stop()
write-host -fore green "took $($stopwatch.Elapsed.TotalMilliSeconds) ms"
```
Best noticeable results can be observed with a remote instance with a lot of databases.

In addition to that, and related to https://github.com/sqlcollaborative/dbatools/issues/3340 , 'IsSystemObject' and 'EncryptionEnabled' were missing (and we use it in Get-DbaDatabase).
On a parallel note, we _may_ want to skip EncryptionEnabled checking in there for anything lower than 2012.

Again, you can test performances with something like this
```
$x = connect-dbainstance -sqlinstance 'foo'
$stopwatch =  [system.diagnostics.stopwatch]::StartNew()
$y = get-dbadatabase -sqlinstance $x
$stopwatch.Stop()
write-host -fore green "took $($stopwatch.Elapsed.TotalMilliSeconds) ms"
```

### Approach
To reorganize the code (maybe it should be reviewed) collections of fields have been prettyfied and put in alphabetical order. At the very least, now they can be better read and compared.


