### PR TITLE
Set-DbaDbCompression - failed for in memory tables, added exclusion

### DIFF
--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -185,7 +185,7 @@ function Set-DbaDbCompression {
                     }
                     else {
                         Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
-                        foreach ($obj in $server.Databases[$($db.name)].Tables | where {!$_.IsMemoryOptimized}) {
+                        foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object {!$_.IsMemoryOptimized}) {
                             if ($obj.HasHeapIndex) {
                                 if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
@@ -219,7 +219,7 @@ function Set-DbaDbCompression {
                                 }
                             }
 
-                            foreach ($index in $($obj.Indexes)) {
+                            foreach ($index in $($obj.Indexes | Where-Object {!$_.IsMemoryOptimized})) {
                                 if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
                                     break

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -185,7 +185,7 @@ function Set-DbaDbCompression {
                     }
                     else {
                         Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
-                        foreach ($obj in $server.Databases[$($db.name)].Tables) {
+                        foreach ($obj in $server.Databases[$($db.name)].Tables | where {!$_.IsMemoryOptimized}) {
                             if ($obj.HasHeapIndex) {
                                 if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -137,7 +137,7 @@ function Set-DbaDbCompression {
                 try {
                     Write-Message -Level Verbose -Message "Querying $instance - $db"
                     if ($db.status -ne 'Normal' -or $db.IsAccessible -eq $false) {
-                        Write-Message -Level Warning -Message "$db is not accessible." -Target $db
+                        Write-Message -Level Warning -Message "$db is not accessible" -Target $db
                         continue
                     }
                     if ($db.CompatibilityLevel -lt 'Version100') {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Can't compress in memory objects so running the following fails if there were in memory objects
`Set-DbaDbCompression -SqlInstance server1 -Database database1 -CompressionType ROW`

### Approach
<!-- How does this change solve that purpose -->
Exclude those objects when looping through all tables and all indexes
`Where-Object {!$_.IsMemoryOptimized})`