### PR TITLE
Disabled indexes don't report space usage hence not visible. Fixes #3402

### DIFF
--- a/functions/Find-DbaDuplicateIndex.ps1
+++ b/functions/Find-DbaDuplicateIndex.ps1
@@ -175,11 +175,11 @@ function Find-DbaDuplicateIndex {
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
                 ,CI1.IndexType
-                ,CSPC.IndexSizeMB
-                ,CSPC.[RowCount]
+                ,COALESCE(CSPC.IndexSizeMB,0) AS 'IndexSizeMB'
+                ,COALESCE(CSPC.[RowCount],0) AS 'RowCount'
                 ,CI1.IsDisabled
             FROM CTE_IndexCols AS CI1
-            INNER JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
+            LEFT JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
                 AND CI1.index_id = CSPC.index_id
             WHERE EXISTS (
                     SELECT 1
@@ -260,11 +260,11 @@ function Find-DbaDuplicateIndex {
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
                 ,CI1.IndexType
-                ,CSPC.IndexSizeMB
-                ,CSPC.[RowCount]
+                ,COALESCE(CSPC.IndexSizeMB,0) AS 'IndexSizeMB'
+                ,COALESCE(CSPC.[RowCount],0) AS 'RowCount'
                 ,CI1.IsDisabled
             FROM CTE_IndexCols AS CI1
-            INNER JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
+            LEFT JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
                 AND CI1.index_id = CSPC.index_id
             WHERE EXISTS (
                     SELECT 1
@@ -357,13 +357,13 @@ function Find-DbaDuplicateIndex {
                 ,CI1.KeyColumns
                 ,CI1.IncludedColumns
                 ,CI1.IndexType
-                ,CSPC.IndexSizeMB
-                ,CSPC.CompressionDescription
-                ,CSPC.[RowCount]
+                ,COALESCE(CSPC.IndexSizeMB,0) AS 'IndexSizeMB'
+                ,COALESCE(CSPC.CompressionDescription, 'NONE') AS 'CompressionDescription'
+                ,COALESCE(CSPC.[RowCount],0) AS 'RowCount'
                 ,CI1.IsDisabled
                 ,CI1.IsFiltered
             FROM CTE_IndexCols AS CI1
-            INNER JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
+            LEFT JOIN CTE_IndexSpace AS CSPC ON CI1.[object_id] = CSPC.[object_id]
                 AND CI1.index_id = CSPC.index_id
             WHERE EXISTS (
                     SELECT 1
@@ -443,13 +443,13 @@ function Find-DbaDuplicateIndex {
                     ,CI1.KeyColumns
                     ,CI1.IncludedColumns
                     ,CI1.IndexType
-                    ,CSPC.IndexSizeMB
-                    ,CSPC.CompressionDescription
-                    ,CSPC.[RowCount]
+                    ,COALESCE(CSPC.IndexSizeMB,0) AS 'IndexSizeMB'
+                    ,COALESCE(CSPC.CompressionDescription, 'NONE') AS 'CompressionDescription'
+                    ,COALESCE(CSPC.[RowCount],0) AS 'RowCount'
                     ,CI1.IsDisabled
                     ,CI1.IsFiltered
             FROM CTE_IndexCols AS CI1
-                INNER JOIN CTE_IndexSpace AS CSPC
+                LEFT JOIN CTE_IndexSpace AS CSPC
                 ON CI1.[object_id] = CSPC.[object_id]
                 AND CI1.index_id = CSPC.index_id
             WHERE EXISTS (SELECT 1


### PR DESCRIPTION
NULL in target SELECT replaced with default values.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ *] Bug fix (non-breaking change, fixes #3402 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes issue #3402 by showing duplicate indexes that are disabled.

### Approach
Disabled index is not present in sys.dm_db_partition_stats nor sys.partitions (part of CTE_IndexSpace), hence inner join of CTE_IndexCols and CTE_IndexSpace filters out this type of index.

Once the LEFT JOIN is added DISABLED indexes are being listed. Some fields return NULL, so it has been replaced by default value:
numeric (IndexSize, RowCounts) by 0 and text (CompressionDescription) by NONE.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/13431760/45061354-1647ef80-b09c-11e8-9257-be6f9daff21d.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
