### PR TITLE
Invoke-DbaSqlQuery, enhance messaging

### DIFF
--- a/internal/functions/Invoke-DbaSqlAsync.ps1
+++ b/internal/functions/Invoke-DbaSqlAsync.ps1
@@ -1,0 +1,301 @@
+﻿function Invoke-DbaSqlAsync {
+    <#
+        .SYNOPSIS
+            Runs a T-SQL script.
+
+        .DESCRIPTION
+            Runs a T-SQL script. It's a stripped down version of https://github.com/sqlcollaborative/Invoke-SqlCmd2 and adapted to use dbatools' facilities.
+            If you're looking for a public usable function, see Invoke-DbaSqlQuery
+
+        .PARAMETER SQLConnection
+            Specifies an existing SQLConnection object to use in connecting to SQL Server.
+
+        .PARAMETER Query
+            Specifies one or more queries to be run. The queries can be Transact-SQL, XQuery statements, or sqlcmd commands. Multiple queries in a single batch may be separated by a semicolon.
+
+            Do not specify the sqlcmd GO separator (or, use the ParseGo parameter). Escape any double quotation marks included in the string.
+
+            Consider using bracketed identifiers such as [MyTable] instead of quoted identifiers such as "MyTable".
+
+        .PARAMETER QueryTimeout
+            Specifies the number of seconds before the queries time out.
+
+        .PARAMETER As
+            Specifies output type. Valid options for this parameter are 'DataSet', 'DataTable', 'DataRow', 'PSObject', and 'SingleValue'
+
+            PSObject output introduces overhead but adds flexibility for working with results: http://powershell.org/wp/forums/topic/dealing-with-dbnull/
+
+        .PARAMETER SqlParameters
+            Specifies a hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
+
+            Example:
+
+        .PARAMETER AppendServerInstance
+            If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
+
+
+        .PARAMETER MessagesToOutput
+            Use this switch to have on the output stream messages too (e.g. PRINT statements). Output will hold the resultset too. See examples for detail
+
+        .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+    #>
+
+    param (
+        [Alias('Connection', 'Conn')]
+        [ValidateNotNullOrEmpty()]
+        [System.Data.SqlClient.SQLConnection]$SQLConnection,
+
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+        [string]
+        $Query,
+
+        [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "SingleValue")]
+        [string]
+        $As = "DataRow",
+
+        [System.Collections.IDictionary]
+        $SqlParameters,
+
+        [switch]
+        $AppendServerInstance,
+
+        [Int32]$QueryTimeout = 600,
+
+        [switch]
+        $MessagesToOutput,
+
+        [switch]
+        $EnableException
+    )
+
+    begin {
+        function Resolve-SqlError {
+            param($Err)
+            if ($Err) {
+                if ($Err.Exception.GetType().Name -eq 'SqlException') {
+                    # For SQL exception
+                    #$Err = $_
+                    Write-Message -Level Debug -Message "Capture SQL Error"
+                    if ($PSBoundParameters.Verbose) {
+                        Write-Message -Level Verbose -Message "SQL Error:  $Err"
+                    } #Shiyang, add the verbose output of exception
+                    switch ($ErrorActionPreference.ToString()) {
+                        { 'SilentlyContinue', 'Ignore' -contains $_ } {   }
+                        'Stop' { throw $Err }
+                        'Continue' { throw $Err }
+                        Default { Throw $Err }
+                    }
+                }
+                else {
+                    # For other exception
+                    Write-Message -Level Debug -Message "Capture Other Error"
+                    if ($PSBoundParameters.Verbose) {
+                        Write-Message -Level Verbose -Message "Other Error:  $Err"
+                    }
+                    switch ($ErrorActionPreference.ToString()) {
+                        { 'SilentlyContinue', 'Ignore' -contains $_ } { }
+                        'Stop' { throw $Err }
+                        'Continue' { throw $Err }
+                        Default { throw $Err }
+                    }
+                }
+            }
+
+        }
+
+        if ($As -eq "PSObject") {
+            #This code scrubs DBNulls.  Props to Dave Wyatt
+            $cSharp = @'
+                using System;
+                using System.Data;
+                using System.Management.Automation;
+
+                public class DBNullScrubber
+                {
+                    public static PSObject DataRowToPSObject(DataRow row)
+                    {
+                        PSObject psObject = new PSObject();
+
+                        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached)
+                        {
+                            foreach (DataColumn column in row.Table.Columns)
+                            {
+                                Object value = null;
+                                if (!row.IsNull(column))
+                                {
+                                    value = row[column];
+                                }
+
+                                psObject.Properties.Add(new PSNoteProperty(column.ColumnName, value));
+                            }
+                        }
+
+                        return psObject;
+                    }
+                }
+'@
+
+            try {
+                Add-Type -TypeDefinition $cSharp -ReferencedAssemblies 'System.Data', 'System.Xml' -ErrorAction stop
+            }
+            catch {
+                if (-not $_.ToString() -like "*The type name 'DBNullScrubber' already exists*") {
+                    Write-Warning "Could not load DBNullScrubber.  Defaulting to DataRow output: $_."
+                    $As = "Datarow"
+                }
+            }
+        }
+
+        $GoSplitterRegex = [regex]'(?smi)^[\s]*GO[\s]*$'
+
+    }
+    process {
+        $Conn = $SQLConnection
+
+
+
+        Write-Message -Level Debug -Message "Stripping GOs from source"
+        $Pieces = $GoSplitterRegex.Split($Query)
+
+        # Only execute non-empty statements
+        $Pieces = $Pieces | Where-Object { $_.Trim().Length -gt 0 }
+        foreach ($piece in $Pieces) {
+            $cmd = New-Object system.Data.SqlClient.SqlCommand($piece, $conn)
+            $cmd.CommandTimeout = $QueryTimeout
+
+            if ($null -ne $SqlParameters) {
+                $SqlParameters.GetEnumerator() |
+                    ForEach-Object {
+                    if ($null -ne $_.Value) {
+                        $cmd.Parameters.AddWithValue($_.Key, $_.Value)
+                    }
+                    else {
+                        $cmd.Parameters.AddWithValue($_.Key, [DBNull]::Value)
+                    }
+                } > $null
+            }
+
+            $ds = New-Object system.Data.DataSet
+            $da = New-Object system.Data.SqlClient.SqlDataAdapter($cmd)
+
+            if ($MessagesToOutput) {
+                $pool = [RunspaceFactory]::CreateRunspacePool(1, [int]$env:NUMBER_OF_PROCESSORS + 1)
+                $pool.ApartmentState = "MTA"
+                $pool.Open()
+                $runspaces = @()
+                $scriptblock = {
+                    Param ($da, $ds, $conn, $queue )
+                    $conn.FireInfoMessageEventOnUserErrors = $false
+                    $handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { $queue.Enqueue($_) }
+                    $conn.add_InfoMessage($handler)
+                    $Err = $null
+                    try {
+                        [void]$da.fill($ds)
+                    }
+                    catch {
+                        $Err = $_
+                    }
+                    finally {
+                        $conn.remove_InfoMessage($handler)
+                    }
+                    return $Err
+                }
+                $queue = New-Object System.Collections.Concurrent.ConcurrentQueue[string]
+                $runspace = [PowerShell]::Create()
+                $null = $runspace.AddScript($scriptblock)
+                $null = $runspace.AddArgument($da)
+                $null = $runspace.AddArgument($ds)
+                $null = $runspace.AddArgument($Conn)
+                $null = $runspace.AddArgument($queue)
+                $runspace.RunspacePool = $pool
+                $runspaces += [PSCustomObject]@{ Pipe = $runspace; Status = $runspace.BeginInvoke() }
+                # While streaming ...
+                while ($runspaces.Status.IsCompleted -notcontains $true) {
+                    $item = $null
+                    if ($queue.TryDequeue([ref]$item)) {
+                        "$item"
+                    }
+                }
+                # Drain the stream as the runspace is closed, just to be safe
+                if ($queue.IsEmpty -ne $true) {
+                    $item = $null
+                    while ($queue.TryDequeue([ref]$item)) {
+                        "$item"
+                    }
+                }
+                foreach ($runspace in $runspaces) {
+                    $results = $runspace.Pipe.EndInvoke($runspace.Status)
+                    $runspace.Pipe.Dispose()
+                    if ($null -ne $results) {
+                        Resolve-SqlError $results[0]
+                    }
+                }
+                $pool.Close()
+                $pool.Dispose()
+            }
+            else {
+                #Following EventHandler is used for PRINT and RAISERROR T-SQL statements. Executed when -Verbose parameter specified by caller and no -MessageToOutput
+                if ($PSBoundParameters.Verbose) {
+                    $conn.FireInfoMessageEventOnUserErrors = $false
+                    $handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] { Write-Verbose -Message "$($_)" }
+                    $conn.add_InfoMessage($handler)
+                }
+                try {
+                    [void]$da.fill($ds)
+                }
+                catch {
+                    $Err = $_
+                }
+                finally {
+                    if ($PSBoundParameters.Verbose) {
+                        $conn.remove_InfoMessage($handler)
+                    }
+                }
+                Resolve-SqlError $Err
+            }
+
+            if ($AppendServerInstance) {
+                #Basics from Chad Miller
+                $Column = New-Object Data.DataColumn
+                $Column.ColumnName = "ServerInstance"
+
+                if ($ds.Tables.Count -ne 0) {
+                    $ds.Tables[0].Columns.Add($Column)
+                    Foreach ($row in $ds.Tables[0]) {
+                        $row.ServerInstance = $SQLInstance
+                    }
+                }
+            }
+
+            switch ($As) {
+                'DataSet' {
+                    $ds
+                }
+                'DataTable' {
+                    $ds.Tables
+                }
+                'DataRow' {
+                    if ($ds.Tables.Count -ne 0) {
+                        $ds.Tables[0]
+                    }
+                }
+                'PSObject' {
+                    if ($ds.Tables.Count -ne 0) {
+                        #Scrub DBNulls - Provides convenient results you can use comparisons with
+                        #Introduces overhead (e.g. ~2000 rows w/ ~80 columns went from .15 Seconds to .65 Seconds - depending on your data could be much more!)
+                        foreach ($row in $ds.Tables[0].Rows) {
+                            [DBNullScrubber]::DataRowToPSObject($row)
+                        }
+                    }
+                }
+                'SingleValue' {
+                    if ($ds.Tables.Count -ne 0) {
+                        $ds.Tables[0] | Select-Object -ExpandProperty $ds.Tables[0].Columns[0].ColumnName
+                    }
+                }
+            }
+        } #foreach ($piece in $Pieces)
+
+    }
+}

