### PR TITLE
Get-DbaHelpIndex, added fragmentation, fixes #1216

### DIFF
--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -148,7 +148,7 @@ function Get-DbaHelpIndex {
         #Add Fragmentation info if requested
         $FragSelectColumn = ", NULL as avg_fragmentation_in_percent"
         $FragJoin = ''
-        $OutputProperties = 'DatabaseName,ObjectName,IndexName,IndexType,KeyColumns,IncludeColumns,FilterDefinition,DataCompression,IndexReads,IndexUpdates,SizeKB,IndexRows,IndexLookups,MostRecentlyUsed,StatsSampleRows,StatsRowMods,HistogramSteps,StatsLastUpdated'
+        $OutputProperties = 'ComputerName,InstanceName,SqlInstance,DatabaseName,ObjectName,IndexName,IndexType,KeyColumns,IncludeColumns,FilterDefinition,DataCompression,IndexReads,IndexUpdates,SizeKB,IndexRows,IndexLookups,MostRecentlyUsed,StatsSampleRows,StatsRowMods,HistogramSteps,StatsLastUpdated'
         if ($IncludeFragmentation) {
             $FragSelectColumn = ', pstat.avg_fragmentation_in_percent'
             $FragJoin = "LEFT JOIN sys.dm_db_index_physical_stats(DB_ID(), NULL, NULL, NULL , 'DETAILED') pstat
@@ -1037,25 +1037,28 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            DatabaseName          = $db.Name
-                            ObjectName            = $detail.FullObjectName
-                            IndexName             = $detail.IndexName
-                            IndexType             = $detail.IndexType
-                            KeyColumns            = $detail.KeyColumns
-                            IncludeColumns        = $detail.IncludeColumns
-                            FilterDefinition      = $detail.FilterDefinition
-                            DataCompression       = $detail.DataCompression
-                            IndexReads            = "{0:N0}" -f $detail.IndexReads
-                            IndexUpdates          = "{0:N0}" -f $detail.IndexUpdates
-                            SizeKB                = "{0:N0}" -f $detail.SizeKB
-                            IndexRows             = "{0:N0}" -f $detail.IndexRows
-                            IndexLookups          = "{0:N0}" -f $detail.IndexLookups
-                            MostRecentlyUsed      = $recentlyused
-                            StatsSampleRows       = "{0:N0}" -f $detail.StatsSampleRows
-                            StatsRowMods          = "{0:N0}" -f $detail.StatsRowMods
-                            HistogramSteps        = $detail.HistogramSteps
-                            StatsLastUpdated      = $detail.StatsLastUpdated
-                            IndexFragInPercent    = "{0:F2}" -f $detail.IndexFragInPercent
+                            ComputerName   = $server.NetName
+                            InstanceName   = $server.ServiceName
+                            SqlInstance    = $server.DomainInstanceName
+                            Database       = $db.Name
+                            Object         = $detail.FullObjectName
+                            Index          = $detail.IndexName
+                            IndexType      = $detail.IndexType
+                            KeyColumns     = $detail.KeyColumns
+                            IncludeColumns = $detail.IncludeColumns
+                            FilterDefinition = $detail.FilterDefinition
+                            DataCompression = $detail.DataCompression
+                            IndexReads     = "{0:N0}" -f $detail.IndexReads
+                            IndexUpdates   = "{0:N0}" -f $detail.IndexUpdates
+                            SizeKB         = "{0:N0}" -f $detail.SizeKB
+                            IndexRows      = "{0:N0}" -f $detail.IndexRows
+                            IndexLookups   = "{0:N0}" -f $detail.IndexLookups
+                            MostRecentlyUsed = $recentlyused
+                            StatsSampleRows = "{0:N0}" -f $detail.StatsSampleRows
+                            StatsRowMods   = "{0:N0}" -f $detail.StatsRowMods
+                            HistogramSteps = $detail.HistogramSteps
+                            StatsLastUpdated = $detail.StatsLastUpdated
+                            IndexFragInPercent = "{0:F2}" -f $detail.IndexFragInPercent
                         } | Select-DefaultView -Property $OutputProperties
                     }
                 }
