### PR TITLE
Add parameter filter for Get-DbaSqlInstanceProperty

### DIFF
--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -90,11 +90,11 @@ function Get-DbaSqlInstanceProperty {
             try {
                 $infoProperties = $server.Information.Properties
 
-                if ($Property) {
-                    $infoProperties = $infoProperties | Where-Object Name -In $Property
+                if ($InstanceProperty) {
+                    $infoProperties = $infoProperties | Where-Object Name -In $InstanceProperty
                 }
-                if ($ExcludeProperty) {
-                    $infoProperties = $infoProperties | Where-Object Name -NotIn $ExcludeProperty
+                if ($ExcludeInstanceProperty) {
+                    $infoProperties = $infoProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $infoProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
@@ -111,11 +111,11 @@ function Get-DbaSqlInstanceProperty {
             try {
                 $userProperties = $server.UserOptions.Properties
 
-                if ($Property) {
-                    $userProperties = $userProperties | Where-Object Name -In $Property
+                if ($InstanceProperty) {
+                    $userProperties = $userProperties | Where-Object Name -In $InstanceProperty
                 }
-                if ($ExcludeProperty) {
-                    $userProperties = $userProperties | Where-Object Name -NotIn $ExcludeProperty
+                if ($ExcludeInstanceProperty) {
+                    $userProperties = $userProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $userProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
@@ -132,11 +132,11 @@ function Get-DbaSqlInstanceProperty {
             try {
                 $settingProperties = $server.Settings.Properties
 
-                if ($Property) {
-                    $settingProperties = $settingProperties | Where-Object Name -In $Property
+                if ($InstanceProperty) {
+                    $settingProperties = $settingProperties | Where-Object Name -In $InstanceProperty
                 }
-                if ($ExcludeProperty) {
-                    $settingProperties = $settingProperties | Where-Object Name -NotIn $ExcludeProperty
+                if ($ExcludeInstanceProperty) {
+                    $settingProperties = $settingProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $settingProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -13,6 +13,12 @@ function Get-DbaSqlInstanceProperty {
         .PARAMETER SqlCredential
             Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
+        .PARAMETER Property
+            SQL Server instance property(ies) to include.
+
+        .PARAMETER ExcludeProperty
+            SQL Server instance property(ies) to exclude.
+
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -44,6 +50,16 @@ function Get-DbaSqlInstanceProperty {
             Returns SQL Instance properties on sql2 and sql4
 
         .EXAMPLE
+            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -Property DefaultFile
+
+            Returns SQL Server instance property DefaultFile on instance sql2 and sql4
+
+        .EXAMPLE
+            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -ExcludeProperty DefaultFile
+
+            Returns all SQL Server instance properties except DefaultFile on instance sql2 and sql4
+
+        .EXAMPLE
             $cred = Get-Credential sqladmin
             Get-DbaSqlInstanceProperty -SqlInstance sql2 -SqlCredential $cred
 
@@ -55,6 +71,8 @@ function Get-DbaSqlInstanceProperty {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [object[]]$Property,
+        [object[]]$ExcludeProperty,
         [Alias('Silent')]
         [switch]$EnableException
     )

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -2,10 +2,10 @@
 function Get-DbaSqlInstanceProperty {
     <#
         .SYNOPSIS
-            Gets SQL Instance properties of one or more instance(s) of SQL Server.
+            Gets SQL Server instance properties of one or more instance(s) of SQL Server.
 
         .DESCRIPTION
-            The Get-DbaSqlInstanceProperty command gets SQL Instance properties from the SMO object sqlserver.
+            The Get-DbaSqlInstanceProperty command gets SQL Server instance properties from the SMO object sqlserver.
 
         .PARAMETER SqlInstance
             SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
@@ -13,10 +13,10 @@ function Get-DbaSqlInstanceProperty {
         .PARAMETER SqlCredential
             Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
-        .PARAMETER Property
+        .PARAMETER InstanceProperty
             SQL Server instance property(ies) to include.
 
-        .PARAMETER ExcludeProperty
+        .PARAMETER ExcludeInstanceProperty
             SQL Server instance property(ies) to exclude.
 
         .PARAMETER EnableException
@@ -37,25 +37,25 @@ function Get-DbaSqlInstanceProperty {
         .EXAMPLE
             Get-DbaSqlInstanceProperty -SqlInstance localhost
 
-            Returns SQL Instance properties on the local default SQL Server instance
+            Returns SQL Server instance properties on the local default SQL Server instance
 
         .EXAMPLE
             Get-DbaSqlInstanceProperty -SqlInstance sql2, sql4\sqlexpress
 
-            Returns SQL Instance properties on default instance on sql2 and sqlexpress instance on sql4
+            Returns SQL Server instance properties on default instance on sql2 and sqlexpress instance on sql4
 
         .EXAMPLE
             'sql2','sql4' | Get-DbaSqlInstanceProperty
 
-            Returns SQL Instance properties on sql2 and sql4
+            Returns SQL Server instance properties on sql2 and sql4
 
         .EXAMPLE
-            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -Property DefaultFile
+            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -InstanceProperty DefaultFile
 
             Returns SQL Server instance property DefaultFile on instance sql2 and sql4
 
         .EXAMPLE
-            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -ExcludeProperty DefaultFile
+            Get-DbaSqlInstanceProperty -SqlInstance sql2,sql4 -ExcludeInstanceProperty DefaultFile
 
             Returns all SQL Server instance properties except DefaultFile on instance sql2 and sql4
 
@@ -63,16 +63,16 @@ function Get-DbaSqlInstanceProperty {
             $cred = Get-Credential sqladmin
             Get-DbaSqlInstanceProperty -SqlInstance sql2 -SqlCredential $cred
 
-            Connects using sqladmin credential and returns SQL Instance properties from sql2
-#>
+            Connects using sqladmin credential and returns SQL Server instance properties from sql2
+    #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
         [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [object[]]$Property,
-        [object[]]$ExcludeProperty,
+        [object[]]$InstanceProperty,
+        [object[]]$ExcludeInstanceProperty,
         [Alias('Silent')]
         [switch]$EnableException
     )
@@ -88,7 +88,15 @@ function Get-DbaSqlInstanceProperty {
             }
 
             try {
-                foreach ($prop in $server.Information.Properties) {
+                $infoProperties = $server.Information.Properties
+
+                if ($Property) {
+                    $infoProperties = $infoProperties | Where-Object Name -In $Property
+                }
+                if ($ExcludeProperty) {
+                    $infoProperties = $infoProperties | Where-Object Name -NotIn $ExcludeProperty
+                }
+                foreach ($prop in $infoProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
@@ -101,7 +109,15 @@ function Get-DbaSqlInstanceProperty {
             }
 
             try {
-                foreach ($prop in $server.Useroptions.Properties) {
+                $userProperties = $server.UserOptions.Properties
+
+                if ($Property) {
+                    $userProperties = $userProperties | Where-Object Name -In $Property
+                }
+                if ($ExcludeProperty) {
+                    $userProperties = $userProperties | Where-Object Name -NotIn $ExcludeProperty
+                }
+                foreach ($prop in $userProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
@@ -114,7 +130,15 @@ function Get-DbaSqlInstanceProperty {
             }
 
             try {
-                foreach ($prop in $server.Settings.Properties) {
+                $settingProperties = $server.Settings.Properties
+
+                if ($Property) {
+                    $settingProperties = $settingProperties | Where-Object Name -In $Property
+                }
+                if ($ExcludeProperty) {
+                    $settingProperties = $settingProperties | Where-Object Name -NotIn $ExcludeProperty
+                }
+                foreach ($prop in $settingProperties) {
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName

--- a/internal/dynamicparams/instanceproperty.ps1
+++ b/internal/dynamicparams/instanceproperty.ps1
@@ -1,0 +1,67 @@
+﻿#region Initialize Cache
+if (-not [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"]) {
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"] = @{ }
+}
+#endregion Initialize Cache
+
+#region Tepp Data return
+$ScriptBlock = {
+    param (
+        $commandName,
+
+        $parameterName,
+
+        $wordToComplete,
+
+        $commandAst,
+
+        $fakeBoundParameter
+    )
+
+
+    $server = $fakeBoundParameter['SqlInstance']
+
+    if (-not $server) {
+        $server = $fakeBoundParameter['Source']
+    }
+
+    if (-not $server) {
+        $server = $fakeBoundParameter['ComputerName']
+    }
+
+    if (-not $server) { return }
+
+    try {
+        [DbaInstanceParameter]$parServer = $server | Select-Object -First 1
+    }
+    catch {
+        return
+    }
+
+    if ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"][$parServer.FullSmoName.ToLower()]) {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*")) {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        return
+    }
+
+    try {
+        foreach ($name in ([Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"][$parServer.FullSmoName.ToLower()] | Where-DbaObject -Like "$wordToComplete*")) {
+            New-DbaTeppCompletionResult -CompletionText $name -ToolTip $name
+        }
+        return
+    }
+    catch {
+        return
+    }
+}
+
+Register-DbaTeppScriptblock -ScriptBlock $ScriptBlock -Name InstanceProperty
+#endregion Tepp Data return
+
+#region Update Cache
+$ScriptBlock = {
+    [Sqlcollaborative.Dbatools.TabExpansion.TabExpansionHost]::Cache["instanceproperty"][$FullSmoName] = $server.Information.Properties.Name + $server.UserOptions.Properties.Name + $server.Settings.Properties.Name
+}
+Register-DbaTeppInstanceCacheBuilder -ScriptBlock $ScriptBlock
+#endregion Update Cache

--- a/internal/scripts/insertTepp.ps1
+++ b/internal/scripts/insertTepp.ps1
@@ -65,6 +65,7 @@ Register-DbaTeppArgumentCompleter -Command $names -Parameter ServerTrigger -Name
 Register-DbaTeppArgumentCompleter -Command $names -Parameter Session -Name Session -All
 Register-DbaTeppArgumentCompleter -Command $names -Parameter Snapshot -Name Snapshot -All
 Register-DbaTeppArgumentCompleter -Command $names -Parameter SqlInstance -Name SqlInstance -All
+Register-DbaTeppArgumentCompleter -Command $names -Parameter InstanceProperty -Name InstanceProperty -All
 #endregion Automatic TEPP by parameter name
 
 #region Explicit TEPP

--- a/tests/Get-DbaSqlInstanceProperty.Tests.ps1
+++ b/tests/Get-DbaSqlInstanceProperty.Tests.ps1
@@ -39,7 +39,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $resultInclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -InstanceProperty DefaultFile
         $resultExclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -ExcludeInstanceProperty DefaultFile
         It "Should only return DefaultFile property" {
-            $resultInclude.Name | Should Be 'DefaultFile'
+            $resultInclude.Name | Should Contain 'DefaultFile'
         }
         It "Should not contain DefaultFile property" {
             $resultExclude.Name | Should Not Contain ([regex]::Escape("DefaultFile"))

--- a/tests/Get-DbaSqlInstanceProperty.Tests.ps1
+++ b/tests/Get-DbaSqlInstanceProperty.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 4
+        $paramCount = 5
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaSqlInstanceProperty).Parameters.Keys
-        $knownParameters = 'Computer', 'SqlInstance', 'SqlCredential', 'Property', 'ExcludeProperty', 'Credential', 'EnableException'
+        $knownParameters = 'Computer', 'SqlInstance', 'SqlCredential', 'InstanceProperty', 'ExcludeInstanceProperty', 'Credential', 'EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -36,8 +36,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
     }
     Context "Property filters work" {
-        $resultInclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -Property DefaultFile
-        $resultExclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -ExcludeProperty DefaultFile
+        $resultInclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -InstanceProperty DefaultFile
+        $resultExclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -ExcludeInstanceProperty DefaultFile
         It "Should only return DefaultFile property" {
             $resultInclude.Name | Should Be 'DefaultFile'
         }

--- a/tests/Get-DbaSqlInstanceProperty.Tests.ps1
+++ b/tests/Get-DbaSqlInstanceProperty.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 3
+        $paramCount = 4
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaSqlInstanceProperty).Parameters.Keys
-        $knownParameters = 'Computer', 'SqlInstance', 'SqlCredential', 'Credential', 'EnableException'
+        $knownParameters = 'Computer', 'SqlInstance', 'SqlCredential', 'Property', 'ExcludeProperty', 'Credential', 'EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -33,6 +33,16 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should get the correct DefaultFile location" {
             $defaultFiles = Get-DbaDefaultPath -SqlInstance $script:instance2
             ($results | Where-Object {$_.name -eq 'DefaultFile'}).Value | Should BeLike "$($defaultFiles.Data)*"
+        }
+    }
+    Context "Property filters work" {
+        $resultInclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -Property DefaultFile
+        $resultExclude = Get-DbaSqlInstanceProperty -SqlInstance $script:instance2 -ExcludeProperty DefaultFile
+        It "Should only return DefaultFile property" {
+            $resultInclude.Name | Should Be 'DefaultFile'
+        }
+        It "Should not contain DefaultFile property" {
+            $resultExclude.Name | Should Not Contain ([regex]::Escape("DefaultFile"))
         }
     }
     Context "Command can handle multiple instances" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding the ability to do direct filter on properties returned by the command. More user friendly and makes code cleaner.

Update test to validate the parameters as well.