### PR TITLE
Fixed Test-DbaWindowsLogin so it copes with Computer accounts

### DIFF
--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -160,6 +160,14 @@ function Test-DbaWindowsLogin {
                 $exists = $false
                 try {
                     $u = Get-DbaADObject -ADObject $adLogin -Type User -EnableException
+                    if ($null -eq $u){
+                        Write-Message -Message "Parsing Login as computer" -Level Verbose
+                        $u = Get-DbaADObject -ADObject $adLogin -Type Computer -EnableException
+                        $adType = 'Computer'
+                    }
+                    else {
+                        $adType = 'User'
+                    }
                     $foundUser = $u.GetUnderlyingObject()
                     $foundSid = $foundUser.ObjectSid.Value -join ''
                     if ($foundUser) {
@@ -208,7 +216,7 @@ function Test-DbaWindowsLogin {
                     Server                            = $server.DomainInstanceName
                     Domain                            = $domain
                     Login                             = $username
-                    Type                              = "User"
+                    Type                              = $adType
                     Found                             = $exists
                     DisabledInSQLServer               = $login.IsDisabled
                     AccountNotDelegated               = $additionalProps.AccountNotDelegated

--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -160,7 +160,7 @@ function Test-DbaWindowsLogin {
                 $exists = $false
                 try {
                     $u = Get-DbaADObject -ADObject $adLogin -Type User -EnableException
-                    if ($null -eq $u){
+                    if ($null -eq $u -and $adLogin -like '*$'){
                         Write-Message -Message "Parsing Login as computer" -Level Verbose
                         $u = Get-DbaADObject -ADObject $adLogin -Type Computer -EnableException
                         $adType = 'Computer'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3792 )
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Implements fix for #3792

Lots of apps use the AD computer account to connect (SCCM, CRM, etc) and Test-DbaWindowsLogin doesn't parse them properly

### Approach
If the account isn't matched as user, check if it's in computer name format ',*`$' and then lookup as a computer


### Screenshots
Before/After:
![image](https://user-images.githubusercontent.com/5613670/42680903-35a889cc-867e-11e8-863a-7097b24d6914.png)


