### PR TITLE
Updated Import-DbaCsvToSql to resolve file locking

### DIFF
--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -1306,9 +1306,12 @@ function Import-DbaCsvToSql {
     End {
         # Close everything just in case & ignore errors
         try {
-            $null = $sqlconn.close(); $null = $sqlconn.Dispose(); $null = $oleconn.close;
-            $null = $olecmd.Dispose(); $null = $oleconn.Dispose(); $null = $bulkCopy.close();
-            $null = $bulkcopy.dispose(); $null = $reader.close; $null = $reader.dispose()
+            if ($oleconn.connection) {$null = $oleconn.close(); $null = $oleconn.dispose()}
+            if ($olecmd.connection) {$null = $olecmd.close()}
+            
+            $null = $sqlconn.close(); $null = $sqlconn.Dispose();
+            $null = $bulkCopy.close(); $bulkcopy.dispose(); 
+            $null =  $reader.close(); $null = $reader.dispose()
         }
         catch {
 

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -1308,9 +1308,9 @@ function Import-DbaCsvToSql {
         try {
             if ($oleconn.connection) {$null = $oleconn.close(); $null = $oleconn.dispose()}
             if ($olecmd.connection) {$null = $olecmd.close()}
-            
+
             $null = $sqlconn.close(); $null = $sqlconn.Dispose();
-            $null = $bulkCopy.close(); $bulkcopy.dispose(); 
+            $null = $bulkCopy.close(); $bulkcopy.dispose();
             $null =  $reader.close(); $null = $reader.dispose()
         }
         catch {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3866 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Resolve the problem with the io.streamreader used in Import-DbaCsvToSql locking the file after execution. 
### Approach
Updated the end block to look for ole active connections before running the close and dispose methods, This allows the reader close and dispose method to when Safe mode is not specified,
