### PR TITLE
Install-DbaMaintenanceSolution - Fixing issue with backup location not being replaced correctly

### DIFF
--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -216,8 +216,8 @@ function Install-DbaMaintenanceSolution {
 
             # Backup location
             if ($BackupLocation) {
-                $findBKP = 'C:\Backup'
-                $replaceBKP = $BackupLocation
+                $findBKP = 'SET @BackupDirectory     = NULL'
+                $replaceBKP = 'SET @BackupDirectory     = N''' + $BackupLocation + ''''
                 foreach ($file in $listOfFiles) {
                     (Get-Content -Path $file -Raw).Replace($findBKP, $replaceBKP) | Set-Content -Path $file
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix issue with the current cmdlet that doesn't replace the backup location variable correctly when being run. When the SQL Agent jobs are being created the backup location is set to NULL instead of the supplied value from the cmdlet.

### Approach
<!-- How does this change solve that purpose -->
Using the same approach as other parts of the cmdlet to replace the built in variables in the script

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Install-DbaMaintenanceSolution -SqlInstance . -Database master -BackupLocation "J:\MSSQL_BACKUP" -InstallJobs -ReplaceExisting -Solution All

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/8750181/42029723-cb3b5622-7ad0-11e8-89a0-85507c4565a3.png)