### PR TITLE
Get-DbaOrphanUser, fixes #3573

### DIFF
--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Repair-DbaOrphanUser {
     <#
         .SYNOPSIS
@@ -22,6 +23,9 @@ function Repair-DbaOrphanUser {
 
         .PARAMETER Database
             Specifies the database(s) to process. Options for this list are auto-populated from the server. If unspecified, all databases will be processed.
+
+        .PARAMETER ExcludeDatabase
+            Specifies the database(s) to exclude from processing. Options for this list are auto-populated from the server
 
         .PARAMETER Users
             Specifies the list of usernames to repair.
@@ -76,6 +80,7 @@ function Repair-DbaOrphanUser {
         .NOTES
             Tags: Orphan
             Author: Claudio Silva (@ClaudioESSilva)
+            Editor: Simone Bizzotto (@niphlod)
             Website: https://dbatools.io
             Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
             License: MIT https://opensource.org/licenses/MIT
@@ -91,6 +96,7 @@ function Repair-DbaOrphanUser {
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
+        [object[]]$ExcludeDatabase,
         [parameter(Mandatory = $false, ValueFromPipeline = $true)]
         [object[]]$Users,
         [switch]$RemoveNotExisting,
@@ -100,7 +106,7 @@ function Repair-DbaOrphanUser {
     )
 
     process {
-        $start = [System.Diagnostics.Stopwatch]::StartNew()
+
         foreach ($instance in $SqlInstance) {
 
             try {
@@ -112,18 +118,13 @@ function Repair-DbaOrphanUser {
                 continue
             }
 
-            if ($Database.Count -eq 0) {
+            $DatabaseCollection = $server.Databases | Where-Object IsAccessible
 
-                $DatabaseCollection = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true }
+            if ($Database) {
+                $DatabaseCollection = $DatabaseCollection | Where-Object Name -In $Database
             }
-            else {
-                if ($pipedatabase.Length -gt 0) {
-                    $Source = $pipedatabase[0].parent.name
-                    $DatabaseCollection = $pipedatabase.name
-                }
-                else {
-                    $DatabaseCollection = $server.Databases | Where-Object { $_.IsSystemObject -eq $false -and $_.IsAccessible -eq $true -and ($Database -contains $_.Name) }
-                }
+            if ($ExcludeDatabase) {
+                $DatabaseCollection = $DatabaseCollection | Where-Object Name -NotIn $ExcludeDatabase
             }
 
             if ($DatabaseCollection.Count -gt 0) {
@@ -144,14 +145,10 @@ function Repair-DbaOrphanUser {
                             $UsersToWork = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false }
                         }
                         else {
-                            if ($pipedatabase.Length -gt 0) {
-                                $Source = $pipedatabase[3].parent.name
-                                $UsersToWork = $pipedatabase.name
-                            }
-                            else {
-                                #the fourth validation will remove from list sql users without login. The rule here is Sid with length higher than 16
-                                $UsersToWork = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($Users -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
-                            }
+
+                            #the fourth validation will remove from list sql users without login. The rule here is Sid with length higher than 16
+                            $UsersToWork = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($Users -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin) -eq $false) }
+
                         }
 
                         if ($UsersToWork.Count -gt 0) {
@@ -175,10 +172,12 @@ function Repair-DbaOrphanUser {
 
                                     if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
                                         $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-                                        Write-Message -Level Verbose -Message "`r`nUser '$($User.Name)' mapped with their login."
+                                        Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
 
                                         [PSCustomObject]@{
-                                            SqlInstance  = $server.name
+                                            ComputerName = $server.NetName
+                                            InstanceName = $server.ServiceName
+                                            SqlInstance  = $server.DomainInstanceName
                                             DatabaseName = $db.Name
                                             User         = $User.Name
                                             Status       = "Success"
@@ -193,7 +192,9 @@ function Repair-DbaOrphanUser {
                                     else {
                                         Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
                                         [PSCustomObject]@{
-                                            SqlInstance  = $server.name
+                                            ComputerName = $server.NetName
+                                            InstanceName = $server.ServiceName
+                                            SqlInstance  = $server.DomainInstanceName
                                             DatabaseName = $db.Name
                                             User         = $User.Name
                                             Status       = "No matching login"
@@ -207,15 +208,15 @@ function Repair-DbaOrphanUser {
                                 if ($Force) {
                                     if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
                                         Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser' with -Force."
-                                        Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove -Force
+                                        Remove-DbaOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove -Force
                                     }
                                 }
-                                Else {
-                                    If ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
-                                    Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser'."
-                                    Remove-DbaOrphanUser -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Database $db.Name -User $UsersToRemove
+                                else {
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaOrphanUser")) {
+                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaOrphanUser'."
+                                        Remove-DbaOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove
+                                    }
                                 }
-                            }
                             }
                         }
                         else {
@@ -235,10 +236,6 @@ function Repair-DbaOrphanUser {
         }
     }
     end {
-        $totaltime = ($start.Elapsed)
-        $start.Stop()
-        Write-Message -Level Verbose -Message "Total Elapsed time: $totaltime."
-
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Repair-SqlOrphanUser
     }
 }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Main thing was to get rid of the unusual behaviour described in #3573 but since functions needed to be adapted no matter what, this includes more fixes.
Let this be a review of all code relating to orphan users (hopefully it won't take weeks though ^_^). Code was "old-ish" and get/remove were actually fast copy-paste from the original repair-. Now everything is more "1.0" ready but we're not there yet completely. 

### Approach
Fixed a few things, removed code paths never executed, added tests stubs
Standardized:
  - params
  - output properties

### Tests
Added proper unittest without relying on the database with just one orphan user in appveyorlabrepo. That is probably the reason behind slipping in a change in behaviour (when multiple orphans are found within the same database). Now the main behaviour is set, and less experienced users/lazier can chime in adding tests for uncovered code branches.

### Discuss
Naming conventions (see #3573): once everyone is on board, I'd feel safer to merge this and then approach just the rename in another PR

Remove-DbaOrphanUser: 
  - doesn't return anything (like Remove-Item) but I'm not sure if that's something dbatools wants. We *may* output the usual properties plus status = 'Dropped' easily
  - Not sure if the output properties should change: in fact, when a schema or owner needs dropping/altering, remove-dbaorphanuser DOES output something
 - again, when everybody is on board, I'll create the relevant test suite