### PR TITLE
Remove CredentialAttribute Type from left overs

### DIFF
--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -58,8 +58,7 @@ function Get-DbaAgDatabase {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [parameter(ValueFromPipeline = $true)]
         [object[]]$AvailabilityGroup,
         [object[]]$Database,

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -54,8 +54,7 @@ function Get-DbaAgReplica {
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [parameter(ValueFromPipeline = $true)]
         [object[]]$AvailabilityGroup,
         [object[]]$Replica,

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -134,7 +134,7 @@ function Get-DbaBackupInformation {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(ParameterSetName = "Create")]
-        [PSCredential][System.Management.Automation.CredentialAttribute()]$SqlCredential,
+        [PSCredential]$SqlCredential,
         [string[]]$DatabaseName,
         [string[]]$SourceInstance,
         [parameter(ParameterSetName = "Create")]

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -74,8 +74,7 @@ function Get-DbaMaintenanceSolutionLog {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [ValidateSet('IndexOptimize', 'DatabaseBackup', 'DatabaseIntegrityCheck')]
         [string[]]$LogType = 'IndexOptimize',
         [datetime]$Since,

--- a/functions/Get-DbaPolicy.ps1
+++ b/functions/Get-DbaPolicy.ps1
@@ -58,8 +58,7 @@ function Get-DbaPolicy {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
-        [PSCredential][System.Management.Automation.CredentialAttribute()]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [string[]]$Policy,
         [string[]]$Category,
         [switch]$IncludeSystemObject,

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -127,7 +127,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Parameter(Mandatory = $false)]
-        [PSCredential][System.Management.Automation.CredentialAttribute()]$SqlCredential,
+        [PSCredential]$SqlCredential,
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,

--- a/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -87,44 +87,29 @@ function New-DbaLogShippingSecondaryPrimary {
         [parameter(Mandatory = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
-
-        [System.Management.Automation.PSCredential]
-        $SqlCredential,
-
+        [PSCredential]$SqlCredential,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupSourceDirectory,
-
         [Parameter(Mandatory = $false)]
         [string]$BackupDestinationDirectory,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJob,
-
         [int]$FileRetentionPeriod = 14420,
-
         [string]$MonitorServer,
-
-        [System.Management.Automation.PSCredential]
-        $MonitorCredential,
-
+        [PSCredential]$MonitorCredential,
         [Parameter(Mandatory = $true)]
         [ValidateSet(0, "sqlserver", 1, "windows")]
         [object]$MonitorServerSecurityMode = 1,
-
         [object]$PrimaryServer,
-
-        [PSCredential][System.Management.Automation.CredentialAttribute()]$PrimarySqlCredential,
+        [PSCredential]$PrimarySqlCredential,
         [object]$PrimaryDatabase,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$RestoreJob,
-
         [Alias('Silent')]
         [switch]$EnableException,
-
         [switch]$Force
     )
 


### PR DESCRIPTION
Cleaning out commands that still had the CredentialAttribute() type added to credential parameters.

This does not allow double-hop situations, particularly when you have remote sessions in use.

It should not break anything but we will see 🤞 