### PR TITLE
Fixing Watch-DbaUpdate to show notification properly

### DIFF
--- a/functions/Watch-DbaUpdate.ps1
+++ b/functions/Watch-DbaUpdate.ps1
@@ -22,7 +22,8 @@ function Watch-DbaUpdate {
 
             Watches the gallery for updates to dbatools.
     #>
-
+    [cmdletbinding()]
+    param()
     process {
         if (([Environment]::OSVersion).Version.Major -lt 10) {
             Write-Warning "This command only supports Windows 10 and higher."
@@ -36,7 +37,7 @@ function Watch-DbaUpdate {
         # leave this in for the scheduled task
         $module = Get-Module -Name dbatools
 
-        if (!$module) {
+        if (-not $module) {
             Import-Module dbatools
             $module = Get-Module -Name dbatools
         }
@@ -48,7 +49,7 @@ function Watch-DbaUpdate {
 
         $file = "$env:LOCALAPPDATA\dbatools\watchupdate.xml"
 
-        $new = [pscustomobject]@{
+        $new = [PSCustomObject]@{
             NotifyVersion = $galleryVersion
         }
 
@@ -60,7 +61,7 @@ function Watch-DbaUpdate {
 
             if ($galleryVersion -gt $old.NotifyVersion) {
                 Export-Clixml -InputObject $new -Path $file
-                Show-Notification
+                Show-Notification -GalleryVersion $galleryVersion
             }
         }
         else {
@@ -71,7 +72,7 @@ function Watch-DbaUpdate {
             }
 
             Export-Clixml -InputObject $new -Path $file
-            Show-Notification
+            Show-Notification -GalleryVersion $galleryVersion
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Windows 10 update fixed a bug that existed in Toast Notifications with the AppId and actually enforces having a legit AppID now.

I came across [SO answer](https://stackoverflow.com/a/46817674/847990) by BurntToast module author that shows simply using the AppID for PowerShell.

The problem or loss that this causes is we can't utilize the thor icon anymore. I am not able to get the notification to work adding that image. If I remove it the notification shows up like it should.

![image](https://user-images.githubusercontent.com/11204251/41448862-001b37e4-7023-11e8-832c-4db8e6425f3c.png)
