### PR TITLE
Invoke-Parallel, keep up with master repo

### DIFF
--- a/internal/functions/Invoke-Parallel.ps1
+++ b/internal/functions/Invoke-Parallel.ps1
@@ -189,6 +189,7 @@ function Invoke-Parallel {
         else {
             $script:MaxQueue = $MaxQueue
         }
+        $ProgressId = Get-Random
         Write-Verbose "Throttle: '$throttle' SleepTimer '$sleepTimer' runSpaceTimeout '$runspaceTimeout' maxQueue '$maxQueue' logFile '$logFile'"
 
         #If they want to import variables or modules, create a clean runspace, get loaded items, use those to exclude items
@@ -247,7 +248,7 @@ function Invoke-Parallel {
 
                     #Progress bar if we have inputobject count (bound parameter)
                     if (-not $Quiet) {
-                        Write-Progress  -Activity "Running Query" -Status "Starting threads"`
+                        Write-Progress -Id $ProgressId -Activity "Running Query" -Status "Starting threads"`
                             -CurrentOperation "$startedCount threads defined - $totalCount input objects - $script:completedCount input objects processed"`
                             -PercentComplete $( Try { $script:completedCount / $totalCount * 100 } Catch {0} )
                     }
@@ -541,7 +542,7 @@ function Invoke-Parallel {
 
             Get-RunspaceData -wait
             if (-not $quiet) {
-                Write-Progress -Activity "Running Query" -Status "Starting threads" -Completed
+                Write-Progress -Id $ProgressId -Activity "Running Query" -Status "Starting threads" -Completed
             }
         }
         finally {


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Invoke-Parallel has been recently updated to support better progress report when run in "inception mode" (i.e. an invoke-parallel within an invoke-parallel). This PR just keeps our version in sync with the one from the master repo.
