### PR TITLE
RegServer - fixed pool exhaustion

### DIFF
--- a/functions/Add-DbaRegisteredServerGroup.ps1
+++ b/functions/Add-DbaRegisteredServerGroup.ps1
@@ -113,6 +113,7 @@ function Add-DbaRegisteredServerGroup {
                     $newgroup.Create()
                     
                     Get-DbaRegisteredServerGroup -SqlInstance $parentserver.ServerConnection.SqlConnectionObject -Group (Get-RegServerGroupReverseParse -object $newgroup)
+                    $parentserver.ServerConnection.Disconnect()
                 }
                 catch {
                     Stop-Function -Message "Failed to add $reggroup on $server" -ErrorRecord $_ -Continue

--- a/functions/Get-DbaRegisteredServer.ps1
+++ b/functions/Get-DbaRegisteredServer.ps1
@@ -123,9 +123,10 @@ function Get-DbaRegisteredServer {
                     Stop-Function -Message "Cannot access Central Management Server '$instance'." -ErrorRecord $_ -Continue
                 }
                 $servers += ($serverstore.DatabaseEngineServerGroup.GetDescendantRegisteredServers())
+                $serverstore.ServerConnection.Disconnect()
             }
         }
-
+        
         if ($Name) {
             Write-Message -Level Verbose -Message "Filtering by name for $name"
             $servers = $servers | Where-Object Name -in $Name

--- a/functions/Get-DbaRegisteredServerGroup.ps1
+++ b/functions/Get-DbaRegisteredServerGroup.ps1
@@ -145,7 +145,7 @@ function Get-DbaRegisteredServerGroup {
                     $groups = $server.DatabaseEngineServerGroup.GetDescendantRegisteredServers().Parent | Where-Object Id -in $Id
                 }
             }
-
+            $server.ServerConnection.Disconnect()
             foreach ($groupobject in $groups) {
                 Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name InstanceName -value $server.InstanceName

--- a/functions/Move-DbaRegisteredServer.ps1
+++ b/functions/Move-DbaRegisteredServer.ps1
@@ -115,6 +115,7 @@ function Move-DbaRegisteredServer {
                 try {
                     $null = $parentserver.ServerConnection.ExecuteNonQuery($regserver.ScriptMove($group).GetScript())
                     Get-DbaRegisteredServer -SqlInstance $server -Name $regserver.Name -ServerName $regserver.ServerName
+                    $parentserver.ServerConnection.Disconnect()
                 }
                 catch {
                     Stop-Function -Message "Failed to move $($regserver.Name) to $NewGroup on $($regserver.SqlInstance)" -ErrorRecord $_ -Continue

--- a/functions/Move-DbaRegisteredServerGroup.ps1
+++ b/functions/Move-DbaRegisteredServerGroup.ps1
@@ -115,6 +115,7 @@ function Move-DbaRegisteredServerGroup {
                     $null = $parentserver.ServerConnection.ExecuteNonQuery($regservergroup.ScriptMove($groupobject).GetScript())
                     Write-Message -Level Verbose -Message "Connecting to $instance to search for $newname"
                     Get-DbaRegisteredServerGroup -SqlInstance $server -Group $newname
+                    $parentserver.ServerConnection.Disconnect()
                 }
                 catch {
                     Stop-Function -Message "Failed to move $($regserver.Name) to $NewGroup on $($regserver.SqlInstance)" -ErrorRecord $_ -Continue

--- a/functions/Remove-DbaRegisteredServer.ps1
+++ b/functions/Remove-DbaRegisteredServer.ps1
@@ -85,8 +85,11 @@ function Remove-DbaRegisteredServer {
 
         foreach ($regserver in $InputObject) {
             $server = $regserver.Parent
+            
             if ($Pscmdlet.ShouldProcess($regserver.Parent, "Removing $regserver")) {
                 $null = $regserver.Drop()
+                Disconnect-RegServer -Server $server
+                
                 try {
                     [pscustomobject]@{
                         ComputerName = $regserver.ComputerName

--- a/functions/Remove-DbaRegisteredServerGroup.ps1
+++ b/functions/Remove-DbaRegisteredServerGroup.ps1
@@ -82,6 +82,7 @@ function Remove-DbaRegisteredServerGroup {
 
             if ($Pscmdlet.ShouldProcess($parentserver.DomainInstanceName, "Removing $($regservergroup.Name) CMS Group")) {
                 $null = $parentserver.ServerConnection.ExecuteNonQuery($regservergroup.ScriptDrop().GetScript())
+                $parentserver.ServerConnection.Disconnect()
                 try {
                     [pscustomobject]@{
                         ComputerName            = $parentserver.ComputerName

--- a/internal/functions/Disconnect-Regserver.ps1
+++ b/internal/functions/Disconnect-Regserver.ps1
@@ -1,0 +1,9 @@
+﻿function Disconnect-Regserver ($Server) {
+    $i = 0
+    do { $server = $server.Parent }
+    until ($null -ne $server.ServerConnection -or $i++ -gt 20)
+    if ($server.ServerConnection) {
+        Write-Warning disconnected
+        $server.ServerConnection.Disconnect()
+    }
+}


### PR DESCRIPTION
Fixed bug report from https://dbatools.io/cms/#comment-8660

Not really sure why the disconnects are required. I guess it's splinters the connection or whatever the word is that I'm too 🤧 to think of.