### PR TITLE
Two new commands

### DIFF
--- a/functions/Get-DbaDbCheckConstraint.ps1
+++ b/functions/Get-DbaDbCheckConstraint.ps1
@@ -1,0 +1,126 @@
+function Get-DbaDbCheckConstraint {
+    <#
+        .SYNOPSIS
+            Gets database Check constraints
+
+        .DESCRIPTION
+            Gets database Checks constraints
+
+        .PARAMETER SqlInstance
+            The target SQL Server instance(s)
+
+        .PARAMETER SqlCredential
+            Allows you to login to SQL Server using alternative credentials
+
+        .PARAMETER Database
+            To get Checks from specific database(s)
+
+        .PARAMETER ExcludeDatabase
+            The database(s) to exclude - this list is auto populated from the server
+
+        .PARAMETER ExcludeSystemSp
+            This switch removes all system objects from the Stored Procedure collection
+
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+        .NOTES
+            Tags: Databases
+            Author: Cláudio Silva ( @ClaudioESSilva | https://claudioessilva.eu)
+
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
+
+        .EXAMPLE
+            Get-DbaDbCheckConstraint -SqlInstance sql2016
+
+            Gets all database check constraints
+
+        .EXAMPLE
+            Get-DbaDbCheckConstraint -SqlInstance Server1 -Database db1
+
+            Gets the check constraints for the db1 database
+
+        .EXAMPLE
+            Get-DbaDbCheckConstraint -SqlInstance Server1 -ExcludeDatabase db1
+
+            Gets the check constraints for all databases except db1
+
+        .EXAMPLE
+            Get-DbaDbCheckConstraint -SqlInstance Server1 -ExcludeSystemSp
+
+            Gets the check constraints for all databases that are not system objects
+
+        .EXAMPLE
+            'Sql1','Sql2/sqlexpress' | Get-DbaDbCheckConstraint
+
+            Gets the check constraints for the databases on Sql1 and Sql2/sqlexpress
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [object[]]$Table,
+        [object[]]$ExcludeTable,
+        [switch]$ExcludeSystemTable,
+        [Alias('Silent')]
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            $databases = $server.Databases | Where-Object IsAccessible
+
+            if ($Database) {
+                $databases = $databases | Where-Object Name -In $Database
+            }
+            if ($ExcludeDatabase) {
+                $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
+            }
+
+            foreach ($db in $databases) {
+                if (!$db.IsAccessible) {
+                    Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
+                    continue
+                }
+
+                foreach($tbl in $db.Tables) {
+                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $bl.IsSystemObject ) {
+                        continue
+                    }
+
+                    if ($tbl.Checks.Count -eq 0) {
+                        Write-Message -Message "No Checks exist in $tbl table on the $db database on $instance" -Target $tbl -Level Output
+                        continue
+                    }
+
+                    foreach ($ck in $tbl.Checks) {
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name Database -value $db.Name
+
+                        $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Parent', 'ID', 'CreateDate',
+                        'DateLastModified', 'Name', 'IsEnabled', 'IsChecked', 'NotForReplication', 'Text', 'State'
+                        Select-DefaultView -InputObject $ck -Property $defaults
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaDbCheckConstraint.ps1
+++ b/functions/Get-DbaDbCheckConstraint.ps1
@@ -18,8 +18,8 @@ function Get-DbaDbCheckConstraint {
         .PARAMETER ExcludeDatabase
             The database(s) to exclude - this list is auto populated from the server
 
-        .PARAMETER ExcludeSystemSp
-            This switch removes all system objects from the Stored Procedure collection
+        .PARAMETER ExcludeSystemTable
+            This switch removes all system objects from the table collection
 
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -50,7 +50,7 @@ function Get-DbaDbCheckConstraint {
             Gets the check constraints for all databases except db1
 
         .EXAMPLE
-            Get-DbaDbCheckConstraint -SqlInstance Server1 -ExcludeSystemSp
+            Get-DbaDbCheckConstraint -SqlInstance Server1 -ExcludeSystemTable
 
             Gets the check constraints for all databases that are not system objects
 
@@ -67,8 +67,6 @@ function Get-DbaDbCheckConstraint {
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [object[]]$Table,
-        [object[]]$ExcludeTable,
         [switch]$ExcludeSystemTable,
         [Alias('Silent')]
         [switch]$EnableException
@@ -100,7 +98,7 @@ function Get-DbaDbCheckConstraint {
                 }
 
                 foreach($tbl in $db.Tables) {
-                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $bl.IsSystemObject ) {
+                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $tbl.IsSystemObject ) {
                         continue
                     }
 

--- a/functions/Get-DbaDbCheckConstraint.ps1
+++ b/functions/Get-DbaDbCheckConstraint.ps1
@@ -103,7 +103,7 @@ function Get-DbaDbCheckConstraint {
                     }
 
                     if ($tbl.Checks.Count -eq 0) {
-                        Write-Message -Message "No Checks exist in $tbl table on the $db database on $instance" -Target $tbl -Level Output
+                        Write-Message -Message "No Checks exist in $tbl table on the $db database on $instance" -Target $tbl -Level Verbose
                         continue
                     }
 

--- a/functions/Get-DbaDbForeignKey.ps1
+++ b/functions/Get-DbaDbForeignKey.ps1
@@ -1,0 +1,126 @@
+function Get-DbaDbForeignKey {
+    <#
+        .SYNOPSIS
+            Gets database Foreign Keys
+
+        .DESCRIPTION
+            Gets database Foreign Keys
+
+        .PARAMETER SqlInstance
+            The target SQL Server instance(s)
+
+        .PARAMETER SqlCredential
+            Allows you to login to SQL Server using alternative credentials
+
+        .PARAMETER Database
+            To get Foreign Keys from specific database(s)
+
+        .PARAMETER ExcludeDatabase
+            The database(s) to exclude - this list is auto populated from the server
+
+        .PARAMETER ExcludeSystemSp
+            This switch removes all system objects from the Stored Procedure collection
+
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+        .NOTES
+            Tags: Databases
+            Author: Cláudio Silva ( @ClaudioESSilva | https://claudioessilva.eu)
+
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
+
+        .EXAMPLE
+            Get-DbaDbForeignKey -SqlInstance sql2016
+
+            Gets all database Foreign Keys
+
+        .EXAMPLE
+            Get-DbaDbForeignKey -SqlInstance Server1 -Database db1
+
+            Gets the Foreign Keys for the db1 database
+
+        .EXAMPLE
+            Get-DbaDbForeignKey -SqlInstance Server1 -ExcludeDatabase db1
+
+            Gets the Foreign Keys for all databases except db1
+
+        .EXAMPLE
+            Get-DbaDbForeignKey -SqlInstance Server1 -ExcludeSystemSp
+
+            Gets the Foreign Keys for all databases that are not system objects
+
+        .EXAMPLE
+            'Sql1','Sql2/sqlexpress' | Get-DbaDbForeignKey
+
+            Gets the Foreign Keys for the databases on Sql1 and Sql2/sqlexpress
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [object[]]$Table,
+        [object[]]$ExcludeTable,
+        [switch]$ExcludeSystemTable,
+        [Alias('Silent')]
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $instance"
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            $databases = $server.Databases | Where-Object IsAccessible
+
+            if ($Database) {
+                $databases = $databases | Where-Object Name -In $Database
+            }
+            if ($ExcludeDatabase) {
+                $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
+            }
+
+            foreach ($db in $databases) {
+                if (!$db.IsAccessible) {
+                    Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
+                    continue
+                }
+
+                foreach($tbl in $db.Tables) {
+                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $bl.IsSystemObject ) {
+                        continue
+                    }
+
+                    if ($tbl.ForeignKeys.Count -eq 0) {
+                        Write-Message -Message "No Foreign Keys exist in $tbl table on the $db database on $instance" -Target $tbl -Level Output
+                        continue
+                    }
+
+                    foreach ($fk in $tbl.ForeignKeys) {
+                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name Database -value $db.Name
+
+                        $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Table', 'ID', 'CreateDate',
+                        'DateLastModified', 'Name', 'IsEnabled', 'IsChecked', 'NotForReplication', 'ReferencedKey', 'ReferencedTable', 'ReferencedTableSchema'
+                        Select-DefaultView -InputObject $fk -Property $defaults
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaDbForeignKey.ps1
+++ b/functions/Get-DbaDbForeignKey.ps1
@@ -18,8 +18,8 @@ function Get-DbaDbForeignKey {
         .PARAMETER ExcludeDatabase
             The database(s) to exclude - this list is auto populated from the server
 
-        .PARAMETER ExcludeSystemSp
-            This switch removes all system objects from the Stored Procedure collection
+        .PARAMETER ExcludeSystemTable
+            This switch removes all system objects from the tables collection
 
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -50,9 +50,9 @@ function Get-DbaDbForeignKey {
             Gets the Foreign Keys for all databases except db1
 
         .EXAMPLE
-            Get-DbaDbForeignKey -SqlInstance Server1 -ExcludeSystemSp
+            Get-DbaDbForeignKey -SqlInstance Server1 -ExcludeSystemTable
 
-            Gets the Foreign Keys for all databases that are not system objects
+            Gets the Foreign Keys from all tables that are not system objects from all databases
 
         .EXAMPLE
             'Sql1','Sql2/sqlexpress' | Get-DbaDbForeignKey
@@ -67,8 +67,6 @@ function Get-DbaDbForeignKey {
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [object[]]$Table,
-        [object[]]$ExcludeTable,
         [switch]$ExcludeSystemTable,
         [Alias('Silent')]
         [switch]$EnableException
@@ -100,7 +98,7 @@ function Get-DbaDbForeignKey {
                 }
 
                 foreach($tbl in $db.Tables) {
-                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $bl.IsSystemObject ) {
+                    if ( (Test-Bound -ParameterName ExcludeSystemTable) -and $tbl.IsSystemObject ) {
                         continue
                     }
 

--- a/functions/Get-DbaDbForeignKey.ps1
+++ b/functions/Get-DbaDbForeignKey.ps1
@@ -103,7 +103,7 @@ function Get-DbaDbForeignKey {
                     }
 
                     if ($tbl.ForeignKeys.Count -eq 0) {
-                        Write-Message -Message "No Foreign Keys exist in $tbl table on the $db database on $instance" -Target $tbl -Level Output
+                        Write-Message -Message "No Foreign Keys exist in $tbl table on the $db database on $instance" -Target $tbl -Level Verbose
                         continue
                     }
 

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -32,7 +32,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $ckName = "dbatools_getdbck"
         $dbname = "dbatoolsci_getdbfk$random"
         $server.Query("CREATE DATABASE $dbname")
-        $server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+        $server.Query("CREATE TABLE $tableName (idTbl1 INT PRIMARY KEY)", $dbname)
         $server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT, id3 INT)", $dbname)
         $server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $ckName CHECK (id3 > 10)", $dbname)
     }

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -41,7 +41,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
     }
 
-    Context "Can get table check constraints" {
+    Context "Command actually works" {
         It "returns no check constraints from excluded DB with -ExcludeDatabase" {
             $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeDatabase master
             $results.where( {$_.Database -eq 'master'}).count | Should Be 0
@@ -50,13 +50,13 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname
             $results.where( {$_.Database -ne 'master'}).count | Should Be 1
         }
-        It "returns no check constraints with -ExcludeTable" {
-            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeTable $tableName2
-            $results.count | Should Be 0
+        It "Should include test check constraint: $ckName" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemTable
+            ($results | Where-Object Name -eq $ckName).Name | Should Be $ckName
         }
-        It "returns check constraints without -ExcludeTable" {
-            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2
-            $results.count | Should BeGreaterThan 0
+        It "Should exclude system tables" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database master -ExcludeSystemTable
+            ($results | Where-Object Name -eq 'spt_fallback_db') | Should Be $null
         }
     }
 }

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -10,10 +10,10 @@ Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
                 - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
                 - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
         #>
-        $paramCount = 8
+        $paramCount = 6
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaDbCheckConstraint).Parameters.Keys
-		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'Table', 'ExcludeTable', 'ExcludeSystemTable'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'ExcludeSystemTable'
         It "Should contain our specific parameters" {
             ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
         }
@@ -24,39 +24,39 @@ Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
 }
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
-	BeforeAll {
+    BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
-		$random = Get-Random
-		$tableName = "dbatools_getdbtbl1"
-		$tableName2 = "dbatools_getdbtbl2"
+        $random = Get-Random
+        $tableName = "dbatools_getdbtbl1"
+        $tableName2 = "dbatools_getdbtbl2"
         $ckName = "dbatools_getdbck"
         $dbname = "dbatoolsci_getdbfk$random"
         $server.Query("CREATE DATABASE $dbname")
-		$server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
-		$server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT, id3 INT)", $dbname)
-		$server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $ckName CHECK (id3 > 10)", $dbname)
+        $server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+        $server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT, id3 INT)", $dbname)
+        $server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $ckName CHECK (id3 > 10)", $dbname)
     }
 
-	AfterAll {
-		$null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
-	}
+    AfterAll {
+        $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+    }
 
-	Context "Can get table check constraints" {
-		It "returns no check constraints from excluded DB with -ExcludeDatabase" {
-			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeDatabase master
-			$results.where( {$_.Database -eq 'master'}).count | Should Be 0
-		}
-		It "returns only check constraints from selected DB with -Database" {
-			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname
-			$results.where( {$_.Database -ne 'master'}).count | Should Be 1
-		}
-		It "returns no check constraints with -ExcludeTable" {
-			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeTable $tableName2
-			$results.count | Should Be 0
-		}
-		It "returns check constraints without -ExcludeTable" {
-			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2
-			$results.count | Should BeGreaterThan 0
-		}
-	}
+    Context "Can get table check constraints" {
+        It "returns no check constraints from excluded DB with -ExcludeDatabase" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeDatabase master
+            $results.where( {$_.Database -eq 'master'}).count | Should Be 0
+        }
+        It "returns only check constraints from selected DB with -Database" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname
+            $results.where( {$_.Database -ne 'master'}).count | Should Be 1
+        }
+        It "returns no check constraints with -ExcludeTable" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeTable $tableName2
+            $results.count | Should Be 0
+        }
+        It "returns check constraints without -ExcludeTable" {
+            $results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2
+            $results.count | Should BeGreaterThan 0
+        }
+    }
 }

--- a/tests/Get-DbaDbCheckConstraint.Tests.ps1
+++ b/tests/Get-DbaDbCheckConstraint.Tests.ps1
@@ -1,0 +1,62 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 8
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaDbCheckConstraint).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'Table', 'ExcludeTable', 'ExcludeSystemTable'
+        It "Should contain our specific parameters" {
+            ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
+	BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+		$random = Get-Random
+		$tableName = "dbatools_getdbtbl1"
+		$tableName2 = "dbatools_getdbtbl2"
+        $ckName = "dbatools_getdbck"
+        $dbname = "dbatoolsci_getdbfk$random"
+        $server.Query("CREATE DATABASE $dbname")
+		$server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+		$server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT, id3 INT)", $dbname)
+		$server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $ckName CHECK (id3 > 10)", $dbname)
+    }
+
+	AfterAll {
+		$null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+	}
+
+	Context "Can get table check constraints" {
+		It "returns no check constraints from excluded DB with -ExcludeDatabase" {
+			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeDatabase master
+			$results.where( {$_.Database -eq 'master'}).count | Should Be 0
+		}
+		It "returns only check constraints from selected DB with -Database" {
+			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -Database $dbname
+			$results.where( {$_.Database -ne 'master'}).count | Should Be 1
+		}
+		It "returns no check constraints with -ExcludeTable" {
+			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2 -ExcludeTable $tableName2
+			$results.count | Should Be 0
+		}
+		It "returns check constraints without -ExcludeTable" {
+			$results = Get-DbaDbCheckConstraint -SqlInstance $script:instance2
+			$results.count | Should BeGreaterThan 0
+		}
+	}
+}

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -32,7 +32,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $fkName = "dbatools_getdbfk"
         $dbname = "dbatoolsci_getdbfk$random"
         $server.Query("CREATE DATABASE $dbname")
-        $server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+        $server.Query("CREATE TABLE $tableName (idTbl1 INT PRIMARY KEY)", $dbname)
         $server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT)", $dbname)
         $server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $fkName FOREIGN KEY (idTbl1) REFERENCES $tableName (idTbl1) ON UPDATE NO ACTION ON DELETE NO ACTION ", $dbname)
     }
