### PR TITLE
Fixed auth issue

### DIFF
--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -186,7 +186,7 @@ function Connect-SqlInstance {
     catch { }
 
     try {
-        if ($NonPooled) {
+        if ($NonPooled -or $authtype -eq "Windows Authentication with Credential") {
             $server.ConnectionContext.Connect()
         }
         else {


### PR DESCRIPTION
`$server.ConnectionContext.SqlConnectionObject.Open()` which enables connection pooling does not support alternative Windows Credentials and passes default credentials

When you look at the SQL Connection Object, the ConnectionString is as follows:
```PowerShell
ConnectionString = Data Source=sql2016;Integrated Security=True;MultipleActiveResultSets=False;Encrypt=False;TrustServerCertificate=False;Application Name="dbatools PowerShell module - dbatools.io"
```

So we have to connect using the non-pooled way (`ConnectionContext`), and this produces an immediate failure when a bad cred is passed.

I should probably write a blog post about this.

