### PR TITLE
Get-DbaDiskSpace CheckForSql Mount Points

### DIFF
--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -141,6 +141,44 @@ function Get-DbaDiskSpace {
                 Stop-Function -Message "Failed to connect to $computer." -EnableException $EnableException -ErrorRecord $_ -Target $computer.ComputerName -Continue
             }
 
+            if ($CheckForSql) {
+                try {
+                    $sqlServices = Get-DbaSqlService -ComputerName $computer -Type Engine
+                }
+                catch {
+                    Write-Message -Level Warning -Message "Failed to connect to $computer to gather SQL Server instances, will not be reporting SQL Information." -ErrorRecord $_ -OverrideExceptionMessage -Target $computer.ComputerName
+                }
+
+                Write-Message -Level Verbose -Message "Instances found on $($computer): $($sqlServices.InstanceName.Count)"
+                if ($sqlServices.InstanceName.Count -gt 0) {
+                    foreach ($sqlService in $sqlServices) {
+                        if ($sqlService.InstanceName -eq "MSSQLSERVER") {
+                            $instanceName = $sqlService.ComputerName
+                        }
+                        else {
+                            $instanceName = "$($sqlService.ComputerName)\$($sqlService.InstanceName)"
+                        }
+                        Write-Message -Level VeryVerbose -Message "Processing instance $($instanceName)"
+                        try {
+                            $server = Connect-SqlInstance -SqlInstance $instanceName -SqlCredential $SqlCredential
+
+                            $files = @()
+                            $files += $server.Databases.LogFiles.FileName | Select-Object -Property @{Label = 'Path'; Expression = { (Split-Path -Path $_ -Parent) + [IO.Path]::DirectorySeparatorChar }}
+                            $files += $server.Databases.FileGroups.Files.FileName | Select-Object -Property @{Label = 'Path'; Expression = { (Split-Path -Path $_ -Parent) + [IO.Path]::DirectorySeparatorChar  }}
+
+                            foreach ($file in $files) {
+                                if (-not $sqlDisks.Contains($file.Path)) {
+                                    $null = $sqlDisks.Add($file.Path)
+                                }
+                            }
+                        }
+                        catch {
+                            Write-Message -Level Warning -Message "Failed to connect to $instanceName on $computer. SQL information may not be accurate or services have been stopped." -ErrorRecord $_ -OverrideExceptionMessage -Target $computer.ComputerName
+                        }
+                    }
+                }
+            }
+
             foreach ($disk in $disks) {
                 if ($disk.Name -in $ExcludeDrive) {
                     continue
@@ -163,46 +201,14 @@ function Get-DbaDiskSpace {
                 $info.Type = $disk.DriveType
 
                 if ($CheckForSql) {
-                    $driveLetter = $disk.DriveLetter.TrimEnd(":")
-                    try {
-                        $sqlServices = Get-DbaSqlService -ComputerName $computer -Type Engine
-                    }
-                    catch {
-                        Write-Message -Level Warning -Message "Failed to connect to $computer to gather SQL Server instances, will not be reporting SQL Information." -ErrorRecord $_ -OverrideExceptionMessage -Target $computer.ComputerName
-                    }
-
-                    Write-Message -Level Verbose -Message "Instances found on $($computer): $($sqlServices.InstanceName.Count)"
-                    if ($sqlServices.InstanceName.Count -gt 0) {
-                        foreach ($sqlService in $sqlServices) {
-                            if ($sqlService.InstanceName -eq "MSSQLSERVER") {
-                                $instanceName = $sqlService.ComputerName
-                            }
-                            else {
-                                $instanceName = "$($sqlService.ComputerName)\$($sqlService.InstanceName)"
-                            }
-                            Write-Message -Level VeryVerbose -Message "Processing instance $($instanceName)"
-                            try {
-                                $server = Connect-SqlInstance -SqlInstance $instanceName -SqlCredential $SqlCredential
-                                if ($server.Version -lt 9) {
-                                    $sql = "SELECT DISTINCT LEFT(filename,1) AS SqlDisk FROM sysaltfiles"
-                                }
-                                else {
-                                    $sql = "SELECT DISTINCT LEFT(physical_name,1) AS SqlDisk FROM sys.master_files"
-                                }
-                                $results = $server.Query($sql)
-                                if ($results.SqlDisk.Count -gt 0) {
-                                    foreach ($sqlDisk in $results.SqlDisk) {
-                                        $null = $sqlDisks.Add($sqlDisk)
-                                    }
-                                }
-                            }
-                            catch {
-                                Write-Message -Level Warning -Message "Failed to connect to $instanceName on $computer. SQL information may not be accurate or services have been stopped." -ErrorRecord $_ -OverrideExceptionMessage -Target $computer.ComputerName
-                            }
+                    $drivePath = $disk.Name
+                    $info.IsSqlDisk = $false
+                    foreach ($sqlDisk in $sqlDisks) {
+                        if ($sqlDisk -like ($drivePath + '*')) {
+                            $info.IsSqlDisk = $true
+                            break
                         }
                     }
-                    $info.IsSqlDisk = ($driveLetter -in $sqlDisks)
-                    $info
                 }
                 $info
             }

--- a/tests/Get-DbaDiskSpace.Tests.ps1
+++ b/tests/Get-DbaDiskSpace.Tests.ps1
@@ -18,26 +18,17 @@ Describe "$commandName Integration Tests" -Tags "IntegrationTests" {
 
     Context "CheckForSql works with mount points" {
         Mock -ModuleName 'dbatools' -CommandName 'Connect-SqlInstance' -ParameterFilter { $SqlInstance -in ('MadeUpServer', 'MadeUpServer\MadeUpInstance') } -MockWith {
-            return @{
-                Databases = @(
-                    @{
-                        LogFiles = @(
-                            @{
-                                FileName = 'D:\Data\FakeLog.ldf'
-                            }
-                        )
-                        FileGroups = @(
-                            @{
-                                Files = @(
-                                    @{
-                                        FileName = 'D:\Data\FakeData.mdf'
-                                    }
-                                )
-                            }
-                        )
-                    }
-                )
+            $object = [PSCustomObject] @{
+                Version = @{
+                    Major = 13
+                }
             }
+            $object | Add-Member -Name 'Query' -MemberType ScriptMethod -Value {
+                return @{
+                    SqlDisk = @('D:\Data\')
+                }
+            }
+            return $object
         }
 
         Mock -ModuleName 'dbatools' -CommandName 'Get-DbaSqlService' -ParameterFilter { $ComputerName.ComputerName -eq 'MadeUpServer' } -MockWith {

--- a/tests/Get-DbaDiskSpace.Tests.ps1
+++ b/tests/Get-DbaDiskSpace.Tests.ps1
@@ -16,10 +16,95 @@ Describe "$commandName Integration Tests" -Tags "IntegrationTests" {
         }
     }
 
-    Context "CheckForSql returns IsSqlDisk property with a value (likely false)" {
-        $results = Get-DbaDiskSpace -ComputerName $env:COMPUTERNAME -CheckForSql -WarningAction SilentlyContinue
-            It "SQL Server drive is not found in there somewhere" {
-                $false | Should BeIn $results.IsSqlDisk
+    Context "CheckForSql works with mount points" {
+        Mock -ModuleName 'dbatools' -CommandName 'Connect-SqlInstance' -ParameterFilter { $SqlInstance -in ('MadeUpServer', 'MadeUpServer\MadeUpInstance') } -MockWith {
+            return @{
+                Databases = @(
+                    @{
+                        LogFiles = @(
+                            @{
+                                FileName = 'D:\Data\FakeLog.ldf'
+                            }
+                        )
+                        FileGroups = @(
+                            @{
+                                Files = @(
+                                    @{
+                                        FileName = 'D:\Data\FakeData.mdf'
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
             }
         }
+
+        Mock -ModuleName 'dbatools' -CommandName 'Get-DbaSqlService' -ParameterFilter { $ComputerName.ComputerName -eq 'MadeUpServer' } -MockWith {
+            return @(
+                @{
+                    ComputerName = 'MadeUpServer'
+                    ServiceName = 'MSSQLSERVER'
+                    ServiceType = 'Engine'
+                    InstanceName = 'MSSQLSERVER'
+                    DisplayName = 'SQL Server (MSSQLSERVER)'
+                    StartName = 'FAKEDOMAIN\FAKEUSER'
+                    State = 'Running'
+                    StartMode = 'Automatic'
+                },
+                @{
+                    ComputerName = 'MadeUpServer'
+                    ServiceName = 'MSSQLSERVER$MADEUPINSTANCE'
+                    ServiceType = 'Engine'
+                    InstanceName = 'MadeUpInstance'
+                    DisplayName = 'SQL Server (MSSQLSERVER)'
+                    StartName = 'FAKEDOMAIN\FAKEUSER'
+                    State = 'Running'
+                    StartMode = 'Automatic'
+                }
+            )
+        }
+
+        Mock -ModuleName 'dbatools' -CommandName 'Get-DbaCmObject' -ParameterFilter { $ComputerName::InputObject -eq 'MadeUpServer' -and $Query -like '*Win32_Volume*' } -MockWith {
+            return @(
+                @{
+                    Name = 'D:\Data\'
+                    Label = 'Log'
+                    Capacity = 32209043456
+                    Freespace = 11653545984
+                    BlockSize = 65536
+                    FileSystem = 'NTFS'
+                    DriveType = 3
+                    DriveLetter = ''
+                },
+                @{
+                    Name = 'C:\'
+                    Label = 'OS'
+                    Capacity = 32209043456
+                    Freespace = 11653545984
+                    BlockSize = 4096
+                    FileSystem = 'NTFS'
+                    DriveType = 2
+                    DriveLetter = 'C:'
+                }
+            )
+        }
+
+        $results = Get-DbaDiskSpace -ComputerName 'MadeUpServer' -CheckForSql -EnableException
+
+        It "SQL Server drive is found in there somewhere" {
+            $true | Should -BeIn $results.IsSqlDisk
+        }
+
+        Assert-MockCalled -ModuleName 'dbatools' -CommandName 'Get-DbaCmObject' -Times 1
+        Assert-MockCalled -ModuleName 'dbatools' -CommandName 'Get-DbaSqlService' -Times 1
+        Assert-MockCalled -ModuleName 'dbatools' -CommandName 'Connect-SqlInstance' -Times 1
+    }
+
+    Context "CheckForSql returns IsSqlDisk property with a value (likely false)" {
+        $results = Get-DbaDiskSpace -ComputerName $env:COMPUTERNAME -CheckForSql -WarningAction SilentlyContinue
+        It "SQL Server drive is not found in there somewhere" {
+            $false | Should BeIn $results.IsSqlDisk
+        }
+    }
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When using CheckForSql mount points cause errors. 

### Approach
<!-- How does this change solve that purpose -->
Change drive letter checking to check paths. Given a path D:\SQL\DataFiles\ and a mount point D:\SQL\ it is on a mount point.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Create a mount point for a drive and execute Get-DbaDiskSpace using CheckForSql.


### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Before
![image](https://user-images.githubusercontent.com/7840633/42952556-b8eb9000-8b46-11e8-8bf9-0d9fad8f4d21.png)

After
![image](https://user-images.githubusercontent.com/7840633/42952566-bfbf73e2-8b46-11e8-90a6-f757699b137f.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