@@ -41,7 +41,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
     }
 
-    Context "Can get table foreign keys" {
+    Context "Command actually works" {
         It "returns no foreign keys from excluded DB with -ExcludeDatabase" {
             $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeDatabase master
             $results.where( {$_.Database -eq 'master'}).count | Should Be 0

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -50,13 +50,13 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname
             $results.where( {$_.Database -ne 'master'}).count | Should Be 1
         }
-        It "returns no foreign keys with -ExcludeTable" {
-            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeTable $tableName2
-            $results.count | Should Be 0
+        It "Should include test foreign keys: $ckName" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemTable
+            ($results | Where-Object Name -eq $ckName).Name | Should Be $ckName
         }
-        It "returns foreign keys without -ExcludeTable" {
-            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2
-            $results.count | Should BeGreaterThan 0
+        It "Should exclude system tables" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database master -ExcludeSystemTable
+            ($results | Where-Object Name -eq 'spt_fallback_db') | Should Be $null
         }
     }
 }

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -10,10 +10,10 @@ Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
                 - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
                 - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
         #>
-        $paramCount = 8
+        $paramCount = 6
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaDbForeignKey).Parameters.Keys
-		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'Table', 'ExcludeTable', 'ExcludeSystemTable'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'ExcludeSystemTable'
         It "Should contain our specific parameters" {
             ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
         }
