### PR TITLE
Added functionality to set the step id

### DIFF
--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -131,49 +131,32 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
         [parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,
-        [Parameter(Mandatory = $false)]
         [int]$StepId,
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$StepName,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('ActiveScripting', 'AnalysisCommand', 'AnalysisQuery', 'CmdExec', 'Distribution', 'LogReader', 'Merge', 'PowerShell', 'QueueReader', 'Snapshot', 'Ssis', 'TransactSql')]
         [string]$Subsystem = 'TransactSql',
-        [Parameter(Mandatory = $false)]
         [string]$Command,
-        [Parameter(Mandatory = $false)]
         [int]$CmdExecSuccessCode,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnSuccessAction = 'QuitWithSuccess',
-        [Parameter(Mandatory = $false)]
         [int]$OnSuccessStepId = 0,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnFailAction = 'QuitWithFailure',
-        [Parameter(Mandatory = $false)]
         [int]$OnFailStepId,
-        [Parameter(Mandatory = $false)]
         [object]$Database,
-        [Parameter(Mandatory = $false)]
         [string]$DatabaseUser,
-        [Parameter(Mandatory = $false)]
         [int]$RetryAttempts,
-        [Parameter(Mandatory = $false)]
         [int]$RetryInterval,
-        [Parameter(Mandatory = $false)]
         [string]$OutputFileName,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('AppendAllCmdExecOutputToJobHistory', 'AppendToJobHistory', 'AppendToLogFile', 'LogToTableWithOverwrite', 'None', 'ProvideStopProcessEvent')]
         [string[]]$Flag,
-        [Parameter(Mandatory = $false)]
         [string]$ProxyName,
-        [Parameter(Mandatory = $false)]
         [switch]$Force,
         [Alias('Silent')]
         [switch]$EnableException
@@ -181,13 +164,13 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 
     begin {
         # Check the parameter on success step id
-        if (($OnSuccessAction -ne 'GoToStep') -and ($OnSuccessStepId -ge 1)) {
+        if (($OnSuccessAction -in 'GoToStep', 'GoToNextStep') -and ($OnSuccessStepId -ge 1)) {
             Stop-Function -Message "Parameter OnSuccessStepId can only be used with OnSuccessAction 'GoToStep'." -Target $SqlInstance
             return
         }
 
         # Check the parameter on success step id
-        if (($OnFailAction -ne 'GoToStep') -and ($OnFailStepId -ge 1)) {
+        if (($OnFailAction -in 'GoToStep', 'GoToNextStep') -and ($OnFailStepId -ge 1)) {
             Stop-Function -Message "Parameter OnFailStepId can only be used with OnFailAction 'GoToStep'." -Target $SqlInstance
             return
         }
@@ -249,18 +232,22 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
                             Stop-Function -Message "The step name $StepName already exists for job $j" -Target $instance -Continue
                         }
                     }
-                    elseif ($StepId) {
+
+                    # If the step id need to be set
+                    if ($StepId) {
                         # Check if the used step id is already in place
                         if ($Job.JobSteps.ID -notcontains $StepId) {
                             Write-Message -Message "Setting job step step id to $StepId" -Level Verbose
                             $JobStep.ID = $StepId
                         }
-                        elseif (($Job.JobSteps.ID -contains $StepId) -and $Force) {
-                            Write-Message -Message "Step ID $StepId already exists for job. Force is used. Removing existing step" -Level Verbose
+                        elseif ($Job.JobSteps.ID -contains $StepId) {
+                            if($Force){
+                                Write-Message -Message "Step ID $StepId already exists for job. Force is used. Removing existing step" -Level Verbose
 
-                            # Remove the existing job step
-                            $StepName = ($Server.JobServer.Jobs['Job2'].JobSteps | Where-Object {$_.ID -eq 1}).Name
-                            Remove-DbaAgentJobStep -SqlInstance $instance -Job $currentjob -StepName $StepName
+                                # Remove the existing job step
+                                $StepName = ($Server.JobServer.Jobs['Job2'].JobSteps | Where-Object {$_.ID -eq 1}).Name
+                                Remove-DbaAgentJobStep -SqlInstance $instance -Job $currentjob -StepName $StepName
+                            }
 
                             # Set the ID job step object
                             $JobStep.ID = $StepId


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
It was not possible to set the tepid for a job step. It was either the step name or the step id.
After some reconfigurations it is not possible to set the step id.
You can even enter a step before another on by supplying the step id where the new step needs to go

### Screenshots
Creating the new step
![image](https://user-images.githubusercontent.com/6154981/42724657-bf680a18-8776-11e8-86db-9818f3c7e6b1.png)

The result
![image](https://user-images.githubusercontent.com/6154981/42724659-d544440a-8776-11e8-9f32-0ca58b3de4a7.png)

