### PR TITLE
to use the parameter we need SqlCredential here

### DIFF
--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -403,7 +403,7 @@ IF OBJECT_ID('tempdb..##tmpEstimatePage', 'U') IS NOT NULL
         foreach ($instance in $SqlInstance) {
             try {
                 Write-Message -Level VeryVerbose -Message "Connecting to $instance" -Target $instance
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SourceSqlCredential -MinimumVersion 10
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             }
             catch {
                 Stop-Function -Message "Failed to process Instance $Instance" -ErrorRecord $_ -Target $instance -Continue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X] Bug fix (non-breaking change, fixes #3933)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Altered code to use parameter name SqlCCredential

### Approach
renamed variable

### Commands to test
Test-DbaDbCompression -SqlInstance $Instance -SqlCredential $cred 

### Screenshots
broken

![image](https://user-images.githubusercontent.com/6729780/44630376-42ed6000-a954-11e8-9abd-43618c347443.png)

fixed

![image](https://user-images.githubusercontent.com/6729780/44630405-c909a680-a954-11e8-833b-c9daaff55a12.png)

Closes #3933