### PR TITLE
Invoke-DbaDatabaseShrink - address PercentFreeSpace issue

### DIFF
--- a/functions/Invoke-DbaDatabaseShrink.ps1
+++ b/functions/Invoke-DbaDatabaseShrink.ps1
@@ -1,127 +1,123 @@
 function Invoke-DbaDatabaseShrink {
     <#
-.SYNOPSIS
-Shrinks all files in a database. This is a command that should rarely be used.
+        .SYNOPSIS
+            Shrinks all files in a database. This is a command that should rarely be used.
 
-- Shrinks can cause severe index fragmentation (to the tune of 99%)
-- Shrinks can cause massive growth in the database's transaction log
-- Shrinks can require a lot of time and system resources to perform data movement
+            - Shrinks can cause severe index fragmentation (to the tune of 99%)
+            - Shrinks can cause massive growth in the database's transaction log
+            - Shrinks can require a lot of time and system resources to perform data movement
 
-.DESCRIPTION
-Shrinks all files in a database. Databases should be shrunk only when completely necessary.
+        .DESCRIPTION
+            Shrinks all files in a database. Databases should be shrunk only when completely necessary.
 
-Many awesome SQL people have written about why you should not shrink your data files. Paul Randal and Kalen Delaney wrote great posts about this topic:
+            Many awesome SQL people have written about why you should not shrink your data files. Paul Randal and Kalen Delaney wrote great posts about this topic:
 
-    http://www.sqlskills.com/blogs/paul/why-you-should-not-shrink-your-data-files
-    http://sqlmag.com/sql-server/shrinking-data-files
+                http://www.sqlskills.com/blogs/paul/why-you-should-not-shrink-your-data-files
+                http://sqlmag.com/sql-server/shrinking-data-files
 
-However, there are some cases where a database will need to be shrunk. In the event that you must shrink your database:
+            However, there are some cases where a database will need to be shrunk. In the event that you must shrink your database:
 
-1. Ensure you have plenty of space for your T-Log to grow
-2. Understand that shrinks require a lot of CPU and disk resources
-3. Consider running DBCC INDEXDEFRAG or ALTER INDEX ... REORGANIZE after the shrink is complete.
+            1. Ensure you have plenty of space for your T-Log to grow
+            2. Understand that shrinks require a lot of CPU and disk resources
+            3. Consider running DBCC INDEXDEFRAG or ALTER INDEX ... REORGANIZE after the shrink is complete.
 
-.PARAMETER SqlInstance
-The SQL Server that you're connecting to.
+        .PARAMETER SqlInstance
+            The SQL Server that you're connecting to.
 
-.PARAMETER SqlCredential
-SqlCredential object used to connect to the SQL Server as a different user.
+        .PARAMETER SqlCredential
+            SqlCredential object used to connect to the SQL Server as a different user.
 
-.PARAMETER Database
-The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
+        .PARAMETER Database
+            The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
 
-.PARAMETER ExcludeDatabase
-The database(s) to exclude - this list is auto-populated from the server
+        .PARAMETER ExcludeDatabase
+            The database(s) to exclude - this list is auto-populated from the server
 
-.PARAMETER AllUserDatabases
-Run command against all user databases
+        .PARAMETER AllUserDatabases
+            Run command against all user databases
 
-.PARAMETER PercentFreeSpace
-Specifies how much to reduce the database in percent, defaults to 0.
+        .PARAMETER PercentFreeSpace
+            Specifies how much to reduce the database in percent, defaults to 0.
 
-.PARAMETER ShrinkMethod
-Specifies the method that is used to shrink the database
+        .PARAMETER ShrinkMethod
+            Specifies the method that is used to shrink the database
+                Default
+                    Data in pages located at the end of a file is moved to pages earlier in the file. Files are truncated to reflect allocated space.
+                EmptyFile
+                    Migrates all of the data from the referenced file to other files in the same filegroup. (DataFile and LogFile objects only).
+                NoTruncate
+                    Data in pages located at the end of a file is moved to pages earlier in the file.
+                TruncateOnly
+                    Data distribution is not affected. Files are truncated to reflect allocated space, recovering free space at the end of any file.
 
-        Default
-            Data in pages located at the end of a file is moved to pages earlier in the file. Files are truncated to reflect allocated space.
-        EmptyFile
-            Migrates all of the data from the referenced file to other files in the same filegroup. (DataFile and LogFile objects only).
-        NoTruncate
-            Data in pages located at the end of a file is moved to pages earlier in the file.
-        TruncateOnly
-            Data distribution is not affected. Files are truncated to reflect allocated space, recovering free space at the end of any file.
+        .PARAMETER StatementTimeout
+            Timeout in minutes. Defaults to infinity (shrinks can take a while.)
 
-.PARAMETER StatementTimeout
-Timeout in minutes. Defaults to infinity (shrinks can take a while.)
+        .PARAMETER LogsOnly
+            Deprecated. Use FileType instead
 
-.PARAMETER LogsOnly
-Deprecated. Use FileType instead
+        .PARAMETER FileType
+            Specifies the files types that will be shrunk
+                All
+                    All Data and Log files are shrunk, using database shrink (Default)
+                Data
+                    Just the Data files are shrunk using file shrink
+                Log
+                    Just the Log files are shrunk using file shrink
 
-.PARAMETER FileType
-Specifies the files types that will be shrunk
+        .PARAMETER ExcludeIndexStats
+            Exclude statistics about fragmentation
 
-        All
-            All Data and Log files are shrunk, using database shrink (Default)
-        Data
-            Just the Data files are shrunk using file shrink
-        Log
-            Just the Log files are shrunk using file shrink
+        .PARAMETER ExcludeUpdateUsage
+            Exclude DBCC UPDATE USAGE for database
 
-.PARAMETER ExcludeIndexStats
-Exclude statistics about fragmentation
+        .PARAMETER WhatIf
+            Shows what would happen if the command were to run
 
-.PARAMETER ExcludeUpdateUsage
-Exclude DBCC UPDATE USAGE for database
+        .PARAMETER Confirm
+            Prompts for confirmation of every step. For example:
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run
+            Are you sure you want to perform this action?
+            Performing the operation "Shrink database" on target "pubs on SQL2016\VNEXT".
+            [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
 
-.PARAMETER Confirm
-Prompts for confirmation of every step. For example:
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-Are you sure you want to perform this action?
-Performing the operation "Shrink database" on target "pubs on SQL2016\VNEXT".
-[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
+        .NOTES
+            Tags: Shrink, Database
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
 
-.NOTES
-Tags: Shrink, Databases
+        .LINK
+            https://dbatools.io/Invoke-DbaDatabaseShrink
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: MIT https://opensource.org/licenses/MIT
+        .EXAMPLE
+            Invoke-DbaDatabaseShrink -SqlInstance sql2016 -Database Northwind,pubs,Adventureworks2014
 
-.LINK
-https://dbatools.io/Invoke-DbaDatabaseShrink
+            Shrinks Northwind, pubs and Adventureworks2014 to have as little free space as possible.
 
-.EXAMPLE
-Invoke-DbaDatabaseShrink -SqlInstance sql2016 -Database Northwind,pubs,Adventureworks2014
+        .EXAMPLE
+            Invoke-DbaDatabaseShrink -SqlInstance sql2014 -Database AdventureWorks2014 -PercentFreeSpace 50
 
-Shrinks Northwind, pubs and Adventureworks2014 to have as little free space as possible.
+            Shrinks AdventureWorks2014 to have 50% free space. So let's say AdventureWorks2014 was 1GB and it's using 100MB space. The database free space would be reduced to 50MB.
 
-.EXAMPLE
-Invoke-DbaDatabaseShrink -SqlInstance sql2014 -Database Adventureworks2014 -PercentFreeSpace 50
+        .EXAMPLE
+            Invoke-DbaDatabaseShrink -SqlInstance sql2012 -AllUserDatabases
 
-Shrinks Adventureworks2014 to have 50% free space. So let's say Adventureworks2014 was 1GB and it's using 100MB space. The database free space would be reduced to 50MB.
-
-.EXAMPLE
-Invoke-DbaDatabaseShrink -SqlInstance sql2012 -AllUserDatabases
-
-Shrinks all databases on SQL2012 (not ideal for production)
-
-#>
+            Shrinks all databases on SQL2012 (not ideal for production)
+    #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
-    Param (
+    param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
-        [PSCredential]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
@@ -158,7 +154,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
                 WHERE indexstats.database_id = DB_ID() AND indexstats.avg_fragmentation_in_percent > 0
                 ORDER BY indexstats.avg_fragmentation_in_percent desc"
 
-        $sqltop1 = "SELECT top 1
+        $sqlTop1 = "SELECT top 1
                 indexstats.avg_fragmentation_in_percent
                 FROM sys.dm_db_index_physical_stats (DB_ID(), NULL, NULL, NULL, NULL) AS indexstats
                 INNER JOIN sys.tables dbtables on dbtables.[object_id] = indexstats.[object_id]
@@ -211,27 +207,27 @@ Shrinks all databases on SQL2012 (not ideal for production)
                     continue
                 }
 
-                $startingsize = $db.Size
+                $startingSize = $db.Size
                 $spaceAvailableMB = $db.SpaceAvailable / 1024
-                $spaceused = $startingsize - $spaceAvailableMB
-                $desiredSpaceAvailable = ($PercentFreeSpace * $spaceused) / 100
+                $spaceUsed = $startingSize - $spaceAvailableMB
+                $desiredSpaceAvailable = ($PercentFreeSpace * $spaceUsed) / 100
 
-                Write-Message -Level Verbose -Message "Starting Size (MB): $startingsize"
-                Write-Message -Level Verbose -Message "Starting Freespace (MB): $([int]$spaceavailableMB)"
+                Write-Message -Level Verbose -Message "Starting Size (MB): $startingSize"
+                Write-Message -Level Verbose -Message "Starting Freespace (MB): $([int]$spaceAvailableMB)"
                 Write-Message -Level Verbose -Message "Desired Freespace (MB): $([int]$desiredSpaceAvailable)"
 
                 if (($db.SpaceAvailable / 1024) -le $desiredSpaceAvailable) {
-                    Write-Message -Level Warning -Message "Space Available ($spaceavailableMB) is less than or equal to the desired outcome ($desiredSpaceAvailable)"
+                    Write-Message -Level Warning -Message "Space Available ($spaceAvailableMB) is less than or equal to the desired outcome ($desiredSpaceAvailable)"
                 }
                 else {
-                    if ($Pscmdlet.ShouldProcess("$db on $instance", "Shrinking from $([int]$spaceavailableMB) MB space available to $([int]$desiredSpaceAvailable) MB space available")) {
+                    if ($Pscmdlet.ShouldProcess("$db on $instance", "Shrinking from $([int]$spaceAvailableMB) MB space available to $([int]$desiredSpaceAvailable) MB space available")) {
                         if ($db.Tables.Indexes.Name -and $server.VersionMajor -gt 8 -and $ExcludeIndexStats -eq $false) {
                             Write-Message -Level Verbose -Message "Getting average fragmentation"
-                            $startingfrag = ($server.Query($sql, $db.name) | Select-Object -ExpandProperty avg_fragmentation_in_percent | Measure-Object -Average).Average
-                            $startingtopfrag = ($server.Query($sqltop1, $db.name)).avg_fragmentation_in_percent
+                            $startingFrag = ($server.Query($sql, $db.name) | Select-Object -ExpandProperty avg_fragmentation_in_percent | Measure-Object -Average).Average
+                            $startingTopFrag = ($server.Query($sqlTop1, $db.name)).avg_fragmentation_in_percent
                         }
                         else {
-                            $startingtopfrag = $startingfrag = $null
+                            $startingTopFrag = $startingFrag = $null
                         }
 
                         $start = Get-Date
@@ -240,7 +236,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
                             'Log' {
                                 try {
                                     Write-Message -Level Verbose -Message "Beginning shrink of log files"
-                                    $db.LogFiles.Shrink($PercentFreeSpace, $ShrinkMethod)
+                                    $db.LogFiles.Shrink($desiredSpaceAvailable, $ShrinkMethod)
                                     $db.Refresh()
                                     Write-Message -Level Verbose -Message "Recalculating space usage"
                                     $success = $true
@@ -256,7 +252,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
                                     Write-Message -Level Verbose -Message "Beginning shrink of data files"
                                     foreach ($fileGroup in $db.FileGroups) {
                                         foreach ($file in $fileGroup.Files) {
-                                            Write-Message -Level Verbose -Message "Beggining shrink of $($file.Name)"
+                                            Write-Message -Level Verbose -Message "Beginning shrink of $($file.Name)"
                                             $file.Shrink($PercentFreeSpace, $ShrinkMethod)
                                         }
                                     }
@@ -274,7 +270,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
                             default {
                                 try {
                                     Write-Message -Level Verbose -Message "Beginning shrink of entire database"
-                                    $db.Shrink($PercentFreeSpace, $ShrinkMethod)
+                                    $db.Shrink($desiredSpaceAvailable, $ShrinkMethod)
                                     $db.Refresh()
                                     Write-Message -Level Verbose -Message "Recalculating space usage"
                                     if (-not $ExcludeUpdateUsage) { $db.RecalculateSpaceUsage() }
@@ -289,23 +285,23 @@ Shrinks all databases on SQL2012 (not ideal for production)
                         }
 
                         $end = Get-Date
-                        $dbsize = $db.Size
+                        $dbSize = $db.Size
                         $newSpaceAvailableMB = $db.SpaceAvailable / 1024
 
-                        Write-Message -Level Verbose -Message "Final database size: $([int]$dbsize) MB"
+                        Write-Message -Level Verbose -Message "Final database size: $([int]$dbSize) MB"
                         Write-Message -Level Verbose -Message "Final space available: $([int]$newSpaceAvailableMB) MB"
 
                         if ($db.Tables.Indexes.Name -and $server.VersionMajor -gt 8 -and $ExcludeIndexStats -eq $false) {
                             Write-Message -Level Verbose -Message "Refreshing indexes and getting average fragmentation"
-                            $endingdefrag = ($server.Query($sql, $db.name) | Select-Object -ExpandProperty avg_fragmentation_in_percent | Measure-Object -Average).Average
-                            $endingtopfrag = ($server.Query($sqltop1, $db.name)).avg_fragmentation_in_percent
+                            $endingDefrag = ($server.Query($sql, $db.name) | Select-Object -ExpandProperty avg_fragmentation_in_percent | Measure-Object -Average).Average
+                            $endingTopDefrag = ($server.Query($sqlTop1, $db.name)).avg_fragmentation_in_percent
                         }
                         else {
-                            $endingtopfrag = $endingdefrag = $null
+                            $endingTopDefrag = $endingDefrag = $null
                         }
 
-                        $timespan = New-TimeSpan -Start $start -End $end
-                        $ts = [timespan]::fromseconds($timespan.TotalSeconds)
+                        $timSpan = New-TimeSpan -Start $start -End $end
+                        $ts = [TimeSpan]::fromseconds($timSpan.TotalSeconds)
                         $elapsed = "{0:HH:mm:ss}" -f ([datetime]$ts.Ticks)
                     }
                 }
@@ -316,8 +312,7 @@ Shrinks all databases on SQL2012 (not ideal for production)
                     if ($null -eq $notes) {
                         $notes = "Database shrinks can cause massive index fragmentation and negatively impact performance. You should now run DBCC INDEXDEFRAG or ALTER INDEX ... REORGANIZE"
                     }
-
-                    $object = [pscustomobject]@{
+                    $object = [PSCustomObject]@{
                         ComputerName                  = $server.NetName
                         InstanceName                  = $server.ServiceName
                         SqlInstance                   = $server.DomainInstanceName
@@ -326,16 +321,16 @@ Shrinks all databases on SQL2012 (not ideal for production)
                         End                           = $end
                         Elapsed                       = $elapsed
                         Success                       = $success
-                        StartingTotalSizeMB           = [math]::Round($startingsize, 2)
-                        StartingUsedMB                = [math]::Round($spaceused, 2)
+                        StartingTotalSizeMB           = [math]::Round($startingSize, 2)
+                        StartingUsedMB                = [math]::Round($spaceUsed, 2)
                         FinalTotalSizeMB              = [math]::Round($db.size, 2)
-                        StartingAvailableMB           = [math]::Round($spaceavailableMB, 2)
+                        StartingAvailableMB           = [math]::Round($spaceAvailableMB, 2)
                         DesiredAvailableMB            = [math]::Round($desiredSpaceAvailable, 2)
                         FinalAvailableMB              = [math]::Round(($db.SpaceAvailable / 1024), 2)
-                        StartingAvgIndexFragmentation = [math]::Round($startingfrag, 1)
-                        EndingAvgIndexFragmentation   = [math]::Round($endingdefrag, 1)
-                        StartingTopIndexFragmentation = [math]::Round($startingtopfrag, 1)
-                        EndingTopIndexFragmentation   = [math]::Round($endingtopfrag, 1)
+                        StartingAvgIndexFragmentation = [math]::Round($startingFrag, 1)
+                        EndingAvgIndexFragmentation   = [math]::Round($endingDefrag, 1)
+                        StartingTopIndexFragmentation = [math]::Round($startingTopFrag, 1)
+                        EndingTopIndexFragmentation   = [math]::Round($endingTopDefrag, 1)
                         Notes                         = $notes
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3625 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
The parameter value being passed in was calculated for a desired value, but the desired value was not being passed to the shrink method properly.

End result was whatever value you passed in was the MB value the database was shrunk to.

As it stands the database does not test for this so the test we have on the command did not validate the value was properly passed. I can't correct that at this time so if someone wants to go back and fix that they can.