--- a/tests/Invoke-DbaSqlQuery.Tests.ps1
+++ b/tests/Invoke-DbaSqlQuery.Tests.ps1
@@ -94,5 +94,62 @@ SELECT @@servername as dbname
 '@
         $results = $script:instance1, $script:instance2 | Invoke-DbaSqlQuery -Database tempdb -Query $Query
         $results.dbname -contains 'tempdb' | Should Be $true
-    }
+	}
+	It "streams correctly 'messages' with Verbose" {
+		$query = @'
+		DECLARE @time char(19)
+		PRINT 'stmt_1|PRINT start|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SET @time= CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		RAISERROR ('stmt_2|RAISERROR before WITHOUT NOWAIT|%s', 0, 1, @time)
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_3|PRINT after the first delay|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SET @time= CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		RAISERROR ('stmt_4|RAISERROR with NOWAIT|%s', 0, 1, @time) WITH NOWAIT
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_5|PRINT after the second delay|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SELECT 'hello' AS TestColumn
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_6|PRINT end|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+'@
+		$results = @()
+		Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -Query $query -Verbose 4>&1 | ForEach-Object {
+			$results += [pscustomobject]@{
+				FiredAt = (Get-Date).ToUniversalTime()
+				Out = $_
+			}
+		}
+		$results.Length | Should -Be 7  # 6 'messages' plus the actual resultset
+		($results  | ForEach-Object { Get-Date -Date $_.FiredAt -f s } | Get-Unique).Count  | Should -Not -Be 1 # the first WITH NOWAIT (stmt_4) and after
+		#($results[0..3]  | ForEach-Object { Get-Date -Date $_.FiredAt -f s } | Get-Unique).Count | Should -Be 1 # everything before stmt_4 is fired at the same time
+		#$parsedstmt_1 = Get-Date -Date $results[0].Out.Message.split('|')[2]
+		#(Get-Date -Date (Get-Date -Date $parsedstmt_1).AddSeconds(3) -f s) | Should -Be (Get-Date -Date $results[0].FiredAt -f s) # stmt_1 is fired 3 seconds after the logged date
+		#$parsedstmt_4 = Get-Date -Date $results[3].Out.Message.split('|')[2]
+		#(Get-Date -Date (Get-Date -Date $parsedstmt_4) -f s) | Should -Be (Get-Date -Date $results[0].FiredAt -f s) # stmt_4 is fired at the same time the logged date is
+	}
+	It "streams correctly 'messages' with MessagesToOutput" {
+		$query = @'
+		DECLARE @time char(19)
+		PRINT 'stmt_1|PRINT start|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SET @time= CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		RAISERROR ('stmt_2|RAISERROR before WITHOUT NOWAIT|%s', 0, 1, @time)
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_3|PRINT after the first delay|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SET @time= CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		RAISERROR ('stmt_4|RAISERROR with NOWAIT|%s', 0, 1, @time) WITH NOWAIT
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_5|PRINT after the second delay|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+		SELECT 'hello' AS TestColumn
+		WAITFOR DELAY '00:00:03'
+		PRINT 'stmt_6|PRINT end|' + CONVERT(VARCHAR(19), GETUTCDATE(), 126)
+'@
+		$results = @()
+		Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -Query $query -MessagesToOutput | ForEach-Object {
+			$results += [pscustomobject]@{
+				FiredAt = (Get-Date).ToUniversalTime()
+				Out = $_
+			}
+		}
+		$results.Length | Should -Be 7  # 6 'messages' plus the actual resultset
+		($results  | ForEach-Object { Get-Date -Date $_.FiredAt -f s } | Get-Unique).Count  | Should -Not -Be 1 # the first WITH NOWAIT (stmt_4) and after
+	}
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Tinker easily with queries where messages (PRINT and RAISERROR) are as important as the result
With stream redirection it has almost been possible to do this but it's always kinda be a PITA. This has been discussed in slack for a while, sorry for the delay

### Approach
Basically stripped down the code we need from invoke-sqlcmd2 and adapted to use dbatools' facilities, coupled with async execution and a good tip from @FriedrichWeinmann. It's safe to assume we can now move invoke-sqlcmd2 to the optional folder, as this, coupled with connect-dbainstance to establish "funny" connections, has all the needed features.

### Commands to test
Added basic tests to make sure output is not buffered (as it is in invoke-sqlcmd and sqlcmd -ge 2012). Think reading the output of ola's maintenance procedures while it is outputted without waiting for the procedure to end.
