### PR TITLE
Fix Get-DbaLastBackup with SQL Auth

### DIFF
--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -99,9 +99,9 @@ function Get-DbaLastBackup {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
             # Get-DbaBackupHistory -Last would make the job in one query but SMO's (and this) report the last backup of this type irregardless of the chain
-            $FullHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastFull -IncludeCopyOnly -Raw
-            $DiffHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastDiff -IncludeCopyOnly -Raw
-            $IncrHistory = Get-DbaBackupHistory -SqlInstance $instance  -Database $dbs.Name -LastLog -IncludeCopyOnly -Raw
+            $FullHistory = Get-DbaBackupHistory -SqlInstance $server -Database $dbs.Name -LastFull -IncludeCopyOnly -Raw
+            $DiffHistory = Get-DbaBackupHistory -SqlInstance $server -Database $dbs.Name -LastDiff -IncludeCopyOnly -Raw
+            $IncrHistory = Get-DbaBackupHistory -SqlInstance $server -Database $dbs.Name -LastLog -IncludeCopyOnly -Raw
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $db on $instance"
 


### PR DESCRIPTION

## Type of Change

 - [ X] Bug fix (non-breaking change, fixes #3587 

### Purpose

Get-DbaLastBackup to work with SQL Auth

### Approach
Uses Server variable instead of instance in call to get-dbalastbackuphistory


### Screenshots

Before
![image](https://user-images.githubusercontent.com/6729780/39672852-0e414448-512a-11e8-8355-34f7523dbb4d.png)

After

![image](https://user-images.githubusercontent.com/6729780/39672995-4b417776-512c-11e8-8b85-fcfb298dcd11.png)

