### PR TITLE
fixed Credential parameter, use FQDN for creating a new CimSession

### DIFF
--- a/functions/Test-DbaDiskAlignment.ps1
+++ b/functions/Test-DbaDiskAlignment.ps1
@@ -285,8 +285,8 @@ function Test-DbaDiskAlignment {
         foreach ($computer in $ComputerName) {
             Write-Message -Level VeryVerbose -Message "Processing: $computer."
 
-            $computer = Resolve-DbaNetworkName -ComputerName $computer -Credential $credential
-            $Computer = $computer.ComputerName
+            $computer = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
+            $Computer = $computer.FullComputerName
 
             if (!$Computer) {
                 Stop-Function -Message "Couldn't resolve hostname. Skipping." -Continue
@@ -306,10 +306,10 @@ function Test-DbaDiskAlignment {
                 Write-Message -Level Verbose -Message "Creating CimSession on $computer over WSMan failed. Creating CimSession on $computer over DCOM."
 
                 if (!$Credential) {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Ignore -Credential $Credential
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Ignore
                 }
                 else {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Ignore
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction Ignore -Credential $Credential
                 }
             }
 

--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -22,6 +22,11 @@ function Test-DbaDiskAllocation {
         .PARAMETER SqlCredential
             Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
+        .PARAMETER Credential
+            Specifies an alternate Windows account to use when enumerating drives on the server. May require Administrator privileges. To use:
+
+            $cred = Get-Credential, then pass $cred object to the -Credential parameter.
+
         .PARAMETER Detailed
             Output all properties, will be deprecated in 1.0.0 release.
 
@@ -69,7 +74,8 @@ function Test-DbaDiskAllocation {
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [object[]]$ComputerName,
         [switch]$NoSqlCheck,
-        [object]$SqlCredential,
+        [PSCredential]$SqlCredential,
+        [PSCredential]$Credential,
         [switch]$Detailed,
         [Alias('Silent')]
         [switch]$EnableException
@@ -184,9 +190,9 @@ function Test-DbaDiskAllocation {
     process {
         foreach ($computer in $ComputerName) {
 
-            $computer = Resolve-DbaNetworkName -ComputerName $computer -Credential $credential
+            $computer = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
             $ipaddr = $computer.IpAddress
-            $Computer = $computer.ComputerName
+            $Computer = $computer.FullComputerName
 
             if (!$Computer) {
                 Stop-Function -Message "Couldn't resolve hostname. Skipping." -Continue
@@ -205,10 +211,10 @@ function Test-DbaDiskAllocation {
                 Write-Message -Level Verbose -Message "Creating CimSession on $computer over WSMan failed. Creating CimSession on $computer over DCOM."
 
                 if (!$Credential) {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
                 }
                 else {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
                 }
             }
 

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -72,7 +72,7 @@ function Test-DbaPowerPlan {
 
     process {
         foreach ($computer in $ComputerName) {
-            $server = Resolve-DbaNetworkName -ComputerName $computer -Credential $credential
+            $server = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
 
             $computerResolved = $server.FullComputerName
 
@@ -93,10 +93,10 @@ function Test-DbaPowerPlan {
                 Write-Message -Level Verbose -Message "Creating CimSession on $computer over WSMan failed. Creating CimSession on $computer over DCOM."
 
                 if (!$Credential) {
-                    $cimSession = New-CimSession -ComputerName $computerResolved -SessionOption $sessionOption -ErrorAction SilentlyContinue -Credential $Credential
+                    $cimSession = New-CimSession -ComputerName $computerResolved -SessionOption $sessionOption -ErrorAction SilentlyContinue
                 }
                 else {
-                    $cimSession = New-CimSession -ComputerName $computerResolved -SessionOption $sessionOption -ErrorAction SilentlyContinue
+                    $cimSession = New-CimSession -ComputerName $computerResolved -SessionOption $sessionOption -ErrorAction SilentlyContinue -Credential $Credential
                 }
             }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
This PR fixes 3 small bugs in those 3 functions:
- Bug: Use FQDN for creating a New-CimSession (as done in all other functions):
-- Functions: Test-DbaDiskAlignment, Test-DbaDiskAllocation
- Bug: Fixed Copy/Paste error that didn't pass $Credential to New-CimSession in case of DCOM fallback.
-- Functions: Test-DbaPowerPlan, Test-DbaDiskAlignment, Test-DbaDiskAllocation
- Bug: Added missing parameter $Credential to function (variable is used in the code, but not part of Param() block)
-- Function: Test-DbaDiskAllocation
