### PR TITLE
fixed interpretation for databases with name *trn

### DIFF
--- a/internal/functions/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/functions/Get-XpDirTreeRestoreFile.ps1
@@ -42,8 +42,8 @@ function Get-XpDirTreeRestoreFile {
     Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
     $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 
-    if ((($path -like '*.bak') -or ($path -like '*.trn')) -and (Test-Path -Path $path -PathType Leaf)) {
-
+    if (($path -like '*.bak') -or ($path -like '*.trn')) {
+        # For a future person who knows what's up, please replace this comment with the reason this is empty
     }
     elseif ($Path[-1] -ne "\") {
         $Path = $Path + "\"

--- a/internal/functions/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/functions/Get-XpDirTreeRestoreFile.ps1
@@ -42,7 +42,7 @@ function Get-XpDirTreeRestoreFile {
     Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
     $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
 
-    if (($path -like '*.bak') -or ($path -like '*trn')) {
+    if ((($path -like '*.bak') -or ($path -like '*.trn')) -and (Test-Path -Path $path -PathType Leaf)) {
 
     }
     elseif ($Path[-1] -ne "\") {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3919)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix Restore-DbaDatabase command for databases with name ended with trn.

### Approach
fixed *.trn filter

