### PR TITLE
Adding time filtering before scanning for Maintenance Plan backups

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -294,9 +294,8 @@ function Get-DbaBackupInformation {
                 Write-Message -Level Warning -Message "Attempting to filter on filename. This may not always work"
                 $tmpFiles = @()
                 Foreach ($file in $files){
-                    $null=$file.fullname -match '[A-z]*_(?<date>[0-9]*_[0-9]*).[A-z]{3}'
+                    $null=$file.fullname -match '[A-z]*_(?<date>[0-9]*_[0-9]*)*.[A-z]{3}'
                     $FileDate = Get-Date -year $matches.date.Substring(0,4) -Month $matches.date.Substring(4,2) -Day $matches.date.Substring(6,2) -Hour $matches.date.Substring(9,2) -Minute $matches.date.Substring(11,2) -Second $matches.date.Substring(13,2)  
-                    Write-Verbose "$fileDate - $RestoreSince"
                     if ($FileDate -gt $RestoreSince){
                         $tmpFiles += $file
                     }

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -288,7 +288,7 @@ function Get-DbaBackupInformation {
                 Write-Message -Level Verbose -Message "Skipping Log Backups as requested"
                 $Files = $Files | Where-Object {$_.FullName -notlike '*\LOG\*'}
             }
-            if($True -eq $MaintenanceSolution -and $null -ne $RestoreSince){
+            if($True -eq $MaintenanceSolution -and $null -ne $RestoreSince -and $RestoreSince -lt (Get-Date)){
                 Write-Message -Level Warning -Message "Attempting to filter on filename. This may not always work"
                 $tmpFiles = @()
                 Foreach ($file in $files){

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -274,9 +274,7 @@ function Get-DbaBackupInformation {
                     }
                     else {
                         if ($true -eq $MaintenanceSolution) {
-                            $Files += Get-XpDirTreeRestoreFile -Path $f -SqlInstance $server 
-                           # $Files += Get-XpDirTreeRestoreFile -Path $f\DIFF -SqlInstance $server -NoRecurse
-                           # $Files += Get-XpDirTreeRestoreFile -Path $f\LOG -SqlInstance $server -NoRecurse
+                            $Files += Get-XpDirTreeRestoreFile -Path $f -SqlInstance $server
                         }
                         else {
                             Write-Message -Level VeryVerbose -Message "File"
@@ -295,7 +293,7 @@ function Get-DbaBackupInformation {
                 $tmpFiles = @()
                 Foreach ($file in $files){
                     $null=$file.fullname -match '[A-z]*_(?<date>[0-9]*_[0-9]*)*.[A-z]{3}'
-                    $FileDate = Get-Date -year $matches.date.Substring(0,4) -Month $matches.date.Substring(4,2) -Day $matches.date.Substring(6,2) -Hour $matches.date.Substring(9,2) -Minute $matches.date.Substring(11,2) -Second $matches.date.Substring(13,2)  
+                    $FileDate = Get-Date -year $matches.date.Substring(0,4) -Month $matches.date.Substring(4,2) -Day $matches.date.Substring(6,2) -Hour $matches.date.Substring(9,2) -Minute $matches.date.Substring(11,2) -Second $matches.date.Substring(13,2)
                     if ($FileDate -gt $RestoreSince){
                         $tmpFiles += $file
                     }
@@ -304,7 +302,7 @@ function Get-DbaBackupInformation {
                     $files = $tmpfiles
                 }
                 else{
-                    Stop-Function -Message "No backup files found after filtering with RestoreSince, exiting" -Category InvalidResult 
+                    Stop-Function -Message "No backup files found after filtering with RestoreSince, exiting" -Category InvalidResult
                     return
                 }
             }

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -250,7 +250,7 @@ function Get-DbaBackupInformation {
             }
             else {
                 ForEach ($f in $path) {
-                    Write-Message -Level VeryVerbose -Message "Not using sql for $f - $($f.GetType().ToString())"
+                    Write-Message -Level VeryVerbose -Message "Not using sql for $f"
                     if ($f -is [System.IO.FileSystemInfo]) {
                         if ($f.PsIsContainer -eq $true -and $true -ne $MaintenanceSolution) {
                             Write-Message -Level VeryVerbose -Message "folder $($f.fullname)"

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -548,7 +548,7 @@ function Restore-DbaDatabase {
                     }
                 }
                 Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
-                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -RestoreSince $RestoreSince -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
+                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -RestoreSince $RestoreTime -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if (-not (Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -333,7 +333,7 @@ function Restore-DbaDatabase {
         [parameter(ParameterSetName = "Restore")]
         [switch]$MaintenanceSolutionBackup,
         [parameter(ParameterSetName = "Restore")]
-        [DateTime]$RestoreSince,
+        [DateTime]$RestoreSince = (Get-Date).AddDays(1),
         [parameter(ParameterSetName = "Restore")]
         [hashtable]$FileMapping,
         [parameter(ParameterSetName = "Restore")]

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -70,10 +70,6 @@ function Restore-DbaDatabase {
         Switch to indicate the backup files are in a folder structure as created by Ola Hallengreen's maintenance scripts.
         This switch enables a faster check for suitable backups. Other options require all files to be read first to ensure we have an anchoring full backup. Because we can rely on specific locations for backups performed with OlaHallengren's backup solution, we can rely on file locations.
 
-    .PARAMETER RestoreSince
-        DateTime parameter only available in conjunction with the MaintenanceSolutionBackup switch.
-        When specified we will attempt to filter the backup files to only those created after this time. We do this based on the standard Maintenance Solution naming convention, so if you've altered that this won't work.
-    
     .PARAMETER FileMapping
         A hashtable that can be used to move specific files to a location.
         $FileMapping = @{'DataFile1'='c:\restoredfiles\Datafile1.mdf';'DataFile3'='d:\DataFile3.mdf'}
@@ -290,7 +286,7 @@ function Restore-DbaDatabase {
         AllowContinue is required to make sure we cope with existing files
 
     .EXAMPLE
-        Restore-DbaDatabase -SqlInstance server\instance1 -Path c:\backups\db1 -MaintenanceSolutionBackup -RestoreSince (Get-Date).AddDays(-2)
+        Restore-DbaDatabase -SqlInstance server\instance1 -Path c:\backups\db1 -MaintenanceSolutionBackup -RestoreTime (Get-Date).AddDays(-2)
 
         Filters the backups fould in c:\backups\db1 down to those created withing the last 2 days based on the standard Maintenance Solution naming convention of yyMMdd_hhmmss
     .NOTES
@@ -332,8 +328,6 @@ function Restore-DbaDatabase {
         [switch]$VerifyOnly,
         [parameter(ParameterSetName = "Restore")]
         [switch]$MaintenanceSolutionBackup,
-        [parameter(ParameterSetName = "Restore")]
-        [DateTime]$RestoreSince = (Get-Date).AddDays(1),
         [parameter(ParameterSetName = "Restore")]
         [hashtable]$FileMapping,
         [parameter(ParameterSetName = "Restore")]
@@ -548,7 +542,7 @@ function Restore-DbaDatabase {
                     }
                 }
                 Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
-                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -RestoreSince $RestoreTime -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
+                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -RestoreTime $RestoreTime -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if (-not (Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -142,7 +142,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results.count | Should Be 2
         }
         It "Should have returned 2 specific files"{
-            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\Simple\test_LOG_20160629_141330.trn".\test
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\Simple\test_LOG_20160629_141330.trn"
             $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\Simple\test_FULL_20160629_141320.bak"
         }
     }
@@ -182,15 +182,15 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
     Context "Check complex filtering to point in time without diff"{
         #Doing the date this way to avoid any locality issues.
-        $date = Get-date -Day 29 -Month 6 -Year 2016 -hour 14 -Minute 20 -Second 30
+        $date = Get-date -Day 29 -Month 6 -Year 2016 -hour 14 -Minute 15
         $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Complex -MaintenanceSolution -RestoreTime $Date
         It "Should return 3 results" {
             $results.count | Should Be 3
         }
         It "Should retun 3 specific files" {
             $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Full\test_FULL_20160629_141300.bak"
-            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_142000.trn"
-            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Diff\test_DIFF_20160629_141900.bak"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_141400.trn"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_141500.trn"
         }
     }
 

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -3,7 +3,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-
+<#
     BeforeAll {
         $DestBackupDir = 'C:\Temp\GetBackups'
         if (-Not(Test-Path $DestBackupDir)) {
@@ -49,6 +49,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $db3 | Backup-DbaDatabase -Type Full -BackupDirectory "$DestBackupDirOla\FULL"
         $db3 | Backup-DbaDatabase -Type Differential -BackupDirectory "$DestBackupDirOla\Diff"
         $db3 | Backup-DbaDatabase -Type Log -BackupDirectory "$DestBackupDirOla\LOG"
+
     }
 
     AfterAll {
@@ -129,6 +130,68 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $resultsSanLog.count | Should Be 3
         }
 
+    }
+#>
+    Context "Check Simple Maintenance Solution Filtering works" {
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Simple
+        It "Should return 4 records without filtering"{
+            $results.count | Should Be 4
+        }
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Simple -MaintenanceSolution -RestoreTime (Get-Date)
+        It "Should return 2 records with filtering" {
+            $results.count | Should Be 2
+        }
+        It "Should have returned 2 specific files"{
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\Simple\test_LOG_20160629_141330.trn".\test
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\Simple\test_FULL_20160629_141320.bak"
+        }
+    }
+
+    Context "Check it doesn't filter without the maintenancesolution switch" {
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Simple -RestoreTime (Get-Date)
+        It "Should return 4 records as no filtering" {
+            $results.count | Should Be 4
+        }
+    }
+
+    Context "Check complex filtering to latest point in time"{
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Complex -MaintenanceSolution -RestoreTime (Get-Date).adddays(1)
+        It "Should return 4 results" {
+            $results.count | Should Be 4
+        }
+        It "Should retun 4 specific files" {
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_143000.trn"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_142900.trn"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Diff\test_DIFF_20160629_142800.bak"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Full\test_FULL_20160629_142200.bak"
+        }
+    }
+
+    Context "Check complex filtering to point in time with diff"{
+        #Doing the date this way to avoid any locality issues.
+        $date = Get-date -Day 29 -Month 6 -Year 2016 -hour 14 -Minute 20 -Second 30
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Complex -MaintenanceSolution -RestoreTime $Date
+        It "Should return 3 results" {
+            $results.count | Should Be 3
+        }
+        It "Should retun 3 specific files" {
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Full\test_FULL_20160629_141300.bak"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_142000.trn"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Diff\test_DIFF_20160629_141900.bak"
+        }
+    }
+    Context "Check complex filtering to point in time without diff"{
+        #Doing the date this way to avoid any locality issues.
+        $date = Get-date -Day 29 -Month 6 -Year 2016 -hour 14 -Minute 20 -Second 30
+        $results = Get-DbaBackupInformation -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\OlaMsFilter\Complex -MaintenanceSolution -RestoreTime $Date
+        It "Should return 3 results" {
+            $results.count | Should Be 3
+        }
+        It "Should retun 3 specific files" {
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Full\test_FULL_20160629_141300.bak"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Log\test_LOG_20160629_142000.trn"
+            $results.fullname | Should Contain "$script:appveyorlabrepo\OlaMsFilter\complex\Diff\test_DIFF_20160629_141900.bak"
+        }
     }
 
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #3704)
 - [x] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Stop the whining :wink:

### Approach
Use the one thing we can trust to filter the files (don't have file creation for XpDirTree so that's out) which is pattern matching on the filename. Only works if people haven't played with Ola's scripts as it relys on it being yyyyMMdd_hhmmss

### Commands to test
Example in Restore-DbaDatabase

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
