### PR TITLE
Fix usage of ForEach in Get-DbaDbPageInfo

### DIFF
--- a/functions/Get-DbaDbPageInfo.ps1
+++ b/functions/Get-DbaDbPageInfo.ps1
@@ -128,7 +128,7 @@ FROM sys.dm_db_database_page_allocations(DB_ID(), NULL, NULL, NULL, 'DETAILED') 
                     }
 
                     # Add the results to the collection
-                    $collection += $results.Foreach{
+                    $collection += $results | % {
                         [PSCustomObject]@{
                             ComputerName    = $server.NetName
                             InstanceName    = $server.ServiceName


### PR DESCRIPTION
Replace the usage of ForEach in Get-DbaDbPageInfo with ForEach-Object so that the function will import successfully in PowerShell version 3.0.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix the usage of ForEach in function Get-DbaDbPageInfo so that it may be imported successfully into PowerShell v3.0

### Approach
Use ForEach-Object instead.

### Commands to test
Simply run `Import-Module` in PowerShell v3.0

