### PR TITLE
ConvertTo-DbaDataTable, handle corner-case

### DIFF
--- a/tests/ConvertTo-DbaDataTable.Tests.ps1
+++ b/tests/ConvertTo-DbaDataTable.Tests.ps1
@@ -237,4 +237,19 @@ Describe "Testing input parameters" {
 
         }
     }
+
+    Context "Verifying a datatable gets cloned when passed in" {
+        $obj = New-Object -TypeName psobject -Property @{
+            col1 = 'col1'
+            col2 = 'col2'
+        }
+        $first = $obj | ConvertTo-DbaDataTable
+        $second = $first | ConvertTo-DbaDataTable
+        It "Should have the same columns" {
+            # does not add ugly RowError,RowState Table, ItemArray, HasErrors
+            $firstColumns = ($first.Columns.ColumnName | Sort-Object) -Join ','
+            $secondColumns = ($second.Columns.ColumnName | Sort-Object) -Join ','
+            $firstColumns | Should -Be $secondColumns
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Happened a few times to me, and has been reported in Slack too... When you had a datatable already, convertto-dbadatatable would do a psobject conversion under the hood ending up 1) with poor performances 2) with added columns such as RowError,RowState Table, ItemArray, HasErrors

### Approach
Unfortunately the conversion gets done at param level so the only way is to shortcircuit all the logic: when the first row in the process loop is a datarow, we just return the cloned datatable.

### Commands to test
The added test shows the "problem". Another way to make the bad behaviour triggered was playing with , e.g., 
```
$sourcetable = Invoke-SqlCmd2 -ServerInstance localhost -query "select top 2 database_id, name from sys.databases" -as DataTable #-As PSObject
$sourcetable_converted = $sourcetable | ConvertTo-DbaDataTable
```
