### PR TITLE
Cleaning up connection verbose message

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -165,7 +165,7 @@ function Backup-DbaDatabase {
         if ($SqlInstance.length -ne 0) {
             Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
             try {
-                $Server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+                $Server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AzureUnsupported
             }
             catch {
                 Write-Message -Level Warning -Message "Cannot connect to $SqlInstance"
@@ -355,7 +355,7 @@ function Backup-DbaDatabase {
                     $FinalBackupPath += $FinalBackupPath[0]
                 }
             }
-            
+
             if ($AzureBaseUrl -or $AzureCredential) {
                 $slash = "/"
             }

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -51,7 +51,7 @@ function Clear-DbaWaitStatistics {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -665,7 +665,7 @@ function Copy-DbaDatabase {
             return
         }
 
-        Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers."
+        Write-Message -Level Verbose -Message "Connecting to SQL Servers."
         $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
         $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
 

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -115,13 +115,13 @@ function Copy-DbaLogin {
             Copy-DbaLogin -LoginRenameHashtable @{ "OldUser" ="newlogin" } -Source $Sql01 -Destination Localhost -SourceSqlCredential $sqlcred
 
             Copies OldUser and then renames it to newlogin.
-    
+
         .EXAMPLE
             Get-DbaLogin -SqlInstance sql2016 | Out-GridView -Passthru | Copy-DbaLogin -Destination sql2017
 
             Displays all available logins on sql2016 in a grid view, then copies all selected logins to sql2017.
     #>
-    
+
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]
     Param (
         [parameter(ParameterSetName = "SqlInstance", Mandatory)]
@@ -492,35 +492,35 @@ function Copy-DbaLogin {
             } #end for each $sourceLogin
         } #end function Copy-Login
     }
-    
+
     process {
-        
+
         if (Test-Bound -ParameterName InputObject) {
             $Source = $InputObject[0].Parent.Name
             $Sourceserver = $InputObject[0].Parent
             $Login = $InputObject.Name
         }
         else {
-            Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers."
+            Write-Message -Level Verbose -Message "Connecting to SQL Servers."
             $sourceServer = Connect-SqlInstance -RegularUser -SqlInstance $Source -SqlCredential $SourceSqlCredential
             $source = $sourceServer.DomainInstanceName
         }
-        
+
         if ($Destination) {
             $destServer = Connect-SqlInstance -RegularUser -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
             $Destination = $destServer.DomainInstanceName
-            
+
             $sourceVersionMajor = $sourceServer.VersionMajor
             $destVersionMajor = $destServer.VersionMajor
             if ($sourceVersionMajor -gt 10 -and $destVersionMajor -lt 11) {
                 Stop-Function -Message "Login migration from version $sourceVersionMajor to $destVersionMajor is not supported." -Category InvalidOperation -ErrorRecord $_ -Target $sourceServer
             }
-            
+
             if ($sourceVersionMajor -lt 8 -or $destVersionMajor -lt 8) {
                 Stop-Function -Message "SQL Server 7 and below are not supported." -Category InvalidOperation -ErrorRecord $_ -Target $sourceServer
             }
         }
-        
+
         if ($SyncOnly) {
             Sync-DbaLoginPermission -Source $sourceServer -Destination $destServer -Login $Login -ExcludeLogin $ExcludeLogin
             return

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -76,7 +76,7 @@ function Disable-DbaAgHadr {
                     try {
                         $computer = $computerName = $instance.ComputerName
                         $instanceName = $instance.InstanceName
-                        Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+                        Write-Message -Level Verbose -Message "Connecting to $computer"
                         $currentState = Invoke-ManagedComputerCommand -ComputerName $computerName -ScriptBlock { $wmi.Services[$args[0]] | Select-Object IsHadrEnabled } -ArgumentList $instanceName -Credential $Credential
                     }
                     catch {

--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -49,7 +49,7 @@ function Disable-DbaTraceFlag {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -110,7 +110,7 @@ function Enable-DbaAgHadr {
                     try {
                         $computer = $computerName = $instance.ComputerName
                         $instanceName = $instance.InstanceName
-                        Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+                        Write-Message -Level Verbose -Message "Connecting to $computer"
                         $currentState = Invoke-ManagedComputerCommand -ComputerName $computerName -ScriptBlock { $wmi.Services[$args[0]] | Select-Object IsHadrEnabled } -ArgumentList $instanceName -Credential $Credential
                     }
                     catch {

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -52,8 +52,7 @@ function Enable-DbaTraceFlag {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
@@ -65,7 +64,7 @@ function Enable-DbaTraceFlag {
 
             # We could combine all trace flags but the granularity is worth it
             foreach ($tf in $TraceFlag) {
-                $TraceFlagInfo = [pscustomobject]@{
+                $TraceFlagInfo = [PSCustomObject]@{
                     SourceServer = $server.NetName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
@@ -74,7 +73,7 @@ function Enable-DbaTraceFlag {
                     Notes        = $null
                     DateTime     = [DbaDateTime](Get-Date)
                 }
-                If ($CurrentRunningTraceFlags.TraceFlag -contains $tf) {
+                if ($CurrentRunningTraceFlags.TraceFlag -contains $tf) {
                     $TraceFlagInfo.Status = 'Skipped'
                     $TraceFlagInfo.Notes = "The Trace flag is already running."
                     $TraceFlagInfo

--- a/functions/Export-DbaAvailabilityGroup.ps1
+++ b/functions/Export-DbaAvailabilityGroup.ps1
@@ -84,7 +84,7 @@ function Export-DbaAvailabilityGroup {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Export-DbaExecutionPlan.ps1
+++ b/functions/Export-DbaExecutionPlan.ps1
@@ -156,7 +156,7 @@ function Export-DbaExecutionPlan {
         }
 
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -143,8 +143,6 @@ function Export-DbaUser {
                 Stop-Function -Message "Parent directory $directory does not exist"
                 return
             }
-
-            Write-Message -Level Output -Message "Attempting to connect to SQL Servers.."
         }
 
         $outsql = @()
@@ -175,7 +173,7 @@ function Export-DbaUser {
 
         try {
             Write-Message -Level Verbose -Message "Connecting to $sqlinstance"
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $sqlcredential
+            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         }
         catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue

--- a/functions/Find-DbaDatabase.ps1
+++ b/functions/Find-DbaDatabase.ps1
@@ -79,7 +79,7 @@ function Find-DbaDatabase {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Find-DbaDbGrowthEvent.ps1
+++ b/functions/Find-DbaDbGrowthEvent.ps1
@@ -225,7 +225,7 @@ function Find-DbaDbGrowthEvent {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Find-DbaDisabledIndex.ps1
+++ b/functions/Find-DbaDisabledIndex.ps1
@@ -101,8 +101,7 @@
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential  -MinimumVersion 9
             }

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -130,8 +130,7 @@ function Find-DbaLoginInGroup {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Find-DbaUnusedIndex.ps1
+++ b/functions/Find-DbaUnusedIndex.ps1
@@ -91,7 +91,7 @@ function Find-DbaUnusedIndex {
 
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
-    Param (
+    param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -163,7 +163,7 @@ function Find-DbaUnusedIndex {
             }
         }
 
-        Write-Message -Level Output -Message "Attempting to connect to Sql Server."
+        Write-Message -Level Output -Message "Connecting to SQL Server."
         $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     }
     process {

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -70,7 +70,7 @@ function Find-DbaUserObject {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -83,7 +83,7 @@ function Get-DbaAgentJob {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -245,7 +245,7 @@ function Get-DbaAgentJobHistory {
                         2 { "Retry" }
                         3 { "Canceled" }
                     }
-                    
+
                     Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name ComputerName -value $server.NetName
                     Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
@@ -294,7 +294,7 @@ function Get-DbaAgentJobHistory {
         }
 
         foreach ($instance in $SqlInstance) {
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaAgentJobOutputFile.ps1
+++ b/functions/Get-DbaAgentJobOutputFile.ps1
@@ -105,7 +105,7 @@ function Get-DbaAgentJobOutputFile {
 
     process {
         foreach ($instance in $sqlinstance) {
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaAgentJobStep.ps1
+++ b/functions/Get-DbaAgentJobStep.ps1
@@ -83,7 +83,7 @@
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaAgentLog.ps1
+++ b/functions/Get-DbaAgentLog.ps1
@@ -60,7 +60,7 @@ function Get-DbaAgentLog {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -229,7 +229,7 @@ function Get-DbaAgentSchedule {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaBackupDevice.ps1
+++ b/functions/Get-DbaBackupDevice.ps1
@@ -51,7 +51,7 @@ function Get-DbaBackupDevice {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -60,7 +60,7 @@ function Get-DbaComputerSystem {
     process {
         foreach ($computer in $ComputerName) {
             try {
-                Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+                Write-Message -Level Verbose -Message "Connecting to $computer"
                 $server = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential
 
                 $computerResolved = $server.FullComputerName

--- a/functions/Get-DbaCredential.ps1
+++ b/functions/Get-DbaCredential.ps1
@@ -20,7 +20,7 @@ function Get-DbaCredential {
 
         .PARAMETER ExcludeName
             Excluded credential names
-    
+
         .PARAMETER Identity
             Only include specific identities
             Note: if spaces exist in the credential identity, you will have to type "" or '' around it.
@@ -53,7 +53,7 @@ function Get-DbaCredential {
             Get-DbaCredential -SqlInstance localhost, sql2016 -Name 'PowerShell Proxy'
 
             Returns the SQL Credentials named 'PowerShell Proxy' for the local and sql2016 SQL Server instances
-    
+
         .EXAMPLE
             Get-DbaCredential -SqlInstance localhost, sql2016 -Identity ad\powershell
 
@@ -77,7 +77,7 @@ function Get-DbaCredential {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
@@ -86,23 +86,23 @@ function Get-DbaCredential {
             }
 
             $credential = $server.Credentials
-            
+
             if ($Name) {
                 $credential = $credential | Where-Object { $Name -contains $_.Name }
             }
-            
+
             if ($ExcludeName) {
                 $credential = $credential | Where-Object { $ExcludeName -notcontains $_.Name }
             }
-            
+
             if ($Identity) {
                 $credential = $credential | Where-Object { $Identity -contains $_.Identity }
             }
-            
+
             if ($ExcludeIdentity) {
                 $credential = $credential | Where-Object { $ExcludeIdentity -notcontains $_.Identity }
             }
-            
+
             foreach ($currentcredential in $credential) {
                 Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name ComputerName -value $currentcredential.Parent.NetName
                 Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name InstanceName -value $currentcredential.Parent.ServiceName

--- a/functions/Get-DbaCustomError.ps1
+++ b/functions/Get-DbaCustomError.ps1
@@ -50,7 +50,7 @@ function Get-DbaCustomError {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaDatabaseAssembly.ps1
+++ b/functions/Get-DbaDatabaseAssembly.ps1
@@ -50,7 +50,7 @@ function Get-DbaDatabaseAssembly {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaDbMailHistory.ps1
+++ b/functions/Get-DbaDbMailHistory.ps1
@@ -65,7 +65,7 @@ function Get-DbaDbMailHistory {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaDbMailLog.ps1
+++ b/functions/Get-DbaDbMailLog.ps1
@@ -65,7 +65,7 @@ function Get-DbaDbMailLog {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaDbPageInfo.ps1
+++ b/functions/Get-DbaDbPageInfo.ps1
@@ -105,7 +105,7 @@ function Get-DbaDbPageInfo {
         foreach ($instance in $SqlInstance) {
 
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             }

--- a/functions/Get-DbaDistributor.ps1
+++ b/functions/Get-DbaDistributor.ps1
@@ -51,7 +51,7 @@ function Get-DbaDistributor {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             # connect to the instance
             try {

--- a/functions/Get-DbaEndpoint.ps1
+++ b/functions/Get-DbaEndpoint.ps1
@@ -51,7 +51,7 @@ function Get-DbaEndpoint {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaErrorLog.ps1
+++ b/functions/Get-DbaErrorLog.ps1
@@ -101,7 +101,7 @@ function Get-DbaErrorLog {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaJobCategory.ps1
+++ b/functions/Get-DbaJobCategory.ps1
@@ -51,7 +51,7 @@ function Get-DbaJobCategory {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaLogShippingError.ps1
+++ b/functions/Get-DbaLogShippingError.ps1
@@ -108,7 +108,7 @@ function Get-DbaLogShippingError {
     process {
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -153,7 +153,7 @@ function Get-DbaLogin {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaOpenTransaction.ps1
+++ b/functions/Get-DbaOpenTransaction.ps1
@@ -86,7 +86,7 @@
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -50,7 +50,7 @@ function Get-DbaOperatingSystem {
     )
     process {
         foreach ($computer in $ComputerName) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $computer"
+            Write-Message -Level Verbose -Message "Connecting to $computer"
             $server = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential
 
             $computerResolved = $server.FullComputerName

--- a/functions/Get-DbaPolicy.ps1
+++ b/functions/Get-DbaPolicy.ps1
@@ -68,7 +68,7 @@ function Get-DbaPolicy {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10

--- a/functions/Get-DbaProcess.ps1
+++ b/functions/Get-DbaProcess.ps1
@@ -92,7 +92,7 @@ function Get-DbaProcess {
     process {
         foreach ($instance in $sqlinstance) {
 
-            Write-Message -Message "Attempting to connect to $instance." -Level Verbose
+            Write-Message -Message "Connecting to $instance." -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaQueryExecutionTime.ps1
+++ b/functions/Get-DbaQueryExecutionTime.ps1
@@ -105,8 +105,8 @@ limiting results to queries with more than 200 total executions and an execution
                 FROM    sys.dm_exec_procedure_stats
                 WHERE   database_id = DB_ID()"
 
-        If ($MinExecs) { $sql += "`n AND execution_count >= " + $MinExecs }
-        If ($MinExecMs) { $sql += "`n AND (total_worker_time / execution_count) / 1000 >= " + $MinExecMs }
+        if ($MinExecs) { $sql += "`n AND execution_count >= " + $MinExecs }
+        if ($MinExecMs) { $sql += "`n AND (total_worker_time / execution_count) / 1000 >= " + $MinExecMs }
 
         $sql += "`n UNION
             SELECT
@@ -132,11 +132,11 @@ limiting results to queries with more than 200 total executions and an execution
             CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) as st
             WHERE st.dbid = DB_ID() OR (pa.attribute = 'dbid' and pa.value = DB_ID())"
 
-        If ($MinExecs) { $sql += "`n AND execution_count >= " + $MinExecs }
-        If ($MinExecMs) { $sql += "`n AND (total_worker_time / execution_count) / 1000 >= " + $MinExecMs }
+        if ($MinExecs) { $sql += "`n AND execution_count >= " + $MinExecs }
+        if ($MinExecMs) { $sql += "`n AND (total_worker_time / execution_count) / 1000 >= " + $MinExecMs }
 
-        If ($MaxResultsPerDb) { $sql += ")`n SELECT TOP " + $MaxResultsPerDb }
-        Else {
+        if ($MaxResultsPerDb) { $sql += ")`n SELECT TOP " + $MaxResultsPerDb }
+        else {
             $sql += ")
                         SELECT "
         }
@@ -156,14 +156,14 @@ limiting results to queries with more than 200 total executions and an execution
                         full_statement_text
                     FROM StatsCTE "
 
-        If ($MinExecs -or $MinExecMs) {
+        if ($MinExecs -or $MinExecMs) {
             $sql += "`n WHERE `n"
 
-            If ($MinExecs) {
+            if ($MinExecs) {
                 $sql += " execution_count >= " + $MinExecs
             }
 
-            If ($MinExecMs -gt 0 -and $MinExecs) {
+            if ($MinExecMs -gt 0 -and $MinExecs) {
                 $sql += "`n AND AvgExec_ms >= " + $MinExecMs
             }
             elseif ($MinExecMs) {
@@ -175,23 +175,17 @@ limiting results to queries with more than 200 total executions and an execution
     }
     process {
         if (!$MaxResultsPerDb -and !$MinExecs -and !$MinExecMs) {
-            Write-Warning "Results may take time, depending on system resources and size of buffer cache."
-            Write-Warning "Consider limiting results using -MaxResultsPerDb, -MinExecs and -MinExecMs parameters."
+            Write-Message -Level Warning -Message "Results may take time, depending on system resources and size of buffer cache."
+            Write-Message -Level Warning -Message "Consider limiting results using -MaxResultsPerDb, -MinExecs and -MinExecMs parameters."
         }
 
         foreach ($instance in $SqlInstance) {
-            Write-Verbose "Attempting to connect to $instance"
+            Write--Message -Level Verbose -Message "Connecting to $instance"
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             }
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
-
-            if ($server.versionMajor -lt 10) {
-                Write-Warning "This function does not support versions lower than SQL Server 2008 (v10). Skipping server $instance."
-
-                Continue
             }
 
             $dbs = $server.Databases
@@ -208,11 +202,11 @@ limiting results to queries with more than 200 total executions and an execution
             }
 
             foreach ($db in $dbs) {
-                Write-Verbose "Processing $db on $instance"
+                Write-Message -Level Verbose -Message "Processing $db on $instance"
 
                 if ($db.IsAccessible -eq $false) {
-                    Write-Warning "The database $db is not accessible. Skipping database."
-                    Continue
+                    Write-Message -Level Warning -Message "The database $db is not accessible. Skipping database."
+                    continue
                 }
 
                 try {
@@ -238,8 +232,7 @@ limiting results to queries with more than 200 total executions and an execution
                     }
                 }
                 catch {
-                    Write-Warning "Could not process $db on $instance. Exception: $_"
-                    Continue
+                    Stop-Function -Message "Could not process $db on $instance" -Target $db -ErrorRecord $_ -Continue
                 }
             }
         }

--- a/functions/Get-DbaSchemaChangeHistory.ps1
+++ b/functions/Get-DbaSchemaChangeHistory.ps1
@@ -84,7 +84,7 @@ function Get-DbaSchemaChangeHistory {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaServerAuditSpecification.ps1
+++ b/functions/Get-DbaServerAuditSpecification.ps1
@@ -50,7 +50,7 @@ function Get-DbaServerAuditSpecification {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Verbose "Attempting to connect to $instance"
+            Write-Verbose "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -79,7 +79,7 @@ function Get-DbaSqlInstanceProperty {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaSqlProductKey.ps1
+++ b/functions/Get-DbaSqlProductKey.ps1
@@ -159,7 +159,7 @@ Gets SQL Server versions, editions and product keys for all instances listed wit
                     else { $SqlInstance = "$clustername\$instance" }
                 }
 
-                Write-Verbose "Attempting to connect to $SqlInstance"
+                Write-Verbose "Connecting to $SqlInstance"
                 try { $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential }
                 catch { Write-Warning "Can't connect to $SqlInstance or access denied. Skipping."; continue }
 

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -64,7 +64,7 @@ function Get-DbaStartupParameter {
 
                 $computerName = (Resolve-DbaNetworkName -ComputerName $computerName).FullComputerName
 
-                Write-Message -Level Verbose -message "Attempting to connect to $computerName"
+                Write-Message -Level Verbose -message "Connecting to $computerName"
 
                 if ($instanceName.Length -eq 0) { $instanceName = "MSSQLSERVER" }
 

--- a/functions/Get-DbaTopResourceUsage.ps1
+++ b/functions/Get-DbaTopResourceUsage.ps1
@@ -245,7 +245,7 @@ function Get-DbaTopResourceUsage {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10

--- a/functions/Get-DbaUserLevelPermission.ps1
+++ b/functions/Get-DbaUserLevelPermission.ps1
@@ -180,7 +180,7 @@ function Get-DbaUserLevelPermission {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10

--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -99,7 +99,7 @@ function Get-DbaWaitingTask {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Invoke-DbaBalanceDataFiles.ps1
+++ b/functions/Invoke-DbaBalanceDataFiles.ps1
@@ -105,7 +105,7 @@ function Invoke-DbaBalanceDataFiles {
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Invoke-DbaDatabaseClone.ps1
+++ b/functions/Invoke-DbaDatabaseClone.ps1
@@ -116,7 +116,7 @@ function Invoke-DbaDatabaseClone {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 12

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -655,7 +655,7 @@ function Invoke-DbaLogShipping {
         Write-Message -Message "Started log shipping for $SourceSqlInstance to $DestinationSqlInstance" -Level Output
 
         # Try connecting to the instance
-        Write-Message -Message "Attempting to connect to source Sql Server $SourceSqlInstance.." -Level Output
+        Write-Message -Message "Connecting to source Sql Server $SourceSqlInstance.." -Level Output
         try {
             $SourceServer = Connect-SqlInstance -SqlInstance $SourceSqlInstance -SqlCredential $SourceSqlCredential
         }
@@ -665,7 +665,7 @@ function Invoke-DbaLogShipping {
         }
 
         # Try connecting to the instance
-        Write-Message -Message "Attempting to connect to destination Sql Server $DestinationSqlInstance.." -Level Output
+        Write-Message -Message "Connecting to destination Sql Server $DestinationSqlInstance.." -Level Output
         try {
             $DestinationServer = Connect-SqlInstance -SqlInstance $DestinationSqlInstance -SqlCredential $DestinationSqlCredential
         }

--- a/functions/Invoke-DbaLogShippingRecovery.ps1
+++ b/functions/Invoke-DbaLogShippingRecovery.ps1
@@ -117,7 +117,7 @@ function Invoke-DbaLogShippingRecovery {
                 $instancename = "MSSQLSERVER"
             }
 
-            Write-Message -Message "Attempting to connect to Sql Server" -Level Output
+            Write-Message -Message "Connecting to Sql Server" -Level Output
             try {
                 $server = Connect-SqlInstance -SqlInstance $sqlinstance -SqlCredential $SqlCredential
             }

--- a/functions/Measure-DbaDiskSpaceRequirement.ps1
+++ b/functions/Measure-DbaDiskSpaceRequirement.ps1
@@ -172,7 +172,7 @@ function Measure-DbaDiskSpaceRequirement {
         }
     }
     process {
-        Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers."
+        Write-Message -Level Verbose -Message "Connecting to SQL Servers."
         try {
             Write-Message -Level Verbose -Message "Connecting to $Source."
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -227,7 +227,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -86,7 +86,7 @@ Creates a new job category with the name 'Category 2' and assign the category ty
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -199,7 +199,7 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -116,8 +116,7 @@ function New-DbaAgentProxy {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -417,7 +417,7 @@ function New-DbaAgentSchedule {
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/New-DbaSsisCatalog.ps1
+++ b/functions/New-DbaSsisCatalog.ps1
@@ -67,11 +67,9 @@ function New-DbaSsisCatalog {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
-                Write-Message -Level Verbose -Message "Connecting to $instance"
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential -MinimumVersion 10
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             }
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -98,8 +98,7 @@ function Remove-DbaAgentJob {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -76,7 +76,7 @@ Remove multiple job categories from the multiple instances.
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -87,7 +87,7 @@ function Remove-DbaAgentJobStep {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -95,7 +95,7 @@ Remove the schedules using a pipeline
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -107,7 +107,7 @@ function Remove-DbaOrphanUser {
     process {
 
         foreach ($Instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $Instance."
+            Write-Message -Level Verbose -Message "Connecting to $Instance."
             try {
                 $server = Connect-SqlInstance -SqlInstance $Instance -SqlCredential $SqlCredential
             }

--- a/functions/Set-DbaAgentAlert.ps1
+++ b/functions/Set-DbaAgentAlert.ps1
@@ -99,7 +99,7 @@ Doesn't Change the alert but shows what would happen.
 
             foreach ($instance in $sqlinstance) {
                 # Try connecting to the instance
-                Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+                Write-Message -Message "Connecting to $instance" -Level Verbose
                 try {
                     $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -82,7 +82,7 @@ The force parameter will ignore some errors in the parameters and assume default
 
 .PARAMETER InputObject
 Enables piping job objects
-    
+
 .PARAMETER WhatIf
 Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -176,73 +176,73 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
         [switch][Alias('Silent')]
         $EnableException
     )
-    
+
     begin {
         # Check of the event log level is of type string and set the integer value
         if (($EventLogLevel -notin 0, 1, 2, 3) -and ($null -ne $EventLogLevel)) {
             $EventLogLevel = switch ($EventLogLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
-        
+
         # Check of the email level is of type string and set the integer value
         if (($EmailLevel -notin 0, 1, 2, 3) -and ($null -ne $EmailLevel)) {
             $EmailLevel = switch ($EmailLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
-        
+
         # Check of the net send level is of type string and set the integer value
         if (($NetsendLevel -notin 0, 1, 2, 3) -and ($null -ne $NetsendLevel)) {
             $NetsendLevel = switch ($NetsendLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
-        
+
         # Check of the page level is of type string and set the integer value
         if (($PageLevel -notin 0, 1, 2, 3) -and ($null -ne $PageLevel)) {
             $PageLevel = switch ($PageLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
-        
+
         # Check of the delete level is of type string and set the integer value
         if (($DeleteLevel -notin 0, 1, 2, 3) -and ($null -ne $DeleteLevel)) {
             $DeleteLevel = switch ($DeleteLevel) { "Never" { 0 } "OnSuccess" { 1 } "OnFailure" { 2 } "Always" { 3 } }
         }
-        
+
         # Check the e-mail operator name
         if (($EmailLevel -ge 1) -and (-not $EmailOperator)) {
             Stop-Function -Message "Please set the e-mail operator when the e-mail level parameter is set." -Target $sqlinstance
             return
         }
-        
+
         # Check the e-mail operator name
         if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
             Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $sqlinstance
             return
         }
-        
+
         # Check the e-mail operator name
         if (($PageLevel -ge 1) -and (-not $PageOperator)) {
             Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $sqlinstance
             return
         }
     }
-    
+
     process {
-        
+
         if (Test-FunctionInterrupt) { return }
-        
+
         if ((-not $InputObject) -and (-not $Job)) {
             Stop-Function -Message "You must specify a job name or pipe in results from another command" -Target $sqlinstance
             return
         }
-        
+
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            
+
             foreach ($j in $Job) {
-                
+
                 # Check if the job exists
                 if ($server.JobServer.Jobs.Name -notcontains $j) {
                     Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
@@ -251,7 +251,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     # Get the job
                     try {
                         $InputObject += $server.JobServer.Jobs[$j]
-                        
+
                         # Refresh the object
                         $InputObject.Refresh()
                     }
@@ -261,24 +261,24 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                 }
             }
         }
-        
+
         foreach ($currentjob in $InputObject) {
             $server = $currentjob.Parent.Parent
-            
+
             #region job options
             # Settings the options for the job
             if ($NewName) {
                 Write-Message -Message "Setting job name to $NewName" -Level Verbose
                 $currentjob.Rename($NewName)
             }
-            
+
             if ($Schedule) {
                 # Loop through each of the schedules
                 foreach ($s in $Schedule) {
                     if ($server.JobServer.SharedSchedules.Name -contains $s) {
                         # Get the schedule ID
                         $sID = $server.JobServer.SharedSchedules[$s].ID
-                        
+
                         # Add schedule to job
                         Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
                         $currentjob.AddSharedSchedule($sID)
@@ -286,10 +286,10 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     else {
                         Stop-Function -Message "Schedule $s cannot be found on instance $instance" -Target $s -Continue
                     }
-                    
+
                 }
             }
-            
+
             if ($ScheduleId) {
                 # Loop through each of the schedules IDs
                 foreach ($sID in $ScheduleId) {
@@ -298,29 +298,29 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                         # Add schedule to job
                         Write-Message -Message "Adding schedule id $sID to job" -Level Verbose
                         $currentjob.AddSharedSchedule($sID)
-                        
+
                     }
                     else {
                         Stop-Function -Message "Schedule ID $sID cannot be found on instance $instance" -Target $sID -Continue
                     }
                 }
             }
-            
+
             if ($Enabled) {
                 Write-Message -Message "Setting job to enabled" -Level Verbose
                 $currentjob.IsEnabled = $true
             }
-            
+
             if ($Disabled) {
                 Write-Message -Message "Setting job to disabled" -Level Verbose
                 $currentjob.IsEnabled = $false
             }
-            
+
             if ($Description) {
                 Write-Message -Message "Setting job description to $Description" -Level Verbose
                 $currentjob.Description = $Description
             }
-            
+
             if ($Category) {
                 # Check if the job category exists
                 if ($Category -notin $server.JobServer.JobCategories.Name) {
@@ -329,7 +329,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                             try {
                                 # Create the category
                                 New-DbaAgentJobCategory -SqlInstance $instance -Category $Category
-                                
+
                                 Write-Message -Message "Setting job category to $Category" -Level Verbose
                                 $currentjob.Category = $Category
                             }
@@ -348,11 +348,11 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     $currentjob.Category = $Category
                 }
             }
-            
+
             if ($StartStepId) {
                 # Get the job steps
                 $currentjobSteps = $currentjob.JobSteps
-                
+
                 # Check if there are any job steps
                 if ($currentjobSteps.Count -ge 1) {
                     # Check if the start step id value is one of the job steps in the job
@@ -363,14 +363,14 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     else {
                         Write-Message -Message "The step id is not present in job $j on instance $instance" -Warning
                     }
-                    
+
                 }
                 else {
                     Stop-Function -Message "There are no job steps present for job $j on instance $instance" -Target $instance -Continue
                 }
-                
+
             }
-            
+
             if ($OwnerLogin) {
                 # Check if the login name is present on the instance
                 if ($server.Logins.Name -contains $OwnerLogin) {
@@ -381,18 +381,18 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     Stop-Function -Message "The given owner log in name $OwnerLogin does not exist on instance $instance" -Target $instance -Continue
                 }
             }
-            
+
             if ($EventLogLevel) {
                 Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
                 $currentjob.EventLogLevel = $EventLogLevel
             }
-            
+
             if ($EmailLevel) {
                 # Check if the notifiction needs to be removed
                 if ($EmailLevel -eq 0) {
                     # Remove the operator
                     $currentjob.OperatorToEmail = $null
-                    
+
                     # Remove the notification
                     $currentjob.EmailLevel = $EmailLevel
                 }
@@ -407,13 +407,13 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     }
                 }
             }
-            
+
             if ($NetsendLevel) {
                 # Check if the notifiction needs to be removed
                 if ($NetsendLevel -eq 0) {
                     # Remove the operator
                     $currentjob.OperatorToNetSend = $null
-                    
+
                     # Remove the notification
                     $currentjob.NetSendLevel = $NetsendLevel
                 }
@@ -428,13 +428,13 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     }
                 }
             }
-            
+
             if ($PageLevel) {
                 # Check if the notifiction needs to be removed
                 if ($PageLevel -eq 0) {
                     # Remove the operator
                     $currentjob.OperatorToPage = $null
-                    
+
                     # Remove the notification
                     $currentjob.PageLevel = $PageLevel
                 }
@@ -449,7 +449,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     }
                 }
             }
-            
+
             # Check the current setting of the job's email level
             if ($EmailOperator) {
                 # Check if the operator name is present
@@ -461,7 +461,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     Stop-Function -Message "The e-mail operator name $EmailOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
                 }
             }
-            
+
             if ($NetsendOperator) {
                 # Check if the operator name is present
                 if ($server.JobServer.Operators.Name -contains $NetsendOperator) {
@@ -472,7 +472,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     Stop-Function -Message "The netsend operator name $NetsendOperator does not exist on instance $instance. Exiting.." -Target $j -Continue
                 }
             }
-            
+
             if ($PageOperator) {
                 # Check if the operator name is present
                 if ($server.JobServer.Operators.Name -contains $PageOperator) {
@@ -483,18 +483,18 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
                     Stop-Function -Message "The page operator name $PageOperator does not exist on instance $instance. Exiting.." -Target $instance -Continue
                 }
             }
-            
+
             if ($DeleteLevel) {
                 Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
                 $currentjob.DeleteLevel = $DeleteLevel
             }
             #endregion job options
-            
+
             # Execute
             if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the job $j")) {
                 try {
                     Write-Message -Message "Changing the job" -Level Verbose
-                    
+
                     # Change the job
                     $currentjob.Alter()
                 }
@@ -505,7 +505,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
             }
         }
     }
-    
+
     end {
         Write-Message -Message "Finished changing job(s)" -Level Verbose
     }

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -84,7 +84,7 @@ Rename multiple jobs in one go on multiple servers.
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -204,7 +204,7 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
         foreach ($instance in $sqlinstance) {
 
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -326,7 +326,7 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
             foreach ($j in $Job) {
 
                 # Try connecting to the instance
-                Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+                Write-Message -Message "Connecting to $instance" -Level Verbose
                 try {
                     $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 }

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -131,7 +131,6 @@ function Set-DbaLogin {
 #>
 
     [CmdletBinding()]
-
     param (
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
@@ -139,7 +138,7 @@ function Set-DbaLogin {
         [PSCredential]$SqlCredential,
         [parameter(Mandatory = $true)]
         [string[]]$Login,
-        [object]$Password,
+        [SecureString]$Password,
         [switch]$Unlock,
         [switch]$MustChange,
         [string]$NewName,
@@ -188,7 +187,7 @@ function Set-DbaLogin {
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -393,7 +393,7 @@ function Set-DbaStartupParameter {
 
         $instance = $SqlInstance.ComputerName
         $instancename = $SqlInstance.InstanceName
-        Write-Message -Level Verbose -Message "Attempting to connect to $instancename on $instance"
+        Write-Message -Level Verbose -Message "Connecting to $instancename on $instance"
 
         if ($instancename.Length -eq 0) { $instancename = "MSSQLSERVER" }
 

--- a/functions/Stop-DbaAgentJob.ps1
+++ b/functions/Stop-DbaAgentJob.ps1
@@ -77,7 +77,7 @@ function Stop-DbaAgentJob {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Verbose "Attempting to connect to $instance"
+            Write-Verbose "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Sync-DbaLoginPermission.ps1
+++ b/functions/Sync-DbaLoginPermission.ps1
@@ -129,19 +129,19 @@ function Sync-DbaLoginPermission {
         }
     }
     process {
-        
+
         if ($source -eq $destination) {
             Stop-Function -Message "Source and Destination SQL Servers are the same. Quitting."
             return
         }
-        
-        Write-Message -Level Verbose -Message "Attempting to connect to SQL Servers."
+
+        Write-Message -Level Verbose -Message "Connecting to SQL Servers."
         $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 8
         $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential -MinimumVersion 8
-        
+
         $source = $sourceServer.DomainInstanceName
         $destination = $destServer.DomainInstanceName
-        
+
         if (!$Login) {
             $login = $sourceServer.Logins.Name
         }

--- a/functions/Test-DbaDatabaseCollation.ps1
+++ b/functions/Test-DbaDatabaseCollation.ps1
@@ -74,7 +74,7 @@ function Test-DbaDatabaseCollation {
     process {
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             }

--- a/functions/Test-DbaDiskSpeed.ps1
+++ b/functions/Test-DbaDiskSpeed.ps1
@@ -104,7 +104,7 @@
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -146,8 +146,7 @@ function Test-DbaIdentityUsage {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
-
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             }

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -165,7 +165,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
     process {
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Attempting to connect to $instance" -Level Verbose
+            Write-Message -Message "Connecting to $instance" -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -74,29 +74,29 @@ function Test-DbaServerName {
         [Alias('Silent')]
         [switch]$EnableException
     )
-    
+
     begin {
         Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
         Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter NoWarning
     }
     process {
-        
+
         foreach ($instance in $SqlInstance) {
-            Write-Verbose "Attempting to connect to $instance"
+            Write-Verbose "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            
+
             if ($server.IsClustered) {
                 Write-Message -Level Warning -Message "$instance is a cluster. Renaming clusters is not supported by Microsoft."
             }
-            
+
             $sqlInstanceName = $server.Query("SELECT @@servername AS ServerName").ServerName
             $instance = $server.InstanceName
-            
+
             if ($instance.Length -eq 0) {
                 $serverInstanceName = $server.NetName
                 $instance = "MSSQLSERVER"
@@ -105,7 +105,7 @@ function Test-DbaServerName {
                 $netname = $server.NetName
                 $serverInstanceName = "$netname\$instance"
             }
-            
+
             $serverInfo = [PSCustomObject]@{
                 ComputerName     = $server.NetName
                 ServerName       = $sqlInstanceName
@@ -116,10 +116,10 @@ function Test-DbaServerName {
                 Warnings         = $null
                 Blockers         = $null
             }
-            
+
             $reasons = @()
             $ssrsService = "SQL Server Reporting Services ($instance)"
-            
+
             Write-Message -Level Verbose -Message "Checking for $serverName on $netBiosName"
             $rs = $null
             if ($SkipSsrs -eq $false -or $NoWarning -eq $false) {
@@ -130,7 +130,7 @@ function Test-DbaServerName {
                     Write-Message -Level Warning -Message "Unable to pull information on $ssrsService." -ErrorRecord $_ -Target $instance
                 }
             }
-            
+
             if ($null -ne $rs -or $rs.Count -gt 0) {
                 if ($rs.State -eq 'Running') {
                     $rstext = "$ssrsService must be stopped and updated."
@@ -143,37 +143,37 @@ function Test-DbaServerName {
             else {
                 $serverInfo.Warnings = "N/A"
             }
-            
+
             # check for mirroring
             $mirroredDb = $server.Databases | Where-Object { $_.IsMirroringEnabled -eq $true }
-            
+
             Write-Message -Level Debug -Message "Found the following mirrored dbs: $($mirroredDb.Name)"
-            
+
             if ($mirroredDb.Length -gt 0) {
                 $dbs = $mirroredDb.Name -join ", "
                 $reasons += "Databases are being mirrored: $dbs"
             }
-            
+
             # check for replication
             $sql = "SELECT name FROM sys.databases WHERE is_published = 1 OR is_subscribed = 1 OR is_distributor = 1"
             Write-Message -Level Debug -Message "SQL Statement: $sql"
             $replicatedDb = $server.Query($sql)
-            
+
             if ($replicatedDb.Count -gt 0) {
                 $dbs = $replicatedDb.Name -join ", "
                 $reasons += "Database(s) are involved in replication: $dbs"
             }
-            
+
             # check for even more replication
             $sql = "SELECT srl.remote_name as RemoteLoginName FROM sys.remote_logins srl JOIN sys.sysservers sss ON srl.server_id = sss.srvid"
             Write-Message -Level Debug -Message "SQL Statement: $sql"
             $results = $server.Query($sql)
-            
+
             if ($results.RemoteLoginName.Count -gt 0) {
                 $remoteLogins = $results.RemoteLoginName -join ", "
                 $reasons += "Remote logins still exist: $remoteLogins"
             }
-            
+
             if ($reasons.Length -gt 0) {
                 $serverInfo.Updatable = $false
                 $serverInfo.Blockers = $reasons
@@ -182,7 +182,7 @@ function Test-DbaServerName {
                 $serverInfo.Updatable = $true
                 $serverInfo.Blockers = "N/A"
             }
-            
+
             $serverInfo | Select-DefaultView -ExcludeProperty InstanceName, SqlInstance
         }
     }

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -242,7 +242,7 @@ function Test-DbaSpn {
                 $spns
             }
 
-            Write-Message -Message "Attempting to connect to SQL WMI on remote computer " -Level Verbose
+            Write-Message -Message "Connecting to SQL WMI on remote computer " -Level Verbose
 
             try {
                 $spns = Invoke-ManagedComputerCommand -ComputerName $hostEntry -ScriptBlock $Scriptblock -ArgumentList $resolved.FullComputerName, $hostEntry, $computer.InstanceName -Credential $Credential -ErrorAction Stop

--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -67,7 +67,7 @@ function Test-DbaTempDbConfiguration {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -83,9 +83,8 @@ function Watch-DbaDbLogin {
             return
         }
 
-        Write-Message -Level Verbose -Message "Attempting to connect to $SqlInstance"
+        Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
         try {
-            Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
             $serverDest = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         }
         catch {
@@ -121,9 +120,8 @@ function Watch-DbaDbLogin {
             Process each server
         #>
         foreach ($instance in $servers) {
-            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+            Write-Message -Level Verbose -Message "Connecting to $instance"
             try {
-                Write-Message -Level Verbose -Message "Connecting to $instance"
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }
             catch {

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -224,7 +224,7 @@ function Connect-SqlInstance {
     }
 
     if ($AzureUnsupported -and $server.DatabaseEngineType -eq "SqlAzureDatabase") {
-        throw "SQL Azure DB not supported :("
+        throw "Azure SQL Database not supported"
     }
 
     if (-not $RegularUser) {

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -142,7 +142,7 @@ function New-DbaLogShippingPrimaryDatabase {
     )
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $SqlInstance" -Level Verbose
+    Write-Message -Message "Connecting to $SqlInstance" -Level Verbose
     try {
         $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     }

--- a/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
+++ b/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
@@ -53,32 +53,24 @@ function New-DbaLogShippingPrimarySecondary {
     param (
         [parameter(Mandatory = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [object]$SqlInstance,
-
-        [System.Management.Automation.PSCredential]
-        $SqlCredential,
-
+        [DbaInstanceParameter]$SqlInstance,
+        [PSCredential]$SqlCredential,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object]$PrimaryDatabase,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object]$SecondaryDatabase,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [object]$SecondaryServer,
-
-        [System.Management.Automation.PSCredential]
-        $SecondarySqlCredential,
-
+        [DBAInstanceParameter]$SecondaryServer,
+        [PSCredential]$SecondarySqlCredential,
         [Alias('Silent')]
         [switch]$EnableException
     )
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $SqlInstance" -Level Verbose
+    Write-Message -Message "Connecting to $SqlInstance" -Level Verbose
     try {
         $ServerPrimary = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     }
@@ -87,7 +79,7 @@ function New-DbaLogShippingPrimarySecondary {
     }
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $SecondaryServer" -Level Verbose
+    Write-Message -Message "Connecting to $SecondaryServer" -Level Verbose
     try {
         $ServerSecondary = Connect-SqlInstance -SqlInstance $SecondaryServer -SqlCredential $SecondarySqlCredential
     }

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -94,73 +94,53 @@ function New-DbaLogShippingSecondaryDatabase {
     param (
         [parameter(Mandatory = $true)]
         [Alias("ServerInstance", "SqlServer")]
-        [object]$SqlInstance,
-
-        [System.Management.Automation.PSCredential]
-        $SqlCredential,
-
+        [DbaInstanceParmeter]$SqlInstance,
+        [PSCredential]$SqlCredential,
         [int]$BufferCount = -1,
-
         [int]$BlockSize = -1,
-
         [switch]$DisconnectUsers,
-
         [int]$HistoryRetention = 14420,
-
         [int]$MaxTransferSize,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [object]$PrimaryServer,
-
-        [System.Management.Automation.PSCredential]
-        $PrimarySqlCredential,
-
+        [DbaInstanceParameter]$PrimaryServer,
+        [PSCredential]$PrimarySqlCredential,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object]$PrimaryDatabase,
-
         [int]$RestoreAll = 1,
-
         [int]$RestoreDelay = 0,
-
         [ValidateSet(0, 'NoRecovery', 1, 'Standby')]
         [object]$RestoreMode = 0,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [int]$RestoreThreshold,
-
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object]$SecondaryDatabase,
-
         [int]$ThresholdAlert = 14420,
-
         [switch]$ThresholdAlertEnabled,
-
         [Alias('Silent')]
         [switch]$EnableException,
-
         [switch]$Force
     )
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $SqlInstance" -Level Verbose
+    Write-Message -Message "Connecting to $SqlInstance" -Level Verbose
     try {
         $ServerSecondary = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     }
     catch {
-        Stop-Function -Message "Could not connect to Sql Server instance $SqlInstance.`n$_" -Target $SqlInstance -Continue
+        Stop-Function -Message "Failure" -Category ConnectionError -Target $SqlInstance -ErrorRecord $_ -Continue
     }
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $PrimaryServer" -Level Verbose
+    Write-Message -Message "Connecting to $PrimaryServer" -Level Verbose
     try {
         $ServerPrimary = Connect-SqlInstance -SqlInstance $PrimaryServer -SqlCredential $PrimarySqlCredential
     }
     catch {
-        Stop-Function -Message "Could not connect to Sql Server instance $PrimaryServer.`n$_" -Target $PrimaryServer -Continue
+        Stop-Function -Message "Failure" -Category ConnectionError -Target $PrimaryServer -ErrorRecord $_ -Continue
     }
 
     # Check if the database is present on the primary sql server

--- a/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -114,21 +114,21 @@ function New-DbaLogShippingSecondaryPrimary {
     )
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $SqlInstance" -Level Verbose
+    Write-Message -Message "Connecting to $SqlInstance" -Level Verbose
     try {
         $ServerSecondary = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     }
     catch {
-        Stop-Function -Message "Could not connect to Sql Server instance"  -ErrorRecord $_ -Target $SqlInstance -Continue
+        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
     }
 
     # Try connecting to the instance
-    Write-Message -Message "Attempting to connect to $PrimaryServer" -Level Verbose
+    Write-Message -Message "Connecting to $PrimaryServer" -Level Verbose
     try {
         $ServerPrimary = Connect-SqlInstance -SqlInstance $PrimaryServer -SqlCredential $PrimarySqlCredential
     }
     catch {
-        Stop-Function -Message "Could not connect to Sql Server instance"  -ErrorRecord $_ -Target $PrimaryServer -Continue
+        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $PrimaryServer -Continue
     }
 
     # Check if the backup UNC path is correct and reachable


### PR DESCRIPTION
Applying some standards for the verbose connection messages.

Majority of the commands have `Connecting to $instance` as the verbose message. Updating the ones that had been set to a different message to get everything standardized.

A few one-off changes:
- `Connect-SqlInstance` update the throw message for Azure Support flag
- Set a few commands to throw error as they are not supported for running against Azure Sql. (Going to work on writing a test to see what all commands will not work.)