### PR TITLE
Fixing Export-DbaDacpac waiting on the stdout stream

### DIFF
--- a/functions/Export-DbaDacpac.ps1
+++ b/functions/Export-DbaDacpac.ps1
@@ -143,9 +143,9 @@ function Export-DbaDacpac {
                     $process = New-Object System.Diagnostics.Process
                     $process.StartInfo = $startprocess
                     $process.Start() | Out-Null
-                    $process.WaitForExit()
                     $stdout = $process.StandardOutput.ReadToEnd()
                     $stderr = $process.StandardError.ReadToEnd()
+                    $process.WaitForExit()
                     Write-Message -level Verbose -Message "StandardOutput: $stdout"
 
                     [pscustomobject]@{


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3953)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Being able to export databases with tons of tables and data

### Approach
Read the output stream right away instead of waiting for process to complete.

### Commands to test
Export-DbaDacpac, but only when used with IncludeData and against a relatively complex database.

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
