### PR TITLE
Add related alerts to Get-DbaAgentOperator

### DIFF
--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -100,16 +100,16 @@ function Get-DbaAgentOperator {
                 $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operat.Name }
                 $lastemail = [dbadatetime]$operat.LastEmailDate
 
-				$operatAlerts = @()
+                $operatAlerts = @()
                 $alerts = $server.JobServer.alerts
-				foreach($alert in $alerts){                                  
-                    $dtAlert = $alert.EnumNotifications($operat.Name)                   
+                foreach($alert in $alerts){
+                    $dtAlert = $alert.EnumNotifications($operat.Name)
                     if ($dtAlert.Rows.Count -gt 0) {
                         $operatAlerts += $alert.Name
                     }
-					$alertlastemail = [dbadatetime]$alert.LastOccurrenceDate
+                    $alertlastemail = [dbadatetime]$alert.LastOccurrenceDate
                 }
-				
+                
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -95,13 +95,14 @@ function Get-DbaAgentOperator {
                 $operators = $server.JobServer.Operators
             }
 
+            $alerts = $server.JobServer.alerts
+
             foreach ($operat in $operators) {
 
                 $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operat.Name }
                 $lastemail = [dbadatetime]$operat.LastEmailDate
 
                 $operatAlerts = @()
-                $alerts = $server.JobServer.alerts
                 foreach($alert in $alerts){
                     $dtAlert = $alert.EnumNotifications($operat.Name)
                     if ($dtAlert.Rows.Count -gt 0) {

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -106,8 +106,8 @@ function Get-DbaAgentOperator {
                     $dtAlert = $alert.EnumNotifications($operat.Name)
                     if ($dtAlert.Rows.Count -gt 0) {
                         $operatAlerts += $alert.Name
+                        $alertlastemail = [dbadatetime]$alert.LastOccurrenceDate
                     }
-                    $alertlastemail = [dbadatetime]$alert.LastOccurrenceDate
                 }
                 
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -100,11 +100,23 @@ function Get-DbaAgentOperator {
                 $jobs = $server.JobServer.jobs | Where-Object { $_.OperatorToEmail, $_.OperatorToNetSend, $_.OperatorToPage -contains $operat.Name }
                 $lastemail = [dbadatetime]$operat.LastEmailDate
 
+				$operatAlerts = @()
+                $alerts = $server.JobServer.alerts
+				foreach($alert in $alerts){                                  
+                    $dtAlert = $alert.EnumNotifications($operat.Name)                   
+                    if ($dtAlert.Rows.Count -gt 0) {
+                        $operatAlerts += $alert.Name
+                    }
+					$alertlastemail = [dbadatetime]$alert.LastOccurrenceDate
+                }
+				
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name RelatedJobs -Value $jobs
                 Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name LastEmail -Value $lastemail
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name RelatedAlerts -Value $operatAlerts
+                Add-Member -Force -InputObject $operat -MemberType NoteProperty -Name AlertLastEmail -Value $alertlastemail
                 Select-DefaultView -InputObject $operat -Property $defaults
             }
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Get-DbaAgentOperator currently pulls agent jobs where the operator is setup for notification. I've added the related alerts, where the operator is setup for alert response.

### Approach
Using the alerts smo EnumNotifications and filtering by current operator name

### Commands to test
Get-DbaAgentOperator -SqlInstance 'localhost' -Verbose | Select-Object -Property SqlInstance, Name, IsEnabled, RelatedJobs, LastEmail, RelatedAlerts, AlertLastEmail | Format-Table -AutoSize;


### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![add_related_alerts](https://user-images.githubusercontent.com/10745602/44276496-a4575580-a215-11e8-9362-01c991b88922.png)


