### PR TITLE
Test-DbaDbCompression - exclude memory optimized tables

### DIFF
--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -176,6 +176,7 @@ WHERE objectproperty(t.object_id, 'IsUserTable') = 1
     AND p.data_compression_desc = 'NONE'
     AND p.rows > 0
     AND t.is_memory_optimized = 0
+    AND t.object_id not in (select object_id from sys.columns where encryption_type IS NOT NULL)
 ORDER BY [TableName] ASC;
 
 DECLARE @schema SYSNAME

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -159,22 +159,23 @@ INSERT INTO ##testdbacompression (
     ,[PercentScan]
     ,[PercentUpdate]
     )
-SELECT s.NAME AS [Schema]
-    ,o.NAME AS [TableName]
+    SELECT s.NAME AS [Schema]
+    ,t.NAME AS [TableName]
     ,x.NAME AS [IndexName]
     ,p.partition_number AS [Partition]
     ,x.Index_ID AS [IndexID]
     ,x.type_desc AS [IndexType]
     ,NULL AS [PercentScan]
     ,NULL AS [PercentUpdate]
-FROM sys.objects o
-INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
-INNER JOIN sys.indexes x ON x.object_id = o.object_id
+FROM sys.tables t
+INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+INNER JOIN sys.indexes x ON x.object_id = t.object_id
 INNER JOIN sys.partitions p ON x.object_id = p.object_id
     AND x.Index_ID = p.Index_ID
-WHERE objectproperty(o.object_id, 'IsUserTable') = 1
+WHERE objectproperty(t.object_id, 'IsUserTable') = 1
     AND p.data_compression_desc = 'NONE'
     AND p.rows > 0
+	AND t.is_memory_optimized = 0
 ORDER BY [TableName] ASC;
 
 DECLARE @schema SYSNAME

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -175,7 +175,7 @@ INNER JOIN sys.partitions p ON x.object_id = p.object_id
 WHERE objectproperty(t.object_id, 'IsUserTable') = 1
     AND p.data_compression_desc = 'NONE'
     AND p.rows > 0
-	AND t.is_memory_optimized = 0
+    AND t.is_memory_optimized = 0
 ORDER BY [TableName] ASC;
 
 DECLARE @schema SYSNAME


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
If you run this against a database with in-memory tables it will fail

### Approach
<!-- How does this change solve that purpose -->
Changed to use sys.tables instead of sys.objects and then only include where is_memoryoptimized = 0