### PR TITLE
Correct spelling classifier

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -471,7 +471,7 @@
         'Get-DbaDbPageInfo',
         'Get-DbaConnection',
         'Test-DbaLoginPassword',
-        'Get-DbaResourceGovernorClassiferFunction'
+        'Get-DbaResourceGovernorClassifierFunction'
     )
 
     # Cmdlets to export from this module

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -85,8 +85,8 @@ function Copy-DbaResourceGovernor {
         $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
         $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
 
-        $sourceClassifierFunction = Get-DbaResourceGovernorClassiferFunction -SqlInstance $sourceServer
-        $destClassifierFunction = Get-DbaResourceGovernorClassiferFunction -SqlInstance $destServer
+        $sourceClassifierFunction = Get-DbaResourceGovernorClassifierFunction -SqlInstance $sourceServer
+        $destClassifierFunction = Get-DbaResourceGovernorClassifierFunction -SqlInstance $destServer
 
         $copyResourceGovSetting = [pscustomobject]@{
             SourceServer       = $sourceServer.Name

--- a/functions/Get-DbaResourceGovernorClassifierFunction.ps1
+++ b/functions/Get-DbaResourceGovernorClassifierFunction.ps1
@@ -1,4 +1,4 @@
-function Get-DbaResourceGovernorClassiferFunction {
+function Get-DbaResourceGovernorClassifierFunction {
 <#
 .SYNOPSIS
 Gets the Resource Governor custom classifier Function
@@ -24,13 +24,16 @@ Website: https://dbatools.io
 Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
 License: MIT https://opensource.org/licenses/MIT
 
+.LINK
+https://dbatools.io/Get-DbaResourceGovernorClassifierFunction
+
 .EXAMPLE
-Get-DbaResourceGovernorClassiferFunction -SqlInstance sql2016
+Get-DbaResourceGovernorClassifierFunction -SqlInstance sql2016
 
 Gets the classifier function object of the SqlInstance sql2016
 
 .EXAMPLE
-'Sql1','Sql2/sqlexpress' | Get-DbaResourceGovernorClassiferFunction
+'Sql1','Sql2/sqlexpress' | Get-DbaResourceGovernorClassifierFunction
 
 Gets the classifier function object on Sql1 and Sql2/sqlexpress instances
 

--- a/tests/Copy-DbaResourceGovernor.Tests.ps1
+++ b/tests/Copy-DbaResourceGovernor.Tests.ps1
@@ -60,7 +60,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.Name | Should -Contain 'dbatoolsci_prod'
         }
         It "returns the proper classifier function" {
-            $results = Get-DbaResourceGovernorClassiferFunction -SqlInstance $script:instance3
+            $results = Get-DbaResourceGovernorClassifierFunction -SqlInstance $script:instance3
             $results.Name | Should -Be 'dbatoolsci_fnRG'
         }
     }

--- a/tests/Get-DbaResourceGovernorClassifierFunction.Tests.ps1
+++ b/tests/Get-DbaResourceGovernorClassifierFunction.Tests.ps1
@@ -2,7 +2,7 @@
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $sql = "CREATE FUNCTION dbatoolsci_fnRG()
                 RETURNS sysname
@@ -22,7 +22,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
 
     Context "Command works" {
         It "returns the proper classifier function" {
-            $results = Get-DbaResourceGovernorClassiferFunction -SqlInstance $script:instance2
+            $results = Get-DbaResourceGovernorClassifierFunction -SqlInstance $script:instance2
             $results.Name | Should -Be 'dbatoolsci_fnRG'
         }
     }

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -52,22 +52,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             @(Get-ChildItem -path $script:PesterOutputPath -filter *.sql).Count | Should -Be 1
         }
 
-        It "verifies returns object with required properties when running with whatif" {
-            [System.Management.Automation.PSObject[]]$results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -WhatIf | Out-Null
-
-            $results.Count                                                             | Should -BeGreaterThan 10
-            ($results.ComputerName     | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.InstanceName     | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.SqlInstance      | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.Number           | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.Name             | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.Description      | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            ($results.DatabaseSpecific | Where-Object {$_ -eq $null}).Count             | Should -Be 0
-            $results.Database.Count                                                     | Should -Be $results.Count
-            $results.Notes.Count                                                        | Should -Be $results.Count
-            $results.Result.Count                                                       | Should -Be $results.Count
-        }
-
         It "exports single database specific query against single database" {
             $null = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2  -ExportQueries  -DatabaseSpecific -QueryName 'Database-scoped Configurations' -Database $database -OutputPath $script:PesterOutputPath
             @(Get-ChildItem -path $script:PesterOutputPath -filter *.sql | Where-Object {$_.FullName -match "($database)"}).Count | Should -Be 1

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -9,7 +9,7 @@ choco install codecov | Out-Null
 
 #Get PSScriptAnalyzer (to check warnings)
 Write-Host -Object "appveyor.prep: Install PSScriptAnalyzer" -ForegroundColor DarkGreen
-Install-Module -Name PSScriptAnalyzer | Out-Null
+Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck | Out-Null
 
 #Get Pester (to run tests)
 Write-Host -Object "appveyor.prep: Install Pester" -ForegroundColor DarkGreen


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system


- Correcting the spelling of Classifier in the command name.
- Sent all that WhatIf output from DiagnosticQuery command to `Out-Null` as we don't need to see the output itself.
- Updated appveyor prepwork to force install of latest version of PSSA. 