### PR TITLE
Adding rename and prefixing to Copy-DbaDatabase

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -633,7 +633,7 @@ function Copy-DbaDatabase {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         # testing twice for whatif reasons
         if ($BackupRestore -and (-not $NetworkShare -and -not $UseLastBackups)) {
             Stop-Function -Message "When using -BackupRestore, you must specify -NetworkShare or -UseLastBackups"
@@ -878,7 +878,7 @@ function Copy-DbaDatabase {
                 Stop-Function -Message "Cannot use NewName when copying multiple databases"
                 return
             }
-            
+
 
             Write-Message -Level Verbose -Message "Building file structure inventory for $dbCount databases."
 
@@ -920,7 +920,7 @@ function Copy-DbaDatabase {
                         $destinationDbName = $prefix+$destinationDbName
                         Write-Message -Level Verbose -Message "Prefix supplied, copying $dbname as $destinationDbName"
                     }
-               
+
                     $filestructure.databases[$dbname].Add('destinationDbName',$destinationDbName)
                     ForEach ($key in $filestructure.databases[$dbname].Destination.Keys){
                         $splitFileName = Split-Path $fileStructure.databases[$dbname].Destination[$key].remotefilename -Leaf
@@ -929,7 +929,6 @@ function Copy-DbaDatabase {
                             $splitFileName = $splitFileName.replace($dbname, $destinationDbName)
                         }
                         $splitFileName = $prefix+$splitFileName
-                        Write-Verbose "$splitfilename"
                         $filestructure.databases[$dbname].Destination.$key.remotefilename = Join-Path $SplitPath $splitFileName
                         $splitFileName = Split-Path $filestructure.databases[$dbname].Destination[$key].physical -Leaf
                         $SplitPath =  Split-Path $fileStructure.databases[$dbname].Destination[$key].physical
@@ -938,7 +937,6 @@ function Copy-DbaDatabase {
                         }
                         $splitFileName = $prefix+$splitFileName
                         $filestructure.databases[$dbname].Destination.$key.physical = Join-Path $SplitPath $splitFileName
-                        Write-Verbose "$splitfilename"
                     }
 
                     $copyDatabaseStatus = [pscustomobject]@{
@@ -964,7 +962,7 @@ function Copy-DbaDatabase {
                     if ($currentdb.IsAccessible -eq $false) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "Skipping $dbName. Database is inaccessible.")) {
                             Write-Message -Level Verbose -Message "Skipping $dbName. Database is inaccessible."
-                            
+
                             $copyDatabaseStatus.Status = "Skipped"
                             $copyDatabaseStatus.Notes = "Database is not accessible"
                             $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
@@ -974,7 +972,7 @@ function Copy-DbaDatabase {
 
                     if ($fsWarning) {
                         $fsRows = $dbFileTable.Tables[0].Select("dbname = '$dbName' and FileType = 'FileStream'")
-                        
+
                         if ($fsRows.Count -gt 0) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Skipping $dbName (contains FILESTREAM).")) {
                                 Write-Message -Level Verbose -Message "Skipping $dbName (contains FILESTREAM)."
@@ -989,7 +987,7 @@ function Copy-DbaDatabase {
                     if ($ReuseSourceFolderStructure) {
                         $fgRows = $dbFileTable.Tables[0].Select("dbname = '$dbName' and FileType = 'ROWS'")[0]
                         $remotePath = Split-Path $fgRows.Filename
-                        
+
                         if (!(Test-DbaSqlPath -SqlInstance $destServer -Path $remotePath)) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "$remotePath does not exist on $destinstance and ReuseSourceFolderStructure was specified")) {
                                 # Stop-Function -Message "Cannot resolve $remotePath on $source. `n`nYou have specified ReuseSourceFolderStructure and exact folder structure does not exist. Halting script."
@@ -1009,45 +1007,45 @@ function Copy-DbaDatabase {
                     }
 
                     $dbStatus = $currentdb.Status.ToString()
-                    
+
                     if ($dbStatus.StartsWith("Normal") -eq $false) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "$dbName is not in a Normal state. Skipping.")) {
                             Write-Message -Level Verbose -Message "$dbName is not in a Normal state. Skipping."
-                            
+
                             $copyDatabaseStatus.Status = "Skipped"
                             $copyDatabaseStatus.Notes = "Not in normal state"
                             $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                         }
                         continue
                     }
-                    
+
                     if ($currentdb.ReplicationOptions -ne "None" -and $DetachAttach -eq $true) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "$dbName is part of replication. Skipping.")) {
                             Write-Message -Level Verbose -Message "$dbName is part of replication. Skipping."
-                            
+
                             $copyDatabaseStatus.Status = "Skipped"
                             $copyDatabaseStatus.Notes = "Part of replication"
                             $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                         }
                         continue
                     }