@@ -1069,25 +1072,28 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            DatabaseName          = $db.Name
-                            ObjectName            = $detail.FullObjectName
-                            IndexName             = $detail.IndexName
-                            IndexType             = $detail.IndexType
-                            KeyColumns            = $detail.KeyColumns
-                            IncludeColumns        = $detail.IncludeColumns
-                            FilterDefinition      = $detail.FilterDefinition
-                            DataCompression       = $detail.DataCompression
-                            IndexReads            = $detail.IndexReads
-                            IndexUpdates          = $detail.IndexUpdates
-                            SizeKB                = $detail.SizeKB
-                            IndexRows             = $detail.IndexRows
-                            IndexLookups          = $detail.IndexLookups
-                            MostRecentlyUsed      = $recentlyused
-                            StatsSampleRows       = $detail.StatsSampleRows
-                            StatsRowMods          = $detail.StatsRowMods
-                            HistogramSteps        = $detail.HistogramSteps
-                            StatsLastUpdated      = $detail.StatsLastUpdated
-                            IndexFragInPercent    = $detail.IndexFragInPercent
+                            ComputerName    = $server.NetName
+                            InstanceName    = $server.ServiceName
+                            SqlInstance     = $server.DomainInstanceName
+                            Database        = $db.Name
+                            Object          = $detail.FullObjectName
+                            Index           = $detail.IndexName
+                            IndexType       = $detail.IndexType
+                            KeyColumns      = $detail.KeyColumns
+                            IncludeColumns  = $detail.IncludeColumns
+                            FilterDefinition = $detail.FilterDefinition
+                            DataCompression = $detail.DataCompression
+                            IndexReads      = $detail.IndexReads
+                            IndexUpdates    = $detail.IndexUpdates
+                            SizeKB          = $detail.SizeKB
+                            IndexRows       = $detail.IndexRows
+                            IndexLookups    = $detail.IndexLookups
+                            MostRecentlyUsed = $recentlyused
+                            StatsSampleRows = $detail.StatsSampleRows
+                            StatsRowMods    = $detail.StatsRowMods
+                            HistogramSteps  = $detail.HistogramSteps
+                            StatsLastUpdated = $detail.StatsLastUpdated
+                            IndexFragInPercent = $detail.IndexFragInPercent
                         } | Select-DefaultView -Property $OutputProperties
                     }
                 }

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -48,6 +48,9 @@ function Get-DbaHelpIndex {
         .PARAMETER IncludeDataTypes
             If this switch is enabled, the output will include the data type of each column that makes up a part of the index definition (key and include columns).
 
+        .PARAMETER IncludeFragmentation
+            If this switch is enabled, the output will include fragmentation information.
+
         .PARAMETER InputObject
            Allows piping from Get-DbaDatabase
    
@@ -148,7 +151,7 @@ function Get-DbaHelpIndex {
         #Add Fragmentation info if requested
         $FragSelectColumn = ", NULL as avg_fragmentation_in_percent"
         $FragJoin = ''
-        $OutputProperties = 'ComputerName,InstanceName,SqlInstance,DatabaseName,ObjectName,IndexName,IndexType,KeyColumns,IncludeColumns,FilterDefinition,DataCompression,IndexReads,IndexUpdates,SizeKB,IndexRows,IndexLookups,MostRecentlyUsed,StatsSampleRows,StatsRowMods,HistogramSteps,StatsLastUpdated'
+        $OutputProperties = 'DatabaseName,ObjectName,IndexName,IndexType,KeyColumns,IncludeColumns,FilterDefinition,DataCompression,IndexReads,IndexUpdates,SizeKB,IndexRows,IndexLookups,MostRecentlyUsed,StatsSampleRows,StatsRowMods,HistogramSteps,StatsLastUpdated'
         if ($IncludeFragmentation) {
             $FragSelectColumn = ', pstat.avg_fragmentation_in_percent'
             $FragJoin = "LEFT JOIN sys.dm_db_index_physical_stats(DB_ID(), NULL, NULL, NULL , 'DETAILED') pstat
@@ -1037,25 +1040,25 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            ComputerName   = $server.NetName
-                            InstanceName   = $server.ServiceName
-                            SqlInstance    = $server.DomainInstanceName
-                            Database       = $db.Name
-                            Object         = $detail.FullObjectName
-                            Index          = $detail.IndexName
-                            IndexType      = $detail.IndexType
-                            KeyColumns     = $detail.KeyColumns
+                            ComputerName  = $server.NetName
+                            InstanceName  = $server.ServiceName
+                            SqlInstance   = $server.DomainInstanceName
+                            Database     = $db.Name
+                            Object        = $detail.FullObjectName
+                            Index         = $detail.IndexName
+                            IndexType     = $detail.IndexType
+                            KeyColumns    = $detail.KeyColumns
                             IncludeColumns = $detail.IncludeColumns
                             FilterDefinition = $detail.FilterDefinition
                             DataCompression = $detail.DataCompression
-                            IndexReads     = "{0:N0}" -f $detail.IndexReads
-                            IndexUpdates   = "{0:N0}" -f $detail.IndexUpdates
-                            SizeKB         = "{0:N0}" -f $detail.SizeKB
-                            IndexRows      = "{0:N0}" -f $detail.IndexRows
-                            IndexLookups   = "{0:N0}" -f $detail.IndexLookups
+                            IndexReads    = "{0:N0}" -f $detail.IndexReads
+                            IndexUpdates  = "{0:N0}" -f $detail.IndexUpdates
+                            SizeKB        = "{0:N0}" -f $detail.SizeKB
+                            IndexRows     = "{0:N0}" -f $detail.IndexRows
+                            IndexLookups  = "{0:N0}" -f $detail.IndexLookups
                             MostRecentlyUsed = $recentlyused
                             StatsSampleRows = "{0:N0}" -f $detail.StatsSampleRows
-                            StatsRowMods   = "{0:N0}" -f $detail.StatsRowMods
+                            StatsRowMods  = "{0:N0}" -f $detail.StatsRowMods
                             HistogramSteps = $detail.HistogramSteps
                             StatsLastUpdated = $detail.StatsLastUpdated
                             IndexFragInPercent = "{0:F2}" -f $detail.IndexFragInPercent
@@ -1072,26 +1075,26 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            ComputerName    = $server.NetName
-                            InstanceName    = $server.ServiceName
-                            SqlInstance     = $server.DomainInstanceName
-                            Database        = $db.Name
-                            Object          = $detail.FullObjectName
-                            Index           = $detail.IndexName
-                            IndexType       = $detail.IndexType
-                            KeyColumns      = $detail.KeyColumns
-                            IncludeColumns  = $detail.IncludeColumns
+                            ComputerName   = $server.NetName
+                            InstanceName   = $server.ServiceName
+                            SqlInstance    = $server.DomainInstanceName
+                            Database       = $db.Name
+                            Object         = $detail.FullObjectName
+                            Index          = $detail.IndexName
+                            IndexType      = $detail.IndexType
+                            KeyColumns     = $detail.KeyColumns
+                            IncludeColumns = $detail.IncludeColumns
                             FilterDefinition = $detail.FilterDefinition
                             DataCompression = $detail.DataCompression
-                            IndexReads      = $detail.IndexReads
-                            IndexUpdates    = $detail.IndexUpdates
-                            SizeKB          = $detail.SizeKB
-                            IndexRows       = $detail.IndexRows
-                            IndexLookups    = $detail.IndexLookups
+                            IndexReads     = $detail.IndexReads
+                            IndexUpdates   = $detail.IndexUpdates
+                            SizeKB         = $detail.SizeKB
+                            IndexRows      = $detail.IndexRows
+                            IndexLookups   = $detail.IndexLookups
                             MostRecentlyUsed = $recentlyused
                             StatsSampleRows = $detail.StatsSampleRows
-                            StatsRowMods    = $detail.StatsRowMods
-                            HistogramSteps  = $detail.HistogramSteps
+                            StatsRowMods   = $detail.StatsRowMods
+                            HistogramSteps = $detail.HistogramSteps
                             StatsLastUpdated = $detail.StatsLastUpdated
                             IndexFragInPercent = $detail.IndexFragInPercent
                         } | Select-DefaultView -Property $OutputProperties


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Add fragmentation info as requested in #1216

### Approach
A simple join to dm_db_index_physical_stats sufficed.

-----
Let's review this in the process and while I'm fresh with it, the select is a beast.........seems to me it needs a bit of love but ATM I lack forces for a good style review to port this to 1.0 readyness. 