### PR TITLE
Set-DbaDbCompression - Workaround for what seems like SMO bug

### DIFF
--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -87,7 +87,7 @@ function Set-DbaDbCompression {
 
             Set the compression run time to 60 minutes and will start the compression of tables/indexes across all listed servers that have a difference of 25% or higher between current and recommended. Output of command is exported to a csv.
     #>
-    [CmdletBinding(DefaultParameterSetName = "Default")]
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
@@ -160,83 +160,127 @@ function Set-DbaDbCompression {
 
                 try {
                     if ($CompressionType -eq "Recommended") {
-                        Write-Message -Level Verbose -Message "Applying suggested compression settings using Test-DbaDbCompression"
-                        $results += $compressionSuggestion | Select-Object *, @{l = 'AlreadyProcesssed'; e = {"False"}}
-                        foreach ($obj in ($results | Where-Object {$_.CompressionTypeRecommendation -ne 'NO_GAIN' -and $_.PercentCompression -ge $PercentCompression} | Sort-Object PercentCompression -Descending)) {
-                            if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
-                                Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
-                                break
-                            }
-                            if ($obj.indexId -le 1) {
-                                ##heaps and clustered indexes
-                                Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName)"
-                                $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
-                                $server.Databases[$obj.Database].Tables[$obj.TableName, $($obj.Schema)].Rebuild()
-                                $obj.AlreadyProcesssed = "True"
-                            }
-                            else {
-                                ##nonclustered indexes
-                                Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName).$($obj.IndexName)"
-                                $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
-                                $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].Rebuild()
-                                $obj.AlreadyProcesssed = "True"
-                            }
-                            $obj
-                        }
-                    }
-                    else {
-                        Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
-                        foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object {!$_.IsMemoryOptimized}) {
-                            if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
-                                Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
-                                break
-                            }
-                            foreach ($p in $($obj.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
-                                Write-Message -Level Verbose -Message "Compressing table $($obj.Schema).$($obj.Name)"
-                                $($obj.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
-                                $obj.Rebuild()
-                                [pscustomobject]@{
-                                    ComputerName                  = $server.NetName
-                                    InstanceName                  = $server.ServiceName
-                                    SqlInstance                   = $server.DomainInstanceName
-                                    Database                      = $db.Name
-                                    Schema                        = $obj.Schema
-                                    TableName                     = $obj.Name
-                                    IndexName                     = $null
-                                    Partition                     = $p.PartitionNumber
-                                    IndexID                       = 0
-                                    IndexType                     = Switch ($obj.HasHeapIndex) {$false {"ClusteredIndex"} $true {"Heap"}}
-                                    PercentScan                   = $null
-                                    PercentUpdate                 = $null
-                                    RowEstimatePercentOriginal    = $null
-                                    PageEstimatePercentOriginal   = $null
-                                    CompressionTypeRecommendation = $CompressionType.ToUpper()
-                                    SizeCurrent                   = $null
-                                    SizeRequested                 = $null
-                                    PercentCompression            = $null
-                                    AlreadyProcesssed             = "True"
-                                }
-                            }
-
-                            foreach ($index in $($obj.Indexes | Where-Object {!$_.IsMemoryOptimized})) {
+                        if ($Pscmdlet.ShouldProcess($db, "Applying suggested compression using results from Test-DbaDbCompression")) {
+                            Write-Message -Level Verbose -Message "Applying suggested compression settings using Test-DbaDbCompression"
+                            $results += $compressionSuggestion | Select-Object *, @{l = 'AlreadyProcesssed'; e = {"False"}}
+                            foreach ($obj in ($results | Where-Object {$_.CompressionTypeRecommendation -ne 'NO_GAIN' -and $_.PercentCompression -ge $PercentCompression} | Sort-Object PercentCompression -Descending)) {
                                 if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
                                     break
                                 }
+                                if ($obj.indexId -le 1) {
+                                    ##heaps and clustered indexes
+                                    Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName)"
+                                    $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
+                                    $server.Databases[$obj.Database].Tables[$obj.TableName, $($obj.Schema)].Rebuild()
+                                    $obj.AlreadyProcesssed = "True"
+                                }
+                                else {
+                                    ##nonclustered indexes
+                                    Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName).$($obj.IndexName)"
+                                    $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
+                                    $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].Rebuild()
+                                    $obj.AlreadyProcesssed = "True"
+                                }
+                                $obj
+                            }
+                        }
+                    }
+                    else {
+                        if ($Pscmdlet.ShouldProcess($db, "Applying $CompressionType compression")) {
+                            Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
+                            foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object {!$_.IsMemoryOptimized}) {
+                                if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
+                                    Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
+                                    break
+                                }
+                                foreach ($p in $($obj.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
+                                    Write-Message -Level Verbose -Message "Compressing table $($obj.Schema).$($obj.Name)"
+                                    $($obj.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
+                                    $obj.Rebuild()
+                                    [pscustomobject]@{
+                                        ComputerName                  = $server.NetName
+                                        InstanceName                  = $server.ServiceName
+                                        SqlInstance                   = $server.DomainInstanceName
+                                        Database                      = $db.Name
+                                        Schema                        = $obj.Schema
+                                        TableName                     = $obj.Name
+                                        IndexName                     = $null
+                                        Partition                     = $p.PartitionNumber
+                                        IndexID                       = 0
+                                        IndexType                     = Switch ($obj.HasHeapIndex) {$false {"ClusteredIndex"} $true {"Heap"}}
+                                        PercentScan                   = $null
+                                        PercentUpdate                 = $null
+                                        RowEstimatePercentOriginal    = $null
+                                        PageEstimatePercentOriginal   = $null
+                                        CompressionTypeRecommendation = $CompressionType.ToUpper()
+                                        SizeCurrent                   = $null
+                                        SizeRequested                 = $null
+                                        PercentCompression            = $null
+                                        AlreadyProcesssed             = "True"
+                                    }
+                                }
+
+                                foreach ($index in $($obj.Indexes | Where-Object {!$_.IsMemoryOptimized})) {
+                                    if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
+                                        Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
+                                        break
+                                    }
+                                    foreach ($p in $($index.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
+                                        Write-Message -Level Verbose -Message "Compressing $($Index.IndexType) $($Index.Name) Partition $($p.PartitionNumber)"
+                                        
+                                        ## There is a bug in SMO where setting compression to None at the index level doesn't work
+                                        ## Once this UserVoice item is fixed the workaround can be removed
+                                        ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
+                                        if ($CompressionType -eq "None") {
+                                            $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH (DATA_COMPRESSION = $CompressionType)"
+                                            $Server.Query($query, $db.Name)
+                                        }
+                                        else {
+                                            $($Index.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
+                                            $index.Rebuild()
+                                        }                                    
+
+                                        [pscustomobject]@{
+                                            ComputerName                  = $server.NetName
+                                            InstanceName                  = $server.ServiceName
+                                            SqlInstance                   = $server.DomainInstanceName
+                                            Database                      = $db.Name
+                                            Schema                        = $obj.Schema
+                                            TableName                     = $obj.Name
+                                            IndexName                     = $index.Name
+                                            Partition                     = $p.PartitionNumber
+                                            IndexID                       = $index.Id
+                                            IndexType                     = $index.IndexType
+                                            PercentScan                   = $null
+                                            PercentUpdate                 = $null
+                                            RowEstimatePercentOriginal    = $null
+                                            PageEstimatePercentOriginal   = $null
+                                            CompressionTypeRecommendation = $CompressionType.ToUpper()
+                                            SizeCurrent                   = $null
+                                            SizeRequested                 = $null
+                                            PercentCompression            = $null
+                                            AlreadyProcesssed             = "True"
+                                        }
+                                    }
+                                }
+                            }
+                            foreach ($index in $($server.Databases[$($db.name)].Views | Where-Object {$_.Indexes}).Indexes) {
                                 foreach ($p in $($index.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
-                                    Write-Message -Level Verbose -Message "Compressing $($Index.IndexType) $($Index.Name) Partition $($p.PartitionNumber)"
+                                    Write-Message -Level Verbose -Message "Compressing $($index.IndexType) $($index.Name) Partition $($p.PartitionNumber)"
                                     
                                     ## There is a bug in SMO where setting compression to None at the index level doesn't work
                                     ## Once this UserVoice item is fixed the workaround can be removed
                                     ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
                                     if ($CompressionType -eq "None") {
                                         $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH (DATA_COMPRESSION = $CompressionType)"
+                                        $query
                                         $Server.Query($query, $db.Name)
                                     }
                                     else {
-                                        $($Index.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
+                                        $($index.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
                                         $index.Rebuild()
-                                    }                                    
+                                    }
 
                                     [pscustomobject]@{
                                         ComputerName                  = $server.NetName
@@ -259,46 +303,6 @@ function Set-DbaDbCompression {
                                         PercentCompression            = $null
                                         AlreadyProcesssed             = "True"
                                     }
-                                }
-                            }
-                        }
-                        foreach ($index in $($server.Databases[$($db.name)].Views | Where-Object {$_.Indexes}).Indexes) {
-                            foreach ($p in $($index.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
-                                Write-Message -Level Verbose -Message "Compressing $($index.IndexType) $($index.Name) Partition $($p.PartitionNumber)"
-                                
-                                ## There is a bug in SMO where setting compression to None at the index level doesn't work
-                                ## Once this UserVoice item is fixed the workaround can be removed
-                                ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
-                                if ($CompressionType -eq "None") {
-                                    $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH (DATA_COMPRESSION = $CompressionType)"
-                                    $query
-                                    $Server.Query($query, $db.Name)
-                                }
-                                else {
-                                    $($index.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
-                                    $index.Rebuild()
-                                }
-
-                                [pscustomobject]@{
-                                    ComputerName                  = $server.NetName
-                                    InstanceName                  = $server.ServiceName
-                                    SqlInstance                   = $server.DomainInstanceName
-                                    Database                      = $db.Name
-                                    Schema                        = $obj.Schema
-                                    TableName                     = $obj.Name
-                                    IndexName                     = $index.Name
-                                    Partition                     = $p.PartitionNumber
-                                    IndexID                       = $index.Id
-                                    IndexType                     = $index.IndexType
-                                    PercentScan                   = $null
-                                    PercentUpdate                 = $null
-                                    RowEstimatePercentOriginal    = $null
-                                    PageEstimatePercentOriginal   = $null
-                                    CompressionTypeRecommendation = $CompressionType.ToUpper()
-                                    SizeCurrent                   = $null
-                                    SizeRequested                 = $null
-                                    PercentCompression            = $null
-                                    AlreadyProcesssed             = "True"
                                 }
                             }
                         }

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -117,7 +117,7 @@ function Set-DbaDbCompression {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             }
             catch {
-                Stop-Function -Message "Failed to process Instance $Instance" -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failed to process Instance $instance" -ErrorRecord $_ -Target $instance -Continue
             }
 
             $Server.ConnectionContext.StatementTimeout = 0
@@ -317,7 +317,7 @@ function Set-DbaDbCompression {
                 catch {
                     Stop-Function -Message "Compression failed for $instance - $db" -Target $db -ErrorRecord $_ -Continue
                 }
-            }
+            }   
         }
     }
 }

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -36,6 +36,12 @@ function Set-DbaDbCompression {
         .PARAMETER InputObject
             Takes the output of Test-DbaDbCompression as an object and applied compression based on those recommendations.
 
+        .PARAMETER WhatIf
+            If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+        .PARAMETER Confirm
+            If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -146,7 +152,7 @@ function Set-DbaDbCompression {
                     if ($CompressionType -eq "Recommended") {
                         if (Test-Bound "InputObject") {
                             Write-Message -Level Verbose -Message "Using passed in compression suggestions"
-                            $compressionSuggestion = $InputObject | Where-Object {$_.Database -eq $db.name}                        
+                            $compressionSuggestion = $InputObject | Where-Object {$_.Database -eq $db.name}
                         }
                         else {
                             Write-Message -Level Verbose -Message "Testing database for compression suggestions for $instance.$db"
@@ -228,7 +234,7 @@ function Set-DbaDbCompression {
                                     }
                                     foreach ($p in $($index.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
                                         Write-Message -Level Verbose -Message "Compressing $($Index.IndexType) $($Index.Name) Partition $($p.PartitionNumber)"
-                                        
+
                                         ## There is a bug in SMO where setting compression to None at the index level doesn't work
                                         ## Once this UserVoice item is fixed the workaround can be removed
                                         ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
@@ -239,7 +245,7 @@ function Set-DbaDbCompression {
                                         else {
                                             $($Index.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
                                             $index.Rebuild()
-                                        }                                    
+                                        }
 
                                         [pscustomobject]@{
                                             ComputerName                  = $server.NetName
@@ -268,7 +274,7 @@ function Set-DbaDbCompression {
                             foreach ($index in $($server.Databases[$($db.name)].Views | Where-Object {$_.Indexes}).Indexes) {
                                 foreach ($p in $($index.PhysicalPartitions | Where-Object {$_.DataCompression -ne $CompressionType})) {
                                     Write-Message -Level Verbose -Message "Compressing $($index.IndexType) $($index.Name) Partition $($p.PartitionNumber)"
-                                    
+
                                     ## There is a bug in SMO where setting compression to None at the index level doesn't work
                                     ## Once this UserVoice item is fixed the workaround can be removed
                                     ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -317,7 +317,7 @@ function Set-DbaDbCompression {
                 catch {
                     Stop-Function -Message "Compression failed for $instance - $db" -Target $db -ErrorRecord $_ -Continue
                 }
-            }   
+            }
         }
     }
 }

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         $paramCount = 9
-        $defaultParamCount = 11
+        $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Set-DbaDbCompression).Parameters.Keys
         $knownParameters = 'SqlInstance', 'SqlCredential','Database','ExcludeDatabase','CompressionType','MaxRunTime','PercentCompression','InputObject','EnableException'
         It "Should contain our specific parameters" {

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -71,4 +71,31 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             }
         }
     }
+    Context "Command sets compression to Row all objects" {
+        $null = Set-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname -CompressionType Row
+        $results = Get-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname
+        foreach ($row in $results) {
+            It "The $($row.IndexType) for $($row.schema).$($row.TableName) is row compressed" {
+                $row.DataCompression | Should Be "Row"
+            }
+        }
+    }
+    Context "Command sets compression to Page for all objects" {
+        $null = Set-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname -CompressionType Page
+        $results = Get-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname
+        foreach ($row in $results) {
+            It "The $($row.IndexType) for $($row.schema).$($row.TableName) is page compressed" {
+                $row.DataCompression | Should Be "Page"
+            }
+        }
+    }
+    Context "Command sets compression to None for all objects" {
+        $null = Set-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname -CompressionType None
+        $results = Get-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname
+        foreach ($row in $results) {
+            It "The $($row.IndexType) for $($row.schema).$($row.TableName) is not compressed" {
+                $row.DataCompression | Should Be "None"
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
- Workaround so that setting CompressionType to 'None' for all objects works. There seems to be a bug in SMO that doesn't generate the DATA_COMPRESSION keyword in the rebuild statement at the index level (works fine if you set the object (heap/CL) to None.
- Adds tests to confirm all objects in a database get row/page/none compression
- Now supports ShouldProcess to resolve ScriptAnalyzer issue

SMO bug report logged: https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug

### Approach
<!-- How does this change solve that purpose -->
- Added logic so that at the index level if setting DataCompression to None it uses T-SQL instead of SMO.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Set-DbaDbCompression -SqlInstance Server -Database DatabaseName -CompressionType None`

### Screenshots
![image](https://user-images.githubusercontent.com/981370/39956679-528378c8-55b3-11e8-9edb-4ca56667563a.png)
