### PR TITLE
Check for running instead of status

### DIFF
--- a/functions/Watch-DbaXESession.ps1
+++ b/functions/Watch-DbaXESession.ps1
@@ -85,8 +85,7 @@ function Watch-DbaXESession {
         }
         
         if ($InputObject) {
-            $status = $InputObject.Status
-            if ($status -ne "Running") {
+            if (-Not $InputObject.IsRunning) {
                 Stop-Function -Message "$($InputObject.Name) is in a $status state."
                 return
             }


### PR DESCRIPTION
Fixes #3583

Altered the check to check the IsRunning property instead of status.

Replaced 

https://github.com/sqlcollaborative/dbatools/blob/development/functions/Watch-DbaXESession.ps1#L89  

Tested against
14.0.3015 2017 RTM
13.0.4001 2016 SP1
12.0.5000 2014 SP2
11.0.7001 2012 SP4

Before

![image](https://user-images.githubusercontent.com/6729780/39637825-0b02fb6a-4fbc-11e8-85d7-0229b80ab3ff.png)

Afterwards

![image](https://user-images.githubusercontent.com/6729780/39638058-e554cb7c-4fbc-11e8-9206-171525b69ea1.png)

![image](https://user-images.githubusercontent.com/6729780/39638173-472cb77e-4fbd-11e8-8a21-c4eb54df90ee.png)

![image](https://user-images.githubusercontent.com/6729780/39638323-ca9b01d8-4fbd-11e8-957f-bbdf601ae8b5.png)

![image](https://user-images.githubusercontent.com/6729780/39638360-e4d0e554-4fbd-11e8-843f-4d3dae3c6f08.png)


