### PR TITLE
login parameter ingestion fix

### DIFF
--- a/functions/Sync-DbaSqlLoginPermission.ps1
+++ b/functions/Sync-DbaSqlLoginPermission.ps1
@@ -144,10 +144,10 @@ function Sync-DbaSqlLoginPermission {
         if (Test-FunctionInterrupt) { return }
 
         if (!$Login) {
-            $logins = $sourceServer.Logins.Name
+            $login = $sourceServer.Logins.Name
         }
 
-        Sync-Only -SourceServer $sourceServer -DestServer $destServer -Logins $logins -Exclude $ExcludeLogin
+        Sync-Only -SourceServer $sourceServer -DestServer $destServer -Logins $login -Exclude $ExcludeLogin
     }
     end {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Sync-SqlLoginPermissions


### PR DESCRIPTION
an empty set would get passed into the Sync-Only function if the user supplied a value for the login parameter

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2176 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes the -Login parameter in Sync-DbaSqlLoginPermission