### PR TITLE
Restore-DbaDatabase: use SqlCredential to call Get-DbaBackupInformation

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -538,7 +538,7 @@ function Restore-DbaDatabase {
                     }
                 }
                 Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
-                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup
+                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if (-not (Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)

 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Pass user-specified SqlCredential to the call of Get-DbaBackupInformation made by Restore-DbaDatabase, so that the function Restore-DbaDatabase will not spawn a credential input dialog unnecessarily. Plus, the dialog will not spawn in non-interactive session, causing Get-DbaBackupInformation to hang.

### Commands to test
Run `Restore-DbaDatabase` with a constructed `PSCredential` passed into parameter `-SqlCredential`.
