### PR TITLE
Fixed QueryName list bugs

### DIFF
--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -273,13 +273,22 @@ function Invoke-DbaDiagnosticQuery {
             if ($UseSelectionHelper -and $first) {
                 $QueryName = Invoke-DiagnosticQuerySelectionHelper $parsedscript
                 $first = $false
+                if ($QueryName.Count -eq 0) {
+                    Write-Message -Level Output -Message "No query selected through SelectionHelper, halting script execution"
+                    return
+                }
             }
-            #since some database level queries can take longer (such as fragmentation) calculate progress with database specific queries * count of databases to run against into context
-            $CountOfDatabases = ($databases).Count
             
+            if ($QueryName.Count -eq 0) {
+                $QueryName = $parsedscript | Select-Object -ExpandProperty QueryName
+            }
+
             if ($ExcludeQuery) {
                 $QueryName = Compare-Object -ReferenceObject $QueryName -DifferenceObject $ExcludeQuery | Where-Object SideIndicator -eq "<=" | Select-Object -ExpandProperty InputObject
             }
+
+            #since some database level queries can take longer (such as fragmentation) calculate progress with database specific queries * count of databases to run against into context
+            $CountOfDatabases = ($databases).Count
 
             if ($QueryName.Count -ne 0) {
                 #if running all queries, then calculate total to run by instance queries count + (db specific count * databases to run each against)

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             @($results).Count | Should be 2
         }
         It "Correctly excludes queries when only ExcludeQuery parameter is used" {
-            $results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -ExcludeQuery "Missing Index Warnings", "Buffer Usage" -whatif 
+            $results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -ExcludeQuery "Missing Index Warnings", "Buffer Usage" -whatif
             @($results).Count | Should -BeGreaterThan 0
             @($results | Where-Object Name -eq "Missing Index Warnings").Count | Should be 0
             @($results | Where-Object Name -eq "Buffer Usage").Count | Should be 0

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -51,9 +51,15 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             @($results | Where-Object {$_.Database -eq $Database}).Count | Should -BeGreaterThan 1
             @($results | Where-Object {$_.Database -eq $Database2}).Count | Should -Be 0
         }
-        It "Correctly excludes queries" {
-            $results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -QueryName 'Version Info', 'Core Counts', 'Server Properties' -ExcludeQuery 'Core Counts'
+        It "Correctly excludes queries when QueryName and ExcludeQuery parameters are used" {
+            $results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -QueryName 'Version Info', 'Core Counts', 'Server Properties' -ExcludeQuery 'Core Counts' -WhatIf
             @($results).Count | Should be 2
+        }
+        It "Correctly excludes queries when only ExcludeQuery parameter is used" {
+            $results = Invoke-DbaDiagnosticQuery -SqlInstance localhost -ExcludeQuery "Missing Index Warnings", "Buffer Usage" -whatif 
+            @($results).Count | Should -BeGreaterThan 0
+            @($results | Where-Object Name -eq "Missing Index Warnings").Count | Should be 0
+            @($results | Where-Object Name -eq "Buffer Usage").Count | Should be 0
         }
 
         $columnnames = 'Item', 'RowError', 'RowState', 'Table', 'ItemArray', 'HasErrors'

--- a/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
+++ b/tests/Invoke-DbaDiagnosticQuery.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             @($results).Count | Should be 2
         }
         It "Correctly excludes queries when only ExcludeQuery parameter is used" {
-            $results = Invoke-DbaDiagnosticQuery -SqlInstance localhost -ExcludeQuery "Missing Index Warnings", "Buffer Usage" -whatif 
+            $results = Invoke-DbaDiagnosticQuery -SqlInstance $script:instance2 -ExcludeQuery "Missing Index Warnings", "Buffer Usage" -whatif 
             @($results).Count | Should -BeGreaterThan 0
             @($results | Where-Object Name -eq "Missing Index Warnings").Count | Should be 0
             @($results | Where-Object Name -eq "Buffer Usage").Count | Should be 0


### PR DESCRIPTION
Query name list was empty when not provided which caused an error when providing ExcludeQuery parameter.

And Selectionhelper would run everything when you press cancel, it now gives a message and stops running

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Query name list was empty when not provided which caused an error when providing ExcludeQuery parameter.
And Selectionhelper would run everything when you press cancel, it now gives a message and stops running

### Commands to test
Invoke-DbaDiagnosticQuery -SqlIntance localhost -UseSelectionhelper
Pressing cancel should give a message and should not run any query

Invoke-DbaDiagnosticQuery -SqlInstance localhost -ExcludeQuery "Missing Index Warnings"
Should run everything except the excluded query without giving an error message
(Before fix it would give error and it would not properly exclude the query)
A pester test is included for this in this pull request
