### PR TITLE
Set/Test-DbaDbCompression fix for issue #3698

### DIFF
--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -116,7 +116,7 @@ CREATE TABLE ##testdbacompression (
     ,[IndexName] SYSNAME NULL
     ,[Partition] INT
     ,[IndexID] INT
-    ,[IndexType] VARCHAR(12)
+    ,[IndexType] VARCHAR(25)
     ,[PercentScan] SMALLINT
     ,[PercentUpdate] SMALLINT
     ,[RowEstimatePercentOriginal] BIGINT
@@ -175,9 +175,32 @@ INNER JOIN sys.partitions p ON x.object_id = p.object_id
 WHERE objectproperty(t.object_id, 'IsUserTable') = 1
     AND p.data_compression_desc = 'NONE'
     AND p.rows > 0
-    AND t.is_memory_optimized = 0
-    AND t.object_id not in (select object_id from sys.columns where encryption_type IS NOT NULL)
 ORDER BY [TableName] ASC;
+
+DECLARE @sqlVersion int
+SELECT @sqlVersion = substring(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')),0,CHARINDEX('.',(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')))))
+IF @sqlVersion >= '12'
+    BEGIN
+		-- remove memory optimized tables
+		DELETE tdc
+		FROM ##testdbacompression tdc
+		INNER JOIN sys.tables t
+			ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
+			AND t.name = tdc.TableName
+		WHERE t.is_memory_optimized = 1
+	END
+IF @sqlVersion >= '13'
+    BEGIN
+		-- remove tables with encrypted columns
+		DELETE tdc
+		FROM ##testdbacompression tdc
+		INNER JOIN sys.tables t
+			ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
+			AND t.name = tdc.TableName
+		INNER JOIN sys.columns c
+			ON t.object_id = c.object_id
+		WHERE encryption_type IS NOT NULL
+	END
 
 DECLARE @schema SYSNAME
     ,@tbname SYSNAME

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -181,36 +181,36 @@ DECLARE @sqlVersion int
 SELECT @sqlVersion = substring(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')),0,CHARINDEX('.',(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')))))
 IF @sqlVersion >= '12'
     BEGIN
-		-- remove memory optimized tables
-		DELETE tdc
-		FROM ##testdbacompression tdc
-		INNER JOIN sys.tables t
-			ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
-			AND t.name = tdc.TableName
-		WHERE t.is_memory_optimized = 1
-	END
+        -- remove memory optimized tables
+        DELETE tdc
+        FROM ##testdbacompression tdc
+        INNER JOIN sys.tables t
+            ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
+            AND t.name = tdc.TableName
+        WHERE t.is_memory_optimized = 1
+    END
 IF @sqlVersion >= '13'
     BEGIN
-		-- remove tables with encrypted columns
-		DELETE tdc
-		FROM ##testdbacompression tdc
-		INNER JOIN sys.tables t
-			ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
-			AND t.name = tdc.TableName
-		INNER JOIN sys.columns c
-			ON t.object_id = c.object_id
-		WHERE encryption_type IS NOT NULL
+        -- remove tables with encrypted columns
+        DELETE tdc
+        FROM ##testdbacompression tdc
+        INNER JOIN sys.tables t
+            ON SCHEMA_NAME(t.schema_id) = tdc.[Schema]
+            AND t.name = tdc.TableName
+        INNER JOIN sys.columns c
+            ON t.object_id = c.object_id
+        WHERE encryption_type IS NOT NULL
     END
 IF @sqlVersion >= '14'
-	BEGIN
-		-- remove graph (node/edge) tables
-		DELETE tdc
-		FROM ##testdbacompression tdc
-		INNER JOIN sys.tables t
-			ON tdc.[Schema] = SCHEMA_NAME(t.schema_id)
-			AND tdc.TableName = t.name
-		WHERE (is_node = 1 OR is_edge = 1)
-	END
+    BEGIN
+        -- remove graph (node/edge) tables
+        DELETE tdc
+        FROM ##testdbacompression tdc
+        INNER JOIN sys.tables t
+            ON tdc.[Schema] = SCHEMA_NAME(t.schema_id)
+            AND tdc.TableName = t.name
+        WHERE (is_node = 1 OR is_edge = 1)
+    END
 
 DECLARE @schema SYSNAME
     ,@tbname SYSNAME

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -200,6 +200,16 @@ IF @sqlVersion >= '13'
 		INNER JOIN sys.columns c
 			ON t.object_id = c.object_id
 		WHERE encryption_type IS NOT NULL
+    END
+IF @sqlVersion >= '14'
+	BEGIN
+		-- remove graph (node/edge) tables
+		DELETE tdc
+		FROM ##testdbacompression tdc
+		INNER JOIN sys.tables t
+			ON tdc.[Schema] = SCHEMA_NAME(t.schema_id)
+			AND tdc.TableName = t.name
+		WHERE (is_node = 1 OR is_edge = 1)
 	END
 
 DECLARE @schema SYSNAME


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3698)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix issue #3698 where function is using columns not available in older version.
Also added logic to avoid node/edge tables as they can't be compressed.

### Approach
<!-- How does this change solve that purpose -->
Removed logic from main query, added logic to determine sql version and remove applicable objects depending on that version.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/41607813-eb7db13c-73b4-11e8-8a7a-804f4d249d34.png)

