### PR TITLE
Backup-DbaDatabase, clearer error

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -382,7 +382,7 @@ function Backup-DbaDatabase {
                             $null = New-DbaSqlDirectory -SqlInstance $server -Path $parentPath
                         }
                         else {
-                            $failreason += "SQL Server cannot write to the location $parentPath"
+                            $failreason += "SQL Server cannot check if $parentPath exists. You can try disabiling this check with -IgnoreFileChecks"
                             $failures += $failreason
                             Write-Message -Level Warning -Message "$failreason"
                         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3629 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
when no sysadmin permissions are granted to the user connecting, there's no safe way to discern if path is accessible or not (unfortunately). This fix just exposes better what the error can be the result of and how to - possibly - circumvent the issue
