### PR TITLE
Fixed support for SQL Server 2016 SP2 & Azure SQL Database in DiagnosticQueries

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -289,7 +289,7 @@ function Get-DbaDatabase {
                 $_.IsAccessible -in $AccessibleFilter -and
                 $_.IsSystemObject -in $DBType -and
                 ((Compare-Object @($_.Status.tostring().split(',').trim()) $Status -ExcludeDifferent -IncludeEqual).inputobject.count -ge 1 -or !$status) -and
-                $_.RecoveryModel -in $RecoveryModel -and
+                ($_.RecoveryModel -in $RecoveryModel -or !$_.RecoveryModel) -and
                 $_.EncryptionEnabled -in $Encrypt
             }
             if ($NoFullBackup -or $NoFullBackupSince) {

--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -250,6 +250,10 @@ function Invoke-DbaDiagnosticQuery {
                 }
             }
 
+            if ($version -eq "2016" -and $server.VersionMinor -gt 5026 ) {
+                $version = "2016SP2"
+            }
+
             if (!$instanceOnly) {
                 if (-not $Database) {
                     $databases = (Get-DbaDatabase -SqlInstance $server -ExcludeAllSystemDb -ExcludeDatabase $ExcludeDatabase).Name

--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -254,6 +254,10 @@ function Invoke-DbaDiagnosticQuery {
                 $version = "2016SP2"
             }
 
+            if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
+                $version = "AzureSQLDatabase"
+            }
+
             if (!$instanceOnly) {
                 if (-not $Database) {
                     $databases = (Get-DbaDatabase -SqlInstance $server -ExcludeAllSystemDb -ExcludeDatabase $ExcludeDatabase).Name

--- a/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
+++ b/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
@@ -27,7 +27,7 @@
 
     foreach ($line in $fullscript) {
         if ($start -eq $false) {
-            if ($line -match "You have the correct major version of SQL Server for this diagnostic information script") {
+            if (($line -match "You have the correct major version of SQL Server for this diagnostic information script") -or ($line.StartsWith("-- Server level queries ***"))) {
                 $start = $true
             }
             continue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
Fixed support for SQL Server 2016 SP2 & Azure SQL Database in DiagnosticQueries
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Glenn added a specific query set for 2016SP2, the parser however only checked majorversion.
Also, Azure SQL DB support did not work due to bugs in parsing and in connecting.
Get-DbaDatabase checks for a bunch of filters but doesn't assume that RecoveryModel can be empty, which it is for Azure SQL Database

### Commands to test
Invoke-DbaDiagnosticQuery, needs to be run against an Azure SQL Database therefore I didn't add a test. (or is it available in the test framework?)
