### PR TITLE
Updating Decimal length to match SQL Server's max values

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -492,7 +492,7 @@ function Write-DbaDataTable {
             'System.UInt16'    = 'int';
             'System.Int64'     = 'bigint';
             'System.UInt64'    = 'decimal(20,0)';
-            'System.Decimal'   = 'decimal(20,5)';
+            'System.Decimal'   = 'decimal(38,5)';
             'System.Single'    = 'bigint';
             'System.Double'    = 'float';
             'System.Byte'      = 'tinyint';
@@ -509,7 +509,7 @@ function Write-DbaDataTable {
             'UInt16'           = 'int';
             'Int64'            = 'bigint';
             'UInt64'           = 'decimal(20,0)';
-            'Decimal'          = 'decimal(20,5)';
+            'Decimal'          = 'decimal(38,5)';
             'Single'           = 'bigint';
             'Double'           = 'float';
             'Byte'             = 'tinyint';


### PR DESCRIPTION


<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (Fixes #3010)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow for high LSN values (greater than 20 digits) to be properly piped from `Get-DbaDatabase | ConvertTo-DbaDataTable | Write-DbaDataTable` 

### Approach
Increases the max size for the columns created for the Decimal data type to match the [max size available](https://docs.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-2017) in SQL Server 

### Commands to test
`Get-DbaDatabase | ConvertTo-DbaDataTable | Write-DbaDataTable` for a database that has a high LSN number.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/16843041/44807826-8df7b500-ab98-11e8-9d2d-595be426007e.png)
