### PR TITLE
Get-DbaDiskSpace Tests

### DIFF
--- a/tests/Get-DbaDiskSpace.Tests.ps1
+++ b/tests/Get-DbaDiskSpace.Tests.ps1
@@ -127,7 +127,7 @@ Describe "$commandName Integration Tests" -Tags "IntegrationTests" {
             )
         }
 
-        It -Skip "SQL Server drive is not found in there somewhere" {
+        It "SQL Server drive is not found in there somewhere" {
             $results = Get-DbaDiskSpace -ComputerName $env:COMPUTERNAME -CheckForSql -WarningAction SilentlyContinue
             $false | Should BeIn $results.IsSqlDisk
         }

--- a/tests/Get-DbaDiskSpace.Tests.ps1
+++ b/tests/Get-DbaDiskSpace.Tests.ps1
@@ -80,7 +80,7 @@ Describe "$commandName Integration Tests" -Tags "IntegrationTests" {
                 }
             )
         }
-        
+
         It -Skip "SQL Server drive is found in there somewhere" {
             $results = Get-DbaDiskSpace -ComputerName 'MadeUpServer' -CheckForSql -EnableException
             $true | Should -BeIn $results.IsSqlDisk
@@ -92,6 +92,41 @@ Describe "$commandName Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "CheckForSql returns IsSqlDisk property with a value (likely false)" {
+        Mock -ModuleName 'dbatools' -CommandName 'Get-DbaCmObject' -ParameterFilter { $Query -like '*Win32_Volume*' } -MockWith {
+            return @(
+                @{
+                    Name = 'D:\Data\'
+                    Label = 'Log'
+                    Capacity = 32209043456
+                    Freespace = 11653545984
+                    BlockSize = 65536
+                    FileSystem = 'NTFS'
+                    DriveType = 3
+                    DriveLetter = ''
+                },
+                @{
+                    Name = 'C:\'
+                    Label = 'OS'
+                    Capacity = 32209043456
+                    Freespace = 11653545984
+                    BlockSize = 4096
+                    FileSystem = 'NTFS'
+                    DriveType = 2
+                    DriveLetter = 'C:'
+                },
+                @{
+                    Name = 'T:\'
+                    Label = 'Data'
+                    Capacity = 32209043456
+                    Freespace = 11653545984
+                    BlockSize = 4096
+                    FileSystem = 'NTFS'
+                    DriveType = 2
+                    DriveLetter = 'T:'
+                }
+            )
+        }
+
         It -Skip "SQL Server drive is not found in there somewhere" {
             $results = Get-DbaDiskSpace -ComputerName $env:COMPUTERNAME -CheckForSql -WarningAction SilentlyContinue
             $false | Should BeIn $results.IsSqlDisk


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix failing Get-DbaDiskSpace test.

### Approach
<!-- How does this change solve that purpose -->
The "CheckForSql returns IsSqlDisk property with a value (likely false)" was incorrectly passing previously. The AppVeyor VM had SQL on every disk, but since IsSqlDisk wasn't being populated correctly it was still passing. Now that IsSqlDisk is fixed I added a mock to return some fake disks which don't have SQL on them.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
