### PR TITLE
Rename Test-DbaValidLogin, fixes #437

### DIFF
--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -1,7 +1,8 @@
-function Test-DbaValidLogin {
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+function Test-DbaWindowsLogin {
     <#
         .SYNOPSIS
-            Test-DbaValidLogin finds any logins on SQL instance that are AD logins with either disabled AD user accounts or ones that no longer exist
+            Test-DbaWindowsLogin finds any logins on SQL instance that are AD logins with either disabled AD user accounts or ones that no longer exist
 
         .DESCRIPTION
             The purpose of this function is to find SQL Server logins that are used by active directory users that are either disabled or removed from the domain. It allows you to keep your logins accurate and up to date by removing accounts that are no longer needed.
@@ -42,20 +43,20 @@ function Test-DbaValidLogin {
             License: MIT https://opensource.org/licenses/MIT
 
         .LINK
-            https://dbatools.io/Test-DbaValidLogin
+            https://dbatools.io/Test-DbaWindowsLogin
 
         .EXAMPLE
-            Test-DbaValidLogin -SqlInstance Dev01
+            Test-DbaWindowsLogin -SqlInstance Dev01
 
             Tests all logins in the current Active Directory domain that are either disabled or do not exist on the SQL Server instance Dev01
 
         .EXAMPLE
-            Test-DbaValidLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Property *
+            Test-DbaWindowsLogin -SqlInstance Dev01 -FilterBy GroupsOnly | Select-Object -Property *
 
             Tests all Active Directory groups that have logins on Dev01, and shows all information for those logins
 
         .EXAMPLE
-            Test-DbaValidLogin -SqlInstance Dev01 -IgnoreDomains testdomain
+            Test-DbaWindowsLogin -SqlInstance Dev01 -IgnoreDomains testdomain
 
             Tests all Domain logins excluding any that are from the testdomain
 
@@ -277,5 +278,8 @@ function Test-DbaValidLogin {
 
             }
         }
+    }
+    end {
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Test-DbaValidLogin
     }
 }

--- a/tests/Test-DbaWindowsLogin.Tests.ps1
+++ b/tests/Test-DbaWindowsLogin.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         #>
         $paramCount = 8
         $defaultParamCount = 11
-        [object[]]$params = (Get-ChildItem function:\Test-DbaValidLogin).Parameters.Keys
+        [object[]]$params = (Get-ChildItem function:\Test-DbaWindowsLogin).Parameters.Keys
         $knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'ExcludeLogin', 'FilterBy', 'IgnoreDomains', 'EnableException', 'Detailed'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
@@ -33,7 +33,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Did not include these tests yet as I was unsure if AppVeyor was capable of testing domain logins. Included these for future use.
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {
-        $results = Test-DbaValidLogin -SqlInstance $script:instance2
+        $results = Test-DbaWindowsLogin -SqlInstance $script:instance2
         It "Should return correct properties" {
             $ExpectedProps = 'AccountNotDelegated,AllowReversiblePasswordEncryption,CannotChangePassword,DisabledInSQLServer,Domain,Enabled,Found,LockedOut,Login,PasswordExpired,PasswordNeverExpires,PasswordNotRequired,Server,SmartcardLogonRequired,TrustedForDelegation,Type,UserAccountControl'.Split(',')
             ($results[0].PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #437)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
This rename was long due.
/cc @gbargsley to rename the relevant page on dbatools.io
/cc @potatoqualitee to update properly manifest

