### PR TITLE
Invoke-DbaSqlQuery, fixes #3668

### DIFF
--- a/functions/Invoke-DbaSqlQuery.ps1
+++ b/functions/Invoke-DbaSqlQuery.ps1
@@ -293,10 +293,10 @@ function Invoke-DbaSqlQuery {
                         if ($null -eq $item) {continue}
                         $filePath = $(Resolve-Path -LiteralPath $item).ProviderPath
                         $QueryfromFile = [System.IO.File]::ReadAllText("$filePath")
-                        Invoke-DbaSqlAsync -SQLConnection $conncontext.SqlConnectionObject @splatInvokeDbaSqlAsync -Query $QueryfromFile
+                        Invoke-DbaSqlAsync -SQLConnection $conncontext @splatInvokeDbaSqlAsync -Query $QueryfromFile
                     }
                 }
-                else { Invoke-DbaSqlAsync -SQLConnection $conncontext.SqlConnectionObject @splatInvokeDbaSqlAsync }
+                else { Invoke-DbaSqlAsync -SQLConnection $conncontext @splatInvokeDbaSqlAsync }
             }
             catch {
                 Stop-Function -Message "[$db] Failed during execution" -ErrorRecord $_ -Target $server -Continue
@@ -320,11 +320,11 @@ function Invoke-DbaSqlQuery {
                         if ($null -eq $item) {continue}
                         $filePath = $(Resolve-Path -LiteralPath $item).ProviderPath
                         $QueryfromFile = [System.IO.File]::ReadAllText("$filePath")
-                        Invoke-DbaSqlAsync -SQLConnection $conncontext.SqlConnectionObject @splatInvokeDbaSqlAsync -Query $QueryfromFile
+                        Invoke-DbaSqlAsync -SQLConnection $conncontext @splatInvokeDbaSqlAsync -Query $QueryfromFile
                     }
                 }
                 else {
-                    Invoke-DbaSqlAsync -SQLConnection $conncontext.SqlConnectionObject @splatInvokeDbaSqlAsync
+                    Invoke-DbaSqlAsync -SQLConnection $conncontext @splatInvokeDbaSqlAsync
                 }
             }
             catch {

--- a/internal/functions/Invoke-DbaSqlAsync.ps1
+++ b/internal/functions/Invoke-DbaSqlAsync.ps1
@@ -44,7 +44,7 @@
     param (
         [Alias('Connection', 'Conn')]
         [ValidateNotNullOrEmpty()]
-        [System.Data.SqlClient.SQLConnection]$SQLConnection,
+        [Microsoft.SqlServer.Management.Common.ServerConnection]$SQLConnection,
 
         [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
         [string]
@@ -151,8 +151,7 @@
 
     }
     process {
-        $Conn = $SQLConnection
-
+        $Conn = $SQLConnection.SqlConnectionObject
 
 
         Write-Message -Level Debug -Message "Stripping GOs from source"
@@ -254,16 +253,15 @@
                 }
                 Resolve-SqlError $Err
             }
-
             if ($AppendServerInstance) {
                 #Basics from Chad Miller
                 $Column = New-Object Data.DataColumn
                 $Column.ColumnName = "ServerInstance"
-
+                
                 if ($ds.Tables.Count -ne 0) {
                     $ds.Tables[0].Columns.Add($Column)
                     Foreach ($row in $ds.Tables[0]) {
-                        $row.ServerInstance = $SQLInstance
+                        $row.ServerInstance = $SQLConnection.ServerInstance
                     }
                 }
             }

--- a/tests/Invoke-DbaSqlQuery.Tests.ps1
+++ b/tests/Invoke-DbaSqlQuery.Tests.ps1
@@ -6,27 +6,31 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     It "supports pipable instances" {
         $results = $script:instance1, $script:instance2 | Invoke-DbaSqlQuery -Database tempdb -Query "Select 'hello' as TestColumn"
         foreach ($result in $results) {
-            $result.TestColumn | Should Be 'hello'
+            $result.TestColumn | Should -Be 'hello'
         }
     }
     It "supports parameters" {
         $sqlParams = @{testvalue = 'hello'}
         $results = $script:instance1 | Invoke-DbaSqlQuery -Database tempdb -Query "Select @testvalue as TestColumn" -SqlParameters $sqlParams
         foreach ($result in $results) {
-            $result.TestColumn | Should Be 'hello'
+            $result.TestColumn | Should -Be 'hello'
         }
     }
     It "supports AppendServerInstance" {
+        $conn1 = Connect-DbaInstance $script:instance1
+        $conn2 = Connect-DbaInstance $script:instance2
+        $serverInstances = $conn1.Name, $conn2.Name
         $results = $script:instance1, $script:instance2 | Invoke-DbaSqlQuery -Database tempdb -Query "Select 'hello' as TestColumn" -AppendServerInstance
         foreach ($result in $results) {
-            $result.ServerInstance | Should Not Be Null
+            $result.ServerInstance | Should -Not -Be Null
+            $result.ServerInstance | Should -BeIn $serverInstances
         }
     }
     It "supports pipable databases" {
         $dbs = Get-DbaDatabase -SqlInstance $script:instance1, $script:instance2
         $results = $dbs | Invoke-DbaSqlQuery -Query "Select 'hello' as TestColumn, DB_NAME() as dbname"
         foreach ($result in $results) {
-            $result.TestColumn | Should Be 'hello'
+            $result.TestColumn | Should -Be 'hello'
         }
         'tempdb' | Should -Bein $results.dbname
     }
@@ -39,7 +43,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         Set-Content $testPath -value "Select 'hello' as TestColumn, DB_NAME() as dbname"
         $results = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -File $testPath
         foreach ($result in $results) {
-            $result.TestColumn | Should Be 'hello'
+            $result.TestColumn | Should -Be 'hello'
         }
         'tempdb' | Should -Bein $results.dbname
     }
@@ -63,7 +67,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -File $CloudQuery
         $check = "SELECT name FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[CommandLog]') AND type in (N'U')"
         $results = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -Query $check
-        $results.Name | Should Be 'CommandLog'
+        $results.Name | Should -Be 'CommandLog'
         $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Database tempdb -Query $cleanup
     }
     It "supports smo objects" {
@@ -83,7 +87,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $dbs = Get-DbaDatabaseState -SqlInstance $script:instance1, $script:instance2
         $results = $dbs | Invoke-DbaSqlQuery -Query "Select 'hello' as TestColumn, DB_NAME() as dbname"
         foreach ($result in $results) {
-            $result.TestColumn | Should Be 'hello'
+            $result.TestColumn | Should -Be 'hello'
         }
     }#>
     It "supports queries with GO statements" {
@@ -93,7 +97,7 @@ GO
 SELECT @@servername as dbname
 '@
         $results = $script:instance1, $script:instance2 | Invoke-DbaSqlQuery -Database tempdb -Query $Query
-        $results.dbname -contains 'tempdb' | Should Be $true
+        $results.dbname -contains 'tempdb' | Should -Be $true
     }
     It "streams correctly 'messages' with Verbose" {
         $query = @'


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3668)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fix #3668. Sorry, was my fault, and it slipped in because of a too permissive unittest

### Approach
Pass around something that can be used to retrieve the actual name of the instance.
Slapped a regression test so it won't ever happen again (see line 26 of tests).
