### PR TITLE
Fix examples3

### DIFF
--- a/functions/Copy-DbaCredential.ps1
+++ b/functions/Copy-DbaCredential.ps1
@@ -7,7 +7,10 @@ function Copy-DbaCredential {
             By using password decryption techniques provided by Antti Rantasaari (NetSPI, 2014), this script migrates SQL Server Credentials from one server to another while maintaining username and password.
 
             Credit: https://blog.netspi.com/decrypting-mssql-database-link-server-passwords/
-            License: BSD 3-Clause http://opensource.org/licenses/BSD-3-Clause
+
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
 
         .PARAMETER Source
             Source SQL Server. You must have sysadmin access and server version must be SQL Server version 2000 or higher.
@@ -30,7 +33,7 @@ function Copy-DbaCredential {
 
         .PARAMETER ExcludeName
             Excluded credential names
-    
+
         .PARAMETER Identity
             Only include specific identities
             Note: if spaces exist in the credential identity, you will have to type "" or '' around it.
@@ -120,7 +123,7 @@ function Copy-DbaCredential {
             Write-Message -Level Verbose -Message "Collecting Credential logins and passwords on $($sourceServer.Name)"
             $sourceCredentials = Get-DecryptedObject -SqlInstance $sourceServer -Type Credential
             $credentialList = Get-DbaCredential -SqlInstance $sourceServer -Name $Name -ExcludeName $ExcludeName -Identity $Identity -ExcludeIdentity $ExcludeIdentity
-            
+
             Write-Message -Level Verbose -Message "Starting migration"
             foreach ($credential in $credentialList) {
                 $destServer.Credentials.Refresh()
@@ -152,7 +155,7 @@ function Copy-DbaCredential {
                         }
                     }
                 }
-                
+
                 Write-Message -Level Verbose -Message "Attempting to migrate $credentialName"
                 try {
                     $currentCred = $sourceCredentials | Where-Object { $_.Name -eq "[$credentialName]" }
@@ -176,7 +179,7 @@ function Copy-DbaCredential {
                 }
             }
         }
-        
+
         try {
             Write-Message -Level Verbose -Message "Connecting to $Source"
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 9
@@ -185,15 +188,15 @@ function Copy-DbaCredential {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance
             return
         }
-        
+
         if ($null -ne $SourceSqlCredential.Username) {
             Write-Message -Level Verbose -Message "You are using SQL credentials and this script requires Windows admin access to the $Source server. Trying anyway."
         }
-        
+
         $sourceNetBios = Resolve-NetBiosName $sourceServer
-        
+
         Invoke-SmoCheck -SqlInstance $sourceServer
-        
+
         Write-Message -Level Verbose -Message "Checking if Remote Registry is enabled on $source"
         try {
             Invoke-Command2 -ComputerName $sourceNetBios -Credential $credential -ScriptBlock { Get-ItemProperty -Path "HKLM:\SOFTWARE\" }
@@ -205,7 +208,7 @@ function Copy-DbaCredential {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         foreach ($destinstance in $Destination) {
             try {
                 Write-Message -Level Verbose -Message "Connecting to $destinstance"
@@ -215,7 +218,7 @@ function Copy-DbaCredential {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $destinstance -Continue
             }
             Invoke-SmoCheck -SqlInstance $destServer
-            
+
             Copy-Credential $credentials -force:$force
         }
     }

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -7,7 +7,10 @@ function Copy-DbaLinkedServer {
             By using password decryption techniques provided by Antti Rantasaari (NetSPI, 2014), this script migrates SQL Server Linked Servers from one server to another, while maintaining username and password.
 
             Credit: https://blog.netspi.com/decrypting-mssql-database-link-server-passwords/
-            License: BSD 3-Clause http://opensource.org/licenses/BSD-3-Clause
+
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
 
         .PARAMETER Source
             Source SQL Server (2005 and above). You must have sysadmin access to both SQL Server and Windows.
@@ -139,7 +142,7 @@ function Copy-DbaLinkedServer {
                         if ($Pscmdlet.ShouldProcess($destinstance, "$linkedServerName exists $($destServer.Name). Skipping.")) {
                             $copyLinkedServer.Status = "Skipped"
                             $copyLinkedServer | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-                            
+
                             Write-Message -Level Verbose -Message "$linkedServerName exists $($destServer.Name). Skipping."
                         }
                         continue
@@ -217,7 +220,7 @@ function Copy-DbaLinkedServer {
                 }
             }
         }
-        
+
         if ($null -ne $SourceSqlCredential.Username) {
             Write-Message -Level Verbose -Message "You are using a SQL Credential. Note that this script requires Windows Administrator access on the source server. Attempting with $($SourceSqlCredential.Username)."
         }
@@ -236,7 +239,7 @@ function Copy-DbaLinkedServer {
         }
         Write-Message -Level Verbose -Message "Getting NetBios name for $source."
         $sourceNetBios = Resolve-NetBiosName $sourceserver
-        
+
         Write-Message -Level Verbose -Message "Checking if Remote Registry is enabled on $source."
         try {
             Invoke-Command2 -Raw -Credential $Credential -ComputerName $sourceNetBios -ScriptBlock { Get-ItemProperty -Path "HKLM:\SOFTWARE\" } -ErrorAction Stop
@@ -248,7 +251,7 @@ function Copy-DbaLinkedServer {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         foreach ($destinstance in $Destination) {
             try {
                 Write-Message -Level Verbose -Message "Connecting to $destinstance"
@@ -260,7 +263,7 @@ function Copy-DbaLinkedServer {
             if (!(Test-SqlSa -SqlInstance $destServer -SqlCredential $DestinationSqlCredential)) {
                 Stop-Function -Message "Not a sysadmin on $destinstance" -Target $destServer -Continue
             }
-            
+
             # Magic happens here
             Copy-DbaLinkedServers $LinkedServer -Force:$force
         }

--- a/functions/Copy-DbaTableData.ps1
+++ b/functions/Copy-DbaTableData.ps1
@@ -115,7 +115,7 @@ function Copy-DbaTableData {
         .EXAMPLE
             Get-DbaTable -SqlInstance sql1 -Database tempdb -Table tb1, tb2 | Copy-DbaTableData -DestinationTable tb3
 
-            Copies all data from tables tb1 and tb2 in tempdb on sql1 to tb3 in tempdb onsql1
+            Copies all data from tables tb1 and tb2 in tempdb on sql1 to tb3 in tempdb on sql1
 
         .EXAMPLE
             Get-DbaTable -SqlInstance sql1 -Database tempdb -Table tb1, tb2 | Copy-DbaTableData -Destination sql2

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -57,7 +57,7 @@ function Set-DbaTcpPort {
         .EXAMPLE
             Set-DbaTcpPort -SqlInstance 'SQLDB2014A' ,'SQLDB2016B' -port 1337
 
-            Sets the port number 1337 for IP Addresses on SqlInstance SQLDB2014A and SQLDB2016B
+            Sets the port number 1337 for all IP Addresses on SqlInstance SQLDB2014A and SQLDB2016B
     #>
     [CmdletBinding(ConfirmImpact = "High")]
     Param (

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -47,7 +47,7 @@ function Set-DbaTcpPort {
         .EXAMPLE
             Set-DbaTcpPort -SqlInstance SqlInstance2014a -Port 1433
 
-            Sets the port number 1433 for allips on the default instance on SqlInstance2014a
+            Sets the port number 1433 for all IP Addresses on the default instance on SqlInstance2014a
 
         .EXAMPLE
             Set-DbaTcpPort -SqlInstance winserver\sqlexpress -IpAddress 192.168.1.22 -Port 1433
@@ -57,7 +57,7 @@ function Set-DbaTcpPort {
         .EXAMPLE
             Set-DbaTcpPort -SqlInstance 'SQLDB2014A' ,'SQLDB2016B' -port 1337
 
-            Sets the port number 1337 for ALLIP's on SqlInstance SQLDB2014A and SQLDB2016B
+            Sets the port number 1337 for IP Addresses on SqlInstance SQLDB2014A and SQLDB2016B
     #>
     [CmdletBinding(ConfirmImpact = "High")]
     Param (

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -93,13 +93,13 @@ function Write-DbaDataTable {
             https://dbatools.io/Write-DbaDataTable
 
         .EXAMPLE
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             Write-DbaDataTable -SqlInstance sql2014 -InputObject $DataTable -Table mydb.dbo.customers
 
             Performs a bulk insert of all the data in customers.csv into database mydb, schema dbo, table customers. A progress bar will be shown as rows are inserted. If the destination table does not exist, the import will be halted.
 
         .EXAMPLE
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             $DataTable | Write-DbaDataTable -SqlInstance sql2014 -Table mydb.dbo.customers
 
             Performs a row by row insert of the data in customers.csv. This is significantly slower than a bulk insert and will not show a progress bar.
@@ -107,19 +107,19 @@ function Write-DbaDataTable {
             This method is not recommended. Use -InputObject instead.
 
         .EXAMPLE
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             Write-DbaDataTable -SqlInstance sql2014 -InputObject $DataTable -Table mydb.dbo.customers -AutoCreateTable
 
             Performs a bulk insert of all the data in customers.csv. If mydb.dbo.customers does not exist, it will be created with inefficient but forgiving DataTypes.
 
         .EXAMPLE
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             Write-DbaDataTable -SqlInstance sql2014 -InputObject $DataTable -Table mydb.dbo.customers -Truncate
 
             Performs a bulk insert of all the data in customers.csv. Prior to importing into mydb.dbo.customers, the user is informed that the table will be truncated and asks for confirmation. The user is prompted again to perform the import.
 
         .EXAMPLE
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             Write-DbaDataTable -SqlInstance sql2014 -InputObject $DataTable -Database mydb -Table customers -KeepNulls
 
             Performs a bulk insert of all the data in customers.csv into mydb.dbo.customers. Because Schema was not specified, dbo was used. NULL values in the destination table will be preserved.
@@ -127,18 +127,18 @@ function Write-DbaDataTable {
         .EXAMPLE
             $passwd = ConvertTo-SecureString "P@ssw0rd" -AsPlainText -Force
             $AzureCredential = New-Object System.Management.Automation.PSCredential("AzureAccount"),$passwd)
-            $DataTable = Import-Csv C:\temp\customers.csv | Out-DbaDataTable
+            $DataTable = Import-Csv C:\temp\customers.csv | ConvertTo-DbaDataTable
             Write-DbaDataTable -SqlInstance AzureDB.database.windows.net -InputObject $DataTable -Database mydb -Table customers -KeepNulls -Credential $AzureCredential -BulkCopyTimeOut 300
 
             This performs the same operation as the previous example, but against a SQL Azure Database instance using the required credentials.
 
         .EXAMPLE
-            $process = Get-Process | Out-DbaDataTable
+            $process = Get-Process | ConvertTo-DbaDataTable
             Write-DbaDataTable -InputObject $process -SqlInstance sql2014 -Database mydb -Table myprocesses -AutoCreateTable
 
             Creates a table based on the Process object with over 60 columns, converted from PowerShell data types to SQL Server data types. After the table is created a bulk insert is performed to add process information into the table.
 
-            This is an example of the type conversion in action. All process properties are converted, including special types like TimeSpan. Script properties are resolved before the type conversion starts thanks to Out-DbaDataTable.
+            This is an example of the type conversion in action. All process properties are converted, including special types like TimeSpan. Script properties are resolved before the type conversion starts thanks to ConvertTo-DbaDataTable.
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes issues with
(a) Incorrect Licence for Copy-DbaCredential and Copy-DbaLinkedServer
(b) Incorrect Examples for Copy-DbaDbAssembly, Copy-DbaResourceGovernor and Copy-DbaTableData.ps1
(c) Use of deprecated command Out-DbaDataTable in Write-DbaDataTable
(d) Spelling issues in Set-DbaTcpPort

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
