### PR TITLE
ignore ncrunch files and nuget packages.

### DIFF
--- a/bin/projects/dbatools/.gitignore
+++ b/bin/projects/dbatools/.gitignore
@@ -4,3 +4,6 @@ obj/
 vstest.*/
 /*.pdb/
 *.user
+packages/ 
+*.v3.ncrunchsolution 
+_NCrunch_*/  


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [X] Build system
 
### Purpose
I started using ncrunch. it made some files that should be ignored. At some point I might tell @fred he should use ncrunch. For now, can someone merge this change that ignores the metadata files. 