@@ -24,39 +24,39 @@ Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
 }
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
-	BeforeAll {
+    BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
-		$random = Get-Random
-		$tableName = "dbatools_getdbtbl1"
-		$tableName2 = "dbatools_getdbtbl2"
+        $random = Get-Random
+        $tableName = "dbatools_getdbtbl1"
+        $tableName2 = "dbatools_getdbtbl2"
         $fkName = "dbatools_getdbfk"
         $dbname = "dbatoolsci_getdbfk$random"
         $server.Query("CREATE DATABASE $dbname")
-		$server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
-		$server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT)", $dbname)
-		$server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $fkName FOREIGN KEY (idTbl1) REFERENCES $tableName (idTbl1) ON UPDATE NO ACTION ON DELETE NO ACTION ", $dbname)
+        $server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+        $server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT)", $dbname)
+        $server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $fkName FOREIGN KEY (idTbl1) REFERENCES $tableName (idTbl1) ON UPDATE NO ACTION ON DELETE NO ACTION ", $dbname)
     }
 
-	AfterAll {
-		$null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
-	}
+    AfterAll {
+        $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+    }
 
-	Context "Can get table foreign keys" {
-		It "returns no foreign keys from excluded DB with -ExcludeDatabase" {
-			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeDatabase master
-			$results.where( {$_.Database -eq 'master'}).count | Should Be 0
-		}
-		It "returns only foreign keys from selected DB with -Database" {
-			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname
-			$results.where( {$_.Database -ne 'master'}).count | Should Be 1
-		}
-		It "returns no foreign keys with -ExcludeTable" {
-			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeTable $tableName2
-			$results.count | Should Be 0
-		}
-		It "returns foreign keys without -ExcludeTable" {
-			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2
-			$results.count | Should BeGreaterThan 0
-		}
-	}
+    Context "Can get table foreign keys" {
+        It "returns no foreign keys from excluded DB with -ExcludeDatabase" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeDatabase master
+            $results.where( {$_.Database -eq 'master'}).count | Should Be 0
+        }
+        It "returns only foreign keys from selected DB with -Database" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname
+            $results.where( {$_.Database -ne 'master'}).count | Should Be 1
+        }
+        It "returns no foreign keys with -ExcludeTable" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeTable $tableName2
+            $results.count | Should Be 0
+        }
+        It "returns foreign keys without -ExcludeTable" {
+            $results = Get-DbaDbForeignKey -SqlInstance $script:instance2
+            $results.count | Should BeGreaterThan 0
+        }
+    }
 }

