### PR TITLE
NetName -> ComputerName for Azure Support

### DIFF
--- a/functions/Backup-DbaDatabaseMasterKey.ps1
+++ b/functions/Backup-DbaDatabaseMasterKey.ps1
@@ -145,7 +145,7 @@ Logs into sql2016 with Windows credentials then backs up db1's keys to the \\nas
                     Write-Message -Level Warning -Message "Backup failure: $($_.Exception.InnerException)"
                 }
 
-                Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $dbname

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -183,7 +183,7 @@ function Backup-DbaDbCertificate {
                     }
 
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Database       = $db.Name
@@ -207,7 +207,7 @@ function Backup-DbaDbCertificate {
                         $exception = $_.Exception
                     }
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Database       = $db.Name

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -70,7 +70,7 @@ function Clear-DbaWaitStatistics {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Status       = $status

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -246,7 +246,7 @@ function Connect-DbaInstance {
                 }
                 if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
                 else {
-                    $parsedcomputername = $server.NetName
+                    $parsedcomputername = $server.ComputerName
                     if (-not $parsedcomputername) {
                         $parsedcomputername = ([dbainstance]$instance).ComputerName
                     }
@@ -362,7 +362,7 @@ function Connect-DbaInstance {
 
             if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
             else {
-                $parsedcomputername = $server.NetName
+                $parsedcomputername = $server.ComputerName
                 if (-not $parsedcomputername) {
                     $parsedcomputername = ([dbainstance]$instance).ComputerName
                 }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -245,7 +245,14 @@ function Connect-DbaInstance {
                     $server.ConnectionContext.Connect()
                 }
                 if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
-                else { return $server }
+                else {
+                    $parsedcomputername = $server.NetName
+                    if (-not $parsedcomputername) {
+                        $parsedcomputername = ([dbainstance]$instance).ComputerName
+                    }
+                    Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
+                    return $server
+                }
             }
 
             if ($instance.IsConnectionString) { $server = New-Object Microsoft.SqlServer.Management.Smo.Server($instance.InputObject) }
@@ -354,7 +361,14 @@ function Connect-DbaInstance {
             }
 
             if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
-            else { return $server }
+            else {
+                $parsedcomputername = $server.NetName
+                if (-not $parsedcomputername) {
+                    $parsedcomputername = ([dbainstance]$instance).ComputerName
+                }
+                Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
+                return $server
+            }
         }
     }
 }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -246,11 +246,13 @@ function Connect-DbaInstance {
                 }
                 if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
                 else {
-                    $parsedcomputername = $server.ComputerName
-                    if (-not $parsedcomputername) {
-                        $parsedcomputername = ([dbainstance]$instance).ComputerName
+                    if (-not $server.ComputerName) {
+                        $parsedcomputername = $server.NetName
+                        if (-not $parsedcomputername) {
+                            $parsedcomputername = ([dbainstance]$instance).ComputerName
+                        }
+                        Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
                     }
-                    Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
                     return $server
                 }
             }
