### PR TITLE
Removed filestream check in reference to Issue #3871

### DIFF
--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -155,29 +155,6 @@ function Test-DbaBackupInformation {
                         }
                     }
                 }
-                #Easier to do FileStream checks out of the loop:
-                if ('s' -in ($DbHistory | Select-Object -ExpandProperty filelist | Select-Object FileType -Unique).FileType) {
-                    if ((Get-DbaSpConfigure -SqlInstance $RestoreInstance -ConfigName FilestreamAccessLevel).RunningValue -eq 0) {
-                        Write-Message -Level Warning -Message "Database $Database contains FileStream data, and FileStream is not enable on the destination server"
-                        $VerificationErrors++
-                    }
-
-                    $ExistingFS = Get-DbaFileStreamFolder -SqlInstance $SqlInstance
-                    foreach ($FileStreamFolder in ($DbHistory | Select-Object -ExpandProperty filelist | Where-Object {$_.FileType -eq 's'} | Select-Object PhysicalName -unique).PhysicalName) {
-                        if ($null -ne $ExistingFS) {
-                            if ($null -ne ($ExistingFs | Where-Object {$_.Database -eq $Database}) -and $Withreplace -ne $True) {
-                                Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data on $SqlInstance and WithReplace not specified, cannot restore"
-                                $VerificationErrors++
-                            }
-                            $OtherOwners = $ExistingFs | Where-Object {$_.FileStreamFolder -eq $FileStreamFolder -and $_.Database -ne $Database}
-                            if ($null -ne $OtherOwners) {
-                                Write-Message -Level Warning -Message "Folder $FileStreamFolder already in use for Filestream data by $($OtherOwners.Database) on $SqlInstance, cannot restore"
-                                $VerificationErrors++
-                            }
-                        }
-                    }
-                }
-
             }
 
             #Test all backups readable


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3871)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For databases with In-Memory OLTP data files, Test-DbaBackupInformation incorrectly assesses that the backup is not able to be restored.

### Approach
Removing the special treatment for FileStream, FileTable, and In-Memory data files

### Commands to test
* Test-DbaBackupInformation