-                    
+
                     if ($currentdb.IsMirroringEnabled -and !$force -and $DetachAttach) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "Database is being mirrored. Use -Force to break mirror and migrate. Alternatively, you can use the safer backup/restore method.")) {
                             Write-Message -Level Verbose -Message "Database is being mirrored. Use -Force to break mirror and migrate. Alternatively, you can use the safer backup/restore method."
-                            
+
                             $copyDatabaseStatus.Status = "Skipped"
                             $copyDatabaseStatus.Notes = "Database is mirrored"
                             $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                         }
-                        
+
                         continue
                     }
-                    
+
                     if (($null -ne $destServer.Databases[$DestinationdbName]) -and !$force -and !$WithReplace) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "$DestinationdbName exists at destination. Use -Force to drop and migrate. Aborting routine for this database.")) {
                             Write-Message -Level Verbose -Message "$DestinationdbName exists at destination. Use -Force to drop and migrate. Aborting routine for this database."
-                            
+
                             $copyDatabaseStatus.Status = "Skipped"
                             $copyDatabaseStatus.Notes = "Already exists"
                             $copyDatabaseStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -10,10 +10,10 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $backuprestoredb2 = "dbatoolsci_backuprestoreother$random"
         $detachattachdb = "dbatoolsci_detachattach$random"
         Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb, $detachattachdb
-        
+
         $server = Connect-DbaInstance -SqlInstance $script:instance3
         $server.Query("CREATE DATABASE $backuprestoredb2; ALTER DATABASE $backuprestoredb2 SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
-        
+
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $server.Query("CREATE DATABASE $backuprestoredb; ALTER DATABASE $backuprestoredb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
         $server.Query("CREATE DATABASE $detachattachdb; ALTER DATABASE $detachattachdb SET AUTO_CLOSE OFF WITH ROLLBACK IMMEDIATE")
@@ -23,22 +23,22 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
         Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb, $detachattachdb, $backuprestoredb2
     }
-    
+
     # if failed Disable-NetFirewallRule -DisplayName 'Core Networking - Group Policy (TCP-Out)'
     Context "Detach Attach" {
         It "Should be success" {
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $detachattachdb -DetachAttach -Reattach -Force #-WarningAction SilentlyContinue
             $results.Status | Should Be "Successful"
         }
-        
+
         $db1 = Get-DbaDatabase -SqlInstance $script:instance2 -Database $detachattachdb
         $db2 = Get-DbaDatabase -SqlInstance $script:instance3 -Database $detachattachdb
-        
+
         It "should not be null"  {
             $db1.Name | Should Be $detachattachdb
             $db2.Name | Should Be $detachattachdb
         }
-        
+
         It "Name, recovery model, and status should match" {
             # Compare its variable
             $db1.Name | Should -Be $db2.Name
@@ -46,23 +46,23 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $db1.Status | Should -Be $db2.Status
             $db1.Owner | Should -Be $db2.Owner
         }
-        
+
         It "Should say skipped" {
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $detachattachdb -DetachAttach -Reattach
             $results.Status | Should be "Skipped"
             $results.Notes | Should be "Already exists"
         }
     }
-    
+
     Context "Backup restore" {
         Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
         $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath 3>$null
-        
+
         It "copies a database successfully" {
             $results.Name -eq $backuprestoredb
             $results.Status -eq "Successful"
         }
-        
+
         It "retains its name, recovery model, and status." {
             $dbs = Get-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb
             $dbs[0].Name -ne $null
@@ -72,14 +72,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $dbs[0].Status -eq $dbs[1].Status
             $dbs[0].Owner -eq $dbs[1].Owner
         }
-        
+
         # needs regr test that uses $backuprestoredb once #3377 is fixed
         It  "Should say skipped" {
             $result = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb2 -BackupRestore -NetworkShare $NetworkPath 3>$null
             $result.Status | Should be "Skipped"
             $result.Notes | Should be "Already exists"
         }
-        
+
         # needs regr test once #3377 is fixed
         if (-not $env:appveyor) {
             It "Should overwrite when forced to" {
@@ -94,14 +94,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
             Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance3 -Database $backuprestoredb
         }
-        
+
         It "copies a database successfully using backup history" {
             # It should already have a backup history by this time
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -UseLastBackups 3>$null
             $results.Name -eq $backuprestoredb
             $results.Status -eq "Successful"
         }
-        
+
         It "retains its name, recovery model, and status." {
             $dbs = Get-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb
             $dbs[0].Name -ne $null
@@ -121,14 +121,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             #Run diff now
             $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $backuprestoredb -BackupDirectory $NetworkPath -Type Diff
         }
-        
+
         It "continues the restore over existing database using backup history" {
             # It should already have a backup history (full+diff) by this time
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -UseLastBackups -Continue 3>$null
             $results.Name -eq $backuprestoredb
             $results.Status -eq "Successful"
         }
-        
+
         It "retains its name, recovery model, and status." {
             $dbs = Get-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb
             $dbs[0].Name -ne $null
@@ -146,7 +146,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         }
         AfterAll {
             Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
-            Get-DbaDatabase -SqlInstance $script:instance3 -ExcludeAllSystemDb | Remove-DbaDatabase -Confirm:$false           
+            Get-DbaDatabase -SqlInstance $script:instance3 -ExcludeAllSystemDb | Remove-DbaDatabase -Confirm:$false
         }
         It "Should have renamed a single db"{
             $newname = "copy$(Get-Random)"
@@ -165,12 +165,12 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         It "Should prefix databasename and files"{
             $prefix = "da$(Get-Random)"
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath -Prefix $prefix
-            $results[0].DestinationDatabase | Should -Be "$prefix$backuprestoredb" 
-            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database "$prefix$backuprestoredb" 
+            $results[0].DestinationDatabase | Should -Be "$prefix$backuprestoredb"
+            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database "$prefix$backuprestoredb"
             ($files.PhysicalName -like  "*$prefix$backuprestoredb*").count | Should -Be $files.count
-        } 
+        }
     }
-    
+
     Context "Copying with renames using detachattach" {
         BeforeAll {
             Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 -Program 'dbatools PowerShell module - dbatools.io' | Stop-DbaProcess -WarningAction SilentlyContinue
@@ -187,10 +187,10 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         It "Should prefix databasename and files"{
             $prefix = "copy$(Get-Random)"
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -DetachAttach -Reattach -Prefix $prefix
-            $results[0].DestinationDatabase | Should -Be "$prefix$backuprestoredb" 
-            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database "$prefix$backuprestoredb" 
+            $results[0].DestinationDatabase | Should -Be "$prefix$backuprestoredb"
+            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database "$prefix$backuprestoredb"
             ($files.PhysicalName -like  "*$prefix$backuprestoredb*").count | Should -Be $files.count
-        } 
+        }
 
         $null = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -useDestinationDefaultDirectories
         It "Should warn and exit if newname and >1 db specified"{

--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -147,7 +147,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         It "Should have renamed a single db"{
             $newname = "copy$(Get-Random)"
             $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath -NewName $newname
-            $results.DestinationDatabase | Should -Be $newname
+            $results[0].DestinationDatabase | Should -Be $newname
             $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database $newname
             ($files.PhysicalName -like  "*$newname*").count | Should -Be $files.count
         }
@@ -156,9 +156,9 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         }
         It "Should prefix databasename and files"{
             $prefix = "copy$(Get-Random)"
-            $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath -Prefix $newname
-            $results.DestinationDatabase | Should -Be $prefix+$backuprestoredb 
-            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database $newname
+            $results = Copy-DbaDatabase -Source $script:instance2 -Destination $script:instance3 -Database $backuprestoredb -BackupRestore -NetworkShare $NetworkPath -Prefix $prefix
+            $results[0].DestinationDatabase | Should -Be "$prefix$backuprestoredb" 
+            $files  = Get-DbaDatabaseFile -Sqlinstance $script:instance3 -Database "$prefix$backuprestoredb" 
             ($files.PhysicalName -like  "*$prefix$backuprestoredb*").count | Should -Be $files.count
         } 
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #3925)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Someone asked about allowing a different name for the output of Copy-DbaDatabase, so I added the option.

### Approach
2 new parameters NewName and Prefix, they are mutually exclusive

NewName can only be used when copying a single db, and copies the db under the newname and replaces the old db name in the Physical filename

prefix works with as many dbs as you like. Prefixes the copied database name and the physical file name with the supplied string

Both work with -BackupRestore and -DetachAttach

### Commands to test
`Copy-DbaDatabase -Source localhost\sql2016 -Destination localhost\sql2017 -Database copy1,copy2 -DetachAttach -Reattach -prefix outputtest6`

will copy database copy1 as outputtest6copy1 and prefix it's datafiles with outputtest16, and do the same for database copy2. Using the Detach, copy and attach path

`Copy-DbaDatabase -Source localhost\sql2016 -Destination localhost\sql2017 -Database copy1 -BackupRestore -NetworkShare \\store\sql -NewName copieddb`

will copy database copy1 as copieddb, and replace copy1 with copieddb in the physical filename (if it's in there) using the BackupRestore path

BTW, I'm now aware that this Issue/Request has been knocked back before so I won't be hugely offended if this isn't wanted/needed. But as I've written it I might as well submit it for review and discussion :)

As far as integration with Start-DbaMigration, this shouldn't make any difference. To get the new features the parameters have to be called explicitly which they aren't in SDM so won't impact on that.
