### PR TITLE
Backupcompress

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -296,7 +296,10 @@ function Backup-DbaDatabase {
             $Suffix = "bak"
 
             if ($CompressBackup) {
-                if ($server.Edition -like 'Express*' -or ($server.VersionMajor -eq 10 -and $server.VersionMinor -eq 0 -and $server.Edition -notlike '*enterprise*') -or $server.VersionMajor -lt 10) {
+                if ($database.EncryptionEnabled) {
+                    Write-Message -Level Warning -Message "$dbname is enabled for encryption, will not compress"
+                    $backup.CompressionOption = 2
+                } elseif ($server.Edition -like 'Express*' -or ($server.VersionMajor -eq 10 -and $server.VersionMinor -eq 0 -and $server.Edition -notlike '*enterprise*') -or $server.VersionMajor -lt 10) {
                     Write-Message -Level Warning -Message "Compression is not supported with this version/edition of Sql Server"
                 }
                 else {

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -188,11 +188,11 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "Should handle an encrypted database when compression is specified" {
-        $sqlencrypt = 
-@"  
-CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<UseStrongPasswordHere>';  
-go  
-CREATE CERTIFICATE MyServerCert WITH SUBJECT = 'My DEK Certificate';  
+        $sqlencrypt =
+@"
+CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<UseStrongPasswordHere>';
+go
+CREATE CERTIFICATE MyServerCert WITH SUBJECT = 'My DEK Certificate';
 go
 CREATE DATABASE encrypted
 go
@@ -200,13 +200,13 @@ go
         $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqlencrypt -Database Master
         $createdb =
 @"
-CREATE DATABASE ENCRYPTION KEY  
-WITH ALGORITHM = AES_128  
-ENCRYPTION BY SERVER CERTIFICATE MyServerCert;  
-GO  
-ALTER DATABASE encrypted  
-SET ENCRYPTION ON;  
-GO  
+CREATE DATABASE ENCRYPTION KEY
+WITH ALGORITHM = AES_128
+ENCRYPTION BY SERVER CERTIFICATE MyServerCert;
+GO
+ALTER DATABASE encrypted
+SET ENCRYPTION ON;
+GO
 "@
         $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $createdb -Database encrypted
         It "Should not compress an encrypted db" {
@@ -214,11 +214,11 @@ GO
             $results.script | Should -BeLike '*NO_COMPRESSION*'
         }
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database encrypted -confirm:$false
-        $sqldrop = 
+        $sqldrop =
 @"
 drop certificate MyServerCert
 go
-drop master key 
+drop master key
 go
 "@
         $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqldrop -Database Master

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -186,6 +186,43 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results | Should -Be "BACKUP DATABASE [master] TO  DISK = N'c:\notexists\file.bak' WITH NOFORMAT, NOINIT, NOSKIP, REWIND, NOUNLOAD,  STATS = 1"
         }
     }
+
+    Context "Should handle an encrypted database when compression is specified" {
+        $sqlencrypt = 
+@"  
+CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<UseStrongPasswordHere>';  
+go  
+CREATE CERTIFICATE MyServerCert WITH SUBJECT = 'My DEK Certificate';  
+go
+CREATE DATABASE encrypted
+go
+"@
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqlencrypt -Database Master
+        $createdb =
+@"
+CREATE DATABASE ENCRYPTION KEY  
+WITH ALGORITHM = AES_128  
+ENCRYPTION BY SERVER CERTIFICATE MyServerCert;  
+GO  
+ALTER DATABASE encrypted  
+SET ENCRYPTION ON;  
+GO  
+"@
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $createdb -Database encrypted
+        It "Should not compress an encrypted db" {
+            $results = Backup-DbaDatabase -SqlInstance $script:instance1 -Database encrypted -Compress
+            $results.script | Should -BeLike '*NO_COMPRESSION*'
+        }
+        Remove-DbaDatabase -SqlInstance $script:instance1 -Database encrypted -confirm:$false
+        $sqldrop = 
+@"
+drop certificate MyServerCert
+go
+drop master key 
+go
+"@
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqldrop -Database Master
+    }
     if ($env:azurepasswd) {
         Context "Azure works" {
             BeforeAll {

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -197,7 +197,7 @@ go
 CREATE DATABASE encrypted
 go
 "@
-        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqlencrypt -Database Master
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance2 -Query $sqlencrypt -Database Master
         $createdb =
 @"
 CREATE DATABASE ENCRYPTION KEY
@@ -208,12 +208,12 @@ ALTER DATABASE encrypted
 SET ENCRYPTION ON;
 GO
 "@
-        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $createdb -Database encrypted
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance2 -Query $createdb -Database encrypted
         It "Should not compress an encrypted db" {
-            $results = Backup-DbaDatabase -SqlInstance $script:instance1 -Database encrypted -Compress
+            $results = Backup-DbaDatabase -SqlInstance $script:instance2 -Database encrypted -Compress
             $results.script | Should -BeLike '*NO_COMPRESSION*'
         }
-        Remove-DbaDatabase -SqlInstance $script:instance1 -Database encrypted -confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance2 -Database encrypted -confirm:$false
         $sqldrop =
 @"
 drop certificate MyServerCert
@@ -221,7 +221,7 @@ go
 drop master key
 go
 "@
-        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance1 -Query $sqldrop -Database Master
+        $null = Invoke-DbaSqlQuery -SqlInstance $script:instance2 -Query $sqldrop -Database Master
     }
     if ($env:azurepasswd) {
         Context "Azure works" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3941 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Don't compress backups from encrypted databases as requested

### Approach
If db is encrypted, set CompressionOption to 2 (NO_COMPRESS) and alerts the user that we're ignoring their compression option
