### PR TITLE
Get-DbaSchemaChangeHistory, fixes #2064

### DIFF
--- a/functions/Get-DbaSchemaChangeHistory.ps1
+++ b/functions/Get-DbaSchemaChangeHistory.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaSchemaChangeHistory {
     <#
     .SYNOPSIS
@@ -107,7 +108,7 @@ function Get-DbaSchemaChangeHistory {
 
             foreach ($db in $Databases) {
                 if ($db.IsAccessible -eq $false) {
-                    Stop-Function -Message "$db on $server is inaccessible" -Continue
+                    Write-Message -Level Verbose -Message "$($db.name) is not accessible, skipping"
                 }
 
                 $sql = "select SERVERPROPERTY('MachineName') AS ComputerName,
@@ -144,7 +145,7 @@ function Get-DbaSchemaChangeHistory {
                 Write-Message -Level Verbose -Message "Querying Database $db on $instance"
                 Write-Message -Level Debug -Message "SQL: $sql"
 
-                $db.Query($sql)  | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, DatabaseName, DateModified, LoginName, UserName, ApplicationName, DDLOperation, Object, ObjectType
+                $db.Query($sql) | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, DatabaseName, DateModified, LoginName, UserName, ApplicationName, DDLOperation, Object, ObjectType
             }
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2064)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Changed a warning into a verbose. Function looks pretty 1.0 to me, so slapped in validationtags too.
