### PR TITLE
Get-DbaCredential: Support for list of instances

### DIFF
--- a/functions/Get-DbaCredential.ps1
+++ b/functions/Get-DbaCredential.ps1
@@ -63,7 +63,7 @@ function Get-DbaCredential {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     param (
         [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
-        [DbaInstanceParameter]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Name,
         [string[]]$ExcludeName,


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Change

 - Updated DbaInstanceParameter to ba an array. Was non-array and thus examples would not work properly when running against multiple instances without piping them.