### PR TITLE
Exception constructors should be internal

### DIFF
--- a/bin/projects/dbatools/dbatools/Exceptions/BloodyHellGiveMeSomethingToWorkWithException.cs
+++ b/bin/projects/dbatools/dbatools/Exceptions/BloodyHellGiveMeSomethingToWorkWithException.cs
@@ -17,29 +17,11 @@ namespace Sqlcollaborative.Dbatools.Exceptions
         public string ParameterClass;
 
         /// <summary>
-        /// Creates an empty exception
-        /// </summary>
-        public BloodyHellGiveMeSomethingToWorkWithException()
-        {
-
-        }
-
-        /// <summary>
-        /// Creates an exception with a simple message
-        /// </summary>
-        /// <param name="Message">The message to tell</param>
-        public BloodyHellGiveMeSomethingToWorkWithException(string Message)
-            : base(Message)
-        {
-
-        }
-
-        /// <summary>
         /// Creates an exception with a message and a nested exception
         /// </summary>
         /// <param name="Message">The message to tell</param>
         /// <param name="Inner">The inner exception to nest</param>
-        public BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner)
+        internal BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner)
             : base(Message, Inner)
         {
 
@@ -50,7 +32,7 @@ namespace Sqlcollaborative.Dbatools.Exceptions
         /// </summary>
         /// <param name="Message">The message to tell</param>
         /// <param name="ParameterClass">The Parameter Class that threw the exception</param>
-        public BloodyHellGiveMeSomethingToWorkWithException(string Message, string ParameterClass)
+        internal BloodyHellGiveMeSomethingToWorkWithException(string Message, string ParameterClass)
             : base(Message)
         {
             this.ParameterClass = ParameterClass;
@@ -62,7 +44,7 @@ namespace Sqlcollaborative.Dbatools.Exceptions
         /// <param name="Message">The message to tell</param>
         /// <param name="Inner">The inner exception to nest</param>
         /// <param name="ParameterClass">The Parameter Class that threw the exception</param>
-        public BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner, string ParameterClass)
+        internal BloodyHellGiveMeSomethingToWorkWithException(string Message, Exception Inner, string ParameterClass)
             : base(Message, Inner)
         {
             this.ParameterClass = ParameterClass;


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [X] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose

The BloddyHell exception should only be thrown in the C# code. So make the constructors internal. This is how SqlException works in ADO.NET.
