### PR TITLE
Tests for Get-DbaAgentLog

### DIFF
--- a/tests/Get-DbaAgentLog.Tests.ps1
+++ b/tests/Get-DbaAgentLog.Tests.ps1
@@ -1,0 +1,39 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = 4
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaAgentLog).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'LogNumber', 'EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command gets agent log" {
+        $results = Get-DbaAgentLog -SqlInstance $script:instance2
+        It "Results are not empty" {
+            $results | Should Not Be $Null
+        }
+        It "Results contain SQLServerAgent version" {
+            $results.text -like '`[100`] Microsoft SQLServerAgent version*' | Should Be $true
+        }
+        It "LogDate is a DateTime type" {
+            $($results | Select-Object -first 1).LogDate | Should BeOfType DateTime
+        }
+    }
+    Context "Command gets current agent log using LogNumber parameter" {
+        $results = Get-DbaAgentLog -SqlInstance $script:instance2 -LogNumber 0
+        It "Results are not empty" {
+            $results | Should Not Be $Null
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Adding tests for Get-DbaAgentLog

### Approach
<!-- How does this change solve that purpose -->
Test command works, returns version info from log, LogDate is of type DateTime

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/40270350-d717971c-5b59-11e8-9179-65b5d5dd60b2.png)