@@ -362,11 +364,13 @@ function Connect-DbaInstance {
 
             if ($SqlConnectionOnly) { return $server.ConnectionContext.SqlConnectionObject }
             else {
-                $parsedcomputername = $server.ComputerName
-                if (-not $parsedcomputername) {
-                    $parsedcomputername = ([dbainstance]$instance).ComputerName
+                if (-not $server.ComputerName) {
+                    $parsedcomputername = $server.NetName
+                    if (-not $parsedcomputername) {
+                        $parsedcomputername = ([dbainstance]$instance).ComputerName
+                    }
+                    Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
                 }
-                Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
                 return $server
             }
         }

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -689,7 +689,7 @@ function Copy-DbaDatabase {
         }
 
         if ($DetachAttach) {
-            if ($sourceServer.NetName -eq $env:COMPUTERNAME -or $destServer.NetName -eq $env:COMPUTERNAME) {
+            if ($sourceServer.ComputerName -eq $env:COMPUTERNAME -or $destServer.ComputerName -eq $env:COMPUTERNAME) {
                 if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
                     Write-Message -Level Verbose -Message "When running DetachAttach locally on the console, it's possible you'll need to Run As Administrator. Trying anyway."
                 }

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -198,7 +198,7 @@ function Copy-DbaLogin {
                 $userBase = ($userName.Split("\")[0]).ToLower()
 
                 if ($serverName -eq $userBase -or $userName.StartsWith("NT ")) {
-                    if ($sourceServer.NetName -ne $destServer.NetName) {
+                    if ($sourceServer.ComputerName -ne $destServer.ComputerName) {
                         if ($Pscmdlet.ShouldProcess("console", "Stating $userName was skipped because it is a local machine name.")) {
                             Write-Message -Level Verbose -Message "$userName was skipped because it is a local machine name."
                         }

--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -62,7 +62,7 @@ function Disable-DbaTraceFlag {
 
             foreach ($tf in $TraceFlag) {
                 $TraceFlagInfo = [pscustomobject]@{
-                    SourceServer = $server.NetName
+                    SourceServer = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     TraceFlag    = $tf

--- a/functions/Dismount-DbaDatabase.ps1
+++ b/functions/Dismount-DbaDatabase.ps1
@@ -194,7 +194,7 @@ function Dismount-DbaDatabase {
                     $server.DetachDatabase($db.Name, $UpdateStatistics)
 
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.name

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -65,7 +65,7 @@ function Enable-DbaTraceFlag {
             # We could combine all trace flags but the granularity is worth it
             foreach ($tf in $TraceFlag) {
                 $TraceFlagInfo = [PSCustomObject]@{
-                    SourceServer = $server.NetName
+                    SourceServer = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     TraceFlag    = $tf

--- a/functions/Expand-DbaTLogResponsibly.ps1
+++ b/functions/Expand-DbaTLogResponsibly.ps1
@@ -484,7 +484,7 @@ function Expand-DbaTLogResponsibly {
                 $currentVLFCount = Test-DbaDbVirtualLogFile -SqlInstance $server -Database $db
 
                 [pscustomobject]@{
-                    ComputerName    = $server.NetName
+                    ComputerName    = $server.ComputerName
                     InstanceName    = $server.ServiceName
                     SqlInstance     = $server.DomainInstanceName
                     Database        = $db

--- a/functions/Export-DbaDacpac.ps1
+++ b/functions/Export-DbaDacpac.ps1
@@ -149,7 +149,7 @@ function Export-DbaDacpac {
                     Write-Message -level Verbose -Message "StandardOutput: $stdout"
 
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $dbname

--- a/functions/Export-DbaExecutionPlan.ps1
+++ b/functions/Export-DbaExecutionPlan.ps1
@@ -229,7 +229,7 @@ function Export-DbaExecutionPlan {
                 $planhandle = "0x"; $row.planhandle | ForEach-Object { $planhandle += ("{0:X}" -f $_).PadLeft(2, "0") }
 
                 $object = [pscustomobject]@{
-                    ComputerName           = $server.NetName
+                    ComputerName           = $server.ComputerName
                     InstanceName           = $server.ServiceName
                     SqlInstance            = $server.DomainInstanceName
                     DatabaseName           = $row.DatabaseName

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -224,7 +224,7 @@ function Find-DbaAgentJob {
             $jobs = $output | Select-Object -Unique
 
             foreach ($job in $jobs) {
-                Add-Member -Force -InputObject $job -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $job -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $job -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $job -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $job -MemberType NoteProperty -Name JobName -value $job.Name

--- a/functions/Find-DbaDatabase.ps1
+++ b/functions/Find-DbaDatabase.ps1
@@ -115,7 +115,7 @@ function Find-DbaDatabase {
                 if ($extendedproperties.count -eq 0) { $extendedproperties = 0 }
 
                 [PSCustomObject]@{
-                    ComputerName       = $server.NetName
+                    ComputerName       = $server.ComputerName
                     InstanceName       = $server.ServiceName
                     SqlInstance        = $server.Name
                     Name               = $db.Name

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -101,7 +101,7 @@ function Find-DbaLoginInGroup {
                             $output += [PSCustomObject]@{
                                 SqlInstance        = $server.Name
                                 InstanceName       = $server.ServiceName
-                                ComputerName       = $server.NetName
+                                ComputerName       = $server.ComputerName
                                 Login              = $memberDomain + "\" + $member.SamAccountName
                                 DisplayName        = $member.DisplayName
                                 MemberOf           = $AdGroup

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -244,11 +244,11 @@ function Find-DbaOrphanedFile {
 
                     $result = [pscustomobject]@{
                         Server         = $server.name
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Filename       = $fullpath
-                        RemoteFilename = Join-AdminUnc -Servername $server.netname -Filepath $fullpath
+                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $fullpath
                     }
 
                     if ($LocalOnly -eq $true) {

--- a/functions/Find-DbaSimilarTable.ps1
+++ b/functions/Find-DbaSimilarTable.ps1
@@ -249,7 +249,7 @@ function Find-DbaSimilarTable {
 
                 foreach ($row in $rows) {
                     [PSCustomObject]@{
-                        ComputerName              = $server.NetName
+                        ComputerName              = $server.ComputerName
                         InstanceName              = $server.ServiceName
                         SqlInstance               = $server.DomainInstanceName
                         Table                     = "$($row.DatabaseName).$($row.SchemaName).$($row.TableName)"

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -145,7 +145,7 @@ function Find-DbaStoredProcedure {
                             $spTextFound = $StoredProcedureText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                             [PSCustomObject]@{
-                                ComputerName             = $server.NetName
+                                ComputerName             = $server.ComputerName
                                 SqlInstance              = $server.ServiceName
                                 Database                 = $db.Name
                                 Schema                   = $sp.Schema
@@ -177,7 +177,7 @@ function Find-DbaStoredProcedure {
                             $spTextFound = $StoredProcedureText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                             [PSCustomObject]@{
-                                ComputerName             = $server.NetName
+                                ComputerName             = $server.ComputerName
                                 SqlInstance              = $server.ServiceName
                                 Database                 = $db.Name
                                 Schema                   = $sp.Schema

--- a/functions/Find-DbaTrigger.ps1
+++ b/functions/Find-DbaTrigger.ps1
@@ -123,7 +123,7 @@ function Find-DbaTrigger {
                         $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                         [PSCustomObject]@{
-                            ComputerName     = $server.NetName
+                            ComputerName     = $server.ComputerName
                             SqlInstance      = $server.ServiceName
                             TriggerLevel     = "Server"
                             Database         = $null
@@ -187,7 +187,7 @@ function Find-DbaTrigger {
                                     $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                                     [PSCustomObject]@{
-                                        ComputerName     = $server.NetName
+                                        ComputerName     = $server.ComputerName
                                         SqlInstance      = $server.ServiceName
                                         TriggerLevel     = "Database"
                                         Database         = $db.name
@@ -226,7 +226,7 @@ function Find-DbaTrigger {
                                     $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                                     [PSCustomObject]@{
-                                        ComputerName     = $server.NetName
+                                        ComputerName     = $server.ComputerName
                                         SqlInstance      = $server.ServiceName
                                         TriggerLevel     = "Object"
                                         Database         = $db.name
@@ -261,7 +261,7 @@ function Find-DbaTrigger {
                                     $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                                     [PSCustomObject]@{
-                                        ComputerName     = $server.NetName
+                                        ComputerName     = $server.ComputerName
                                         SqlInstance      = $server.ServiceName
                                         TriggerLevel     = "Database"
                                         Database         = $db.name
@@ -295,7 +295,7 @@ function Find-DbaTrigger {
                                     $trTextFound = $triggerText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                                     [PSCustomObject]@{
-                                        ComputerName     = $server.NetName
+                                        ComputerName     = $server.ComputerName
                                         SqlInstance      = $server.ServiceName
                                         TriggerLevel     = "Object"
                                         Database         = $db.name

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -107,7 +107,7 @@ function Find-DbaUserObject {
                     Write-Message -Level Verbose -Message "checking if $db is owned "
 
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Database"
@@ -120,7 +120,7 @@ function Find-DbaUserObject {
             else {
                 foreach ($db in $server.Databases | Where-Object { $_.Owner -match $pattern }) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Database"
@@ -135,7 +135,7 @@ function Find-DbaUserObject {
             if (-not $pattern) {
                 foreach ($job in $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -ne $saname }) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Agent Job"
@@ -148,7 +148,7 @@ function Find-DbaUserObject {
             else {
                 foreach ($job in $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -match $pattern }) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Agent Job"
@@ -164,7 +164,7 @@ function Find-DbaUserObject {
                 ## list credentials using the account
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Type         = "Credential"
@@ -177,7 +177,7 @@ function Find-DbaUserObject {
             ## proxies
             foreach ($proxy in $proxies) {
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Type         = "Proxy"
@@ -190,7 +190,7 @@ function Find-DbaUserObject {
                 foreach ($job in $server.JobServer.Jobs) {
                     foreach ($step in $job.JobSteps | Where-Object { $_.ProxyName -eq $proxy.Name }) {
                         [PSCustomObject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Type         = "Agent Step"
@@ -206,7 +206,7 @@ function Find-DbaUserObject {
             ## endpoints
             foreach ($endPoint in $endPoints) {
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Type         = "Endpoint"
@@ -221,7 +221,7 @@ function Find-DbaUserObject {
                 foreach ($role in $server.Roles | Where-Object { $_.Owner -ne $saname }) {
                     Write-Message -Level Verbose -Message "checking if $db is owned "
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Server Role"
@@ -234,7 +234,7 @@ function Find-DbaUserObject {
             else {
                 foreach ($role in $server.Roles | Where-Object { $_.Owner -match $pattern }) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Server Role"
@@ -259,7 +259,7 @@ function Find-DbaUserObject {
                 }
                 foreach ($schema in $schemas) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Schema"
@@ -278,7 +278,7 @@ function Find-DbaUserObject {
                 }
                 foreach ($role in $roles) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Database Role"
@@ -298,7 +298,7 @@ function Find-DbaUserObject {
 
                 foreach ($assembly in $assemblies) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Database Assembly"
@@ -318,7 +318,7 @@ function Find-DbaUserObject {
 
                 foreach ($synonym in $synonyms) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Type         = "Database Synonyms"

--- a/functions/Find-DbaView.ps1
+++ b/functions/Find-DbaView.ps1
@@ -145,7 +145,7 @@ function Find-DbaView {
                             $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                             [PSCustomObject]@{
-                                ComputerName   = $server.NetName
+                                ComputerName   = $server.ComputerName
                                 SqlInstance    = $server.ServiceName
                                 Database       = $db.Name
                                 Schema         = $vw.Schema
@@ -177,7 +177,7 @@ function Find-DbaView {
                             $vwTextFound = $viewText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                             [PSCustomObject]@{
-                                ComputerName   = $server.NetName
+                                ComputerName   = $server.ComputerName
                                 SqlInstance    = $server.ServiceName
                                 Database       = $db.Name
                                 Schema         = $vw.Schema

--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -91,10 +91,10 @@ function Get-DbaAgDatabase {
                         continue
                     }
 
-                    Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-                    Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name Replica -value $server.NetName
+                    Add-Member -Force -InputObject $agDb -MemberType NoteProperty -Name Replica -value $server.ComputerName
 
                     $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Parent as AvailabilityGroup', 'Replica', 'Name as DatabaseName', 'SynchronizationState', 'IsFailoverReady', 'IsJoined', 'IsSuspended'
                     Select-DefaultView -InputObject $agDb -Property $defaults

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -53,7 +53,7 @@ function Get-DbaAgHadr {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            Add-Member -Force -InputObject $server -MemberType NoteProperty -Name ComputerName -value $server.NetName
+            Add-Member -Force -InputObject $server -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
             Add-Member -Force -InputObject $server -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $server -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaAgListener.ps1
+++ b/functions/Get-DbaAgListener.ps1
@@ -75,7 +75,7 @@ function Get-DbaAgListener {
         $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'AvailabilityGroup', 'Name', 'PortNumber', 'ClusterIPConfiguration'
         foreach ($aglistener in $InputObject.AvailabilityGroupListeners) {
             $server = $aglistener.Parent.Parent
-            Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name ComputerName -value $server.NetName
+            Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
             Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
             Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name AvailabilityGroup -value $aglistener.Parent.Name

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -87,7 +87,7 @@ function Get-DbaAgReplica {
                         continue
                     }
 
-                    Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $currentReplica -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaAgentAlert.ps1
+++ b/functions/Get-DbaAgentAlert.ps1
@@ -71,7 +71,7 @@ function Get-DbaAgentAlert {
             foreach ($alert in $alerts) {
                 $lastraised = [dbadatetime]$alert.LastOccurrenceDate
 
-                Add-Member -Force -InputObject $alert -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $alert -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $alert -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $alert -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $alert -MemberType NoteProperty Notifications -value $alert.EnumNotifications()

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -105,7 +105,7 @@ function Get-DbaAgentJob {
             }
 
             foreach ($agentJob in $jobs) {
-                Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.NetName
+                Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.ComputerName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name InstanceName -value $agentJob.Parent.Parent.ServiceName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName
 

--- a/functions/Get-DbaAgentJobCategory.ps1
+++ b/functions/Get-DbaAgentJobCategory.ps1
@@ -98,7 +98,7 @@ function Get-DbaAgentJobCategory {
                     $jobCount = ($server.JobServer.Jobs | Where-Object {$_.CategoryID -eq $cat.ID}).Count
 
                     # Add new properties to the category object
-                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name JobCount -Value $jobCount

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -142,7 +142,7 @@ function Get-DbaAgentJobHistory {
             $tokenrex = [regex]'\$\((?<method>[^()]+)\((?<tok>[^)]+)\)\)|\$\((?<tok>[^)]+)\)'
             $propmap = @{
                 'INST'      = $Server.ServiceName
-                'MACH'      = $Server.NetName
+                'MACH'      = $Server.ComputerName
                 'SQLDIR'    = $Server.InstallDataDirectory
                 'SQLLOGDIR' = $Server.ErrorLogPath
                 #'STEPCT' loop number ?
@@ -246,7 +246,7 @@ function Get-DbaAgentJobHistory {
                         3 { "Canceled" }
                     }
 
-                    Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $execution -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     $DurationInSeconds = ($execution.RunDuration % 100) + [int]( ($execution.RunDuration % 10000 ) / 100 ) * 60 + [int]( ($execution.RunDuration % 1000000 ) / 10000 ) * 60 * 60
@@ -261,7 +261,7 @@ function Get-DbaAgentJobHistory {
                         try {
                             $outname = $outmap[$execution.JobName][$execution.StepID]
                             $outname = Resolve-JobToken -exec $execution -outcome $outcome -outfile $outname
-                            $outremote = Join-AdminUNC $Server.NetName $outname
+                            $outremote = Join-AdminUNC $Server.ComputerName $outname
                         }
                         catch {
                             $outname = ''

--- a/functions/Get-DbaAgentJobOutputFile.ps1
+++ b/functions/Get-DbaAgentJobOutputFile.ps1
@@ -124,13 +124,13 @@ function Get-DbaAgentJobOutputFile {
                 foreach ($Step in $j.JobSteps) {
                     if ($Step.OutputFileName) {
                         [pscustomobject]@{
-                            ComputerName         = $server.NetName
+                            ComputerName         = $server.ComputerName
                             InstanceName         = $server.ServiceName
                             SqlInstance          = $server.DomainInstanceName
                             Job                  = $j.Name
                             JobStep              = $Step.Name
                             OutputFileName       = $Step.OutputFileName
-                            RemoteOutputFileName = Join-AdminUNC $Server.NetName $Step.OutputFileName
+                            RemoteOutputFileName = Join-AdminUNC $Server.ComputerName $Step.OutputFileName
                             StepId               = $Step.Id
                         } | Select-DefaultView -ExcludeProperty StepId
                     }

--- a/functions/Get-DbaAgentJobStep.ps1
+++ b/functions/Get-DbaAgentJobStep.ps1
@@ -105,7 +105,7 @@
             }
             Write-Message -Level Verbose -Message "Collecting job steps on $instance"
             foreach ($agentJobStep in $jobs.jobsteps) {
-                Add-Member -Force -InputObject $agentJobStep -MemberType NoteProperty -Name ComputerName -value $agentJobStep.Parent.Parent.Parent.NetName
+                Add-Member -Force -InputObject $agentJobStep -MemberType NoteProperty -Name ComputerName -value $agentJobStep.Parent.Parent.Parent.ComputerName
                 Add-Member -Force -InputObject $agentJobStep -MemberType NoteProperty -Name InstanceName -value $agentJobStep.Parent.Parent.Parent.ServiceName
                 Add-Member -Force -InputObject $agentJobStep -MemberType NoteProperty -Name SqlInstance -value $agentJobStep.Parent.Parent.Parent.DomainInstanceName
                 Add-Member -Force -InputObject $agentJobStep -MemberType NoteProperty -Name AgentJob -value $agentJobStep.Parent.Name

--- a/functions/Get-DbaAgentLog.ps1
+++ b/functions/Get-DbaAgentLog.ps1
@@ -74,7 +74,7 @@ function Get-DbaAgentLog {
                     try {
                         foreach ($object in $server.JobServer.ReadErrorLog($number)) {
                             Write-Message -Level Verbose -Message "Processing $object"
-                            Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.NetName
+                            Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.ComputerName
                             Add-Member -Force -InputObject $object -MemberType NoteProperty InstanceName -value $server.ServiceName
                             Add-Member -Force -InputObject $object -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
 
@@ -91,7 +91,7 @@ function Get-DbaAgentLog {
                 try {
                     foreach ($object in $server.JobServer.ReadErrorLog()) {
                         Write-Message -Level Verbose -Message "Processing $object"
-                        Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $object -MemberType NoteProperty InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $object -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -100,7 +100,7 @@ function Get-DbaAgentOperator {
                 $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operat.Name }
                 $lastemail = [dbadatetime]$operat.LastEmailDate
 
-                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name RelatedJobs -Value $jobs

--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -255,7 +255,7 @@ function Get-DbaAgentSchedule {
         foreach ($schedule in $scheduleCollection) {
             $description = Get-ScheduleDescription -Schedule $schedule
 
-            Add-Member -Force -InputObject $schedule -MemberType NoteProperty ComputerName -value $server.NetName
+            Add-Member -Force -InputObject $schedule -MemberType NoteProperty ComputerName -value $server.ComputerName
             Add-Member -Force -InputObject $schedule -MemberType NoteProperty InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $schedule -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
             Add-Member -Force -InputObject $schedule -MemberType NoteProperty Description -Value $description

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -85,7 +85,7 @@ function Get-DbaAvailabilityGroup {
             }
 
             foreach ($ag in $ags) {
-                Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaAvailableCollation.ps1
+++ b/functions/Get-DbaAvailableCollation.ps1
@@ -99,7 +99,7 @@ function Get-DbaAvailableCollation {
 
             $availableCollations = $server.EnumCollations()
             foreach ($collation in $availableCollations) {
-                Add-Member -Force -InputObject $collation -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $collation -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $collation -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $collation -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $collation -MemberType NoteProperty -Name CodePageName -Value (Get-CodePageDescription $collation.CodePage)

--- a/functions/Get-DbaBackupDevice.ps1
+++ b/functions/Get-DbaBackupDevice.ps1
@@ -60,7 +60,7 @@ function Get-DbaBackupDevice {
             }
 
             foreach ($backupDevice in $server.BackupDevices) {
-                Add-Member -Force -InputObject $backupDevice -MemberType NoteProperty -Name ComputerName -value $backupDevice.Parent.NetName
+                Add-Member -Force -InputObject $backupDevice -MemberType NoteProperty -Name ComputerName -value $backupDevice.Parent.ComputerName
                 Add-Member -Force -InputObject $backupDevice -MemberType NoteProperty -Name InstanceName -value $backupDevice.Parent.ServiceName
                 Add-Member -Force -InputObject $backupDevice -MemberType NoteProperty -Name SqlInstance -value $backupDevice.Parent.DomainInstanceName
 

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -565,7 +565,7 @@ function Get-DbaBackupHistory {
                         $ratio = 1
                     }
                     $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
-                    $historyObject.ComputerName = $server.NetName
+                    $historyObject.ComputerName = $server.ComputerName
                     $historyObject.InstanceName = $server.ServiceName
                     $historyObject.SqlInstance = $server.DomainInstanceName
                     $historyObject.Database = $commonFields.Database

--- a/functions/Get-DbaCpuUsage.ps1
+++ b/functions/Get-DbaCpuUsage.ps1
@@ -137,7 +137,7 @@
                 $ThreadStateValue = $threadstates.$threadstate
                 $ThreadWaitReasonValue = $threadwaitreasons.$threadwaitreason
 
-                Add-Member -Force -InputObject $thread -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $thread -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $thread -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $thread -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $thread -MemberType NoteProperty -Name Processes -Value ($processes | Where-Object HostProcessID -eq $thread.IDProcess)

--- a/functions/Get-DbaCredential.ps1
+++ b/functions/Get-DbaCredential.ps1
@@ -104,7 +104,7 @@ function Get-DbaCredential {
             }
 
             foreach ($currentcredential in $credential) {
-                Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name ComputerName -value $currentcredential.Parent.NetName
+                Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name ComputerName -value $currentcredential.Parent.ComputerName
                 Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name InstanceName -value $currentcredential.Parent.ServiceName
                 Add-Member -Force -InputObject $currentcredential -MemberType NoteProperty -Name SqlInstance -value $currentcredential.Parent.DomainInstanceName
 

--- a/functions/Get-DbaCustomError.ps1
+++ b/functions/Get-DbaCustomError.ps1
@@ -59,7 +59,7 @@ function Get-DbaCustomError {
             }
 
             foreach ($customError in $server.UserDefinedMessages) {
-                Add-Member -Force -InputObject $customError -MemberType NoteProperty -Name ComputerName -value $customError.Parent.NetName
+                Add-Member -Force -InputObject $customError -MemberType NoteProperty -Name ComputerName -value $customError.Parent.ComputerName
                 Add-Member -Force -InputObject $customError -MemberType NoteProperty -Name InstanceName -value $customError.Parent.ServiceName
                 Add-Member -Force -InputObject $customError -MemberType NoteProperty -Name SqlInstance -value $customError.Parent.DomainInstanceName
 

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -342,7 +342,7 @@ function Get-DbaDatabase {
 
                     $lastusedinfo = $dblastused | Where-Object { $_.dbname -eq $db.name }
                     Add-Member -Force -InputObject $db -MemberType NoteProperty BackupStatus -value $Notes
-                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name LastRead -value $lastusedinfo.last_read

--- a/functions/Get-DbaDatabaseAssembly.ps1
+++ b/functions/Get-DbaDatabaseAssembly.ps1
@@ -62,7 +62,7 @@ function Get-DbaDatabaseAssembly {
                 try {
                     foreach ($assembly in $database.assemblies) {
 
-                        Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name ComputerName -value $assembly.Parent.Parent.NetName
+                        Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name ComputerName -value $assembly.Parent.Parent.ComputerName
                         Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name InstanceName -value $assembly.Parent.Parent.ServiceName
                         Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name SqlInstance -value $assembly.Parent.Parent.DomainInstanceName
 

--- a/functions/Get-DbaDatabaseEncryption.ps1
+++ b/functions/Get-DbaDatabaseEncryption.ps1
@@ -108,7 +108,7 @@ function Get-DbaDatabaseEncryption {
 
                 if ($db.EncryptionEnabled -eq $true) {
                     [PSCustomObject]@{
-                        ComputerName             = $server.NetName
+                        ComputerName             = $server.ComputerName
                         InstanceName             = $server.ServiceName
                         SqlInstance              = $server.DomainInstanceName
                         Database                 = $db.Name
@@ -127,7 +127,7 @@ function Get-DbaDatabaseEncryption {
 
                 foreach ($cert in $db.Certificates) {
                     [PSCustomObject]@{
-                        ComputerName             = $server.NetName
+                        ComputerName             = $server.ComputerName
                         InstanceName             = $server.ServiceName
                         SqlInstance              = $server.DomainInstanceName
                         Database                 = $db.Name
@@ -146,7 +146,7 @@ function Get-DbaDatabaseEncryption {
 
                 foreach ($ak in $db.AsymmetricKeys) {
                     [PSCustomObject]@{
-                        ComputerName             = $server.NetName
+                        ComputerName             = $server.ComputerName
                         InstanceName             = $server.ServiceName
                         SqlInstance              = $server.DomainInstanceName
                         Database                 = $db.Name

--- a/functions/Get-DbaDatabaseFile.ps1
+++ b/functions/Get-DbaDatabaseFile.ps1
@@ -223,7 +223,7 @@ ON fd.Drive = LEFT(df.physical_name, 1);
                     if ( ($nextgrowtheventadd.Byte -gt ($MaxSize.Byte - $size.Byte)) -and $maxsize -gt 0 ) { [dbasize]$nextgrowtheventadd = 0 }
 
                     [PSCustomObject]@{
-                        ComputerName             = $server.NetName
+                        ComputerName             = $server.ComputerName
                         InstanceName             = $server.ServiceName
                         SqlInstance              = $server.DomainInstanceName
                         Database                 = $db.name

--- a/functions/Get-DbaDatabaseMasterKey.ps1
+++ b/functions/Get-DbaDatabaseMasterKey.ps1
@@ -91,7 +91,7 @@ Gets the master key for the db1 database
                     continue
                 }
 
-                Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDatabasePartitionFunction.ps1
+++ b/functions/Get-DbaDatabasePartitionFunction.ps1
@@ -98,7 +98,7 @@ Gets the Partition Functions for the databases on Sql1 and Sql2/sqlexpress
 
                 $partitionfunctions | foreach {
 
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDatabasePartitionScheme.ps1
+++ b/functions/Get-DbaDatabasePartitionScheme.ps1
@@ -98,7 +98,7 @@ Gets the Partition Schemes for the databases on Sql1 and Sql2/sqlexpress
 
                 $PartitionSchemes | foreach {
 
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDatabaseSpace.ps1
+++ b/functions/Get-DbaDatabaseSpace.ps1
@@ -203,7 +203,7 @@ function Get-DbaDatabaseSpace {
                         }
 
                         [pscustomobject]@{
-                            ComputerName         = $server.NetName
+                            ComputerName         = $server.ComputerName
                             InstanceName         = $server.ServiceName
                             SqlInstance          = $server.DomainInstanceName
                             Database             = $row.DBName

--- a/functions/Get-DbaDatabaseState.ps1
+++ b/functions/Get-DbaDatabaseState.ps1
@@ -120,7 +120,7 @@ FROM sys.databases
                 [PSCustomObject]@{
                     SqlInstance  = $server.Name
                     InstanceName = $server.ServiceName
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     DatabaseName = $db.Name
                     RW           = $db_status.RW
                     Status       = $db_status.Status

--- a/functions/Get-DbaDatabaseUdf.ps1
+++ b/functions/Get-DbaDatabaseUdf.ps1
@@ -106,7 +106,7 @@ Gets the User Defined Functions for the databases on Sql1 and Sql2/sqlexpress
 
                 $UserDefinedFunctions | foreach {
 
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDatabaseUser.ps1
+++ b/functions/Get-DbaDatabaseUser.ps1
@@ -106,7 +106,7 @@ Gets the users for the databases on Sql1 and Sql2/sqlexpress
 
                 $users | foreach {
 
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDatabaseView.ps1
+++ b/functions/Get-DbaDatabaseView.ps1
@@ -105,7 +105,7 @@ function Get-DbaDatabaseView {
 
                 $views | Foreach-Object {
 
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDbCertificate.ps1
+++ b/functions/Get-DbaDbCertificate.ps1
@@ -107,7 +107,7 @@ Gets the cert1 certificate within the db1 database
 
                 foreach ($cert in $certs) {
 
-                    Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name Database -value $currentdb.Name

--- a/functions/Get-DbaDbCheckConstraint.ps1
+++ b/functions/Get-DbaDbCheckConstraint.ps1
@@ -108,7 +108,7 @@ function Get-DbaDbCheckConstraint {
                     }
 
                     foreach ($ck in $tbl.Checks) {
-                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                         Add-Member -Force -InputObject $ck -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDbCompression.ps1
+++ b/functions/Get-DbaDbCompression.ps1
@@ -87,7 +87,7 @@ function Get-DbaDbCompression {
                         if ($obj.HasHeapIndex) {
                             foreach ($p in $obj.PhysicalPartitions) {
                                 [pscustomobject]@{
-                                    ComputerName        = $server.NetName
+                                    ComputerName        = $server.ComputerName
                                     InstanceName        = $server.ServiceName
                                     SqlInstance         = $server.DomainInstanceName
                                     Database            = $db.Name
@@ -107,7 +107,7 @@ function Get-DbaDbCompression {
                         foreach ($index in $obj.Indexes) {
                             foreach ($p in $index.PhysicalPartitions) {
                                 [pscustomobject]@{
-                                    ComputerName        = $server.NetName
+                                    ComputerName        = $server.ComputerName
                                     InstanceName        = $server.ServiceName
                                     SqlInstance         = $server.DomainInstanceName
                                     Database            = $db.Name

--- a/functions/Get-DbaDbExtentDiff.ps1
+++ b/functions/Get-DbaDbExtentDiff.ps1
@@ -120,7 +120,7 @@ function Get-DbaDbExtentDiff {
                     "
                     $DBCCPageResults = $server.Query($DBCCPageQueryDMV, $db.Name)
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         DatabaseName   = $db.Name
@@ -155,7 +155,7 @@ function Get-DbaDbExtentDiff {
                     }
                     $extents = Get-DbaExtent $dbExtents.Field
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         DatabaseName   = $db.Name

--- a/functions/Get-DbaDbForeignKey.ps1
+++ b/functions/Get-DbaDbForeignKey.ps1
@@ -108,7 +108,7 @@ function Get-DbaDbForeignKey {
                     }
 
                     foreach ($fk in $tbl.ForeignKeys) {
-                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                         Add-Member -Force -InputObject $fk -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDbQueryStoreOptions.ps1
+++ b/functions/Get-DbaDbQueryStoreOptions.ps1
@@ -90,7 +90,7 @@ function Get-DbaDbQueryStoreOptions {
                 Write-Message -Level Verbose -Message "Processing $($db.Name) on $instance"
                 $QSO = $db.QueryStoreOptions
 
-                Add-Member -Force -InputObject $QSO -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $QSO -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $QSO -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $QSO -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $QSO -MemberType NoteProperty Database -value $db.Name

--- a/functions/Get-DbaDbRole.ps1
+++ b/functions/Get-DbaDbRole.ps1
@@ -126,7 +126,7 @@ Returns SQLServer, Database, Role for DatabaseRoles on sql instance ServerB\sql1
                 }
 
                 foreach ($dbrole in $dbroles) {
-                    Add-Member -Force -InputObject $dbrole -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $dbrole -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $dbrole -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $dbrole -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $dbrole -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDbSnapshot.ps1
+++ b/functions/Get-DbaDbSnapshot.ps1
@@ -82,7 +82,7 @@ function Get-DbaDbSnapshot {
             foreach ($db in $dbs) {
                 try {
                     $BytesOnDisk = $db.Query("SELECT SUM(BytesOnDisk) AS BytesOnDisk FROM fn_virtualfilestats(DB_ID(),NULL) S JOIN sys.databases D on D.database_id = S.dbid", $db.Name)
-                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $db -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $db -MemberType NoteProperty -Name DiskUsage -value ([dbasize]($BytesOnDisk.BytesOnDisk))

--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -106,7 +106,7 @@ function Get-DbaDbStoredProcedure {
                         continue
                     }
 
-                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name

--- a/functions/Get-DbaDbVirtualLogFile.ps1
+++ b/functions/Get-DbaDbVirtualLogFile.ps1
@@ -108,7 +108,7 @@ function Get-DbaDbVirtualLogFile {
 
                     foreach ($d in $data) {
                         [pscustomobject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Database       = $db.Name

--- a/functions/Get-DbaDefaultPath.ps1
+++ b/functions/Get-DbaDefaultPath.ps1
@@ -91,7 +91,7 @@ function Get-DbaDefaultPath {
             $logPath = $logPath.Trim().TrimEnd("\")
 
             [PSCustomObject]@{
-                ComputerName = $server.NetName
+                ComputerName = $server.ComputerName
                 InstanceName = $server.ServiceName
                 SqlInstance  = $server.DomainInstanceName
                 Data         = $dataPath

--- a/functions/Get-DbaDependency.ps1
+++ b/functions/Get-DbaDependency.ps1
@@ -166,7 +166,7 @@ function Get-DbaDependency {
                     $parent = $Server.GetSmoObject($Item.Parent.Urn)
 
                     $NewObject = New-Object Sqlcollaborative.Dbatools.Database.Dependency
-                    $NewObject.ComputerName = $server.NetName
+                    $NewObject.ComputerName = $server.ComputerName
                     $NewObject.ServiceName = $server.ServiceName
                     $NewObject.SqlInstance = $server.DomainInstanceName
                     $NewObject.Dependent = $richobject.Name

--- a/functions/Get-DbaDistributor.ps1
+++ b/functions/Get-DbaDistributor.ps1
@@ -72,7 +72,7 @@ function Get-DbaDistributor {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            Add-Member -Force -InputObject $distributor -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+            Add-Member -Force -InputObject $distributor -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
             Add-Member -Force -InputObject $distributor -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
             Add-Member -Force -InputObject $distributor -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
 

--- a/functions/Get-DbaDump.ps1
+++ b/functions/Get-DbaDump.ps1
@@ -63,7 +63,7 @@ function Get-DbaDump {
             try {
                 foreach ($result in $server.Query($sql)) {
                     [PSCustomObject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         FileName     = $result.filename

--- a/functions/Get-DbaEndpoint.ps1
+++ b/functions/Get-DbaEndpoint.ps1
@@ -60,7 +60,7 @@ function Get-DbaEndpoint {
             }
 
             foreach ($endpoint in $server.Endpoints) {
-                Add-Member -Force -InputObject $endpoint -MemberType NoteProperty -Name ComputerName -value $endpoint.Parent.NetName
+                Add-Member -Force -InputObject $endpoint -MemberType NoteProperty -Name ComputerName -value $endpoint.Parent.ComputerName
                 Add-Member -Force -InputObject $endpoint -MemberType NoteProperty -Name InstanceName -value $endpoint.Parent.ServiceName
                 Add-Member -Force -InputObject $endpoint -MemberType NoteProperty -Name SqlInstance -value $endpoint.Parent.DomainInstanceName
 

--- a/functions/Get-DbaErrorLog.ps1
+++ b/functions/Get-DbaErrorLog.ps1
@@ -117,7 +117,7 @@ function Get-DbaErrorLog {
                             continue
                         }
                         Write-Message -Level Verbose -Message "Processing $object"
-                        Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $object -MemberType NoteProperty InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $object -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
 
@@ -132,7 +132,7 @@ function Get-DbaErrorLog {
                         continue
                     }
                     Write-Message -Level Verbose -Message "Processing $object"
-                    Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $object -MemberType NoteProperty ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $object -MemberType NoteProperty InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $object -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaErrorLogConfig.ps1
+++ b/functions/Get-DbaErrorLogConfig.ps1
@@ -62,7 +62,7 @@ function Get-DbaErrorLogConfig {
             }
 
             [PSCustomObject]@{
-                ComputerName       = $server.NetName
+                ComputerName       = $server.ComputerName
                 InstanceName       = $server.ServiceName
                 SqlInstance        = $server.DomainInstanceName
                 LogCount           = $numLogs

--- a/functions/Get-DbaEstimatedCompletionTime.ps1
+++ b/functions/Get-DbaEstimatedCompletionTime.ps1
@@ -137,7 +137,7 @@ Gets estimated completion times for queries performed against the Northwind, pub
             Write-Message -Level Debug -Message $sql
             foreach ($row in ($server.Query($sql))) {
                 [pscustomobject]@{
-                    ComputerName            = $server.NetName
+                    ComputerName            = $server.ComputerName
                     InstanceName            = $server.ServiceName
                     SqlInstance             = $server.DomainInstanceName
                     Database                = $row.Database

--- a/functions/Get-DbaExecutionPlan.ps1
+++ b/functions/Get-DbaExecutionPlan.ps1
@@ -180,7 +180,7 @@ Gets super detailed information for execution plans on only for AdventureWorks20
                         $planWarnings = $simple.QueryPlan.Warnings.PlanAffectingConvert;
 
                         [pscustomobject]@{
-                            ComputerName                      = $server.NetName
+                            ComputerName                      = $server.ComputerName
                             InstanceName                      = $server.ServiceName
                             SqlInstance                       = $server.DomainInstanceName
                             DatabaseName                      = $row.DatabaseName

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -188,11 +188,11 @@ Finds files in E:\Dir1 ending with ".fsf" and ".mld" for both the servers sql201
                     foreach ($type in $FileTypeComparison) {
                         if ($row.filename.ToLower().EndsWith(".$type")) {
                             [pscustomobject]@{
-                                ComputerName   = $server.NetName
+                                ComputerName   = $server.ComputerName
                                 InstanceName   = $server.ServiceName
                                 SqlInstance    = $server.DomainInstanceName
                                 Filename       = $row.fullpath
-                                RemoteFilename = Join-AdminUnc -Servername $server.netname -Filepath $row.fullpath
+                                RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
                             } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                         }
                     }
@@ -201,11 +201,11 @@ Finds files in E:\Dir1 ending with ".fsf" and ".mld" for both the servers sql201
             else {
                 foreach ($row in $datatable) {
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Filename       = $row.fullpath
-                        RemoteFilename = Join-AdminUnc -Servername $server.netname -Filepath $row.fullpath
+                        RemoteFilename = Join-AdminUnc -Servername $server.ComputerName -Filepath $row.fullpath
                     } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName, RemoteFilename
                 }
             }

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -1040,7 +1040,7 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            ComputerName  = $server.NetName
+                            ComputerName  = $server.ComputerName
                             InstanceName  = $server.ServiceName
                             SqlInstance   = $server.DomainInstanceName
                             Database     = $db.Name
@@ -1075,7 +1075,7 @@ function Get-DbaHelpIndex {
                         }
                         
                         [pscustomobject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Database       = $db.Name

--- a/functions/Get-DbaJobCategory.ps1
+++ b/functions/Get-DbaJobCategory.ps1
@@ -60,7 +60,7 @@ function Get-DbaJobCategory {
             }
 
             foreach ($jobCategory in $server.JobServer.JobCategories) {
-                Add-Member -Force -InputObject $jobCategory -MemberType NoteProperty -Name ComputerName -value $jobCategory.Parent.Parent.NetName
+                Add-Member -Force -InputObject $jobCategory -MemberType NoteProperty -Name ComputerName -value $jobCategory.Parent.Parent.ComputerName
                 Add-Member -Force -InputObject $jobCategory -MemberType NoteProperty -Name InstanceName -value $jobCategory.Parent.Parent.ServiceName
                 Add-Member -Force -InputObject $jobCategory -MemberType NoteProperty -Name SqlInstance -value $jobCategory.Parent.Parent.DomainInstanceName
 

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -148,7 +148,7 @@ function Get-DbaLastBackup {
                 }
 
                 $result = [PSCustomObject]@{
-                    ComputerName       = $server.NetName
+                    ComputerName       = $server.ComputerName
                     InstanceName       = $server.ServiceName
                     SqlInstance        = $server.DomainInstanceName
                     Database           = $db.Name

--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -147,7 +147,7 @@ function Get-DbaLastGoodCheckDb {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName             = $server.NetName
+                    ComputerName             = $server.ComputerName
                     InstanceName             = $server.ServiceName
                     SqlInstance              = $server.DomainInstanceName
                     Database                 = $db.name

--- a/functions/Get-DbaLinkedServer.ps1
+++ b/functions/Get-DbaLinkedServer.ps1
@@ -70,7 +70,7 @@ function Get-DbaLinkedServer {
         }
 
         foreach ($ls in $lservers) {
-            Add-Member -Force -InputObject $ls -MemberType NoteProperty -Name ComputerName -value $server.NetName
+            Add-Member -Force -InputObject $ls -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
             Add-Member -Force -InputObject $ls -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $ls -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
             Add-Member -Force -InputObject $ls -MemberType NoteProperty -Name Impersonate -value $ls.LinkedServerLogins.Impersonate

--- a/functions/Get-DbaLogShippingError.ps1
+++ b/functions/Get-DbaLogShippingError.ps1
@@ -214,7 +214,7 @@ DROP TABLE #DatabaseID;"
                 foreach ($result in $results) {
                     # Set up the custom object
                     $null = $collection.Add([PSCustomObject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Database       = $result.DatabaseName

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -225,7 +225,7 @@ function Get-DbaLogin {
                     Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $null
                 }
 
-                Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
 

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -170,10 +170,10 @@ function Get-DbaMaintenanceSolutionLog {
                 Continue
             }
             if ($Path) {
-                $logdir = Join-AdminUnc -Servername $server.netname -Filepath $Path
+                $logdir = Join-AdminUnc -Servername $server.ComputerName -Filepath $Path
             }
             else {
-                $logdir = Join-AdminUnc -Servername $server.netname -Filepath $server.errorlogpath # -replace '^(.):', "\\$computername\`$1$"
+                $logdir = Join-AdminUnc -Servername $server.ComputerName -Filepath $server.errorlogpath # -replace '^(.):', "\\$computername\`$1$"
             }
             if (!$logdir) {
                 Write-Message -Level Warning -Message "No log directory returned from $instance"
@@ -207,7 +207,7 @@ function Get-DbaMaintenanceSolutionLog {
                 Continue
             }
             $instanceinfo = @{ }
-            $instanceinfo['ComputerName'] = $server.NetName
+            $instanceinfo['ComputerName'] = $server.ComputerName
             $instanceinfo['InstanceName'] = $server.ServiceName
             $instanceinfo['SqlInstance'] = $server.Name
 

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -65,7 +65,7 @@ function Get-DbaMaxMemory {
             }
 
             [pscustomobject]@{
-                ComputerName = $server.NetName
+                ComputerName = $server.ComputerName
                 InstanceName = $server.ServiceName
                 SqlInstance  = $server.DomainInstanceName
                 TotalMB      = [int]$totalMemory

--- a/functions/Get-DbaOrphanUser.ps1
+++ b/functions/Get-DbaOrphanUser.ps1
@@ -103,7 +103,7 @@ function Get-DbaOrphanUser {
                             Write-Message -Level Verbose -Message "Orphan users found"
                             foreach ($user in $UsersToWork) {
                                 [PSCustomObject]@{
-                                    ComputerName = $server.NetName
+                                    ComputerName = $server.ComputerName
                                     InstanceName = $server.ServiceName
                                     SqlInstance  = $server.DomainInstanceName
                                     DatabaseName = $db.Name

--- a/functions/Get-DbaPolicy.ps1
+++ b/functions/Get-DbaPolicy.ps1
@@ -102,7 +102,7 @@ function Get-DbaPolicy {
 
             foreach ($currentpolicy in $allpolicies) {
                 Write-Message -Level Verbose -Message "Processing $currentpolicy"
-                Add-Member -Force -InputObject $currentpolicy -MemberType NoteProperty ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $currentpolicy -MemberType NoteProperty ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $currentpolicy -MemberType NoteProperty InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $currentpolicy -MemberType NoteProperty SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaProcess.ps1
+++ b/functions/Get-DbaProcess.ps1
@@ -167,7 +167,7 @@ function Get-DbaProcess {
                 $row = $results | Where-Object { $_.Spid -eq $session.Spid }
 
                 Add-Member -Force -InputObject $session -MemberType NoteProperty -Name Parent -value $server
-                Add-Member -Force -InputObject $session -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $session -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $session -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $session -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $session -MemberType NoteProperty -Name Status -value $status

--- a/functions/Get-DbaQueryExecutionTime.ps1
+++ b/functions/Get-DbaQueryExecutionTime.ps1
@@ -212,7 +212,7 @@ limiting results to queries with more than 200 total executions and an execution
                 try {
                     foreach ($row in $db.ExecuteWithResults($sql).Tables.Rows) {
                         [PSCustomObject]@{
-                            ComputerName       = $server.NetName
+                            ComputerName       = $server.ComputerName
                             InstanceName       = $server.ServiceName
                             SqlInstance        = $server.DomainInstanceName
                             Database           = $row.DatabaseName

--- a/functions/Get-DbaRegisteredServerStore.ps1
+++ b/functions/Get-DbaRegisteredServerStore.ps1
@@ -62,7 +62,7 @@ function Get-DbaRegisteredServerStore {
                 Stop-Function -Message "Cannot access Central Management Server on $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ComputerName -value $server.NetName
+            Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaResourceGovernorClassifierFunction.ps1
+++ b/functions/Get-DbaResourceGovernorClassifierFunction.ps1
@@ -68,7 +68,7 @@ Gets the classifier function object on Sql1 and Sql2/sqlexpress instances
             }
 
             if ($classifierFunction) {
-                Add-Member -Force -InputObject $classifierFunction -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $classifierFunction -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $classifierFunction -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $classifierFunction -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                 Add-Member -Force -InputObject $classifierFunction -MemberType NoteProperty -Name Database -value 'master'

--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -100,7 +100,7 @@ function Get-DbaRestoreHistory {
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
-                $computername = $server.NetName
+                $computername = $server.ComputerName
                 $instancename = $server.ServiceName
                 $servername = $server.DomainInstanceName
 

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -69,7 +69,7 @@ function Get-DbaRunningJob {
             else {
                 foreach ($job in $jobs) {
                     [pscustomobject]@{
-                        ComputerName     = $server.NetName
+                        ComputerName     = $server.ComputerName
                         InstanceName     = $server.ServiceName
                         SqlInstance      = $server.DomainInstanceName
                         Name             = $job.name

--- a/functions/Get-DbaServerAudit.ps1
+++ b/functions/Get-DbaServerAudit.ps1
@@ -81,9 +81,9 @@ function Get-DbaServerAudit {
                 $filename = $currentaudit.FileName
                 $fullname = "$directory\$filename"
                 $remote = $fullname.Replace(":", "$")
-                $remote = "\\$($currentaudit.Parent.NetName)\$remote"
+                $remote = "\\$($currentaudit.Parent.ComputerName)\$remote"
 
-                Add-Member -Force -InputObject $currentaudit -MemberType NoteProperty -Name ComputerName -value $currentaudit.Parent.NetName
+                Add-Member -Force -InputObject $currentaudit -MemberType NoteProperty -Name ComputerName -value $currentaudit.Parent.ComputerName
                 Add-Member -Force -InputObject $currentaudit -MemberType NoteProperty -Name InstanceName -value $currentaudit.Parent.ServiceName
                 Add-Member -Force -InputObject $currentaudit -MemberType NoteProperty -Name SqlInstance -value $currentaudit.Parent.DomainInstanceName
                 Add-Member -Force -InputObject $currentaudit -MemberType NoteProperty -Name FullName -value $fullname

--- a/functions/Get-DbaServerAuditSpecification.ps1
+++ b/functions/Get-DbaServerAuditSpecification.ps1
@@ -64,7 +64,7 @@ function Get-DbaServerAuditSpecification {
             }
 
             foreach ($auditSpecification in $server.ServerAuditSpecifications) {
-                Add-Member -Force -InputObject $auditSpecification -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $auditSpecification -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $auditSpecification -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $auditSpecification -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaServerInstallDate.ps1
+++ b/functions/Get-DbaServerInstallDate.ps1
@@ -110,7 +110,7 @@ Returns an object with SQL Instance install date as a string for every server li
             }
 
             $object = [PSCustomObject]@{
-                ComputerName       = $server.NetName
+                ComputerName       = $server.ComputerName
                 InstanceName       = $server.ServiceName
                 SqlInstance        = $server.DomainInstanceName
                 SqlInstallDate     = $sqlInstallDate

--- a/functions/Get-DbaServerRole.ps1
+++ b/functions/Get-DbaServerRole.ps1
@@ -82,7 +82,7 @@ function Get-DbaServerRole {
                 $members = $role.EnumMemberNames()
 
                 Add-Member -Force -InputObject $role -MemberType NoteProperty -Name Login -Value $members
-                Add-Member -Force -InputObject $role -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                Add-Member -Force -InputObject $role -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                 Add-Member -Force -InputObject $role -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                 Add-Member -Force -InputObject $role -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -100,7 +100,7 @@ function Get-DbaSpConfigure {
 
                     [pscustomobject]@{
                         ServerName            = $server.Name
-                        ComputerName          = $server.NetName
+                        ComputerName          = $server.ComputerName
                         InstanceName          = $server.ServiceName
                         SqlInstance           = $server.DomainInstanceName
                         Name                  = $prop.Name

--- a/functions/Get-DbaSqlInstanceProperty.ps1
+++ b/functions/Get-DbaSqlInstanceProperty.ps1
@@ -98,7 +98,7 @@ function Get-DbaSqlInstanceProperty {
                     $infoProperties = $infoProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $infoProperties) {
-                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'Information'
@@ -119,7 +119,7 @@ function Get-DbaSqlInstanceProperty {
                     $userProperties = $userProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $userProperties) {
-                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'UserOption'
@@ -140,7 +140,7 @@ function Get-DbaSqlInstanceProperty {
                     $settingProperties = $settingProperties | Where-Object Name -NotIn $ExcludeInstanceProperty
                 }
                 foreach ($prop in $settingProperties) {
-                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                    Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                     Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name PropertyType -Value 'Setting'

--- a/functions/Get-DbaSqlInstanceUserOption.ps1
+++ b/functions/Get-DbaSqlInstanceUserOption.ps1
@@ -64,7 +64,7 @@ function Get-DbaSqlInstanceUserOption {
             }
             $props = $server.useroptions.properties
             foreach ($prop in $props) {
-                Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $prop -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Select-DefaultView -InputObject $prop -Property ComputerName, InstanceName, SqlInstance, Name, Value

--- a/functions/Get-DbaSqlModule.ps1
+++ b/functions/Get-DbaSqlModule.ps1
@@ -153,7 +153,7 @@ function Get-DbaSqlModule {
 
                 foreach ($row in $server.Query($sql, $db.name)) {
                     [PSCustomObject]@{
-                        ComputerName  = $server.NetName
+                        ComputerName  = $server.ComputerName
                         InstanceName  = $server.ServiceName
                         SqlInstance   = $server.DomainInstanceName
                         Database      = $row.DatabaseName

--- a/functions/Get-DbaSsisEnvironmentVariable.ps1
+++ b/functions/Get-DbaSsisEnvironmentVariable.ps1
@@ -234,7 +234,7 @@ function Get-DbaSsisEnvironmentVariable {
                                 }
 
                                 [PSCustomObject]@{
-                                    ComputerName = $server.NetName
+                                    ComputerName = $server.ComputerName
                                     InstanceName = $server.ServiceName
                                     SqlInstance  = $server.DomainInstanceName
                                     Folder       = $f

--- a/functions/Get-DbaSuspectPage.ps1
+++ b/functions/Get-DbaSuspectPage.ps1
@@ -91,7 +91,7 @@ function Get-DbaSuspectPage {
         }
         foreach ($row in $results) {
             [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
                 Database       = $row.DBName

--- a/functions/Get-DbaTable.ps1
+++ b/functions/Get-DbaTable.ps1
@@ -187,7 +187,7 @@ Returns information on the CommandLog table in the DBA database on both instance
                 }
 
                 foreach ($sqltable in $tables) {
-                    $sqltable | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                    $sqltable | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                     $sqltable | Add-Member -Force -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     $sqltable | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                     $sqltable | Add-Member -Force -MemberType NoteProperty -Name Database -Value $db.Name

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -188,7 +188,7 @@ function Get-DbaTcpPort {
                 $port = $server.Query($sql)
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Port         = $port.local_tcp_port

--- a/functions/Get-DbaTrace.ps1
+++ b/functions/Get-DbaTrace.ps1
@@ -90,14 +90,14 @@ function Get-DbaTrace {
 
             foreach ($row in $results) {
                 if ($row.Path.ToString().Length -gt 0) {
-                    $remotefile = Join-AdminUnc -servername $server.NetName -filepath $row.path
+                    $remotefile = Join-AdminUnc -servername $server.ComputerName -filepath $row.path
                 }
                 else {
                     $remotefile = $null
                 }
 
                 [PSCustomObject]@{
-                    ComputerName             = $server.NetName
+                    ComputerName             = $server.ComputerName
                     InstanceName             = $server.ServiceName
                     SqlInstance              = $server.DomainInstanceName
                     Id                       = $row.id

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -82,7 +82,7 @@ function Get-DbaTraceFlag {
 
             foreach ($tflag in $tflags) {
                 [pscustomobject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     TraceFlag    = $tflag.TraceFlag

--- a/functions/Get-DbaTrigger.ps1
+++ b/functions/Get-DbaTrigger.ps1
@@ -80,7 +80,7 @@ Returns a custom object displaying ComputerName, SqlInstance, Database, TriggerN
             $server.Triggers |
                 ForEach-Object {
                 [PSCustomObject]@{
-                    ComputerName     = $server.NetName
+                    ComputerName     = $server.ComputerName
                     InstanceName     = $server.ServiceName
                     SqlInstance      = $server.DomainInstanceName
                     TriggerLevel     = "Server"
@@ -108,7 +108,7 @@ Returns a custom object displaying ComputerName, SqlInstance, Database, TriggerN
                 $_.Triggers |
                     ForEach-Object {
                     [PSCustomObject]@{
-                        ComputerName     = $server.NetName
+                        ComputerName     = $server.ComputerName
                         InstanceName     = $server.ServiceName
                         SqlInstance      = $server.DomainInstanceName
                         TriggerLevel     = "Database"

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -75,7 +75,7 @@ function Get-DbaUptime {
                 $servername = $instance.SqlInstance
             }
             elseif ($instance.Gettype().FullName -eq [Microsoft.SqlServer.Management.Smo.Server]) {
-                $servername = $instance.NetName
+                $servername = $instance.ComputerName
             }
             else {
                 $servername = $instance.ComputerName;

--- a/functions/Get-DbaUserLevelPermission.ps1
+++ b/functions/Get-DbaUserLevelPermission.ps1
@@ -227,7 +227,7 @@ function Get-DbaUserLevelPermission {
 
                     foreach ($row in $serverDT) {
                         [PSCustomObject]@{
-                            ComputerName       = $server.NetName
+                            ComputerName       = $server.ComputerName
                             InstanceName       = $server.ServiceName
                             SqlInstance        = $server.DomainInstanceName
                             Object             = 'SERVER'
@@ -252,7 +252,7 @@ function Get-DbaUserLevelPermission {
 
                 foreach ($row in $dbDT) {
                     [PSCustomObject]@{
-                        ComputerName       = $server.NetName
+                        ComputerName       = $server.ComputerName
                         InstanceName       = $server.ServiceName
                         SqlInstance        = $server.DomainInstanceName
                         Object             = $db.Name

--- a/functions/Get-DbaWaitStatistic.ps1
+++ b/functions/Get-DbaWaitStatistic.ps1
@@ -887,7 +887,7 @@
                 }
 
                 [PSCustomObject]@{
-                    ComputerName           = $server.NetName
+                    ComputerName           = $server.ComputerName
                     InstanceName           = $server.ServiceName
                     SqlInstance            = $server.DomainInstanceName
                     WaitType               = $waitType

--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -114,7 +114,7 @@ function Get-DbaWaitingTask {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Spid         = $row.Spid

--- a/functions/Get-DbaXESession.ps1
+++ b/functions/Get-DbaXESession.ps1
@@ -98,11 +98,11 @@ function Get-DbaXESession {
                             $file = "$directory\$file"
                         }
                         $filecollection += $file
-                        $remotefile += Join-AdminUnc -servername $server.netName -filepath $file
+                        $remotefile += Join-AdminUnc -servername $server.ComputerName -filepath $file
                     }
                 }
 
-                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                Add-Member -Force -InputObject $x -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $x -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $x -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Add-Member -Force -InputObject $x -MemberType NoteProperty -Name Status -Value $status

--- a/functions/Get-DbaXESessionTarget.ps1
+++ b/functions/Get-DbaXESessionTarget.ps1
@@ -98,11 +98,11 @@ function Get-DbaXESessionTarget {
                                 $file = "$directory\$file"
                             }
                             $filecollection += $file
-                            $remotefile += Join-AdminUnc -servername $server.netName -filepath $file
+                            $remotefile += Join-AdminUnc -servername $server.ComputerName -filepath $file
                         }
                     }
 
-                    Add-Member -Force -InputObject $xtarget -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+                    Add-Member -Force -InputObject $xtarget -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                     Add-Member -Force -InputObject $xtarget -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                     Add-Member -Force -InputObject $xtarget -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                     Add-Member -Force -InputObject $xtarget -MemberType NoteProperty -Name Session -Value $sessionname

--- a/functions/Get-DbaXEStore.ps1
+++ b/functions/Get-DbaXEStore.ps1
@@ -55,7 +55,7 @@
             $SqlStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $SqlConn
             $store = New-Object  Microsoft.SqlServer.Management.XEvent.XEStore $SqlStoreConnection
 
-            Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ComputerName -Value $server.NetName
+            Add-Member -Force -InputObject $store -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
             Add-Member -Force -InputObject $store -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
             Select-DefaultView -InputObject $store -Property ComputerName, InstanceName, SqlInstance, ServerName, Sessions, Packages, RunningSessionCount

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -170,7 +170,7 @@ function Install-DbaFirstResponderKit {
                             $scriptError = $true
                         }
                         $baseres = @{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $Database

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -218,7 +218,7 @@ function Install-DbaWhoIsActive {
                             $status = 'Installed'
                         }
                         [PSCustomObject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $Database

--- a/functions/Invoke-DbaBalanceDataFiles.ps1
+++ b/functions/Invoke-DbaBalanceDataFiles.ps1
@@ -345,7 +345,7 @@ function Invoke-DbaBalanceDataFiles {
                 $dataFilesEnding = Get-DbaDatabaseFile -SqlInstance $server -Database $db.Name | Where-Object { $_.TypeDescription -eq 'ROWS' } | Select-Object ID, LogicalName, PhysicalName, Size, UsedSpace, AvailableSpace | Sort-Object ID
 
                 [pscustomobject]@{
-                    ComputerName   = $server.NetName
+                    ComputerName   = $server.ComputerName
                     InstanceName   = $server.ServiceName
                     SqlInstance    = $server.DomainInstanceName
                     Database       = $db.Name

--- a/functions/Invoke-DbaCycleErrorLog.ps1
+++ b/functions/Invoke-DbaCycleErrorLog.ps1
@@ -109,7 +109,7 @@ function Invoke-DbaCycleErrorLog {
                 if ($Pscmdlet.ShouldProcess($server, "Cycle the log(s): $logs")) {
                     $null = $server.Query($sql)
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         LogType      = $logToCycle
@@ -120,7 +120,7 @@ function Invoke-DbaCycleErrorLog {
             }
             catch {
                 [pscustomobject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     LogType      = $logToCycle

--- a/functions/Invoke-DbaDatabaseShrink.ps1
+++ b/functions/Invoke-DbaDatabaseShrink.ps1
@@ -301,7 +301,7 @@ function Invoke-DbaDatabaseShrink {
                         $notes = "Database shrinks can cause massive index fragmentation and negatively impact performance. You should now run DBCC INDEXDEFRAG or ALTER INDEX ... REORGANIZE"
                     }
                     $object = [PSCustomObject]@{
-                        ComputerName                  = $server.NetName
+                        ComputerName                  = $server.ComputerName
                         InstanceName                  = $server.ServiceName
                         SqlInstance                   = $server.DomainInstanceName
                         Database                      = $db.name

--- a/functions/Invoke-DbaDatabaseUpgrade.ps1
+++ b/functions/Invoke-DbaDatabaseUpgrade.ps1
@@ -271,7 +271,7 @@ function Invoke-DbaDatabaseUpgrade {
                 $db.Refresh()
 
                 [PSCustomObject]@{
-                    ComputerName          = $server.NetName
+                    ComputerName          = $server.ComputerName
                     InstanceName          = $server.ServiceName
                     SqlInstance           = $server.DomainInstanceName
                     Database              = $db.name

--- a/functions/Invoke-DbaDbDecryptObject.ps1
+++ b/functions/Invoke-DbaDbDecryptObject.ps1
@@ -332,7 +332,7 @@ function Invoke-DbaDbDecryptObject {
 
                         # Add the results to the custom object
                         [PSCustomObject]@{
-                                ComputerName    = $server.NetName
+                                ComputerName    = $server.ComputerName
                                 InstanceName    = $server.ServiceName
                                 SqlInstance     = $server.DomainInstanceName
                                 Database        = $db.Name

--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -316,7 +316,7 @@ function Invoke-DbaDiagnosticQuery {
                             Write-Message -Level Verbose -Message "Processed $($scriptpart.QueryName) on $instance"
                             if (!$result) {
                                 [pscustomobject]@{
-                                    ComputerName     = $server.NetName
+                                    ComputerName     = $server.ComputerName
                                     InstanceName     = $server.ServiceName
                                     SqlInstance      = $server.DomainInstanceName
                                     Number           = $scriptpart.QueryNr
@@ -335,7 +335,7 @@ function Invoke-DbaDiagnosticQuery {
                         }
                         if ($result) {
                             [pscustomobject]@{
-                                ComputerName     = $server.NetName
+                                ComputerName     = $server.ComputerName
                                 InstanceName     = $server.ServiceName
                                 SqlInstance      = $server.DomainInstanceName
                                 Number           = $scriptpart.QueryNr
@@ -353,7 +353,7 @@ function Invoke-DbaDiagnosticQuery {
                         # if running WhatIf, then return the queries that would be run as an object, not just whatif output
 
                         [pscustomobject]@{
-                            ComputerName     = $server.NetName
+                            ComputerName     = $server.ComputerName
                             InstanceName     = $server.ServiceName
                             SqlInstance      = $server.DomainInstanceName
                             Number           = $scriptpart.QueryNr
@@ -392,7 +392,7 @@ function Invoke-DbaDiagnosticQuery {
                                 $result = $server.Query($scriptpart.Text, $currentDb)
                                 if (!$result) {
                                     [pscustomobject]@{
-                                        ComputerName     = $server.NetName
+                                        ComputerName     = $server.ComputerName
                                         InstanceName     = $server.ServiceName
                                         SqlInstance      = $server.DomainInstanceName
                                         Number           = $scriptpart.QueryNr
@@ -411,7 +411,7 @@ function Invoke-DbaDiagnosticQuery {
                             }
 
                             [pscustomobject]@{
-                                ComputerName     = $server.NetName
+                                ComputerName     = $server.ComputerName
                                 InstanceName     = $server.ServiceName
                                 SqlInstance      = $server.DomainInstanceName
                                 Number           = $scriptpart.QueryNr
@@ -427,7 +427,7 @@ function Invoke-DbaDiagnosticQuery {
                             # if running WhatIf, then return the queries that would be run as an object, not just whatif output
 
                             [pscustomobject]@{
-                                ComputerName     = $server.NetName
+                                ComputerName     = $server.ComputerName
                                 InstanceName     = $server.ServiceName
                                 SqlInstance      = $server.DomainInstanceName
                                 Number           = $scriptpart.QueryNr

--- a/functions/Measure-DbaDiskSpaceRequirement.ps1
+++ b/functions/Measure-DbaDiskSpaceRequirement.ps1
@@ -208,7 +208,7 @@ function Measure-DbaDiskSpaceRequirement {
         }
         else {
             Write-Message -Level Verbose -Message "Database [$DestinationDatabase] does not exist on Destination Instance $Destination."
-            $computerName = $destServer.NetName
+            $computerName = $destServer.ComputerName
         }
 
         foreach ($sourceFile in $sourceFiles) {
@@ -216,10 +216,10 @@ function Measure-DbaDiskSpaceRequirement {
                 if ($found = ($sourceFile.Name -eq $destFile.Name)) {
                     # Files found on both sides
                     [PSCustomObject]@{
-                            SourceComputerName      = $sourceServer.NetName
+                            SourceComputerName      = $sourceServer.ComputerName
                             SourceInstance          = $sourceServer.ServiceName
                             SourceSqlInstance       = $sourceServer.DomainInstanceName
-                            DestinationComputerName = $destServer.NetName
+                            DestinationComputerName = $destServer.ComputerName
                             DestinationInstance     = $destServer.ServiceName
                             DestinationSqlInstance  = $destServer.DomainInstanceName
                             SourceDatabase          = $sourceDb.Name
@@ -239,10 +239,10 @@ function Measure-DbaDiskSpaceRequirement {
             if (!$found) {
                 # Files on source but not on destination
                 [PSCustomObject]@{
-                        SourceComputerName      = $sourceServer.NetName
+                        SourceComputerName      = $sourceServer.ComputerName
                         SourceInstance          = $sourceServer.ServiceName
                         SourceSqlInstance       = $sourceServer.DomainInstanceName
-                        DestinationComputerName = $destServer.NetName
+                        DestinationComputerName = $destServer.ComputerName
                         DestinationInstance     = $destServer.ServiceName
                         DestinationSqlInstance  = $destServer.DomainInstanceName
                         SourceDatabase          = $sourceDb.Name
@@ -263,10 +263,10 @@ function Measure-DbaDiskSpaceRequirement {
             $destFilesNotSource = Compare-Object -ReferenceObject $destFiles -DifferenceObject $sourceFiles -Property Name -PassThru
             foreach ($destFileNotSource in $destFilesNotSource) {
                 [PSCustomObject]@{
-                        SourceComputerName      = $sourceServer.NetName
+                        SourceComputerName      = $sourceServer.ComputerName
                         SourceInstance          = $sourceServer.ServiceName
                         SourceSqlInstance       = $sourceServer.DomainInstanceName
-                        DestinationComputerName = $destServer.NetName
+                        DestinationComputerName = $destServer.ComputerName
                         DestinationInstance     = $destServer.ServiceName
                         DestinationSqlInstance  = $destServer.DomainInstanceName
                         SourceDatabaseName      = $Database

--- a/functions/Mount-DbaDatabase.ps1
+++ b/functions/Mount-DbaDatabase.ps1
@@ -135,7 +135,7 @@ function Mount-DbaDatabase {
                         $server.AttachDatabase($db, $FileStructure, $DatabaseOwner, [Microsoft.SqlServer.Management.Smo.AttachOptions]::$AttachOption)
 
                         [pscustomobject]@{
-                            ComputerName  = $server.NetName
+                            ComputerName  = $server.ComputerName
                             InstanceName  = $server.ServiceName
                             SqlInstance   = $server.DomainInstanceName
                             Database      = $db

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -212,7 +212,7 @@ function New-DbaAgentProxy {
                 if ($Pscmdlet.ShouldProcess("console", "Outputting Proxy object")) {
                     $proxy.Alter()
                     $proxy.Refresh()
-                    Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                    Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                     Add-Member -Force -InputObject $proxy -MemberType NoteProperty -Name Logins -value $proxy.EnumLogins()

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -134,7 +134,7 @@ Password needs to be passed the Shared Access Token (SAS Key).
                         $credential.ProviderName = $ProviderName
                         $credential.Create($Identity, $Password)
 
-                        Add-Member -Force -InputObject $credential -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $credential -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $credential -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $credential -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
 

--- a/functions/New-DbaDatabaseMasterKey.ps1
+++ b/functions/New-DbaDatabaseMasterKey.ps1
@@ -87,7 +87,7 @@ Suppresses all prompts to install but prompts to securely enter your password an
                         $masterkey = New-Object Microsoft.SqlServer.Management.Smo.MasterKey $smodb
                         $masterkey.Create(([System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password))))
 
-                        Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                        Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                         Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                         Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                         Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $smodb

--- a/functions/New-DbaDbCertificate.ps1
+++ b/functions/New-DbaDbCertificate.ps1
@@ -128,7 +128,7 @@ Suppresses all prompts to install but prompts to securely enter your password an
                                 $smocert.Create()
                             }
 
-                            Add-Member -Force -InputObject $smocert -MemberType NoteProperty -Name ComputerName -value $server.NetName
+                            Add-Member -Force -InputObject $smocert -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                             Add-Member -Force -InputObject $smocert -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                             Add-Member -Force -InputObject $smocert -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
                             Add-Member -Force -InputObject $smocert -MemberType NoteProperty -Name Database -value $currentdb.Name

--- a/functions/New-DbaSsisCatalog.ps1
+++ b/functions/New-DbaSsisCatalog.ps1
@@ -76,7 +76,7 @@ function New-DbaSsisCatalog {
             }
 
             ## check if SSIS and Engine running on box
-            $services = Get-DbaSqlService -ComputerName $server.NetName
+            $services = Get-DbaSqlService -ComputerName $server.ComputerName
 
             $ssisservice = $Services | Where-Object { $_.ServiceType -eq "SSIS" -and $_.State -eq "Running" }
 
@@ -109,7 +109,7 @@ function New-DbaSsisCatalog {
                         $ssisdb.Create()
 
                         [pscustomobject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             SsisCatalog  = $SsisCatalog

--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -113,7 +113,7 @@ Removes all the user databases from server\instance without any confirmation
                     $server.Refresh()
 
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.name
@@ -127,7 +127,7 @@ Removes all the user databases from server\instance without any confirmation
                         $null = $server.Query("if exists (select * from sys.databases where name = '$($db.name)' and state = 0) alter database $db set single_user with rollback immediate; drop database $db")
 
                         [pscustomobject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $db.name
@@ -142,7 +142,7 @@ Removes all the user databases from server\instance without any confirmation
                             $server.Refresh()
 
                             [pscustomobject]@{
-                                ComputerName = $server.NetName
+                                ComputerName = $server.ComputerName
                                 InstanceName = $server.ServiceName
                                 SqlInstance  = $server.DomainInstanceName
                                 Database     = $db.name
@@ -154,7 +154,7 @@ Removes all the user databases from server\instance without any confirmation
                         Write-Message -Level Verbose -Message "Could not drop database $db on $server"
 
                         [pscustomobject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $db.name

--- a/functions/Remove-DbaDatabaseMasterKey.ps1
+++ b/functions/Remove-DbaDatabaseMasterKey.ps1
@@ -115,7 +115,7 @@ function Remove-DbaDatabaseMasterKey {
                     Write-Message -Level Verbose -Message "Successfully removed master key from the $db database on $instance"
 
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.Name
@@ -124,7 +124,7 @@ function Remove-DbaDatabaseMasterKey {
                 }
                 catch {
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.Name
@@ -163,7 +163,7 @@ function Remove-DbaDatabaseMasterKey {
                         }
                         [DbaMode]::Report {
                             [pscustomobject]@{
-                                ComputerName = $server.NetName
+                                ComputerName = $server.ComputerName
                                 InstanceName = $server.ServiceName
                                 SqlInstance  = $server.DomainInstanceName
                                 Database     = $db
@@ -185,7 +185,7 @@ function Remove-DbaDatabaseMasterKey {
                         }
                         "Report" {
                             [pscustomobject]@{
-                                ComputerName = $server.NetName
+                                ComputerName = $server.ComputerName
                                 InstanceName = $server.ServiceName
                                 SqlInstance  = $server.DomainInstanceName
                                 Database     = $smodb.Name

--- a/functions/Remove-DbaDbCertificate.ps1
+++ b/functions/Remove-DbaDbCertificate.ps1
@@ -76,7 +76,7 @@ Suppresses all prompts to remove the certificate in the 'db1' database and drops
             $db = $smocert.Parent.Name
 
             $output = [pscustomobject]@{
-                ComputerName = $server.NetName
+                ComputerName = $server.ComputerName
                 InstanceName = $server.ServiceName
                 SqlInstance  = $instance
                 Database     = $db

--- a/functions/Remove-DbaDbSnapshot.ps1
+++ b/functions/Remove-DbaDbSnapshot.ps1
@@ -149,7 +149,7 @@ function Remove-DbaDbSnapshot {
                         $server.Refresh()
 
                         [pscustomobject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Database       = $db.name
@@ -161,7 +161,7 @@ function Remove-DbaDbSnapshot {
                     Write-Message -Level Verbose -Message "Could not drop database $db on $server"
 
                     [pscustomobject]@{
-                        ComputerName   = $server.NetName
+                        ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
                         SqlInstance    = $server.DomainInstanceName
                         Database       = $db.name

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -192,7 +192,7 @@ function Remove-DbaDbUser {
                     }
 
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.name

--- a/functions/Remove-DbaLogin.ps1
+++ b/functions/Remove-DbaLogin.ps1
@@ -103,7 +103,7 @@ removes mylogin on SQL Server server\instance
                     $currentlogin.Drop()
                     
                     [pscustomobject]@{
-                        ComputerName  = $server.NetName
+                        ComputerName  = $server.ComputerName
                         InstanceName  = $server.ServiceName
                         SqlInstance   = $server.DomainInstanceName
                         Login         = $currentlogin.name
@@ -113,7 +113,7 @@ removes mylogin on SQL Server server\instance
             }
             catch {
                 [pscustomobject]@{
-                    ComputerName  = $server.NetName
+                    ComputerName  = $server.ComputerName
                     InstanceName  = $server.ServiceName
                     SqlInstance   = $server.DomainInstanceName
                     Login         = $currentlogin.name

--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -217,7 +217,7 @@ function Remove-DbaOrphanUser {
                                                         $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
                                                         [pscustomobject]@{
-                                                            ComputerName      = $server.NetName
+                                                            ComputerName      = $server.ComputerName
                                                             InstanceName      = $server.ServiceName
                                                             SqlInstance       = $server.DomainInstanceName
                                                             DatabaseName      = $db.Name
@@ -242,7 +242,7 @@ function Remove-DbaOrphanUser {
                                                         $DropSchema += "DROP SCHEMA [$($sch.Name)]"
 
                                                         [pscustomobject]@{
-                                                            ComputerName      = $server.NetName
+                                                            ComputerName      = $server.ComputerName
                                                             InstanceName      = $server.ServiceName
                                                             SqlInstance       = $server.DomainInstanceName
                                                             DatabaseName      = $db.Name
@@ -260,7 +260,7 @@ function Remove-DbaOrphanUser {
                                                         $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
                                                         [pscustomobject]@{
-                                                            ComputerName      = $server.NetName
+                                                            ComputerName      = $server.ComputerName
                                                             InstanceName      = $server.ServiceName
                                                             SqlInstance       = $server.DomainInstanceName
                                                             DatabaseName      = $db.Name

--- a/functions/Remove-DbaTrace.ps1
+++ b/functions/Remove-DbaTrace.ps1
@@ -83,7 +83,7 @@
                     $server.Query($removesql)
                 }
                 [pscustomobject]@{
-                    ComputerName      = $server.NetName
+                    ComputerName      = $server.ComputerName
                     InstanceName      = $server.ServiceName
                     SqlInstance       = $server.DomainInstanceName
                     Id                = $traceid

--- a/functions/Remove-DbaXESession.ps1
+++ b/functions/Remove-DbaXESession.ps1
@@ -94,7 +94,7 @@
                     try {
                         $xe.Drop()
                         [pscustomobject]@{
-                            ComputerName = $xe.Parent.NetName
+                            ComputerName = $xe.Parent.ComputerName
                             InstanceName = $xe.Parent.ServiceName
                             SqlInstance  = $xe.Parent.DomainInstanceName
                             Session      = $session

--- a/functions/Rename-DbaDatabase.ps1
+++ b/functions/Rename-DbaDatabase.ps1
@@ -707,19 +707,19 @@ function Rename-DbaDatabase {
                 #region move
                 $ComputerName = $null
                 $Final_Renames = New-Object System.Collections.ArrayList
-                if ([DbaValidate]::IsLocalhost($server.NetName)) {
+                if ([DbaValidate]::IsLocalhost($server.ComputerName)) {
                     # locally ran so we can just use rename-item
-                    $ComputerName = $server.NetName
+                    $ComputerName = $server.ComputerName
                 }
                 else {
-                    # let's start checking if we can access .NetName
+                    # let's start checking if we can access .ComputerName
                     $testPS = $false
                     if ($SqlCredential) {
                         # why does Test-PSRemoting require a Credential param ? this is ugly...
-                        $testPS = Test-PSRemoting -ComputerName $server.NetName -Credential $SqlCredential -ErrorAction Stop
+                        $testPS = Test-PSRemoting -ComputerName $server.ComputerName -Credential $SqlCredential -ErrorAction Stop
                     }
                     else {
-                        $testPS = Test-PSRemoting -ComputerName $server.NetName -ErrorAction Stop
+                        $testPS = Test-PSRemoting -ComputerName $server.ComputerName -ErrorAction Stop
                     }
                     if (!($testPS)) {
                         # let's try to resolve it to a more qualified name, without "cutting" knowledge about the domain (only $server.Name possibly holds the complete info)
@@ -735,11 +735,11 @@ function Rename-DbaDatabase {
                         }
                     }
                     else {
-                        $ComputerName = $server.NetName
+                        $ComputerName = $server.ComputerName
                     }
                 }
                 foreach ($op in $pending_renames) {
-                    if ([DbaValidate]::IsLocalhost($server.NetName)) {
+                    if ([DbaValidate]::IsLocalhost($server.ComputerName)) {
                         $null = $Final_Renames.Add([pscustomobject]@{
                                 Source       = $op.Source
                                 Destination  = $op.Destination
@@ -749,11 +749,11 @@ function Rename-DbaDatabase {
                     else {
                         if ($null -eq $ComputerName) {
                             # if we don't have remote access ($ComputerName is null) we can fallback to admin shares if they're available
-                            if (Test-Path (Join-AdminUnc -ServerName $server.NetName -filepath $op.Source)) {
+                            if (Test-Path (Join-AdminUnc -ServerName $server.ComputerName -filepath $op.Source)) {
                                 $null = $Final_Renames.Add([pscustomobject]@{
-                                        Source       = Join-AdminUnc -ServerName $server.NetName -filepath $op.Source
-                                        Destination  = Join-AdminUnc -ServerName $server.NetName -filepath $op.Destination
-                                        ComputerName = $server.NetName
+                                        Source       = Join-AdminUnc -ServerName $server.ComputerName -filepath $op.Source
+                                        Destination  = Join-AdminUnc -ServerName $server.ComputerName -filepath $op.Destination
+                                        ComputerName = $server.ComputerName
                                     })
                             }
                             else {
@@ -857,7 +857,7 @@ function Rename-DbaDatabase {
                 }
             }
             [pscustomobject]@{
-                ComputerName       = $server.NetName
+                ComputerName       = $server.ComputerName
                 InstanceName       = $server.ServiceName
                 SqlInstance        = $server.DomainInstanceName
                 Database           = $db

--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -90,7 +90,7 @@ WhatIf Example
                     $dbenums = $currentLogin.EnumDatabaseMappings()
                     $currentLogin.rename($NewLogin)
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $null
@@ -102,7 +102,7 @@ WhatIf Example
                 catch {
                     $dbenums = $null
                     [pscustomobject]@{
-                        ComputerName = $server.NetName
+                        ComputerName = $server.ComputerName
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $null
@@ -124,7 +124,7 @@ WhatIf Example
                         $oldname = $user.name
                         $user.Rename($NewLogin)
                         [pscustomobject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $db.name
@@ -139,7 +139,7 @@ WhatIf Example
                         $currentLogin.rename($Login)
 
                         [pscustomobject]@{
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             InstanceName = $server.ServiceName
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $db.name

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -175,7 +175,7 @@ function Repair-DbaOrphanUser {
                                         Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
 
                                         [PSCustomObject]@{
-                                            ComputerName = $server.NetName
+                                            ComputerName = $server.ComputerName
                                             InstanceName = $server.ServiceName
                                             SqlInstance  = $server.DomainInstanceName
                                             DatabaseName = $db.Name
@@ -192,7 +192,7 @@ function Repair-DbaOrphanUser {
                                     else {
                                         Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
                                         [PSCustomObject]@{
-                                            ComputerName = $server.NetName
+                                            ComputerName = $server.ComputerName
                                             InstanceName = $server.ServiceName
                                             SqlInstance  = $server.DomainInstanceName
                                             DatabaseName = $db.Name

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -123,7 +123,7 @@ Rename multiple jobs in one go on multiple servers.
 
                         # Set up the custom object
                         $null = $collection.Add([PSCustomObject]@{
-                                ComputerName    = $server.NetName
+                                ComputerName    = $server.ComputerName
                                 InstanceName    = $server.ServiceName
                                 SqlInstance     = $server.DomainInstanceName
                                 CategoryName    = $originalCategoryName

--- a/functions/Set-DbaAgentJobOutputFile.ps1
+++ b/functions/Set-DbaAgentJobOutputFile.ps1
@@ -134,7 +134,7 @@ function Set-DbaAgentJobOutputFile {
                         $jobstep.Refresh()
 
                         [pscustomobject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Job            = $currentJob.Name

--- a/functions/Set-DbaDatabaseOwner.ps1
+++ b/functions/Set-DbaDatabaseOwner.ps1
@@ -141,7 +141,7 @@ function Set-DbaDatabaseOwner {
                         else {
                             $db.SetOwner($TargetLogin)
                             [PSCustomObject]@{
-                                ComputerName = $server.NetName
+                                ComputerName = $server.ComputerName
                                 InstanceName = $server.ServiceName
                                 SqlInstance  = $server.DomainInstanceName
                                 Database     = $db

--- a/functions/Set-DbaDatabaseState.ps1
+++ b/functions/Set-DbaDatabaseState.ps1
@@ -484,7 +484,7 @@ function Set-DbaDatabaseState {
             }
             if ($Detached -eq $true) {
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     DatabaseName = $db.Name
@@ -506,7 +506,7 @@ function Set-DbaDatabaseState {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     DatabaseName = $db.Name

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -205,7 +205,7 @@ function Set-DbaDbCompression {
                                     $($obj.PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $P.PartitionNumber}).DataCompression = $CompressionType
                                     $obj.Rebuild()
                                     [pscustomobject]@{
-                                        ComputerName                  = $server.NetName
+                                        ComputerName                  = $server.ComputerName
                                         InstanceName                  = $server.ServiceName
                                         SqlInstance                   = $server.DomainInstanceName
                                         Database                      = $db.Name
@@ -248,7 +248,7 @@ function Set-DbaDbCompression {
                                         }
 
                                         [pscustomobject]@{
-                                            ComputerName                  = $server.NetName
+                                            ComputerName                  = $server.ComputerName
                                             InstanceName                  = $server.ServiceName
                                             SqlInstance                   = $server.DomainInstanceName
                                             Database                      = $db.Name
@@ -289,7 +289,7 @@ function Set-DbaDbCompression {
                                     }
 
                                     [pscustomobject]@{
-                                        ComputerName                  = $server.NetName
+                                        ComputerName                  = $server.ComputerName
                                         InstanceName                  = $server.ServiceName
                                         SqlInstance                   = $server.DomainInstanceName
                                         Database                      = $db.Name

--- a/functions/Set-DbaErrorLogConfig.ps1
+++ b/functions/Set-DbaErrorLogConfig.ps1
@@ -82,7 +82,7 @@ function Set-DbaErrorLogConfig {
             $currentLogSize = $server.ErrorLogSizeKb
 
             $collection = [PSCustomObject]@{
-                ComputerName              = $server.NetName
+                ComputerName              = $server.ComputerName
                 InstanceName              = $server.ServiceName
                 SqlInstance               = $server.DomainInstanceName
                 LogCount                  = $currentNumLogs

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -342,7 +342,7 @@ function Set-DbaLogin {
 
                 # Return the results
                 [PSCustomObject]@{
-                    ComputerName           = $server.NetName
+                    ComputerName           = $server.ComputerName
                     InstanceName           = $server.ServiceName
                     SqlInstance            = $server.DomainInstanceName
                     LoginName              = $l.Name

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -238,7 +238,7 @@ function Set-DbaMaxDop {
                     }
 
                     $results += [pscustomobject]@{
-                        ComputerName           = $server.NetName
+                        ComputerName           = $server.ComputerName
                         InstanceName           = $server.ServiceName
                         SqlInstance            = $server.DomainInstanceName
                         InstanceVersion        = $row.InstanceVersion

--- a/functions/Set-DbaSpConfigure.ps1
+++ b/functions/Set-DbaSpConfigure.ps1
@@ -108,7 +108,7 @@ function Set-DbaSpConfigure {
                     $server.Configuration.Alter()
                     
                     [pscustomobject]@{
-                        ComputerName           = $server.NetName
+                        ComputerName           = $server.ComputerName
                         InstanceName           = $server.ServiceName
                         SqlInstance            = $server.DomainInstanceName
                         ConfigName             = $configuration

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -153,11 +153,11 @@ function Set-DbaTcpPort {
                 $resolved = Resolve-DbaNetworkName -ComputerName $computerName
 
                 Write-Message -Level Verbose -Message "Writing TCPPort $port for $instance to $($resolved.FQDN)..."
-                Invoke-ManagedComputerCommand -ComputerName $resolved.FQDN -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $IpAddress, $server.DomainInstanceName -Credential $Credential
+                Invoke-ManagedComputerCommand -ComputerName $resolved.FQDN -ScriptBlock $scriptblock -ArgumentList $Server.ComputerName, $wmiinstancename, $port, $IpAddress, $server.DomainInstanceName -Credential $Credential
 
             }
             catch {
-                Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -ScriptBlock $scriptblock -ArgumentList $Server.NetName, $wmiinstancename, $port, $IpAddress, $server.DomainInstanceName -Credential $Credential
+                Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -ScriptBlock $scriptblock -ArgumentList $Server.ComputerName, $wmiinstancename, $port, $IpAddress, $server.DomainInstanceName -Credential $Credential
             }
         }
     }

--- a/functions/Set-DbaTempDbConfiguration.ps1
+++ b/functions/Set-DbaTempDbConfiguration.ps1
@@ -246,7 +246,7 @@ function Set-DbaTempDbConfiguration {
                     Write-Message -Level Verbose -Message "tempdb successfully reconfigured."
 
                     [PSCustomObject]@{
-                        ComputerName         = $server.NetName
+                        ComputerName         = $server.ComputerName
                         InstanceName         = $server.ServiceName
                         SqlInstance          = $server.DomainInstanceName
                         DataFileCount        = $DataFileCount

--- a/functions/Stop-DbaTrace.ps1
+++ b/functions/Stop-DbaTrace.ps1
@@ -81,7 +81,7 @@
                 $output = Get-DbaTrace -SqlInstance $server -Id $traceid
                 if (-not $output) {
                     $output = [PSCustomObject]@{
-                        ComputerName            = $server.NetName
+                        ComputerName            = $server.ComputerName
                         InstanceName            = $server.ServiceName
                         SqlInstance             = $server.DomainInstanceName
                         Id                      = $traceid

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -135,7 +135,7 @@ function Test-DbaBackupInformation {
                             $VerificationErrors++
                         }
                         elseif ($path -in $DBHistoryPhysicalPathsExists) {
-                                Write-Message -Message "File $path already exists on $($SqlInstance.NetName), not owned by any database in $SqlInstance, will not overwrite." -Level Warning
+                                Write-Message -Message "File $path already exists on $($SqlInstance.ComputerName), not owned by any database in $SqlInstance, will not overwrite." -Level Warning
                                 $VerificationErrors++
                         }
                     }

--- a/functions/Test-DbaDatabaseCollation.ps1
+++ b/functions/Test-DbaDatabaseCollation.ps1
@@ -95,7 +95,7 @@ function Test-DbaDatabaseCollation {
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $servername."
                 [PSCustomObject]@{
-                    ComputerName      = $server.NetName
+                    ComputerName      = $server.ComputerName
                     InstanceName      = $server.ServiceName
                     SqlInstance       = $server.DomainInstanceName
                     Database          = $db.name

--- a/functions/Test-DbaDatabaseCompatibility.ps1
+++ b/functions/Test-DbaDatabaseCompatibility.ps1
@@ -97,7 +97,7 @@ function Test-DbaDatabaseCompatibility {
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $($db.name) on $instance."
                 [PSCustomObject]@{
-                    ComputerName          = $server.NetName
+                    ComputerName          = $server.ComputerName
                     InstanceName          = $server.ServiceName
                     SqlInstance           = $server.DomainInstanceName
                     ServerLevel           = $serverversion

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -113,7 +113,7 @@ function Test-DbaDatabaseOwner {
 
             Write-Message -Level Verbose -Message "Checking $db"
             [pscustomobject]@{
-                ComputerName = $server.NetName
+                ComputerName = $server.ComputerName
                 InstanceName = $server.ServiceName
                 SqlInstance  = $server.DomainInstanceName
                 Server       = $server.DomainInstanceName

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -456,7 +456,7 @@ IF OBJECT_ID('tempdb..##tmpEstimatePage', 'U') IS NOT NULL
                     #Execute query against individual database and add to output
                     foreach ($row in ($server.Query($sql, $db.Name))) {
                         [pscustomobject]@{
-                            ComputerName                  = $server.NetName
+                            ComputerName                  = $server.ComputerName
                             InstanceName                  = $server.ServiceName
                             SqlInstance                   = $server.DomainInstanceName
                             Database                      = $row.DBName

--- a/functions/Test-DbaDbVirtualLogFile.ps1
+++ b/functions/Test-DbaDbVirtualLogFile.ps1
@@ -110,7 +110,7 @@ function Test-DbaDbVirtualLogFile {
                     $inactive = $data | Where-Object Status -eq 0
 
                     [PSCustomObject]@{
-                        ComputerName      = $server.NetName
+                        ComputerName      = $server.ComputerName
                         InstanceName      = $server.ServiceName
                         SqlInstance       = $server.DomainInstanceName
                         Database          = $db.name

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -189,7 +189,7 @@ function Test-DbaIdentityUsage {
 
                     if ($row.PercentUsed -ge $threshold) {
                         [PSCustomObject]@{
-                            ComputerName   = $server.NetName
+                            ComputerName   = $server.ComputerName
                             InstanceName   = $server.ServiceName
                             SqlInstance    = $server.DomainInstanceName
                             Database       = $row.DatabaseName

--- a/functions/Test-DbaLinkedServerConnection.ps1
+++ b/functions/Test-DbaLinkedServerConnection.ps1
@@ -94,7 +94,7 @@ function Test-DbaLinkedServerConnection {
                     $connectivity = $false
                 }
 
-                New-Object Sqlcollaborative.Dbatools.Validation.LinkedServerResult($ls.parent.NetName, $ls.parent.ServiceName, $ls.parent.DomainInstanceName, $ls.Name, $ls.DataSource, $connectivity, $result)
+                New-Object Sqlcollaborative.Dbatools.Validation.LinkedServerResult($ls.parent.ComputerName, $ls.parent.ServiceName, $ls.parent.DomainInstanceName, $ls.Name, $ls.DataSource, $connectivity, $result)
             }
         }
     }

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -263,7 +263,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
 
                 # Set up the custom object
                 $null = $collection.Add([PSCustomObject]@{
-                        ComputerName          = $server.NetName
+                        ComputerName          = $server.ComputerName
                         InstanceName          = $server.ServiceName
                         SqlInstance           = $server.DomainInstanceName
                         Database              = $result.DatabaseName

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -162,7 +162,7 @@ function Test-DbaMaxDop {
             }
 
             [pscustomobject]@{
-                ComputerName          = $server.NetName
+                ComputerName          = $server.ComputerName
                 InstanceName          = $server.ServiceName
                 SqlInstance           = $server.DomainInstanceName
                 InstanceVersion       = $server.Version
@@ -192,7 +192,7 @@ function Test-DbaMaxDop {
                     $dbmaxdop = $database.MaxDop
 
                     [pscustomobject]@{
-                        ComputerName          = $server.NetName
+                        ComputerName          = $server.ComputerName
                         InstanceName          = $server.ServiceName
                         SqlInstance           = $server.DomainInstanceName
                         InstanceVersion       = $server.Version

--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -110,7 +110,7 @@ function Test-DbaMaxMemory {
             $recommendedMax = $recommendedMax / $instanceCount
 
             [pscustomobject]@{
-                ComputerName  = $server.NetName
+                ComputerName  = $server.ComputerName
                 InstanceName  = $server.ServiceName
                 SqlInstance   = $server.DomainInstanceName
                 InstanceCount = $instanceCount

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -109,7 +109,7 @@ function Test-DbaNetworkLatency {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName     = $server.NetName
+                    ComputerName     = $server.ComputerName
                     InstanceName     = $server.ServiceName
                     SqlInstance      = $server.DomainInstanceName
                     Count            = $count

--- a/functions/Test-DbaOptimizeForAdHoc.ps1
+++ b/functions/Test-DbaOptimizeForAdHoc.ps1
@@ -74,7 +74,7 @@ function Test-DbaOptimizeForAdHoc {
             }
 
             [pscustomobject]@{
-                ComputerName             = $server.NetName
+                ComputerName             = $server.ComputerName
                 InstanceName             = $server.ServiceName
                 SqlInstance              = $server.DomainInstanceName
                 CurrentOptimizeAdHoc     = $optimizeAdHoc

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -98,23 +98,23 @@ function Test-DbaServerName {
             $instance = $server.InstanceName
 
             if ($instance.Length -eq 0) {
-                $serverInstanceName = $server.ComputerName
+                $serverInstanceName = $server.NetName
                 $instance = "MSSQLSERVER"
             }
             else {
-                $ComputerName = $server.ComputerName
-                $serverInstanceName = "$ComputerName\$instance"
+                $netname = $server.NetName
+                $serverInstanceName = "$netname\$instance"
             }
 
             $serverInfo = [PSCustomObject]@{
-                ComputerName     = $server.ComputerName
-                ServerName       = $sqlInstanceName
-                InstanceName     = $server.ServiceName
-                SqlInstance      = $server.DomainInstanceName
-                RenameRequired   = $serverInstanceName -ne $sqlInstanceName
-                Updatable        = "N/A"
-                Warnings         = $null
-                Blockers         = $null
+                ComputerName = $server.NetName
+                ServerName   = $sqlInstanceName
+                InstanceName = $server.ServiceName
+                SqlInstance  = $server.DomainInstanceName
+                RenameRequired = $serverInstanceName -ne $sqlInstanceName
+                Updatable    = "N/A"
+                Warnings     = $null
+                Blockers     = $null
             }
 
             $reasons = @()

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -98,16 +98,16 @@ function Test-DbaServerName {
             $instance = $server.InstanceName
 
             if ($instance.Length -eq 0) {
-                $serverInstanceName = $server.NetName
+                $serverInstanceName = $server.ComputerName
                 $instance = "MSSQLSERVER"
             }
             else {
-                $netname = $server.NetName
-                $serverInstanceName = "$netname\$instance"
+                $ComputerName = $server.ComputerName
+                $serverInstanceName = "$ComputerName\$instance"
             }
 
             $serverInfo = [PSCustomObject]@{
-                ComputerName     = $server.NetName
+                ComputerName     = $server.ComputerName
                 ServerName       = $sqlInstanceName
                 InstanceName     = $server.ServiceName
                 SqlInstance      = $server.DomainInstanceName

--- a/functions/Test-DbaSqlPath.ps1
+++ b/functions/Test-DbaSqlPath.ps1
@@ -95,7 +95,7 @@ function Test-DbaSqlPath {
                         [pscustomobject]@{
                             SqlInstance  = $server.Name
                             InstanceName = $server.ServiceName
-                            ComputerName = $server.NetName
+                            ComputerName = $server.ComputerName
                             FilePath     = $PathsBatch[$i]
                             FileExists   = $DoesPass
                             IsContainer  = $r[1] -eq $true

--- a/functions/Test-DbaTempDbConfiguration.ps1
+++ b/functions/Test-DbaTempDbConfiguration.ps1
@@ -80,7 +80,7 @@ function Test-DbaTempDbConfiguration {
                 $notes = 'SQL Server 2016 has this functionality enabled by default'
                 # DBA May have changed setting. May need to check.
                 $value = [PSCustomObject]@{
-                    ComputerName   = $server.NetName
+                    ComputerName   = $server.ComputerName
                     InstanceName   = $server.ServiceName
                     SqlInstance    = $server.DomainInstanceName
                     Rule           = 'TF 1118 Enabled'
@@ -94,7 +94,7 @@ function Test-DbaTempDbConfiguration {
                 $notes = 'KB328551 describes how TF 1118 can benefit performance.'
 
                 $value = [PSCustomObject]@{
-                    ComputerName   = $server.NetName
+                    ComputerName   = $server.ComputerName
                     InstanceName   = $server.ServiceName
                     SqlInstance    = $server.DomainInstanceName
                     Rule           = 'TF 1118 Enabled'
@@ -122,7 +122,7 @@ function Test-DbaTempDbConfiguration {
             Write-Message -Level Verbose -Message "TempDB file objects gathered"
 
             $value = [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
                 Rule           = 'File Count'
@@ -156,7 +156,7 @@ function Test-DbaTempDbConfiguration {
             }
 
             $value = [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
                 Rule           = 'File Growth in Percent'
@@ -187,7 +187,7 @@ function Test-DbaTempDbConfiguration {
             }
 
             $value = [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
                 Rule           = 'File Location'
@@ -218,7 +218,7 @@ function Test-DbaTempDbConfiguration {
             }
 
             $value = [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
                 Rule           = 'File MaxSize Set'

--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -126,7 +126,7 @@ function Test-DbaWindowsLogin {
             $allWindowsLoginsGroups = $server.Logins | Where-Object { $_.LoginType -in ('WindowsUser', 'WindowsGroup') }
 
             # we cannot validate local users
-            $allWindowsLoginsGroups = $allWindowsLoginsGroups | Where-Object { $_.Name.StartsWith("NT ") -eq $false -and $_.Name.StartsWith($server.NetName) -eq $false -and $_.Name.StartsWith("BUILTIN") -eq $false }
+            $allWindowsLoginsGroups = $allWindowsLoginsGroups | Where-Object { $_.Name.StartsWith("NT ") -eq $false -and $_.Name.StartsWith($server.ComputerName) -eq $false -and $_.Name.StartsWith("BUILTIN") -eq $false }
             if ($Login) {
                 $allWindowsLoginsGroups = $allWindowsLoginsGroups | Where-Object Name -In $Login
             }

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -152,7 +152,7 @@ function Watch-DbaDbLogin {
             $procs = $procs | Where-Object { $systemdbs -notcontains $_.Database -and $excludedPrograms -notcontains $_.Program }
 
             if ($procs.Count -gt 0) {
-                $procs | Select-Object @{Label = "ComputerName"; Expression = {$server.NetName}}, @{Label = "InstanceName"; Expression = {$server.ServiceName}}, @{Label = "SqlInstance"; Expression = {$server.DomainInstanceName}}, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
+                $procs | Select-Object @{Label = "ComputerName"; Expression = {$server.ComputerName}}, @{Label = "InstanceName"; Expression = {$server.ServiceName}}, @{Label = "SqlInstance"; Expression = {$server.DomainInstanceName}}, LoginTime, Login, Host, Program, DatabaseId, Database, IsSystem, CaptureTime | ConvertTo-DbaDataTable | Write-DbaDataTable -SqlInstance $serverDest -Database $Database -Table $Table -AutoCreateTable
 
                 Write-Output "Added process information for $instance to datatable."
             }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -39,7 +39,8 @@ function Connect-SqlInstance {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidDefaultValueSwitchParameter", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
     param (
-        [Parameter(Mandatory = $true)][object]$SqlInstance,
+        [Parameter(Mandatory = $true)]
+        [object]$SqlInstance,
         [object]$SqlCredential,
         [switch]$ParameterConnection,
         [switch]$RegularUser = $true,
@@ -52,8 +53,7 @@ function Connect-SqlInstance {
     function Invoke-TEPPCacheUpdate {
         [CmdletBinding()]
         param (
-            [System.Management.Automation.ScriptBlock]
-            $ScriptBlock
+            [System.Management.Automation.ScriptBlock]$ScriptBlock
         )
 
         try {
@@ -138,24 +138,16 @@ function Connect-SqlInstance {
                 Invoke-TEPPCacheUpdate -ScriptBlock $scriptBlock
             }
         }
+        $parsedcomputername = $server.NetName
+        if (-not $parsedcomputername) {
+            $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+        }
+        Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
         return $server
     }
     #endregion Input Object was a server object
 
     #region Input Object was anything else
-    # This seems a little complex but is required because some connections do TCP,SqlInstance
-    $loadedSmoVersion = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName -like "Microsoft.SqlServer.SMO,*" }
-
-    if ($loadedSmoVersion) {
-        $loadedSmoVersion = $loadedSmoVersion | ForEach-Object {
-            if ($_.Location -match "__") {
-                ((Split-Path (Split-Path $_.Location) -Leaf) -split "__")[0]
-            }
-            else {
-                ((Get-ChildItem -Path $_.Location).VersionInfo.ProductVersion)
-            }
-        }
-    }
 
     $server = New-Object Microsoft.SqlServer.Management.Smo.Server $ConvertedSqlInstance.FullSmoName
     $server.ConnectionContext.ApplicationName = "dbatools PowerShell module - dbatools.io"
@@ -232,53 +224,51 @@ function Connect-SqlInstance {
     $Fields200x_Db = $Fields2000_Db + @('BrokerEnabled', 'DatabaseSnapshotBaseName', 'IsMirroringEnabled', 'Trustworthy')
     $Fields201x_Db = $Fields200x_Db + @('ActiveConnections', 'AvailabilityDatabaseSynchronizationState', 'AvailabilityGroupName', 'ContainmentType', 'EncryptionEnabled')
 
-    $Fields2000_Login = 'CreateDate' , 'DateLastModified' , 'DefaultDatabase' , 'DenyWindowsLogin' , 'IsSystemObject' , 'Language' , 'LanguageAlias' , 'LoginType' , 'Name' , 'Sid' , 'WindowsLoginAccessType'
+    $Fields2000_Login = 'CreateDate', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'Name', 'Sid', 'WindowsLoginAccessType'
     $Fields200x_Login = $Fields2000_Login + @('AsymmetricKey', 'Certificate', 'Credential', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'MustChangePassword', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced')
     $Fields201x_Login = $Fields200x_Login + @('PasswordHashAlgorithm')
 
-    if ($loadedSmoVersion -ge 11) {
-        try {
-            if ($Server.ServerType -ne 'SqlAzureDatabase') {
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Trigger], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Schema], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.SqlAssembly], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Table], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.View], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.StoredProcedure], 'IsSystemObject')
-                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.UserDefinedFunction], 'IsSystemObject')
+    try {
+        if ($Server.ServerType -ne 'SqlAzureDatabase') {
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Trigger], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Schema], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.SqlAssembly], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Table], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.View], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.StoredProcedure], 'IsSystemObject')
+            $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.UserDefinedFunction], 'IsSystemObject')
 
-                if ($server.VersionMajor -eq 8) {
-                    # 2000
-                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsDb.AddRange($Fields2000_Db)
-                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsLogin.AddRange($Fields2000_Login)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
-                }
-                elseif ($server.VersionMajor -eq 9 -or $server.VersionMajor -eq 10) {
-                    # 2005 and 2008
-                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsDb.AddRange($Fields200x_Db)
-                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsLogin.AddRange($Fields200x_Login)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
-                }
-                else {
-                    # 2012 and above
-                    $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsDb.AddRange($Fields201x_Db)
-                    $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
-                    [void]$initFieldsLogin.AddRange($Fields201x_Login)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
-                    $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
-                }
+            if ($server.VersionMajor -eq 8) {
+                # 2000
+                $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsDb.AddRange($Fields2000_Db)
+                $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsLogin.AddRange($Fields2000_Login)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
+            }
+            elseif ($server.VersionMajor -eq 9 -or $server.VersionMajor -eq 10) {
+                # 2005 and 2008
+                $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsDb.AddRange($Fields200x_Db)
+                $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsLogin.AddRange($Fields200x_Login)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
+            }
+            else {
+                # 2012 and above
+                $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsDb.AddRange($Fields201x_Db)
+                $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                [void]$initFieldsLogin.AddRange($Fields201x_Login)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
+                $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
             }
         }
-        catch {
-            # perhaps a DLL issue, continue going
-        }
+    }
+    catch {
+        # perhaps a DLL issue, continue going
     }
 
     # Register the connected instance, so that the TEPP updater knows it's been connected to and starts building the cache
@@ -297,6 +287,11 @@ function Connect-SqlInstance {
         }
     }
 
+    $parsedcomputername = $server.NetName
+    if (-not $parsedcomputername) {
+        $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+    }
+    Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
     return $server
     #endregion Input Object was anything else
 }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -138,7 +138,7 @@ function Connect-SqlInstance {
                 Invoke-TEPPCacheUpdate -ScriptBlock $scriptBlock
             }
         }
-        $parsedcomputername = $server.NetName
+        $parsedcomputername = $server.ComputerName
         if (-not $parsedcomputername) {
             $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
         }
@@ -287,7 +287,7 @@ function Connect-SqlInstance {
         }
     }
 
-    $parsedcomputername = $server.NetName
+    $parsedcomputername = $server.ComputerName
     if (-not $parsedcomputername) {
         $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
     }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -138,11 +138,14 @@ function Connect-SqlInstance {
                 Invoke-TEPPCacheUpdate -ScriptBlock $scriptBlock
             }
         }
-        $parsedcomputername = $server.ComputerName
-        if (-not $parsedcomputername) {
-            $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+        
+        if (-not $server.ComputerName) {
+            $parsedcomputername = $server.NetName
+            if (-not $parsedcomputername) {
+                $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+            }
+            Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
         }
-        Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
         return $server
     }
     #endregion Input Object was a server object
@@ -286,12 +289,14 @@ function Connect-SqlInstance {
             Invoke-TEPPCacheUpdate -ScriptBlock $scriptBlock
         }
     }
-
-    $parsedcomputername = $server.ComputerName
-    if (-not $parsedcomputername) {
-        $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+    
+    if (-not $server.ComputerName) {
+        $parsedcomputername = $server.NetName
+        if (-not $parsedcomputername) {
+            $parsedcomputername = ([dbainstance]$SqlInstance).ComputerName
+        }
+        Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
     }
-    Add-Member -InputObject $server -NotePropertyName ComputerName -NotePropertyValue $parsedcomputername -Force
     return $server
     #endregion Input Object was anything else
 }

--- a/internal/functions/Get-BackupAncientHistory.ps1
+++ b/internal/functions/Get-BackupAncientHistory.ps1
@@ -150,7 +150,7 @@ function Get-BackupAncientHistory {
                 Write-Message -Level Debug -Message "FileSQL: $fileSql"
 
                 $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
-                $historyObject.ComputerName = $server.NetName
+                $historyObject.ComputerName = $server.ComputerName
                 $historyObject.InstanceName = $server.ServiceName
                 $historyObject.SqlInstance = $server.DomainInstanceName
                 $historyObject.Database = $group.Group[0].Database

--- a/internal/functions/Invoke-DbaDatabaseCorruption.ps1
+++ b/internal/functions/Invoke-DbaDatabaseCorruption.ps1
@@ -178,7 +178,7 @@ function Invoke-DbaDatabaseCorruption {
         $null = Set-DbaDatabaseState -SqlServer $Server -Database $Database -MultiUser -Force
 
         [pscustomobject]@{
-            ComputerName = $Server.NetName
+            ComputerName = $Server.ComputerName
             InstanceName = $Server.ServiceName
             SqlInstance  = $Server.DomainInstanceName
             Database     = $db.Name

--- a/internal/functions/Resolve-IpAddress.ps1
+++ b/internal/functions/Resolve-IpAddress.ps1
@@ -8,7 +8,7 @@ function Resolve-IpAddress {
     )
 
     if ($Server.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
-        return $ipaddress = ((Test-Connection $Server.NetName -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+        return $ipaddress = ((Test-Connection $Server.ComputerName -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
     }
     else {
         return $ipaddress = ((Test-Connection $server.Split('\')[0] -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString

--- a/tests/Get-DbaAgDatabase.Tests.ps1
+++ b/tests/Get-DbaAgDatabase.Tests.ps1
@@ -23,6 +23,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 InModuleScope dbatools {
     . "$PSScriptRoot\constants.ps1"
+    $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
     Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         Mock Connect-SqlInstance {
             Import-Clixml $script:appveyorlabrepo\agserver.xml

--- a/tests/Get-DbaAgListener.Tests.ps1
+++ b/tests/Get-DbaAgListener.Tests.ps1
@@ -23,6 +23,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 InModuleScope dbatools {
     . "$PSScriptRoot\constants.ps1"
+    $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
     Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         Mock Connect-SqlInstance {
             Import-CliXml $script:appveyorlabrepo\agserver.xml

--- a/tests/Get-DbaAgentJobHistory.Tests.ps1
+++ b/tests/Get-DbaAgentJobHistory.Tests.ps1
@@ -24,7 +24,7 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             # Thanks @Fred
             $obj = [PSCustomObject]@{
                 Name                 = 'BASEName'
-                NetName              = 'BASENetName'
+                ComputerName              = 'BASEComputerName'
                 InstanceName         = 'BASEInstanceName'
                 DomainInstanceName   = 'BASEDomainInstanceName'
                 InstallDataDirectory = 'BASEInstallDataDirectory'
@@ -189,7 +189,7 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
                 $Results = @()
                 $Results += Get-DbaAgentJobHistory -SqlInstance 'SQLServerName' -WithOutputFile
 
-                ($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASENetName__Job1Output1'
+                ($Results | Where-Object StepID -eq 1 | Where-Object JobName -eq 'Job1').OutputFileName | Should Be 'BASEComputerName__Job1Output1'
 
             }
             It "Handles SQLDIR" {

--- a/tests/Get-DbaAgentJobOutputFile.Tests.ps1
+++ b/tests/Get-DbaAgentJobOutputFile.Tests.ps1
@@ -23,7 +23,7 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             Mock Connect-SQLInstance -MockWith {
                 [object]@{
                     Name      = 'SQLServerName'
-                    NetName   = 'SQLServerName'
+                    ComputerName   = 'SQLServerName'
                     JobServer = @{
                         Jobs = @(
                             @{


### PR DESCRIPTION
Azure does not support NetName, which we rely on for ComputerName.

This adds a new property to $server in both Connect-SqlInstance and Connect-DbaInstance. It checks to see if NetName exists and if it does, then that will be used, otherwise, it'll use `[dbainstance]`'s ComputerName property.