### PR TITLE
Remove-DbaClientAlias Updates

### DIFF
--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -13,7 +13,7 @@ function Remove-DbaClientAlias {
     Allows you to login to remote computers using alternative credentials
 
     .PARAMETER Alias
-    The alias to be deleted
+    The alias or array of aliases to be deleted
 
     .PARAMETER EnableException
     By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -15,6 +15,12 @@ function Remove-DbaClientAlias {
         .PARAMETER Alias
             The alias or array of aliases to be deleted
 
+        .PARAMETER WhatIf
+            If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+        .PARAMETER Confirm
+            If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -58,16 +58,6 @@ function Remove-DbaClientAlias {
             $scriptblock = {
                 $Alias = $args
 
-                function Get-ItemPropertyValue {
-                    Param (
-                        [parameter()]
-                        [String]$Path,
-                        [parameter()]
-                        [String]$Name
-                    )
-                    Get-ItemProperty -LiteralPath $Path -Name $Name
-                }
-
                 $basekeys = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer", "HKLM:\SOFTWARE\Microsoft\MSSQLServer"
 
                 foreach ($basekey in $basekeys) {

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -96,18 +96,12 @@ function Remove-DbaClientAlias {
                         $architecture = "64-bit"
                     }
 
-
                     $all = Get-Item -Path $connect
                     foreach ($entry in $all) {
-
                         foreach ($en in $entry) {
                             $e = $entry.ToString().Replace('HKEY_LOCAL_MACHINE', 'HKLM:\')
-
-                            Write-Verbose "Processing $($en.Property)"
                             foreach ($a in $Alias) {
-                                Write-Verbose "Checking $($en.Property) for $a"
                                 if ($en.Property -contains $a) {
-                                    Write-Verbose "Removing $e"
                                     Remove-ItemProperty -Path $e -Name $a
                                 }
                             }

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -1,106 +1,88 @@
 function Remove-DbaClientAlias {
     <#
-    .SYNOPSIS
-    Removes a sql alias for the specified server - mimics cliconfg.exe
+        .SYNOPSIS
+            Removes a sql alias for the specified server - mimics cliconfg.exe
 
-    .DESCRIPTION
-    Removes a SQL Server alias by altering HKLM:\SOFTWARE\Microsoft\MSSQLServer\Client
+        .DESCRIPTION
+            Removes a SQL Server alias by altering HKLM:\SOFTWARE\Microsoft\MSSQLServer\Client
 
-    .PARAMETER ComputerName
-    The target computer where the alias will be created
+        .PARAMETER ComputerName
+            The target computer where the alias will be created
 
-    .PARAMETER Credential
-    Allows you to login to remote computers using alternative credentials
+        .PARAMETER Credential
+            Allows you to login to remote computers using alternative credentials
 
-    .PARAMETER Alias
-    The alias or array of aliases to be deleted
+        .PARAMETER Alias
+            The alias or array of aliases to be deleted
 
-    .PARAMETER EnableException
-    By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-    This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-    Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-    .NOTES
-    Tags: Alias
+        .NOTES
+            Tags: Alias
 
-    Website: https://dbatools.io
-    Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-    License: MIT https://opensource.org/licenses/MIT
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
 
-    .LINK
-    https://dbatools.io/Remove-DbaClientAlias
+        .LINK
+            https://dbatools.io/Remove-DbaClientAlias
 
-    .EXAMPLE
-    Remove-DbaClientAlias -ComputerName workstationx -Alias sqlps
-    Removes the sqlps SQL client alias on workstationx
+        .EXAMPLE
+            Remove-DbaClientAlias -ComputerName workstationx -Alias sqlps
 
-    .EXAMPLE
-    Get-DbaClientAlias | Remove-DbaClientAlias
-    Removes all SQL Server client aliases on the local computer
+            Removes the sqlps SQL client alias on workstationx
 
-#>
-    [CmdletBinding()]
-    Param (
-        [parameter(ValueFromPipelineByPropertyName)]
+        .EXAMPLE
+            Get-DbaClientAlias | Remove-DbaClientAlias
+
+            Removes all SQL Server client aliases on the local computer
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param (
+        [parameter(ValueFromPipelineByPropertyName = $true)]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('AliasName')]
         [string[]]$Alias,
         [Alias('Silent')]
         [switch]$EnableException
     )
 
-    process {
-        foreach ($computer in $ComputerName) {
-            $null = Test-ElevationRequirement -ComputerName $computer -Continue
+    begin {
+        $scriptblock = {
+            $Alias = $args
 
-            $scriptblock = {
-                $Alias = $args
+            $basekeys = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer", "HKLM:\SOFTWARE\Microsoft\MSSQLServer"
 
-                $basekeys = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer", "HKLM:\SOFTWARE\Microsoft\MSSQLServer"
+            foreach ($basekey in $basekeys) {
+                $fullKey = "$basekey\Client\ConnectTo"
+                if ((Test-Path $fullKey) -eq $false) {
+                    Write-Warning "Registry key ($fullKey) does not exist. Quitting."
+                    continue
+                }
 
-                foreach ($basekey in $basekeys) {
-
-                    if ((Test-Path $basekey) -eq $false) {
-                        Write-Warning "Base key ($basekey) does not exist. Quitting."
-                        continue
-                    }
-
-                    $client = "$basekey\Client"
-
-                    if ((Test-Path $client) -eq $false) {
-                        continue
-                    }
-
-                    $connect = "$client\ConnectTo"
-
-                    if ((Test-Path $connect) -eq $false) {
-                        continue
-                    }
-
-                    if ($basekey -like "*WOW64*") {
-                        $architecture = "32-bit"
-                    }
-                    else {
-                        $architecture = "64-bit"
-                    }
-
-                    $all = Get-Item -Path $connect
-                    foreach ($entry in $all) {
-                        foreach ($en in $entry) {
-                            $e = $entry.ToString().Replace('HKEY_LOCAL_MACHINE', 'HKLM:\')
-                            foreach ($a in $Alias) {
-                                if ($en.Property -contains $a) {
-                                    Remove-ItemProperty -Path $e -Name $a
-                                }
-                            }
+                $all = Get-Item -Path $fullKey
+                foreach ($entry in $all) {
+                    $e = $entry.ToString().Replace('HKEY_LOCAL_MACHINE', 'HKLM:\')
+                    foreach ($a in $Alias) {
+                        if ($entry.Property -contains $a) {
+                            Remove-ItemProperty -Path $e -Name $a
                         }
                     }
                 }
             }
+        }
+    }
 
-            if ($PScmdlet.ShouldProcess($computer, "Getting aliases")) {
+    process {
+        foreach ($computer in $ComputerName) {
+            $null = Test-ElevationRequirement -ComputerName $computer -Continue
+
+            if ($PSCmdlet.ShouldProcess("$($Alias -join ', ') on $computer", "Remove aliases")) {
                 try {
                     $null = Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock $scriptblock -ErrorAction Stop -Verbose:$false -ArgumentList $Alias
                     Get-DbaClientAlias -ComputerName $computer

--- a/tests/Remove-DbaClientAlias.Tests.ps1
+++ b/tests/Remove-DbaClientAlias.Tests.ps1
@@ -7,7 +7,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias1 -Verbose:$false
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias2 -Verbose:$false
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias3 -Verbose:$false
+        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias4 -Verbose:$false
     }
+
     Context "removes the alias" {
         $results = Remove-DbaClientAlias -Alias dbatoolscialias1 -Verbose:$false
         It "alias is not included in results" {
@@ -35,6 +37,19 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             param ($Alias)
 
             $aliases.AliasName -notcontains $Alias | Should Be $true
+        }
+    }
+
+    Context "removes an alias through the pipeline" {
+        $aliases = Get-DbaClientAlias
+        It "alias exists" {
+            $aliases.AliasName -contains 'dbatoolscialias4' | Should Be $true
+        }
+
+        $null = Get-DbaClientAlias | Where-Object { $_.AliasName -eq 'dbatoolscialias4' } | Remove-DbaClientAlias
+        $aliases = Get-DbaClientAlias
+        It "alias was removed" {
+            $aliases.AliasName -notcontains 'dbatoolscialias4' | Should Be $true
         }
     }
 }

--- a/tests/Remove-DbaClientAlias.Tests.ps1
+++ b/tests/Remove-DbaClientAlias.Tests.ps1
@@ -8,48 +8,75 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias2 -Verbose:$false
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias3 -Verbose:$false
         $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias4 -Verbose:$false
+        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias5 -Verbose:$false
     }
 
-    Context "removes the alias" {
-        $results = Remove-DbaClientAlias -Alias dbatoolscialias1 -Verbose:$false
-        It "alias is not included in results" {
-            $results.AliasName -notcontains 'dbatoolscialias1' | Should Be $true
-        }
-    }
+    InModuleScope 'dbatools' {
+        Context "removes the alias" {
+            $aliases = Get-DbaClientAlias
+            It "alias exists" {
+                $aliases.AliasName -contains 'dbatoolscialias1' | Should Be $true
+            }
 
-    Context "removes an array of aliases" {
-        $testCases = @(
-            @{'Alias' = 'dbatoolscialias2'},
-            @{'Alias' = 'dbatoolscialias3'}
-        )
+            $null = Remove-DbaClientAlias -Alias dbatoolscialias1 -Verbose:$false
 
-        $aliases = Get-DbaClientAlias
-        It "alias <Alias> exists" -TestCases $testCases {
-            param ($Alias)
-
-             $aliases.AliasName -contains $Alias | Should Be $true
+            $aliases = Get-DbaClientAlias
+            It "alias is not included in results" {
+                $aliases.AliasName -notcontains 'dbatoolscialias1' | Should Be $true
+            }
         }
 
-        $null = Remove-DbaClientAlias -Alias @('dbatoolscialias2', 'dbatoolscialias3')
+        Context "removes an array of aliases" {
+            $testCases = @(
+                @{'Alias' = 'dbatoolscialias2'},
+                @{'Alias' = 'dbatoolscialias3'}
+            )
 
-        $aliases = Get-DbaClientAlias
-        It "alias <Alias> was removed" -TestCases $testCases {
-            param ($Alias)
+            $aliases = Get-DbaClientAlias
+            It "alias <Alias> exists" -TestCases $testCases {
+                param ($Alias)
 
-            $aliases.AliasName -notcontains $Alias | Should Be $true
+                $aliases.AliasName -contains $Alias | Should Be $true
+            }
+
+            $null = Remove-DbaClientAlias -Alias @('dbatoolscialias2', 'dbatoolscialias3')
+
+            $aliases = Get-DbaClientAlias
+            It "alias <Alias> was removed" -TestCases $testCases {
+                param ($Alias)
+
+                $aliases.AliasName -notcontains $Alias | Should Be $true
+            }
         }
-    }
 
-    Context "removes an alias through the pipeline" {
-        $aliases = Get-DbaClientAlias
-        It "alias exists" {
-            $aliases.AliasName -contains 'dbatoolscialias4' | Should Be $true
+        Context "removes an alias through the pipeline" {
+            $aliases = Get-DbaClientAlias
+            It "alias exists" {
+                $aliases.AliasName -contains 'dbatoolscialias4' | Should Be $true
+            }
+
+            $null = Get-DbaClientAlias | Where-Object { $_.AliasName -eq 'dbatoolscialias4' } | Remove-DbaClientAlias
+            $aliases = Get-DbaClientAlias
+            It "alias was removed" {
+                $aliases.AliasName -notcontains 'dbatoolscialias4' | Should Be $true
+            }
         }
 
-        $null = Get-DbaClientAlias | Where-Object { $_.AliasName -eq 'dbatoolscialias4' } | Remove-DbaClientAlias
-        $aliases = Get-DbaClientAlias
-        It "alias was removed" {
-            $aliases.AliasName -notcontains 'dbatoolscialias4' | Should Be $true
+        Context "SQL client is not installed" {
+            Mock -CommandName 'Test-Path' -MockWith {
+                return $false
+            }
+
+            $defaultParamValues = $PSDefaultParameterValues
+            $PSDefaultParameterValues=@{"*:WarningVariable"="+buffer"}
+
+            $null = Remove-DbaClientAlias -Alias 'dbatoolscialias5' -WarningAction 'SilentlyContinue'
+
+            $PSDefaultParameterValues = $defaultParamValues
+
+            It "warns that the key doesn't exist" {
+                $buffer.Count -ge 4 | Should -Be $true
+            }
         }
     }
 }

--- a/tests/Remove-DbaClientAlias.Tests.ps1
+++ b/tests/Remove-DbaClientAlias.Tests.ps1
@@ -4,12 +4,37 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
-        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias-new -Verbose:$false
+        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias1 -Verbose:$false
+        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias2 -Verbose:$false
+        $null = New-DbaClientAlias -ServerName sql2016 -Alias dbatoolscialias3 -Verbose:$false
     }
-    Context "adds the alias" {
-        $results = Remove-DbaClientAlias -Alias dbatoolscialias-new -Verbose:$false
+    Context "removes the alias" {
+        $results = Remove-DbaClientAlias -Alias dbatoolscialias1 -Verbose:$false
         It "alias is not included in results" {
-            $results.AliasName -notcontains 'dbatoolscialias-new' | Should Be $true
+            $results.AliasName -notcontains 'dbatoolscialias1' | Should Be $true
+        }
+    }
+
+    Context "removes an array of aliases" {
+        $testCases = @(
+            @{'Alias' = 'dbatoolscialias2'},
+            @{'Alias' = 'dbatoolscialias3'}
+        )
+
+        $aliases = Get-DbaClientAlias
+        It "alias <Alias> exists" -TestCases $testCases {
+            param ($Alias)
+
+             $aliases.AliasName -contains $Alias | Should Be $true
+        }
+
+        $null = Remove-DbaClientAlias -Alias @('dbatoolscialias2', 'dbatoolscialias3')
+
+        $aliases = Get-DbaClientAlias
+        It "alias <Alias> was removed" -TestCases $testCases {
+            param ($Alias)
+
+            $aliases.AliasName -notcontains $Alias | Should Be $true
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
1. Cleanup code to match newer templates
2. Optimize/remove (seemingly) unnecessary code
3. Allow Alias parameter to accept an array of aliases instead of a single alias
4. Add code coverage
5. Change output to be what action was taken instead of returning a list of existing aliases **BREAKING CHANGE**

### Commands to test
```
Remove-DbaClientAlias -Alias @('sql1', 'sql2', 'sql3')
```

### Screenshots
New output
![image](https://user-images.githubusercontent.com/7840633/44537404-b9782c80-a6cc-11e8-9433-0d0c70a02043.png)

### Learning
To add code coverage I wanted to be able to test if the register key didn't exist. This executed Write-Warning inside a (potentially) remove script block. Earlier this week during PSPowerHour I witnessed @potatoqualitee present on PSDefaultParameterValues! I was able to set the -WarningAction parameter on all executed commands to see if a warning was thrown that the registery keys didn't exist (implying that the SQL client isn't installed on the computer you're trying to remove aliases from). 

Presentation: https://t.co/U75g9d5YQr