--- a/tests/Get-DbaDbForeignKey.Tests.ps1
+++ b/tests/Get-DbaDbForeignKey.Tests.ps1
@@ -1,0 +1,62 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 8
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaDbForeignKey).Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Database', 'ExcludeDatabase', 'Table', 'ExcludeTable', 'ExcludeSystemTable'
+        It "Should contain our specific parameters" {
+            ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
+	BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+		$random = Get-Random
+		$tableName = "dbatools_getdbtbl1"
+		$tableName2 = "dbatools_getdbtbl2"
+        $fkName = "dbatools_getdbfk"
+        $dbname = "dbatoolsci_getdbfk$random"
+        $server.Query("CREATE DATABASE $dbname")
+		$server.Query("CREATE TABLE $tableName (idTbl1 INT)", $dbname)
+		$server.Query("CREATE TABLE $tableName2 (idTbl2 INT, idTbl1 INT)", $dbname)
+		$server.Query("ALTER TABLE $tableName2 ADD CONSTRAINT $fkName FOREIGN KEY (idTbl1) REFERENCES $tableName (idTbl1) ON UPDATE NO ACTION ON DELETE NO ACTION ", $dbname)
+    }
+
+	AfterAll {
+		$null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+	}
+
+	Context "Can get table foreign keys" {
+		It "returns no foreign keys from excluded DB with -ExcludeDatabase" {
+			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeDatabase master
+			$results.where( {$_.Database -eq 'master'}).count | Should Be 0
+		}
+		It "returns only foreign keys from selected DB with -Database" {
+			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname
+			$results.where( {$_.Database -ne 'master'}).count | Should Be 1
+		}
+		It "returns no foreign keys with -ExcludeTable" {
+			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2 -ExcludeTable $tableName2
+			$results.count | Should Be 0
+		}
+		It "returns foreign keys without -ExcludeTable" {
+			$results = Get-DbaDbForeignKey -SqlInstance $script:instance2
+			$results.count | Should BeGreaterThan 0
+		}
+	}
+}


### PR DESCRIPTION
Let me know if the name of both commands sounds good or if we should change it.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add two new commands
- Get-DbaDbForeignKey
- Get-DbaDbCheckConstraint

### Commands to test
Both

### Screenshots
`Get-DbaDbCheckConstraint -SqlInstance "." | OGV`
![image](https://user-images.githubusercontent.com/19521315/39199425-55ba16d0-47e1-11e8-8d00-ed8becb33a7a.png)


`Get-DbaDbCheckConstraint -SqlInstance "."`
![image](https://user-images.githubusercontent.com/19521315/39199472-6f5c61e2-47e1-11e8-9cdd-8d59d40a4353.png)


`Get-DbaDbForeignKey -SqlInstance "." -Database ReportServer | OGV`
![image](https://user-images.githubusercontent.com/19521315/39199394-42707bfa-47e1-11e8-8d94-8ec2d40b9c96.png)

`Get-DbaDbForeignKey -SqlInstance "." -Database ReportServer -Verbose`
![image](https://user-images.githubusercontent.com/19521315/39199495-7ff604e0-47e1-11e8-9cd7-7c0bedd87506.png)


### Note
Once they got approved, will add a new pester test to [dbachecks](https://github.com/sqlcollaborative/dbachecks)
