### PR TITLE
Updated ValueFromPipeline and Mandatory

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -138,7 +138,7 @@ function Backup-DbaDatabase {
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")] #For AzureCredential
     param (
-        [parameter(ParameterSetName = "Pipe", Mandatory = $true)]
+        [parameter(ParameterSetName = "Pipe", Mandatory)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
@@ -149,7 +149,7 @@ function Backup-DbaDatabase {
         [switch]$CopyOnly,
         [ValidateSet('Full', 'Log', 'Differential', 'Diff', 'Database')]
         [string]$Type = 'Database',
-        [parameter(ParameterSetName = "NoPipe", Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(ParameterSetName = "NoPipe", Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
         [switch]$CreateFolder,
         [int]$FileCount = 0,

--- a/functions/Clear-DbaConnectionPool.ps1
+++ b/functions/Clear-DbaConnectionPool.ps1
@@ -43,7 +43,7 @@ function Clear-DbaConnectionPool {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -42,7 +42,7 @@ function Clear-DbaWaitStatistics {
     #>
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess)]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -169,7 +169,7 @@ function Connect-DbaInstance {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("SqlCredential")]

--- a/functions/ConvertTo-DbaDataTable.ps1
+++ b/functions/ConvertTo-DbaDataTable.ps1
@@ -67,18 +67,18 @@ function ConvertTo-DbaDataTable {
     [OutputType([System.Object[]])]
     param (
         [Parameter(Position = 0,
-            Mandatory = $true,
-            ValueFromPipeline = $true)]
+                   Mandatory,
+                   ValueFromPipeline)]
         [AllowNull()]
         [PSObject[]]$InputObject,
         [Parameter(Position = 1)]
         [ValidateSet("Ticks",
-            "TotalDays",
-            "TotalHours",
-            "TotalMinutes",
-            "TotalSeconds",
-            "TotalMilliseconds",
-            "String")]
+                     "TotalDays",
+                     "TotalHours",
+                     "TotalMinutes",
+                     "TotalSeconds",
+                     "TotalMilliseconds",
+                     "String")]
         [ValidateNotNullOrEmpty()]
         [string]$TimeSpanType = "TotalMilliseconds",
         [ValidateSet("Int64", "Int32", "String")]
@@ -102,11 +102,8 @@ function ConvertTo-DbaDataTable {
             [CmdletBinding()]
             param (
                 $type,
-
                 $value,
-
                 $timespantype = 'TotalMilliseconds',
-
                 $sizetype = 'Int64'
             )
 
@@ -204,7 +201,8 @@ function ConvertTo-DbaDataTable {
             [CmdletBinding()]
             Param (
                 $Value,
-                [ValidateSet('Timespan', 'Size')] [string]$Type,
+                [ValidateSet('Timespan', 'Size')]
+                [string]$Type,
                 [string]$SizeType,
                 [string]$TimeSpanType
             )
@@ -408,6 +406,6 @@ function ConvertTo-DbaDataTable {
 
     end {
         Write-Message -Level InternalComment -Message "Finished."
-        , $datatable
+         , $datatable
     }
 }

--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -72,10 +72,10 @@ function Copy-DbaAgentAlert {
     #>
     [cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$Alert,

--- a/functions/Copy-DbaAgentCategory.ps1
+++ b/functions/Copy-DbaAgentCategory.ps1
@@ -82,10 +82,10 @@ function Copy-DbaAgentCategory {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldprocess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [Parameter(ParameterSetName = 'SpecificAlerts')]

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -74,10 +74,10 @@ function Copy-DbaAgentJob {
     #>
     [cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$Job,

--- a/functions/Copy-DbaAgentOperator.ps1
+++ b/functions/Copy-DbaAgentOperator.ps1
@@ -69,11 +69,11 @@ function Copy-DbaAgentOperator {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -69,10 +69,10 @@ function Copy-DbaAgentProxyAccount {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [string[]]$ProxyAccount,

--- a/functions/Copy-DbaAgentServer.ps1
+++ b/functions/Copy-DbaAgentServer.ps1
@@ -69,10 +69,10 @@ function Copy-DbaAgentServer {
     #>
     [cmdletbinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [Switch]$DisableJobsOnDestination,

--- a/functions/Copy-DbaAgentSharedSchedule.ps1
+++ b/functions/Copy-DbaAgentSharedSchedule.ps1
@@ -58,11 +58,11 @@ function Copy-DbaAgentSharedSchedule {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -66,10 +66,10 @@ function Copy-DbaBackupDevice {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$BackupDevice,

--- a/functions/Copy-DbaCentralManagementServer.ps1
+++ b/functions/Copy-DbaCentralManagementServer.ps1
@@ -73,10 +73,10 @@ function Copy-DbaCentralManagementServer {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$CMSGroup,

--- a/functions/Copy-DbaCustomError.ps1
+++ b/functions/Copy-DbaCustomError.ps1
@@ -74,11 +74,11 @@ function Copy-DbaCustomError {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaDataCollector.ps1
+++ b/functions/Copy-DbaDataCollector.ps1
@@ -77,11 +77,11 @@ function Copy-DbaDataCollector {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -166,7 +166,7 @@ function Copy-DbaDatabase {
         [parameter(Mandatory = $false)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [Alias("Databases")]
@@ -176,7 +176,7 @@ function Copy-DbaDatabase {
         [parameter(ParameterSetName = "DbBackup")]
         [parameter(ParameterSetName = "DbAttachDetach")]
         [switch]$AllDatabases,
-        [parameter(Mandatory = $true, ParameterSetName = "DbBackup")]
+        [parameter(Mandatory, ParameterSetName = "DbBackup")]
         [switch]$BackupRestore,
         [parameter(ParameterSetName = "DbBackup",
                    HelpMessage = "Specify a valid network share in the format \\server\share that can be accessed by your account and the SQL Server service accounts for both Source and Destination.")]
@@ -190,7 +190,7 @@ function Copy-DbaDatabase {
         [parameter(ParameterSetName = "DbBackup")]
         [ValidateRange(1, 64)]
         [int]$NumberFiles = 3,
-        [parameter(Mandatory = $true, ParameterSetName = "DbAttachDetach")]
+        [parameter(Mandatory, ParameterSetName = "DbAttachDetach")]
         [switch]$DetachAttach,
         [parameter(ParameterSetName = "DbAttachDetach")]
         [switch]$Reattach,
@@ -252,10 +252,10 @@ function Copy-DbaDatabase {
         #>
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateNotNullOrEmpty()]
                 [string]$servername,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateNotNullOrEmpty()]
                 [string]$filepath
 

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -73,10 +73,10 @@ function Copy-DbaDbAssembly {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$Assembly,

--- a/functions/Copy-DbaDbMail.ps1
+++ b/functions/Copy-DbaDbMail.ps1
@@ -69,9 +69,9 @@ function Copy-DbaDbMail {
     #>
     [cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [Parameter(ParameterSetName = 'SpecificTypes')]
         [ValidateSet('ConfigurationValues', 'Profiles', 'Accounts', 'mailServers')]

--- a/functions/Copy-DbaEndpoint.ps1
+++ b/functions/Copy-DbaEndpoint.ps1
@@ -69,11 +69,11 @@ function Copy-DbaEndpoint {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaExtendedEvent.ps1
+++ b/functions/Copy-DbaExtendedEvent.ps1
@@ -74,9 +74,9 @@ function Copy-DbaExtendedEvent {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $SourceSqlCredential,

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -72,10 +72,10 @@ function Copy-DbaLinkedServer {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$LinkedServer,

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -127,7 +127,7 @@ function Copy-DbaLogin {
         [parameter(ParameterSetName = "SqlInstance", Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$Login,

--- a/functions/Copy-DbaPolicyManagement.ps1
+++ b/functions/Copy-DbaPolicyManagement.ps1
@@ -80,11 +80,11 @@ function Copy-DbaPolicyManagement {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaQueryStoreConfig.ps1
+++ b/functions/Copy-DbaQueryStoreConfig.ps1
@@ -64,12 +64,12 @@ function Copy-DbaQueryStoreConfig {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object]$SourceDatabase,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$DestinationDatabase,

--- a/functions/Copy-DbaResourceGovernor.ps1
+++ b/functions/Copy-DbaResourceGovernor.ps1
@@ -69,10 +69,10 @@ function Copy-DbaResourceGovernor {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$ResourcePool,

--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -69,11 +69,11 @@ function Copy-DbaServerAudit {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaServerAuditSpecification.ps1
+++ b/functions/Copy-DbaServerAuditSpecification.ps1
@@ -69,10 +69,10 @@ function Copy-DbaServerAuditSpecification {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$AuditSpecification,

--- a/functions/Copy-DbaServerTrigger.ps1
+++ b/functions/Copy-DbaServerTrigger.ps1
@@ -69,11 +69,11 @@ function Copy-DbaServerTrigger {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]
         $DestinationSqlCredential,

--- a/functions/Copy-DbaSpConfigure.ps1
+++ b/functions/Copy-DbaSpConfigure.ps1
@@ -69,10 +69,10 @@ function Copy-DbaSpConfigure {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$ConfigName,

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -85,9 +85,9 @@ function Copy-DbaSsisCatalog {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$SourceSqlCredential,
         [PSCredential]$DestinationSqlCredential,

--- a/functions/Copy-DbaSysDbUserObject.ps1
+++ b/functions/Copy-DbaSysDbUserObject.ps1
@@ -54,11 +54,11 @@ function Copy-DbaSysDbUserObject {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -51,7 +51,7 @@ function Disable-DbaAgHadr {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
@@ -63,7 +63,7 @@ function Disable-DbaAgHadr {
         function GetDbaAgHadr {
             [CmdletBinding()]
             param (
-                [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+                [parameter(Mandatory, ValueFromPipeline)]
                 [Alias("ServerInstance", "SqlServer")]
                 [DbaInstanceParameter[]]$SqlInstance,
                 [PSCredential]$Credential,

--- a/functions/Disable-DbaForceNetworkEncryption.ps1
+++ b/functions/Disable-DbaForceNetworkEncryption.ps1
@@ -51,7 +51,7 @@ function Disable-DbaForceNetworkEncryption {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]$SqlInstance = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -37,7 +37,7 @@ function Disable-DbaTraceFlag {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -51,7 +51,7 @@ function Enable-DbaAgHadr {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
@@ -97,7 +97,7 @@ function Enable-DbaAgHadr {
     #>
             [CmdletBinding()]
             param (
-                [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+                [parameter(Mandatory, ValueFromPipeline)]
                 [Alias("ServerInstance", "SqlServer")]
                 [DbaInstanceParameter[]]$SqlInstance,
                 [PSCredential]$Credential,

--- a/functions/Enable-DbaForceNetworkEncryption.ps1
+++ b/functions/Enable-DbaForceNetworkEncryption.ps1
@@ -50,7 +50,7 @@ function Enable-DbaForceNetworkEncryption {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low", DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -40,7 +40,7 @@ function Enable-DbaTraceFlag {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Expand-DbaTLogResponsibly.ps1
+++ b/functions/Expand-DbaTLogResponsibly.ps1
@@ -132,7 +132,7 @@ function Expand-DbaTLogResponsibly {
     #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Default')]
     param (
-        [parameter(Position = 1, Mandatory = $true)]
+        [parameter(Position = 1, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(Position = 3)]
@@ -141,15 +141,15 @@ function Expand-DbaTLogResponsibly {
         [object[]]$Database,
         [parameter(Position = 4)]
         [object[]]$ExcludeDatabase,
-        [parameter(Position = 5, Mandatory = $true)]
+        [parameter(Position = 5, Mandatory)]
         [int]$TargetLogSizeMB,
         [parameter(Position = 6)]
         [int]$IncrementSizeMB = -1,
         [parameter(Position = 7)]
         [int]$LogFileId = -1,
-        [parameter(Position = 8, ParameterSetName = 'Shrink', Mandatory = $true)]
+        [parameter(Position = 8, ParameterSetName = 'Shrink', Mandatory)]
         [switch]$ShrinkLogFile,
-        [parameter(Position = 9, ParameterSetName = 'Shrink', Mandatory = $true)]
+        [parameter(Position = 9, ParameterSetName = 'Shrink', Mandatory)]
         [int]$ShrinkSizeMB,
         [parameter(Position = 10, ParameterSetName = 'Shrink')]
         [AllowEmptyString()]

--- a/functions/Export-DbaAvailabilityGroup.ps1
+++ b/functions/Export-DbaAvailabilityGroup.ps1
@@ -69,7 +69,7 @@ function Export-DbaAvailabilityGroup {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -55,7 +55,7 @@ function Export-DbaDiagnosticQuery {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
         [ValidateSet("Excel", "Csv")]
         [string]$ConvertTo = "Csv",
@@ -94,9 +94,9 @@ function Export-DbaDiagnosticQuery {
         Function Remove-InvalidFileNameChars {
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true,
+                [Parameter(Mandatory,
                     Position = 0,
-                    ValueFromPipeline = $true,
+                    ValueFromPipeline,
                     ValueFromPipelineByPropertyName = $true)]
                 [String]$Name
             )

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -95,7 +95,7 @@ function Export-DbaLogin {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -128,7 +128,7 @@ function Export-DbaScript {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
         [Alias("ScriptingOptionObject")]
         [Microsoft.SqlServer.Management.Smo.ScriptingOptions]$ScriptingOptionsObject,

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -110,7 +110,7 @@ function Export-DbaUser {
     [CmdletBinding(DefaultParameterSetName = "Default")]
     [OutputType([String])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -110,7 +110,7 @@ function Find-DbaAgentJob {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -64,12 +64,12 @@ function Find-DbaBackup {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, HelpMessage = "Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
+        [parameter(Mandatory, HelpMessage = "Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
         [Alias("BackupFolder")]
         [string]$Path,
-        [parameter(Mandatory = $true, HelpMessage = "Backup File extension to remove (ex. bak, trn, dif)")]
+        [parameter(Mandatory, HelpMessage = "Backup File extension to remove (ex. bak, trn, dif)")]
         [string]$BackupFileExtension ,
-        [parameter(Mandatory = $true, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
+        [parameter(Mandatory, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
         [string]$RetentionPeriod ,
         [parameter(Mandatory = $false)]
         [switch]$CheckArchiveBit = $false ,

--- a/functions/Find-DbaDatabase.ps1
+++ b/functions/Find-DbaDatabase.ps1
@@ -60,14 +60,14 @@ function Find-DbaDatabase {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
         [ValidateSet('Name', 'ServiceBrokerGuid', 'Owner')]
         [string]$Property = 'Name',
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Pattern,
         [switch]$Exact,
         [switch]$Detailed,

--- a/functions/Find-DbaDbGrowthEvent.ps1
+++ b/functions/Find-DbaDbGrowthEvent.ps1
@@ -87,7 +87,7 @@ function Find-DbaDbGrowthEvent {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaDisabledIndex.ps1
+++ b/functions/Find-DbaDisabledIndex.ps1
@@ -69,7 +69,7 @@
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Find-DbaDuplicateIndex.ps1
+++ b/functions/Find-DbaDuplicateIndex.ps1
@@ -95,7 +95,7 @@ function Find-DbaDuplicateIndex {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -189,9 +189,9 @@ function Find-DbaInstance {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = 'Computer', ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ParameterSetName = 'Computer', ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
-        [Parameter(Mandatory = $true, ParameterSetName = 'Discover')]
+        [Parameter(Mandatory, ParameterSetName = 'Discover')]
         [Sqlcollaborative.Dbatools.Discovery.DbaInstanceDiscoveryType]$DiscoveryType,
         [System.Management.Automation.PSCredential]$Credential,
         [System.Management.Automation.PSCredential]$SqlCredential,
@@ -230,7 +230,7 @@ function Find-DbaInstance {
         #>
             [CmdletBinding()]
             param (
-                [Parameter(ValueFromPipeline = $true)][DbaInstance[]]$Target,
+                [Parameter(ValueFromPipeline)][DbaInstance[]]$Target,
                 [PSCredential]$Credential,
                 [PSCredential]$SqlCredential,
                 [Sqlcollaborative.Dbatools.Discovery.DbaInstanceScanType]$ScanType,
@@ -607,7 +607,7 @@ function Find-DbaInstance {
         #>
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true, ValueFromPipeline = $true)][DbaInstance[]]$ComputerName,
+                [Parameter(Mandatory, ValueFromPipeline)][DbaInstance[]]$ComputerName,
                 [int]$UDPTimeOut = 2,
                 [switch]$EnableException
             )
@@ -683,7 +683,7 @@ function Find-DbaInstance {
             [CmdletBinding()]
             param (
                 [DbaInstance]$ComputerName,
-                [Parameter(ValueFromPipeline = $true)][int[]]$Port
+                [Parameter(ValueFromPipeline)][int[]]$Port
             )
 
             begin {

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -52,7 +52,7 @@ function Find-DbaLoginInGroup {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -81,7 +81,7 @@ function Find-DbaOrphanedFile {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(Mandatory = $false)]
@@ -126,7 +126,7 @@ function Find-DbaOrphanedFile {
         function Get-SqlFileStructure {
             param
             (
-                [Parameter(Mandatory = $true, Position = 1)]
+                [Parameter(Mandatory, Position = 1)]
                 [Microsoft.SqlServer.Management.Smo.SqlSmoObject]$smoserver
             )
             if ($smoserver.versionMajor -eq 8) {

--- a/functions/Find-DbaSimilarTable.ps1
+++ b/functions/Find-DbaSimilarTable.ps1
@@ -85,7 +85,7 @@ function Find-DbaSimilarTable {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -67,14 +67,14 @@ function Find-DbaStoredProcedure {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Pattern,
         [switch]$IncludeSystemObjects,
         [switch]$IncludeSystemDatabases,

--- a/functions/Find-DbaTrigger.ps1
+++ b/functions/Find-DbaTrigger.ps1
@@ -71,14 +71,14 @@ function Find-DbaTrigger {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Pattern,
         [ValidateSet('All', 'Server', 'Database', 'Object')]
         [string]$TriggerLevel = 'All',

--- a/functions/Find-DbaUnusedIndex.ps1
+++ b/functions/Find-DbaUnusedIndex.ps1
@@ -92,7 +92,7 @@ function Find-DbaUnusedIndex {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -54,7 +54,7 @@ function Find-DbaUserObject {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlInstances")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Find-DbaView.ps1
+++ b/functions/Find-DbaView.ps1
@@ -67,14 +67,14 @@ function Find-DbaView {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Pattern,
         [switch]$IncludeSystemObjects,
         [switch]$IncludeSystemDatabases,

--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -93,7 +93,7 @@ function Format-DbaBackupInformation {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$BackupHistory,
         [object]$ReplaceDatabaseName,
         [switch]$ReplaceDbNameInFile,

--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -55,11 +55,11 @@ function Get-DbaAgDatabase {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [object[]]$AvailabilityGroup,
         [object[]]$Database,
         [Alias('Silent')]

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -35,7 +35,7 @@ function Get-DbaAgHadr {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaAgListener.ps1
+++ b/functions/Get-DbaAgListener.ps1
@@ -57,7 +57,7 @@ function Get-DbaAgListener {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [string[]]$AvailabilityGroup,
         [string[]]$Listener,
         [object[]]$InputObject,

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -51,11 +51,11 @@ function Get-DbaAgReplica {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [object[]]$AvailabilityGroup,
         [object[]]$Replica,
         [Alias('Silent')]

--- a/functions/Get-DbaAgentAlert.ps1
+++ b/functions/Get-DbaAgentAlert.ps1
@@ -37,7 +37,7 @@ function Get-DbaAgentAlert {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -70,7 +70,7 @@ function Get-DbaAgentJob {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaAgentJobCategory.ps1
+++ b/functions/Get-DbaAgentJobCategory.ps1
@@ -55,7 +55,7 @@ function Get-DbaAgentJobCategory {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaAgentJobOutputFile.ps1
+++ b/functions/Get-DbaAgentJobOutputFile.ps1
@@ -83,8 +83,8 @@ function Get-DbaAgentJobOutputFile {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, HelpMessage = 'The SQL Server Instance',
-            ValueFromPipeline = $true,
+        [Parameter(Mandatory, HelpMessage = 'The SQL Server Instance',
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false,
             Position = 0)]

--- a/functions/Get-DbaAgentJobStep.ps1
+++ b/functions/Get-DbaAgentJobStep.ps1
@@ -69,7 +69,7 @@
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Get-DbaAgentLog.ps1
+++ b/functions/Get-DbaAgentLog.ps1
@@ -47,7 +47,7 @@ function Get-DbaAgentLog {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaAgentOperator.ps1
+++ b/functions/Get-DbaAgentOperator.ps1
@@ -56,7 +56,7 @@ function Get-DbaAgentOperator {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Get-DbaAgentProxy.ps1
+++ b/functions/Get-DbaAgentProxy.ps1
@@ -40,7 +40,7 @@
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -43,7 +43,7 @@ function Get-DbaAgentSchedule {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Schedules")]
@@ -56,7 +56,7 @@ function Get-DbaAgentSchedule {
     begin {
         function Get-ScheduleDescription {
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateNotNullOrEmpty()]
                 [object]$Schedule
 

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -56,7 +56,7 @@ function Get-DbaAvailabilityGroup {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaAvailableCollation.ps1
+++ b/functions/Get-DbaAvailableCollation.ps1
@@ -36,7 +36,7 @@ function Get-DbaAvailableCollation {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaBackupDevice.ps1
+++ b/functions/Get-DbaBackupDevice.ps1
@@ -42,7 +42,7 @@ function Get-DbaBackupDevice {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -130,7 +130,7 @@ function Get-DbaBackupHistory {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]
         $SqlInstance,

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -128,9 +128,9 @@ function Get-DbaBackupInformation {
     #>
     [CmdletBinding( DefaultParameterSetName = "Create")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$Path,
-        [parameter(Mandatory = $true, ParameterSetName = "Create")]
+        [parameter(Mandatory, ParameterSetName = "Create")]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(ParameterSetName = "Create")]

--- a/functions/Get-DbaBuildReference.ps1
+++ b/functions/Get-DbaBuildReference.ps1
@@ -62,7 +62,7 @@ function Get-DbaBuildReference {
         [version[]]
         $Build,
 
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [parameter(Mandatory = $false, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]
         $SqlInstance,

--- a/functions/Get-DbaClusterNode.ps1
+++ b/functions/Get-DbaClusterNode.ps1
@@ -46,7 +46,7 @@ function Get-DbaClusterNode {
 
     #>
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaCmConnection.ps1
+++ b/functions/Get-DbaCmConnection.ps1
@@ -46,7 +46,7 @@ function Get-DbaCmConnection {
     [CmdletBinding()]
     param
     (
-        [Parameter(Position = 0, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipeline)]
         [Alias('Filter')]
         [String[]]
         $ComputerName = "*",

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -69,16 +69,16 @@ function Get-DbaCmObject {
     #>
     [CmdletBinding(DefaultParameterSetName = "Class")]
     param (
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Class")]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = "Class")]
         [Alias('Class')]
         [string]
         $ClassName,
 
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = "Query")]
         [string]
         $Query,
 
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
         $ComputerName = $env:COMPUTERNAME,
 

--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -49,7 +49,7 @@ function Get-DbaComputerSystem {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Get-DbaConnection.ps1
+++ b/functions/Get-DbaConnection.ps1
@@ -35,7 +35,7 @@ function Get-DbaConnection {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential", "Cred")]

--- a/functions/Get-DbaCredential.ps1
+++ b/functions/Get-DbaCredential.ps1
@@ -62,7 +62,7 @@ function Get-DbaCredential {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Name,

--- a/functions/Get-DbaCustomError.ps1
+++ b/functions/Get-DbaCustomError.ps1
@@ -41,7 +41,7 @@ function Get-DbaCustomError {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -145,7 +145,7 @@ function Get-DbaDatabase {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaDbAssembly.ps1
+++ b/functions/Get-DbaDbAssembly.ps1
@@ -41,7 +41,7 @@ function Get-DbaDbAssembly {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/functions/Get-DbaDbCompression.ps1
+++ b/functions/Get-DbaDbCompression.ps1
@@ -47,7 +47,7 @@ function Get-DbaDbCompression {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaDbEncryption.ps1
+++ b/functions/Get-DbaDbEncryption.ps1
@@ -57,7 +57,7 @@ function Get-DbaDbEncryption {
             List all encryption found for all databases including the system databases.
     #>
     [CmdletBinding()]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaDbExtentDiff.ps1
+++ b/functions/Get-DbaDbExtentDiff.ps1
@@ -51,7 +51,7 @@ function Get-DbaDbExtentDiff {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaDbMailHistory.ps1
+++ b/functions/Get-DbaDbMailHistory.ps1
@@ -51,7 +51,7 @@ function Get-DbaDbMailHistory {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDbMailLog.ps1
+++ b/functions/Get-DbaDbMailLog.ps1
@@ -51,7 +51,7 @@ function Get-DbaDbMailLog {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDbQueryStoreOption.ps1
+++ b/functions/Get-DbaDbQueryStoreOption.ps1
@@ -57,7 +57,7 @@ function Get-DbaDbQueryStoreOption {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDbSnapshot.ps1
+++ b/functions/Get-DbaDbSnapshot.ps1
@@ -41,7 +41,7 @@ function Get-DbaDbSnapshot {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDbSpace.ps1
+++ b/functions/Get-DbaDbSpace.ps1
@@ -59,7 +59,7 @@ function Get-DbaDbSpace {
             Returns database files and free space information for the db1 and db2 on localhost.
     #>
     [CmdletBinding()]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [System.Management.Automation.PSCredential]$SqlCredential,

--- a/functions/Get-DbaDbState.ps1
+++ b/functions/Get-DbaDbState.ps1
@@ -64,7 +64,7 @@ Gets options for all databases of sqlserver2014a and sqlserver2014b instances
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseLiteralInitializerForHashtable", "")]
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDbVirtualLogFile.ps1
+++ b/functions/Get-DbaDbVirtualLogFile.ps1
@@ -67,7 +67,7 @@ function Get-DbaDbVirtualLogFile {
     #>
     [CmdletBinding()]
     [OutputType([System.Collections.ArrayList])]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaDefaultPath.ps1
+++ b/functions/Get-DbaDefaultPath.ps1
@@ -40,7 +40,7 @@ function Get-DbaDefaultPath {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaDependency.ps1
+++ b/functions/Get-DbaDependency.ps1
@@ -51,7 +51,7 @@ function Get-DbaDependency {
     #>
     [CmdletBinding()]
     Param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         $InputObject,
 
         [switch]
@@ -139,7 +139,7 @@ function Get-DbaDependency {
         function Get-DependencyTreeNodeDetail {
             [CmdletBinding()]
             Param (
-                [Parameter(ValueFromPipeline = $true)]
+                [Parameter(ValueFromPipeline)]
                 $SmoObject,
 
                 $Server,
@@ -195,7 +195,7 @@ function Get-DbaDependency {
         function Select-DependencyPrecedence {
             [CmdletBinding()]
             Param (
-                [Parameter(ValueFromPipeline = $true)]
+                [Parameter(ValueFromPipeline)]
                 $Dependency
             )
 

--- a/functions/Get-DbaDetachedDatabaseInfo.ps1
+++ b/functions/Get-DbaDetachedDatabaseInfo.ps1
@@ -39,10 +39,10 @@ function Get-DbaDetachedDatabaseInfo {
 
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("Mdf")]
         [string]$Path,
         [PSCredential]$SqlCredential

--- a/functions/Get-DbaDiskSpace.ps1
+++ b/functions/Get-DbaDiskSpace.ps1
@@ -91,7 +91,7 @@ function Get-DbaDiskSpace {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlInstance', 'SqlServer')]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Get-DbaDump.ps1
+++ b/functions/Get-DbaDump.ps1
@@ -42,7 +42,7 @@ function Get-DbaDump {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaEndpoint.ps1
+++ b/functions/Get-DbaEndpoint.ps1
@@ -42,7 +42,7 @@ function Get-DbaEndpoint {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/functions/Get-DbaErrorLog.ps1
+++ b/functions/Get-DbaErrorLog.ps1
@@ -82,7 +82,7 @@ function Get-DbaErrorLog {
         #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaEstimatedCompletionTime.ps1
+++ b/functions/Get-DbaEstimatedCompletionTime.ps1
@@ -73,7 +73,7 @@ Gets estimated completion times for queries performed against the Northwind, pub
 #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaExecutionPlan.ps1
+++ b/functions/Get-DbaExecutionPlan.ps1
@@ -74,7 +74,7 @@ Gets super detailed information for execution plans on only for AdventureWorks20
 #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -68,7 +68,7 @@ Finds files in E:\Dir1 ending with ".fsf" and ".mld" for both the servers sql201
 #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaForceNetworkEncryption.ps1
+++ b/functions/Get-DbaForceNetworkEncryption.ps1
@@ -46,7 +46,7 @@ function Get-DbaForceNetworkEncryption {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,

--- a/functions/Get-DbaInstanceProperty.ps1
+++ b/functions/Get-DbaInstanceProperty.ps1
@@ -68,7 +68,7 @@ function Get-DbaInstanceProperty {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaInstanceUserOption.ps1
+++ b/functions/Get-DbaInstanceUserOption.ps1
@@ -46,7 +46,7 @@ function Get-DbaInstanceUserOption {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -57,7 +57,7 @@ function Get-DbaLastBackup {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -65,7 +65,7 @@ function Get-DbaLastGoodCheckDb {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaLogShippingError.ps1
+++ b/functions/Get-DbaLogShippingError.ps1
@@ -82,7 +82,7 @@ function Get-DbaLogShippingError {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -133,7 +133,7 @@ function Get-DbaLogin {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -70,7 +70,7 @@ function Get-DbaMaintenanceSolutionLog {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaMaxMemory.ps1
+++ b/functions/Get-DbaMaxMemory.ps1
@@ -39,7 +39,7 @@ function Get-DbaMaxMemory {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaModule.ps1
+++ b/functions/Get-DbaModule.ps1
@@ -65,7 +65,7 @@ function Get-DbaModule {
 #>
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaMsdtc.ps1
+++ b/functions/Get-DbaMsdtc.ps1
@@ -46,7 +46,7 @@ function Get-DbaMsdtc {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias('cn', 'host', 'Server')]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME
     )

--- a/functions/Get-DbaOpenTransaction.ps1
+++ b/functions/Get-DbaOpenTransaction.ps1
@@ -39,7 +39,7 @@
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -41,7 +41,7 @@ function Get-DbaOperatingSystem {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Get-DbaOrphanUser.ps1
+++ b/functions/Get-DbaOrphanUser.ps1
@@ -57,7 +57,7 @@ function Get-DbaOrphanUser {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaPageFileSetting.ps1
+++ b/functions/Get-DbaPageFileSetting.ps1
@@ -45,7 +45,7 @@ function Get-DbaPageFileSetting {
     
     [CmdletBinding()]
     param (
-        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName = $true)]
         [Alias("cn", "host", "ServerInstance", "Server", "SqlServer")]
         [DbaInstance]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -69,7 +69,7 @@ function Get-DbaPermission {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaProcess.ps1
+++ b/functions/Get-DbaProcess.ps1
@@ -73,7 +73,7 @@ function Get-DbaProcess {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaProductKey.ps1
+++ b/functions/Get-DbaProductKey.ps1
@@ -56,7 +56,7 @@ Gets SQL Server versions, editions and product keys for all instances within eac
         Function Unlock-SqlInstanceKey {
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [byte[]]$data,
                 [int]$version
             )

--- a/functions/Get-DbaQueryExecutionTime.ps1
+++ b/functions/Get-DbaQueryExecutionTime.ps1
@@ -64,7 +64,7 @@ limiting results to queries with more than 200 total executions and an execution
 #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaRepPublication.ps1
+++ b/functions/Get-DbaRepPublication.ps1
@@ -48,7 +48,7 @@ function Get-DbaRepPublication {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [object[]]$Database,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaRestoreHistory.ps1
+++ b/functions/Get-DbaRestoreHistory.ps1
@@ -73,7 +73,7 @@ function Get-DbaRestoreHistory {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -44,7 +44,7 @@ function Get-DbaRunningJob {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaSchemaChangeHistory.ps1
+++ b/functions/Get-DbaSchemaChangeHistory.ps1
@@ -67,7 +67,7 @@ function Get-DbaSchemaChangeHistory {
 
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaServerAudit.ps1
+++ b/functions/Get-DbaServerAudit.ps1
@@ -47,7 +47,7 @@ function Get-DbaServerAudit {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaServerAuditSpecification.ps1
+++ b/functions/Get-DbaServerAuditSpecification.ps1
@@ -41,7 +41,7 @@ function Get-DbaServerAuditSpecification {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/functions/Get-DbaServerInstallDate.ps1
+++ b/functions/Get-DbaServerInstallDate.ps1
@@ -64,7 +64,7 @@ Returns an object with SQL Instance install date as a string for every server li
 #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Get-DbaServerRole.ps1
+++ b/functions/Get-DbaServerRole.ps1
@@ -47,7 +47,7 @@ function Get-DbaServerRole {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$ServerRole,

--- a/functions/Get-DbaService.ps1
+++ b/functions/Get-DbaService.ps1
@@ -73,7 +73,7 @@ function Get-DbaService {
     #>
     [CmdletBinding(DefaultParameterSetName = "Search")]
     Param (
-        [parameter(ValueFromPipeline = $true, Position = 1)]
+        [parameter(ValueFromPipeline, Position = 1)]
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [Parameter(ParameterSetName = "Search")]
@@ -201,7 +201,7 @@ function Get-DbaService {
                                 }
                                 Add-Member -Force -InputObject $service -MemberType ScriptMethod -Name "ChangeStartMode" -Value {
                                     Param (
-                                        [parameter(Mandatory = $true)]
+                                        [parameter(Mandatory)]
                                         [string]$Mode
                                     )
                                     $supportedModes = @("Automatic", "Manual", "Disabled")

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -55,7 +55,7 @@ function Get-DbaSpConfigure {
         #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -50,7 +50,7 @@ function Get-DbaSpn {
     #>
     [cmdletbinding()]
     param (
-        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $false, ValueFromPipeline)]
         [string[]]$ComputerName,
         [Parameter(Mandatory = $false)]
         [string[]]$AccountName,

--- a/functions/Get-DbaSsisExecutionHistory.ps1
+++ b/functions/Get-DbaSsisExecutionHistory.ps1
@@ -63,7 +63,7 @@ function Get-DbaSsisExecutionHistory {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [datetime]$Since,

--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -45,7 +45,7 @@ function Get-DbaStartupParameter {
         https://dbatools.io/Get-DbaStartupParameter
 #>
     [CmdletBinding()]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("SqlCredential")]

--- a/functions/Get-DbaTable.ps1
+++ b/functions/Get-DbaTable.ps1
@@ -66,7 +66,7 @@ Returns information on the CommandLog table in the DBA database on both instance
 
 #>
     [CmdletBinding()]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -63,7 +63,7 @@ function Get-DbaTcpPort {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Get-DbaTempdbUsage.ps1
+++ b/functions/Get-DbaTempdbUsage.ps1
@@ -39,7 +39,7 @@ function Get-DbaTempdbUsage {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaTopResourceUsage.ps1
+++ b/functions/Get-DbaTopResourceUsage.ps1
@@ -68,7 +68,7 @@ function Get-DbaTopResourceUsage {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaTraceFlag.ps1
+++ b/functions/Get-DbaTraceFlag.ps1
@@ -50,7 +50,7 @@ function Get-DbaTraceFlag {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Get-DbaUptime.ps1
+++ b/functions/Get-DbaUptime.ps1
@@ -57,7 +57,7 @@ function Get-DbaUptime {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -62,7 +62,7 @@ function Get-DbaUserPermission {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaWaitResource.ps1
+++ b/functions/Get-DbaWaitResource.ps1
@@ -51,11 +51,11 @@ function Get-DbaWaitResource {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance]$SqlInstance,
         [PsCredential]$SqlCredential,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [string]$WaitResource,
         [switch]$Row,
         [switch]$EnableException

--- a/functions/Get-DbaWaitStatistic.ps1
+++ b/functions/Get-DbaWaitStatistic.ps1
@@ -77,7 +77,7 @@
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaWaitingTask.ps1
+++ b/functions/Get-DbaWaitingTask.ps1
@@ -47,7 +47,7 @@ function Get-DbaWaitingTask {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbaWindowsLog.ps1
+++ b/functions/Get-DbaWindowsLog.ps1
@@ -56,7 +56,7 @@ function Get-DbaWindowsLog {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,

--- a/functions/Get-DbaXESession.ps1
+++ b/functions/Get-DbaXESession.ps1
@@ -49,7 +49,7 @@ function Get-DbaXESession {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Get-DbatoolsConfigValue.ps1
+++ b/functions/Get-DbatoolsConfigValue.ps1
@@ -37,7 +37,7 @@ function Get-DbatoolsConfigValue {
     [CmdletBinding()]
     Param (
         [Alias('Name')]
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$FullName,
         [object]$Fallback,
         [switch]$NotNull

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -178,7 +178,7 @@ function Import-DbaCsvToSql {
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
         [string[]]$Csv,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [object]$SqlCredential,
@@ -277,11 +277,11 @@ function Import-DbaCsvToSql {
             #>
 
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string[]]$Csv,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string]$Delimiter,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [bool]$FirstRowColumns
             )
 
@@ -317,9 +317,9 @@ function Import-DbaCsvToSql {
                     Array of column data
              #>
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string[]]$Csv,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string]$Delimiter
             )
             $columnparser = New-Object Microsoft.VisualBasic.FileIO.TextFieldParser($csv[0])
@@ -360,14 +360,14 @@ function Import-DbaCsvToSql {
                     Returns an array of existing schema files that have been moved, if any.
              #>
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string[]]$Csv,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string[]]$Columns,
                 [string[]]$ColumnText,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string]$Delimiter,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [bool]$FirstRowColumns
             )
 
@@ -438,9 +438,9 @@ function Import-DbaCsvToSql {
             #>
 
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string[]]$Csv,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string]$Delimiter,
                 [string[]]$Columns,
                 [string[]]$ColumnText,

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -103,7 +103,7 @@ function Install-DbaMaintenanceSolution {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -66,7 +66,7 @@ function Install-DbaWhoIsActive {
 
     [CmdletBinding(SupportsShouldProcess)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [parameter(Mandatory, ValueFromPipeline, Position = 0)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PsCredential]$SqlCredential,

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -100,7 +100,7 @@ function Invoke-DbaAdvancedRestore {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Object[]]$BackupHistory,
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,

--- a/functions/Invoke-DbaBalanceDataFiles.ps1
+++ b/functions/Invoke-DbaBalanceDataFiles.ps1
@@ -84,7 +84,7 @@ function Invoke-DbaBalanceDataFiles {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(ParameterSetName = "Pipe", Mandatory = $true)]
+        [parameter(ParameterSetName = "Pipe", Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]

--- a/functions/Invoke-DbaCycleErrorLog.ps1
+++ b/functions/Invoke-DbaCycleErrorLog.ps1
@@ -55,7 +55,7 @@ function Invoke-DbaCycleErrorLog {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Invoke-DbaDbDecryptObject.ps1
+++ b/functions/Invoke-DbaDbDecryptObject.ps1
@@ -87,7 +87,7 @@ function Invoke-DbaDbDecryptObject {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [object[]]$Database,
         [string[]]$ObjectName,
         [ValidateSet('ASCII', 'UTF8')]
@@ -100,11 +100,11 @@ function Invoke-DbaDbDecryptObject {
 
         function Invoke-DecryptData() {
             param(
-                [parameter(Mandatory = $true)]
+                [parameter(Mandatory)]
                 [byte[]]$Secret,
-                [parameter(Mandatory = $true)]
+                [parameter(Mandatory)]
                 [byte[]]$KnownPlain,
-                [parameter(Mandatory = $true)]
+                [parameter(Mandatory)]
                 [byte[]]$KnownSecret
             )
 

--- a/functions/Invoke-DbaDbShrink.ps1
+++ b/functions/Invoke-DbaDbShrink.ps1
@@ -123,7 +123,7 @@ function Invoke-DbaDbShrink {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -133,7 +133,7 @@ function Invoke-DbaDiagnosticQuery {
     [CmdletBinding(SupportsShouldProcess)]
     [outputtype([pscustomobject[]])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [parameter(Mandatory, ValueFromPipeline, Position = 0)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
 
@@ -168,7 +168,7 @@ function Invoke-DbaDiagnosticQuery {
         function Invoke-DiagnosticQuerySelectionHelper {
             [CmdletBinding()]
             Param (
-                [parameter(Mandatory = $true)]
+                [parameter(Mandatory)]
                 $ParsedScript
             )
 

--- a/functions/Invoke-DbaLogShipping.ps1
+++ b/functions/Invoke-DbaLogShipping.ps1
@@ -387,12 +387,12 @@ function Invoke-DbaLogShipping {
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
 
     param(
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("SourceServerInstance", "SourceSqlServerSqlServer", "Source")]
         [object]$SourceSqlInstance,
 
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("DestinationServerInstance", "DestinationSqlServer", "Destination")]
         [object]$DestinationSqlInstance,
@@ -413,10 +413,10 @@ function Invoke-DbaLogShipping {
         [System.Management.Automation.PSCredential]
         $DestinationCredential,
 
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [object[]]$Database,
 
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$BackupNetworkPath,
 
         [parameter(Mandatory = $false)]

--- a/functions/Invoke-DbaLogShippingRecovery.ps1
+++ b/functions/Invoke-DbaLogShippingRecovery.ps1
@@ -89,10 +89,10 @@ function Invoke-DbaLogShippingRecovery {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [object[]]$Database,
         [PSCredential]$SqlCredential,
         [switch]$NoRecovery,

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -88,7 +88,7 @@ function Invoke-DbaQuery {
     #>
     [CmdletBinding(DefaultParameterSetName = "Query")]
     Param (
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]
         $SqlInstance,
@@ -99,18 +99,18 @@ function Invoke-DbaQuery {
 
         [object]$Database,
 
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = "Query")]
         [string]
         $Query,
 
         [Int32]
         $QueryTimeout = 600,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "File")]
+        [Parameter(Mandatory, ParameterSetName = "File")]
         [object[]]
         $File,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "SMO")]
+        [Parameter(Mandatory, ParameterSetName = "SMO")]
         [Microsoft.SqlServer.Management.Smo.SqlSmoObject[]]
         $SqlObject,
 
@@ -127,7 +127,7 @@ function Invoke-DbaQuery {
         [switch]
         $MessagesToOutput,
 
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
 
         [Alias('Silent')]

--- a/functions/Invoke-DbaWhoisActive.ps1
+++ b/functions/Invoke-DbaWhoisActive.ps1
@@ -194,7 +194,7 @@ function Invoke-DbaWhoIsActive {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]

--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -176,15 +176,15 @@ function Invoke-Sqlcmd2 {
     param (
         [Parameter(ParameterSetName = 'Ins-Que',
             Position = 0,
-            Mandatory = $true,
-            ValueFromPipeline = $true,
+            Mandatory,
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false,
             HelpMessage = 'SQL Server Instance required...')]
         [Parameter(ParameterSetName = 'Ins-Fil',
             Position = 0,
-            Mandatory = $true,
-            ValueFromPipeline = $true,
+            Mandatory,
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false,
             HelpMessage = 'SQL Server Instance required...')]
@@ -198,23 +198,23 @@ function Invoke-Sqlcmd2 {
         [string]$Database,
         [Parameter(ParameterSetName = 'Ins-Que',
             Position = 2,
-            Mandatory = $true,
+            Mandatory,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Con-Que',
             Position = 2,
-            Mandatory = $true,
+            Mandatory,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [string]$Query,
         [Parameter(ParameterSetName = 'Ins-Fil',
             Position = 2,
-            Mandatory = $true,
+            Mandatory,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Con-Fil',
             Position = 2,
-            Mandatory = $true,
+            Mandatory,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [ValidateScript( { Test-Path -LiteralPath $_ })]

--- a/functions/Measure-DbaBackupThroughput.ps1
+++ b/functions/Measure-DbaBackupThroughput.ps1
@@ -89,7 +89,7 @@ function Measure-DbaBackupThroughput {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Measure-DbaDiskSpaceRequirement.ps1
+++ b/functions/Measure-DbaDiskSpaceRequirement.ps1
@@ -70,13 +70,13 @@ function Measure-DbaDiskSpaceRequirement {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [DbaInstanceParameter]$Source,
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [string]$Database,
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [PSCredential]$SourceSqlCredential,
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [DbaInstanceParameter]$Destination,
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
         [string]$DestinationDatabase,
@@ -93,7 +93,7 @@ function Measure-DbaDiskSpaceRequirement {
         function Get-MountPoint {
             [CmdletBinding()]
             param(
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 $computerName,
                 [PSCredential]$credential
             )
@@ -103,9 +103,9 @@ function Measure-DbaDiskSpaceRequirement {
         function Get-MountPointFromPath {
             [CmdletBinding()]
             param(
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 $path,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 $computerName,
                 [PSCredential]$credential
             )
@@ -133,10 +133,10 @@ function Measure-DbaDiskSpaceRequirement {
         function Get-MountPointFromDefaultPath {
             [CmdletBinding()]
             param(
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateSet('Log', 'Data')]
                 $DefaultPathType,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 $SqlInstance,
                 [PSCredential]$SqlCredential,
                 # Could probably use the computer defined in SqlInstance but info was already available from the caller

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -128,7 +128,7 @@ Creates a job with the name "Job One" on multiple servers using the pipe line
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -59,11 +59,11 @@ Creates a new job category with the name 'Category 2' and assign the category ty
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Category,
         [ValidateSet("LocalJob", "MultiServerJob", "None")]

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -128,15 +128,15 @@ Create a step in "Job1" with the name Step1 where the database will the "msdb" f
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,
         [int]$StepId,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$StepName,
         [ValidateSet('ActiveScripting', 'AnalysisCommand', 'AnalysisQuery', 'CmdExec', 'Distribution', 'LogReader', 'Merge', 'PowerShell', 'QueueReader', 'Snapshot', 'Ssis', 'TransactSql')]

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -94,7 +94,7 @@ function New-DbaAgentProxy {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
-        [parameter(Mandatory, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -124,7 +124,7 @@ function New-DbaAgentSchedule {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [System.Management.Automation.PSCredential]

--- a/functions/New-DbaCmConnection.ps1
+++ b/functions/New-DbaCmConnection.ps1
@@ -99,7 +99,7 @@ function New-DbaCmConnection {
     #>
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
         $ComputerName = $env:COMPUTERNAME,
         [Parameter(ParameterSetName = "Credential")]

--- a/functions/New-DbaConnectionStringBuilder.ps1
+++ b/functions/New-DbaConnectionStringBuilder.ps1
@@ -62,7 +62,7 @@ function New-DbaConnectionStringBuilder {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams", "")]
     param (
-        [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $false, ValueFromPipeline)]
         [string[]]$ConnectionString = "",
         [Parameter(Mandatory = $false)]
         [string]$ApplicationName = "dbatools Powershell Module",

--- a/functions/New-DbaDirectory.ps1
+++ b/functions/New-DbaDirectory.ps1
@@ -48,10 +48,10 @@ function New-DbaDirectory {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$Path,
         [PSCredential]$SqlCredential,
         [switch]$EnableException

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -114,7 +114,7 @@ function New-DbaLogin {
         [parameter(ParameterSetName = "MapToCertificate")]
         [parameter(ParameterSetName = "MapToAsymmetricKey")]
         [string[]]$Login,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [parameter(ParameterSetName = "Password")]
         [parameter(ParameterSetName = "PasswordHash")]
         [parameter(ParameterSetName = "MapToCertificate")]

--- a/functions/New-DbaSsisCatalog.ps1
+++ b/functions/New-DbaSsisCatalog.ps1
@@ -54,11 +54,11 @@ function New-DbaSsisCatalog {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Security.SecureString]$Password,
         [string]$SsisCatalog = "SSISDB",
         [Alias('Silent')]

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -87,11 +87,11 @@ function Read-DbaBackupHeader {
     <# AzureCredential is utilized in this command is not a formal Credential object. #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance]$SqlInstance,
         [PsCredential]$SqlCredential,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$Path,
         [switch]$Simple,
         [switch]$FileList,

--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -50,11 +50,11 @@ Will read the contents of the transaction log of MyDatabase on SQL Server Instan
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Position = 0, Mandatory = $true)]
+        [parameter(Position = 0, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [object]$Database,
         [Switch]$IgnoreLimit,
         [Alias('Silent')]

--- a/functions/Register-DbatoolsConfig.ps1
+++ b/functions/Register-DbatoolsConfig.ps1
@@ -53,11 +53,11 @@
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Configuration.Config[]]$Config,
-        [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline)]
         [string[]]$FullName,
-        [Parameter(Mandatory = $true, ParameterSetName = "Name", Position = 0)]
+        [Parameter(Mandatory, ParameterSetName = "Name", Position = 0)]
         [string]$Module,
         [Parameter(ParameterSetName = "Name", Position = 1)]
         [string]$Name = "*",

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -60,7 +60,7 @@ Remove multiple job categories from the multiple instances.
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -69,15 +69,15 @@ function Remove-DbaAgentJobStep {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$StepName,
         [DbaMode]$Mode = (Get-DbatoolsConfigValue -Name 'message.mode.default' -Fallback "Strict"),

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -75,12 +75,12 @@ Remove the schedules using a pipeline
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
 
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "instance")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "instance")]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [System.Management.Automation.PSCredential]
         $SqlCredential,
-        [Parameter(Mandatory = $true, ParameterSetName = "instance")]
+        [Parameter(Mandatory, ParameterSetName = "instance")]
         [ValidateNotNullOrEmpty()]
         [Alias("Schedules")]
         [object[]]$Schedule,

--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -84,12 +84,12 @@ function Remove-DbaBackup {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, HelpMessage = "Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
+        [parameter(Mandatory, HelpMessage = "Full path to the root level backup folder (ex. 'C:\SQL\Backups'")]
         [Alias("BackupFolder")]
         [string]$Path,
-        [parameter(Mandatory = $true, HelpMessage = "Backup File extension to remove (ex. bak, trn, dif)")]
+        [parameter(Mandatory, HelpMessage = "Backup File extension to remove (ex. bak, trn, dif)")]
         [string]$BackupFileExtension ,
-        [parameter(Mandatory = $true, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
+        [parameter(Mandatory, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
         [string]$RetentionPeriod ,
         [parameter(Mandatory = $false)]
         [switch]$CheckArchiveBit = $false ,

--- a/functions/Remove-DbaClientAlias.ps1
+++ b/functions/Remove-DbaClientAlias.ps1
@@ -51,7 +51,7 @@ function Remove-DbaClientAlias {
         [parameter(ValueFromPipelineByPropertyName = $true)]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [Alias('AliasName')]
         [string[]]$Alias,
         [Alias('Silent')]

--- a/functions/Remove-DbaCmConnection.ps1
+++ b/functions/Remove-DbaCmConnection.ps1
@@ -38,7 +38,7 @@ function Remove-DbaCmConnection {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [Parameter(ValueFromPipeline, Mandatory)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
         $ComputerName,
 

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -110,7 +110,7 @@ function Remove-DbaDatabaseSafely {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [Alias("Credential")]
@@ -125,7 +125,7 @@ function Remove-DbaDatabaseSafely {
         [parameter(Mandatory = $false)]
         [Alias("NoCheck")]
         [switch]$NoDbccCheckDb,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$BackupFolder,
         [parameter(Mandatory = $false)]
         [string]$CategoryName = 'Rationalisation',
@@ -304,16 +304,16 @@ function Remove-DbaDatabaseSafely {
             #>
 
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [Alias('ServerInstance', 'SqlInstance', 'SqlServer')]
                 [object]$server,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateNotNullOrEmpty()]
                 [string]$dbname,
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [string]$backupfile,
                 [string]$filetype = 'Database',
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [object]$filestructure,
                 [switch]$norecovery,
                 [PSCredential]$sqlCredential,

--- a/functions/Remove-DbaNetworkCertificate.ps1
+++ b/functions/Remove-DbaNetworkCertificate.ps1
@@ -49,7 +49,7 @@ function Remove-DbaNetworkCertificate {
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low", DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,

--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -88,7 +88,7 @@ function Remove-DbaOrphanUser {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
@@ -97,7 +97,7 @@ function Remove-DbaOrphanUser {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [parameter(Mandatory = $false, ValueFromPipeline)]
         [object[]]$User,
         [switch]$Force,
         [Alias('Silent')]

--- a/functions/Remove-DbaSpn.ps1
+++ b/functions/Remove-DbaSpn.ps1
@@ -71,10 +71,10 @@ Removes all set SPNs for sql2005 and the relative delegations
 #>
     [cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Default")]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("RequiredSPN")]
         [string]$SPN,
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("InstanceServiceAccount", "AccountName")]
         [string]$ServiceAccount,
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]

--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -63,12 +63,12 @@ WhatIf Example
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Login,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$NewLogin,
         [switch]$EnableException
     )

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -90,14 +90,14 @@ function Repair-DbaOrphanUser {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [parameter(Mandatory = $false, ValueFromPipeline)]
         [object[]]$Users,
         [switch]$RemoveNotExisting,
         [switch]$Force,

--- a/functions/Repair-DbaServerName.ps1
+++ b/functions/Repair-DbaServerName.ps1
@@ -62,7 +62,7 @@ function Repair-DbaServerName {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -84,7 +84,7 @@ function Reset-DbaAdmin {
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]
         $SqlInstance,
@@ -106,7 +106,7 @@ function Reset-DbaAdmin {
              #>
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [Security.SecureString]
                 $Password
             )
@@ -124,7 +124,7 @@ function Reset-DbaAdmin {
             [OutputType([System.Boolean])]
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [Alias("ServerInstance", "SqlServer")]
                 [DbaInstanceParameter]
                 $SqlInstance,

--- a/functions/Restart-DbaService.ps1
+++ b/functions/Restart-DbaService.ps1
@@ -88,7 +88,7 @@ function Restart-DbaService {
         [string[]]$InstanceName,
         [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS")]
         [string[]]$Type,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "Service")]
+        [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "Service")]
         [Alias("ServiceCollection")]
         [object[]]$InputObject,
         [int]$Timeout = 30,

--- a/functions/Restore-DbaBackupFromDirectory.ps1
+++ b/functions/Restore-DbaBackupFromDirectory.ps1
@@ -52,10 +52,10 @@ function Restore-DbaBackupFromDirectory {
     #Requires -Version 3.0
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string]$Path,
         [switch]$NoRecovery,
         [Alias("ReuseFolderStructure")]

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -302,14 +302,14 @@ function Restore-DbaDatabase {
 #>
     [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Restore")]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "Restore")]
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "RestorePage")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
         [object[]]$Path,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Alias("Name")]
         [object[]]$DatabaseName,
         [parameter(ParameterSetName = "Restore")]
@@ -381,9 +381,9 @@ function Restore-DbaDatabase {
         [switch]$StopAfterFormatBackupInformation,
         [string]$TestBackupInformation,
         [switch]$StopAfterTestBackupInformation,
-        [parameter(Mandatory = $true, ParameterSetName = "RestorePage")]
+        [parameter(Mandatory, ParameterSetName = "RestorePage")]
         [object]$PageRestore,
-        [parameter(Mandatory = $true, ParameterSetName = "RestorePage")]
+        [parameter(Mandatory, ParameterSetName = "RestorePage")]
         [string]$PageRestoreTailFolder,
         [int]$StatementTimeout = 0
 

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -47,12 +47,12 @@ Imports all the certificates in the specified path.
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$Path,
         [object]$Database = "master",
         [Security.SecureString]$Password = (Read-Host "Password" -AsSecureString),

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -74,7 +74,7 @@ function Select-DbaBackupInformation {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object]$BackupHistory,
         [DateTime]$RestoreTime = (get-date).addmonths(1),
         [switch]$IgnoreLogs,

--- a/functions/Set-DbaAgentAlert.ps1
+++ b/functions/Set-DbaAgentAlert.ps1
@@ -80,7 +80,7 @@ Doesn't Change the alert but shows what would happen.
         [switch]$Enabled,
         [switch]$Disabled,
         [switch]$Force,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Agent.Alert[]]$InputObject,
         [switch][Alias('Silent')]
         $EnableException

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -171,7 +171,7 @@ Changes a job with the name "Job1" on multiple servers to have another descripti
         [ValidateSet(0, "Never", 1, "OnSuccess", 2, "OnFailure", 3, "Always")]
         [object]$DeleteLevel,
         [switch]$Force,
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Agent.Job[]]$InputObject,
         [switch][Alias('Silent')]
         $EnableException

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -57,7 +57,7 @@ Rename multiple jobs in one go on multiple servers.
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Set-DbaAgentJobOutputFile.ps1
+++ b/functions/Set-DbaAgentJobOutputFile.ps1
@@ -49,8 +49,8 @@ function Set-DbaAgentJobOutputFile {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true, HelpMessage = 'The SQL Server Instance',
-            ValueFromPipeline = $true,
+        [Parameter(Mandatory, HelpMessage = 'The SQL Server Instance',
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false,
             Position = 0)]
@@ -59,19 +59,19 @@ function Set-DbaAgentJobOutputFile {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Parameter(Mandatory = $false, HelpMessage = 'SQL Credential',
-            ValueFromPipeline = $true,
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [PSCredential]$SqlCredential,
         [object[]]$Job,
         [Parameter(Mandatory = $false, HelpMessage = 'The Job Step name',
-            ValueFromPipeline = $true,
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNull()]
         [ValidateNotNullOrEmpty()]
         [object[]]$Step,
-        [Parameter(Mandatory = $true, HelpMessage = 'The Full Output File Path',
-            ValueFromPipeline = $true,
+        [Parameter(Mandatory, HelpMessage = 'The Full Output File Path',
+            ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [ValidateNotNull()]

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -131,15 +131,15 @@ Changes the database of the step in "Job1" with the name Step1 to msdb for multi
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$StepName,
         [Parameter(Mandatory = $false)]

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -123,15 +123,15 @@ Changes the schedule for Job1 with the name 'daily' to enabled on multiple serve
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
 
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [object[]]$Job,
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$ScheduleName,
         [Parameter(Mandatory = $false)]

--- a/functions/Set-DbaCmConnection.ps1
+++ b/functions/Set-DbaCmConnection.ps1
@@ -126,7 +126,7 @@ function Set-DbaCmConnection {
     #>
     [CmdletBinding(DefaultParameterSetName = 'Credential')]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
         $ComputerName = $env:COMPUTERNAME,
 

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -95,7 +95,7 @@ function Set-DbaDbCompression {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Set-DbaDbOwner.ps1
+++ b/functions/Set-DbaDbOwner.ps1
@@ -62,7 +62,7 @@ function Set-DbaDbOwner {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Set-DbaDbQueryStoreOption.ps1
+++ b/functions/Set-DbaDbQueryStoreOption.ps1
@@ -91,7 +91,7 @@ function Set-DbaDbQueryStoreOption {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Set-DbaDbState.ps1
+++ b/functions/Set-DbaDbState.ps1
@@ -117,7 +117,7 @@ function Set-DbaDbState {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipelineByPropertyName, ParameterSetName = "Server")]
+        [parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = "Server")]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
@@ -139,7 +139,7 @@ function Set-DbaDbState {
         [switch]$Force,
         [Alias('Silent')]
         [switch]$EnableException,
-        [parameter(Mandatory = $true, ValueFromPipeline, ParameterSetName = "Database")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Database")]
         [PsCustomObject[]]$InputObject
     )
 

--- a/functions/Set-DbaJobOwner.ps1
+++ b/functions/Set-DbaJobOwner.ps1
@@ -68,7 +68,7 @@ function Set-DbaJobOwner {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -132,11 +132,11 @@ function Set-DbaLogin {
 
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string[]]$Login,
         [SecureString]$Password,
         [switch]$Unlock,

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -81,7 +81,7 @@ function Set-DbaMaxDop {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
@@ -90,7 +90,7 @@ function Set-DbaMaxDop {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [int]$MaxDop = -1,
-        [Parameter(ValueFromPipeline = $True)]
+        [Parameter(ValueFromPipeline)]
         [object]$Collection,
         [Alias("All")]
         [switch]$AllDatabases,

--- a/functions/Set-DbaNetworkCertificate.ps1
+++ b/functions/Set-DbaNetworkCertificate.ps1
@@ -57,7 +57,7 @@ function Set-DbaNetworkCertificate {
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low", DefaultParameterSetName = 'Default')]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "ComputerName")]
         [DbaInstanceParameter[]]
         $SqlInstance = $env:COMPUTERNAME,

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -57,7 +57,7 @@ function Set-DbaPowerPlan {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [object[]]$ComputerName,
         [ValidateSet('High Performance', 'Balanced', 'Power saver')]

--- a/functions/Set-DbaPrivilege.ps1
+++ b/functions/Set-DbaPrivilege.ps1
@@ -50,7 +50,7 @@ function Set-DbaPrivilege {
         [Alias("cn", "host", "Server")]
         [dbainstanceparameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateSet('IFI', 'LPIM', 'BatchLogon')]
         [string[]]$Type,
         [switch][Alias('Silent')]

--- a/functions/Set-DbaSpn.ps1
+++ b/functions/Set-DbaSpn.ps1
@@ -77,10 +77,10 @@ Displays what would happen trying to set all missing SPNs for sql2016
 #>
     [cmdletbinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Default")]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("RequiredSPN")]
         [string]$SPN,
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("InstanceServiceAccount", "AccountName")]
         [string]$ServiceAccount,
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -169,7 +169,7 @@ function Set-DbaStartupParameter {
             After the work has been completed, we can push the original startup parameters back to server1\instance1 and resume normal operation
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
-    param ([parameter(Mandatory = $true)]
+    param ([parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -61,12 +61,12 @@ function Set-DbaTcpPort {
     #>
     [CmdletBinding(ConfirmImpact = "High")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [PSCredential]$Credential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [ValidateRange(1, 65535)]
         [int]$Port,
         [IpAddress[]]$IpAddress,

--- a/functions/Set-DbaTempDbConfig.ps1
+++ b/functions/Set-DbaTempDbConfig.ps1
@@ -93,12 +93,12 @@ function Set-DbaTempdbConfig {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [int]$DataFileCount,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [int]$DataFileSizeMB,
         [int]$LogFileSizeMB,
         [int]$DataFileGrowthMB = 512,

--- a/functions/Set-DbatoolsConfig.ps1
+++ b/functions/Set-DbatoolsConfig.ps1
@@ -109,9 +109,9 @@ function Set-DbatoolsConfig {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding(DefaultParameterSetName = "FullName")]
     Param (
-        [Parameter(ParameterSetName = "FullName", Position = 0, Mandatory = $true)]
+        [Parameter(ParameterSetName = "FullName", Position = 0, Mandatory)]
         [string]$FullName,
-        [Parameter(ParameterSetName = "Module", Position = 1, Mandatory = $true)]
+        [Parameter(ParameterSetName = "Module", Position = 1, Mandatory)]
         [string]$Name,
         [Parameter(ParameterSetName = "Module", Position = 0)]
         [string]$Module,

--- a/functions/Show-DbaDbList.ps1
+++ b/functions/Show-DbaDbList.ps1
@@ -42,7 +42,7 @@ function Show-DbaDbList {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Show-DbaServerFileSystem.ps1
+++ b/functions/Show-DbaServerFileSystem.ps1
@@ -42,7 +42,7 @@ function Show-DbaServerFileSystem {
     #>
     [CmdletBinding(SupportsShouldProcess)]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [object]$SqlCredential

--- a/functions/Start-DbaMigration.ps1
+++ b/functions/Start-DbaMigration.ps1
@@ -206,15 +206,15 @@ function Start-DbaMigration {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     Param (
-        [parameter(Position = 1, Mandatory = $true)]
+        [parameter(Position = 1, Mandatory)]
         [DbaInstanceParameter]$Source,
-        [parameter(Position = 2, Mandatory = $true)]
+        [parameter(Position = 2, Mandatory)]
         [DbaInstanceParameter[]]$Destination,
-        [parameter(Position = 3, Mandatory = $true, ParameterSetName = "DbAttachDetach")]
+        [parameter(Position = 3, Mandatory, ParameterSetName = "DbAttachDetach")]
         [switch]$DetachAttach,
         [parameter(Position = 4, ParameterSetName = "DbAttachDetach")]
         [switch]$Reattach,
-        [parameter(Position = 5, Mandatory = $true, ParameterSetName = "DbBackup")]
+        [parameter(Position = 5, Mandatory, ParameterSetName = "DbBackup")]
         [switch]$BackupRestore,
         [parameter(Position = 6, ParameterSetName = "DbBackup",
             HelpMessage = "Specify a valid network share in the format \\server\share that can be accessed by your account and both Sql Server service accounts.")]

--- a/functions/Start-DbaService.ps1
+++ b/functions/Start-DbaService.ps1
@@ -80,7 +80,7 @@ function Start-DbaService {
         [string[]]$InstanceName,
         [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS")]
         [string[]]$Type,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "Service")]
+        [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "Service")]
         [Alias("ServiceCollection")]
         [object[]]$InputObject,
         [int]$Timeout = 30,

--- a/functions/Stop-DbaProcess.ps1
+++ b/functions/Stop-DbaProcess.ps1
@@ -103,7 +103,7 @@ function Stop-DbaProcess {
         [string[]]$Login,
         [string[]]$Hostname,
         [string[]]$Program,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "Process")]
+        [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "Process")]
         [object[]]$InputObject,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Stop-DbaService.ps1
+++ b/functions/Stop-DbaService.ps1
@@ -91,7 +91,7 @@ function Stop-DbaService {
         [string[]]$InstanceName,
         [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS")]
         [string[]]$Type,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "Service")]
+        [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "Service")]
         [Alias("ServiceCollection")]
         [object[]]$InputObject,
         [int]$Timeout = 30,

--- a/functions/Sync-DbaLoginPermission.ps1
+++ b/functions/Sync-DbaLoginPermission.ps1
@@ -65,11 +65,11 @@ function Sync-DbaLoginPermission {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter]$Source,
         [PSCredential]
         $SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstanceParameter]$Destination,
         [PSCredential]
         $DestinationSqlCredential,
@@ -82,7 +82,7 @@ function Sync-DbaLoginPermission {
         function Sync-Only {
             [CmdletBinding()]
             param (
-                [Parameter(Mandatory = $true)]
+                [Parameter(Mandatory)]
                 [ValidateNotNullOrEmpty()]
                 [object]$sourceServer,
                 [object]$destServer,

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -67,7 +67,7 @@ function Test-DbaBackupInformation {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$BackupHistory,
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,

--- a/functions/Test-DbaBuild.ps1
+++ b/functions/Test-DbaBuild.ps1
@@ -112,7 +112,7 @@ function Test-DbaBuild {
         [switch]
         $Latest,
 
-        [parameter(Mandatory = $false, ValueFromPipeline = $true)]
+        [parameter(Mandatory = $false, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]
         $SqlInstance,

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -64,7 +64,7 @@ function Test-DbaCmConnection {
         #>
     [CmdletBinding()]
     Param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]
         $ComputerName = $env:COMPUTERNAME,
 

--- a/functions/Test-DbaConnectionAuthScheme.ps1
+++ b/functions/Test-DbaConnectionAuthScheme.ps1
@@ -57,7 +57,7 @@ function Test-DbaConnectionAuthScheme {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential", "Cred")]

--- a/functions/Test-DbaDbCompatibility.ps1
+++ b/functions/Test-DbaDbCompatibility.ps1
@@ -58,7 +58,7 @@ function Test-DbaDbCompatibility {
     [CmdletBinding()]
     [OutputType("System.Collections.ArrayList")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -87,7 +87,7 @@ function Test-DbaDbCompression {
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaDbOwner.ps1
+++ b/functions/Test-DbaDbOwner.ps1
@@ -56,7 +56,7 @@ function Test-DbaDbOwner {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaDbVirtualLogFile.ps1
+++ b/functions/Test-DbaDbVirtualLogFile.ps1
@@ -67,7 +67,7 @@ function Test-DbaDbVirtualLogFile {
     #>
     [CmdletBinding()]
     [OutputType([System.Collections.ArrayList])]
-    param ([parameter(ValueFromPipeline, Mandatory = $true)]
+    param ([parameter(ValueFromPipeline, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaDiskAlignment.ps1
+++ b/functions/Test-DbaDiskAlignment.ps1
@@ -80,7 +80,7 @@ function Test-DbaDiskAlignment {
             https://dbatools.io/Test-DbaDiskAlignment
     #>
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [object[]]$ComputerName,
         [switch]$Detailed,

--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -70,7 +70,7 @@ function Test-DbaDiskAllocation {
     [CmdletBinding(SupportsShouldProcess = $true)]
     [OutputType("System.Collections.ArrayList", "System.Boolean")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [object[]]$ComputerName,
         [switch]$NoSqlCheck,

--- a/functions/Test-DbaDiskSpeed.ps1
+++ b/functions/Test-DbaDiskSpeed.ps1
@@ -48,7 +48,7 @@
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -57,7 +57,7 @@ function Test-DbaIdentityUsage {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaJobOwner.ps1
+++ b/functions/Test-DbaJobOwner.ps1
@@ -65,7 +65,7 @@ function Test-DbaJobOwner {
     [CmdletBinding()]
     [OutputType('System.Object[]')]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -127,7 +127,7 @@ function Test-DbaLastBackup {
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "Source")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -79,7 +79,7 @@ function Test-DbaLogShippingStatus {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -61,7 +61,7 @@ function Test-DbaMaxDop {
     [CmdletBinding()]
     [OutputType([System.Collections.ArrayList])]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -44,7 +44,7 @@ function Test-DbaMaxMemory {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaMigrationConstraint.ps1
+++ b/functions/Test-DbaMigrationConstraint.ps1
@@ -71,10 +71,10 @@ function Test-DbaMigrationConstraint {
     #>
     [CmdletBinding(DefaultParameterSetName = "DbMigration")]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstance]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [DbaInstance]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [Alias("Databases")]

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -63,7 +63,7 @@ function Test-DbaNetworkLatency {
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaOptimizeForAdHoc.ps1
+++ b/functions/Test-DbaOptimizeForAdHoc.ps1
@@ -38,7 +38,7 @@ function Test-DbaOptimizeForAdHoc {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $True)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaPath.ps1
+++ b/functions/Test-DbaPath.ps1
@@ -49,11 +49,11 @@ function Test-DbaPath {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [object]$Path,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -49,7 +49,7 @@ function Test-DbaPowerPlan {
             Checks the Power Plan settings for sqlserver2014a and indicates whether or not it is set to the custom plan "Maximum Performance".
     #>
     param (
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlInstance")]
         [DbaInstance[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,

--- a/functions/Test-DbaRecoveryModel.ps1
+++ b/functions/Test-DbaRecoveryModel.ps1
@@ -67,7 +67,7 @@ function Test-DbaRecoveryModel {
     [CmdletBinding()]
     [OutputType("System.Collections.ArrayList")]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Databases")]

--- a/functions/Test-DbaRepLatency.ps1
+++ b/functions/Test-DbaRepLatency.ps1
@@ -59,7 +59,7 @@ function Test-DbaRepLatency {
 #>
     [CmdletBinding()]
     Param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]] $SqlInstance, #Publisher
         [object[]]$Database,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaServerName.ps1
+++ b/functions/Test-DbaServerName.ps1
@@ -64,7 +64,7 @@ function Test-DbaServerName {
     [CmdletBinding()]
     [OutputType([System.Collections.ArrayList])]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -62,7 +62,7 @@ function Test-DbaSpn {
     #>
     [cmdletbinding()]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
         [PSCredential]$Credential,
         [Alias('Silent')]

--- a/functions/Test-DbaTempDbConfig.ps1
+++ b/functions/Test-DbaTempDbConfig.ps1
@@ -52,7 +52,7 @@ function Test-DbaTempdbConfig {
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -63,7 +63,7 @@ function Test-DbaWindowsLogin {
     #>
     [CmdletBinding()]
     Param (
-        [parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,

--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -85,10 +85,10 @@ function Update-DbaServiceAccount {
         [Alias("cn", "host", "Server")]
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true, ParameterSetName = "InputObject")]
+        [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "InputObject")]
         [Alias("ServiceCollection")]
         [object[]]$InputObject,
-        [parameter(ParameterSetName = "ServiceName", Position = 1, Mandatory = $true)]
+        [parameter(ParameterSetName = "ServiceName", Position = 1, Mandatory)]
         [Alias("Name", "Service")]
         [string[]]$ServiceName,
         [Alias("User")]

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -61,7 +61,7 @@ function Watch-DbaDbLogin {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstance]$SqlInstance,
         [object]$Database,

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -142,7 +142,7 @@ function Write-DbaDataTable {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
     param (
-        [Parameter(Position = 0, Mandatory = $true)]
+        [Parameter(Position = 0, Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [ValidateNotNull()]
         [DbaInstanceParameter]$SqlInstance,
@@ -152,11 +152,11 @@ function Write-DbaDataTable {
         [PSCredential]$SqlCredential,
         [Parameter(Position = 2)]
         [object]$Database,
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [Alias("DataTable")]
         [ValidateNotNull()]
         [object]$InputObject,
-        [Parameter(Position = 3, Mandatory = $true)]
+        [Parameter(Position = 3, Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$Table,
         [Parameter(Position = 4)]

--- a/internal/functions/Connect-AsServer.ps1
+++ b/internal/functions/Connect-AsServer.ps1
@@ -24,7 +24,7 @@ Connects to SSAS on the local server
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [object]$AsServer,
         [switch]$ParameterConnection
     )

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -39,7 +39,7 @@ function Connect-SqlInstance {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidDefaultValueSwitchParameter", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "")]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [object]$SqlInstance,
         [object]$SqlCredential,
         [switch]$ParameterConnection,

--- a/internal/functions/Convert-DbaMessageException.ps1
+++ b/internal/functions/Convert-DbaMessageException.ps1
@@ -24,14 +24,14 @@ function Convert-DbaMessageException {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         $Exception,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $FunctionName,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $ModuleName
     )

--- a/internal/functions/Convert-DbaMessageLevel.ps1
+++ b/internal/functions/Convert-DbaMessageLevel.ps1
@@ -32,24 +32,24 @@
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Sqlcollaborative.Dbatools.Message.MessageLevel]
         $OriginalLevel,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [bool]
         $FromStopFunction,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [AllowNull()]
         [string[]]
         $Tags,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $FunctionName,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $ModuleName
     )

--- a/internal/functions/Convert-DbaMessageTarget.ps1
+++ b/internal/functions/Convert-DbaMessageTarget.ps1
@@ -24,14 +24,14 @@
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         $Target,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $FunctionName,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $ModuleName
     )

--- a/internal/functions/Convert-DbaTimelineStatusColor.ps1
+++ b/internal/functions/Convert-DbaTimelineStatusColor.ps1
@@ -39,7 +39,7 @@
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Status
     )

--- a/internal/functions/ConvertTo-JsDate.ps1
+++ b/internal/functions/ConvertTo-JsDate.ps1
@@ -36,7 +36,7 @@
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [datetime]
         $InputDate
     )

--- a/internal/functions/Get-BackupAncientHistory.ps1
+++ b/internal/functions/Get-BackupAncientHistory.ps1
@@ -25,7 +25,7 @@ function Get-BackupAncientHistory {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     Param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [Alias("Credential")]

--- a/internal/functions/Get-DBAServiceErrorMessage.ps1
+++ b/internal/functions/Get-DBAServiceErrorMessage.ps1
@@ -5,7 +5,7 @@ function Get-DbaServiceErrorMessage {
 
 #>
     param(
-        [parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 1)]
+        [parameter(Mandatory, ValueFromPipeline, Position = 1)]
         [int]$ErrorNumber
     )
     $returnCodes = @("The request was accepted.",

--- a/internal/functions/Get-DbaDbPhysicalFile.ps1
+++ b/internal/functions/Get-DbaDbPhysicalFile.ps1
@@ -23,7 +23,7 @@ function Get-DbaDbPhysicalFile {
     #>
     [CmdletBinding()]
     param(
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [Alias("Credential")]

--- a/internal/functions/Get-DirectoryRestoreFile.ps1
+++ b/internal/functions/Get-DirectoryRestoreFile.ps1
@@ -8,7 +8,7 @@ Takes path, checks for validity. Scans for usual backup file
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [string]$Path,
         [switch]$Recurse,
         [Alias('Silent')]

--- a/internal/functions/Get-InternalService.ps1
+++ b/internal/functions/Get-InternalService.ps1
@@ -52,7 +52,7 @@ function Get-InternalService {
         [string[]]
         $DisplayName,
 
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter[]]
         $ComputerName = $env:COMPUTERNAME,
 

--- a/internal/functions/Get-JobList.ps1
+++ b/internal/functions/Get-JobList.ps1
@@ -56,7 +56,7 @@ function Get-JobList {
     #>
     [cmdletbinding()]
     param(
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$JobFilter,

--- a/internal/functions/Get-OfflineSqlFileStructure.ps1
+++ b/internal/functions/Get-OfflineSqlFileStructure.ps1
@@ -6,12 +6,12 @@ Internal function. Returns dictionary object that contains file structures for S
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [object]$SqlInstance,
-        [Parameter(Mandatory = $true, Position = 1)]
+        [Parameter(Mandatory, Position = 1)]
         [string]$dbname,
-        [Parameter(Mandatory = $true, Position = 2)]
+        [Parameter(Mandatory, Position = 2)]
         [object]$filelist,
         [Parameter(Mandatory = $false, Position = 3)]
         [bool]$ReuseSourceFolderStructure,

--- a/internal/functions/Get-RestoreContinuableDatabase.ps1
+++ b/internal/functions/Get-RestoreContinuableDatabase.ps1
@@ -10,7 +10,7 @@ function Get-RestoreContinuableDatabase {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential,
         [Alias('Silent')]

--- a/internal/functions/Get-SaLoginName.ps1
+++ b/internal/functions/Get-SaLoginName.ps1
@@ -22,7 +22,7 @@ function Get-SaLoginName {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential

--- a/internal/functions/Get-SqlCmdVars.ps1
+++ b/internal/functions/Get-SqlCmdVars.ps1
@@ -61,7 +61,7 @@ function Get-SqlCmdVars {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         $SqlCommandVariableValues,
         [switch]$EnableException
     )

--- a/internal/functions/Get-SqlDefaultPaths.ps1
+++ b/internal/functions/Get-SqlDefaultPaths.ps1
@@ -6,11 +6,11 @@ function Get-SqlDefaultPaths {
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$filetype,
         [PSCredential]$SqlCredential

--- a/internal/functions/Get-SqlDefaultSpConfigure.ps1
+++ b/internal/functions/Get-SqlDefaultSpConfigure.ps1
@@ -21,7 +21,7 @@ function Get-SqlDefaultSpConfigure {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("Version")]
         [object]$SqlVersion

--- a/internal/functions/Get-SqlFileStructure.ps1
+++ b/internal/functions/Get-SqlFileStructure.ps1
@@ -6,10 +6,10 @@ function Get-SqlFileStructure {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [object]$source,
-        [Parameter(Mandatory = $true, Position = 1)]
+        [Parameter(Mandatory, Position = 1)]
         [ValidateNotNullOrEmpty()]
         [object]$destination,
         [Parameter(Mandatory = $false, Position = 2)]

--- a/internal/functions/Get-SqlSaLogin.ps1
+++ b/internal/functions/Get-SqlSaLogin.ps1
@@ -9,7 +9,7 @@ function Get-SqlSaLogin {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential

--- a/internal/functions/Get-XpDirTreeRestoreFile.ps1
+++ b/internal/functions/Get-XpDirTreeRestoreFile.ps1
@@ -27,9 +27,9 @@ function Get-XpDirTreeRestoreFile {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [string]$Path,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [System.Management.Automation.PSCredential]$SqlCredential,

--- a/internal/functions/Import-DbaCmdlet.ps1
+++ b/internal/functions/Import-DbaCmdlet.ps1
@@ -36,11 +36,11 @@
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [String]
         $Name,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Type]
         $Type,
         

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -46,7 +46,7 @@
         [ValidateNotNullOrEmpty()]
         [Microsoft.SqlServer.Management.Common.ServerConnection]$SQLConnection,
 
-        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = "Query")]
+        [Parameter(Mandatory, Position = 0, ParameterSetName = "Query")]
         [string]
         $Query,
 

--- a/internal/functions/Invoke-DbaDatabaseCorruption.ps1
+++ b/internal/functions/Invoke-DbaDatabaseCorruption.ps1
@@ -53,7 +53,7 @@ function Invoke-DbaDbCorruption {
   #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [parameter(Mandatory = $false)]

--- a/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
+++ b/internal/functions/Invoke-DbaDiagnosticQueryScriptParser.ps1
@@ -2,7 +2,7 @@
     [CmdletBinding(DefaultParameterSetName = "Default")]
 
     Param(
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [ValidateScript( {Test-Path $_})]
         [System.IO.FileInfo]$filename,
         [Switch]$NoQueryTextColumn,

--- a/internal/functions/Invoke-ManagedComputerCommand.ps1
+++ b/internal/functions/Invoke-ManagedComputerCommand.ps1
@@ -27,11 +27,11 @@ function Invoke-ManagedComputerCommand {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("Server")]
         [dbainstanceparameter]$ComputerName,
         [PSCredential]$Credential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [scriptblock]$ScriptBlock,
         [string[]]$ArgumentList,
         [switch][Alias('Silent')]

--- a/internal/functions/Invoke-SmoCheck.ps1
+++ b/internal/functions/Invoke-SmoCheck.ps1
@@ -6,7 +6,7 @@ function Invoke-SmoCheck {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [object]$SqlInstance
     )
 

--- a/internal/functions/Invoke-SteppablePipeline.ps1
+++ b/internal/functions/Invoke-SteppablePipeline.ps1
@@ -22,10 +22,10 @@ function Invoke-SteppablePipeline
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         $InputObject,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         $Pipeline
     )
     

--- a/internal/functions/Join-AdminUnc.ps1
+++ b/internal/functions/Join-AdminUnc.ps1
@@ -5,10 +5,10 @@ function Join-AdminUnc {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$servername,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$filepath
 

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -91,29 +91,29 @@ function New-DbaLogShippingPrimaryDatabase {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
 
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
 
         [System.Management.Automation.PSCredential]
         $SqlCredential,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$Database,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupDirectory,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupJob,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [int]$BackupRetention,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupShare,
 

--- a/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
+++ b/internal/functions/New-DbaLogShippingPrimarySecondary.ps1
@@ -51,17 +51,17 @@ function New-DbaLogShippingPrimarySecondary {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$PrimaryDatabase,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$SecondaryDatabase,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [DBAInstanceParameter]$SecondaryServer,
         [PSCredential]$SecondarySqlCredential,

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -92,7 +92,7 @@ function New-DbaLogShippingSecondaryDatabase {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
 
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
@@ -101,21 +101,21 @@ function New-DbaLogShippingSecondaryDatabase {
         [switch]$DisconnectUsers,
         [int]$HistoryRetention = 14420,
         [int]$MaxTransferSize,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [DbaInstanceParameter]$PrimaryServer,
         [PSCredential]$PrimarySqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$PrimaryDatabase,
         [int]$RestoreAll = 1,
         [int]$RestoreDelay = 0,
         [ValidateSet(0, 'NoRecovery', 1, 'Standby')]
         [object]$RestoreMode = 0,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [int]$RestoreThreshold,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$SecondaryDatabase,
         [int]$ThresholdAlert = 14420,

--- a/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -84,28 +84,28 @@ function New-DbaLogShippingSecondaryPrimary {
     #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupSourceDirectory,
         [Parameter(Mandatory = $false)]
         [string]$BackupDestinationDirectory,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$CopyJob,
         [int]$FileRetentionPeriod = 14420,
         [string]$MonitorServer,
         [PSCredential]$MonitorCredential,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateSet(0, "sqlserver", 1, "windows")]
         [object]$MonitorServerSecurityMode = 1,
         [object]$PrimaryServer,
         [PSCredential]$PrimarySqlCredential,
         [object]$PrimaryDatabase,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$RestoreJob,
         [Alias('Silent')]

--- a/internal/functions/New-DbaMessageLevelModifier.ps1
+++ b/internal/functions/New-DbaMessageLevelModifier.ps1
@@ -62,11 +62,11 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Name,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [int]
         $Modifier,
         

--- a/internal/functions/New-DbaTeppCompletionResult.ps1
+++ b/internal/functions/New-DbaTeppCompletionResult.ps1
@@ -28,7 +28,7 @@
             Returns a CompletionResult with the text and tooltip 'master'
     #>
     param (
-        [Parameter(Position = 0, ValueFromPipelineByPropertyName = $true, Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Position = 0, ValueFromPipelineByPropertyName = $true, Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]
         $CompletionText,

--- a/internal/functions/Register-DbaMaintenanceTask.ps1
+++ b/internal/functions/Register-DbaMaintenanceTask.ps1
@@ -43,19 +43,19 @@ function Register-DbaMaintenanceTask {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [System.Management.Automation.ScriptBlock]
         $ScriptBlock,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "Once")]
+        [Parameter(Mandatory, ParameterSetName = "Once")]
         [switch]
         $Once,
 
-        [Parameter(Mandatory = $true, ParameterSetName = "Repeating")]
+        [Parameter(Mandatory, ParameterSetName = "Repeating")]
         [System.TimeSpan]
         $Interval,
 

--- a/internal/functions/Register-DbaMessageEvent.ps1
+++ b/internal/functions/Register-DbaMessageEvent.ps1
@@ -60,11 +60,11 @@
 #>
     [CmdletBinding(PositionalBinding = $false)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Name,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [System.Management.Automation.ScriptBlock]
         $ScriptBlock,
         

--- a/internal/functions/Register-DbaMessageTransform.ps1
+++ b/internal/functions/Register-DbaMessageTransform.ps1
@@ -74,23 +74,23 @@
 #>
     [CmdletBinding(PositionalBinding = $false)]
     param (
-        [Parameter(Mandatory = $true, ParameterSetName = "Target")]
+        [Parameter(Mandatory, ParameterSetName = "Target")]
         [string]
         $TargetType,
         
-        [Parameter(Mandatory = $true, ParameterSetName = "Exception")]
+        [Parameter(Mandatory, ParameterSetName = "Exception")]
         [string]
         $ExceptionType,
         
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ScriptBlock]
         $ScriptBlock,
         
-        [Parameter(Mandatory = $true, ParameterSetName = "TargetFilter")]
+        [Parameter(Mandatory, ParameterSetName = "TargetFilter")]
         [string]
         $TargetTypeFilter,
         
-        [Parameter(Mandatory = $true, ParameterSetName = "ExceptionFilter")]
+        [Parameter(Mandatory, ParameterSetName = "ExceptionFilter")]
         [string]
         $ExceptionTypeFilter,
         

--- a/internal/functions/Register-DbaRunspace.ps1
+++ b/internal/functions/Register-DbaRunspace.ps1
@@ -41,11 +41,11 @@ function Register-DbaRunspace {
     [CmdletBinding(PositionalBinding = $false)]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Scriptblock]
         $ScriptBlock,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [String]
         $Name,
 

--- a/internal/functions/Register-DbaTeppInstanceCacheBuilder.ps1
+++ b/internal/functions/Register-DbaTeppInstanceCacheBuilder.ps1
@@ -35,7 +35,7 @@
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [System.Management.Automation.ScriptBlock]
         $ScriptBlock,
 

--- a/internal/functions/Register-DbatoolsConfigValidation.ps1
+++ b/internal/functions/Register-DbatoolsConfigValidation.ps1
@@ -27,11 +27,11 @@
     #>
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Name,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ScriptBlock]
         $ScriptBlock
     )

--- a/internal/functions/Remove-DbaMessageLevelModifier.ps1
+++ b/internal/functions/Remove-DbaMessageLevelModifier.ps1
@@ -32,11 +32,11 @@ function Remove-DbaMessageLevelModifier {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [string[]]
         $Name,
         
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Message.MessageLevelModifier[]]
         $Modifier,
         

--- a/internal/functions/Resolve-IpAddress.ps1
+++ b/internal/functions/Resolve-IpAddress.ps1
@@ -2,7 +2,7 @@ function Resolve-IpAddress {
     # Uses the Beard's method to resolve IPs
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlInstance", "ComputerName", "SqlServer")]
         [object]$Server
     )

--- a/internal/functions/Resolve-NetBiosName.ps1
+++ b/internal/functions/Resolve-NetBiosName.ps1
@@ -5,7 +5,7 @@ Internal function. Takes a best guess at the NetBIOS name of a server.
  #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential

--- a/internal/functions/Resolve-SqlIpAddress.ps1
+++ b/internal/functions/Resolve-SqlIpAddress.ps1
@@ -1,7 +1,7 @@
 function Resolve-SqlIpAddress {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
         [PSCredential]$SqlCredential

--- a/internal/functions/Select-DefaultView.ps1
+++ b/internal/functions/Select-DefaultView.ps1
@@ -13,7 +13,7 @@ function Select-DefaultView {
     
     [CmdletBinding()]
     param (
-        [parameter(ValueFromPipeline = $true)]
+        [parameter(ValueFromPipeline)]
         [object]
         $InputObject,
         

--- a/internal/functions/Set-ServiceStartMode.ps1
+++ b/internal/functions/Set-ServiceStartMode.ps1
@@ -40,7 +40,7 @@ function Set-ServiceStartMode {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [string]$Mode,
-        [parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [parameter(ValueFromPipeline, Mandatory)]
         [object[]]$InputObject
     )
     begin {

--- a/internal/functions/Start-DbaRunspace.ps1
+++ b/internal/functions/Start-DbaRunspace.ps1
@@ -25,11 +25,11 @@ function Start-DbaRunspace {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [string[]]
         $Name,
 
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Runspace.RunspaceContainer[]]
         $Runspace,
 

--- a/internal/functions/Stop-DbaRunspace.ps1
+++ b/internal/functions/Stop-DbaRunspace.ps1
@@ -33,11 +33,11 @@ function Stop-DbaRunspace {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [string[]]
         $Name,
 
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Runspace.RunspaceContainer[]]
         $Runspace,
 

--- a/internal/functions/Stop-Function.ps1
+++ b/internal/functions/Stop-Function.ps1
@@ -97,7 +97,7 @@ function Stop-Function {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding(DefaultParameterSetName = 'Plain')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]
         $Message,
 

--- a/internal/functions/Test-Bound.ps1
+++ b/internal/functions/Test-Bound.ps1
@@ -39,7 +39,7 @@
     #>
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Mandatory, Position = 0)]
         [string[]]
         $ParameterName,
 

--- a/internal/functions/Test-ComputerTarget.ps1
+++ b/internal/functions/Test-ComputerTarget.ps1
@@ -28,7 +28,7 @@
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [Parameter(ValueFromPipeline, Mandatory)]
         [string[]]
         $ComputerName
     )

--- a/internal/functions/Test-DbaDeprecation.ps1
+++ b/internal/functions/Test-DbaDeprecation.ps1
@@ -55,7 +55,7 @@ function Test-DbaDeprecation {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Version]
         $DeprecatedOn,
 
@@ -65,11 +65,11 @@ function Test-DbaDeprecation {
         [object]
         $Call = (Get-PSCallStack)[0].InvocationInfo,
 
-        [Parameter(ParameterSetName = "Param", Mandatory = $true)]
+        [Parameter(ParameterSetName = "Param", Mandatory)]
         [string]
         $Parameter,
 
-        [Parameter(ParameterSetName = "Alias", Mandatory = $true)]
+        [Parameter(ParameterSetName = "Alias", Mandatory)]
         [string]
         $Alias,
 

--- a/internal/functions/Test-DbaLsnChain.ps1
+++ b/internal/functions/Test-DbaLsnChain.ps1
@@ -28,7 +28,7 @@ function Test-DbaLsnChain {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$FilteredRestoreFiles,
         [switch]$Continue,
         [switch]$EnableException

--- a/internal/functions/Test-DbaRestoreVersion.ps1
+++ b/internal/functions/Test-DbaRestoreVersion.ps1
@@ -37,10 +37,10 @@ function Test-DbaRestoreVersion {
 #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [object[]]$FilteredRestoreFiles,
         [PSCredential]$SqlCredential,
         [switch]$SystemDatabaseRestore

--- a/internal/functions/Test-SqlAgent.ps1
+++ b/internal/functions/Test-SqlAgent.ps1
@@ -5,7 +5,7 @@ function Test-SqlAgent {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,

--- a/internal/functions/Test-SqlLoginAccess.ps1
+++ b/internal/functions/Test-SqlLoginAccess.ps1
@@ -5,7 +5,7 @@ function Test-SqlLoginAccess {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,

--- a/internal/functions/Test-SqlSa.ps1
+++ b/internal/functions/Test-SqlSa.ps1
@@ -5,7 +5,7 @@ function Test-SqlSa {
 #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,

--- a/internal/functions/Update-ServiceStatus.ps1
+++ b/internal/functions/Update-ServiceStatus.ps1
@@ -52,9 +52,9 @@ function Update-ServiceStatus {
 #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [parameter(ValueFromPipeline, Mandatory)]
         [object[]]$InputObject,
-        [parameter(Mandatory = $true)]
+        [parameter(Mandatory)]
         [string[]]$Action,
         [int]$Timeout = 30,
         [PSCredential] $Credential,

--- a/internal/functions/Update-SqlDbOwner.ps1
+++ b/internal/functions/Update-SqlDbOwner.ps1
@@ -6,10 +6,10 @@ function Update-SqlDbOwner {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$source,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$destination,
         [string]$dbname,

--- a/internal/functions/Update-SqlDbReadOnly.ps1
+++ b/internal/functions/Update-SqlDbReadOnly.ps1
@@ -6,14 +6,14 @@ function Update-SqlDbReadOnly {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [object]$SqlInstance,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$dbname,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [bool]$readonly
     )

--- a/internal/functions/Update-SqlPermissions.ps1
+++ b/internal/functions/Update-SqlPermissions.ps1
@@ -17,16 +17,16 @@ function Update-SqlPermissions {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$SourceServer,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$SourceLogin,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$DestServer,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [object]$DestLogin,
         [Alias('Silent')]

--- a/internal/functions/Where-DbaObject.ps1
+++ b/internal/functions/Where-DbaObject.ps1
@@ -49,7 +49,7 @@
     #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
+        [Parameter(ValueFromPipeline, Mandatory)]
         [object]
         $InputObject,
 

--- a/internal/functions/Write-HostColor.ps1
+++ b/internal/functions/Write-HostColor.ps1
@@ -53,7 +53,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
     [CmdletBinding()]
     Param (
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ValueFromPipeline)]
         [string[]]
         $String,
 

--- a/internal/scripts/updateTeppAsync.ps1
+++ b/internal/scripts/updateTeppAsync.ps1
@@ -13,7 +13,7 @@
     function Update-TeppCache {
         [CmdletBinding()]
         Param (
-            [Parameter(ValueFromPipeline = $true)]
+            [Parameter(ValueFromPipeline)]
             $ServerAccess
         )
 

--- a/optional/Compress-Archive.ps1
+++ b/optional/Compress-Archive.ps1
@@ -79,22 +79,22 @@ Which ships with PowerShell Version 5 but will run under v3.
         [CmdletBinding(DefaultParameterSetName = "Path", SupportsShouldProcess = $true, HelpUri = "http://go.microsoft.com/fwlink/?LinkID=393252")]
         param
         (
-            [parameter (mandatory = $true, Position = 0, ParameterSetName = "Path", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-            [parameter (mandatory = $true, Position = 0, ParameterSetName = "PathWithForce", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-            [parameter (mandatory = $true, Position = 0, ParameterSetName = "PathWithUpdate", ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, Position = 0, ParameterSetName = "Path", ValueFromPipeline, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, Position = 0, ParameterSetName = "PathWithForce", ValueFromPipeline, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, Position = 0, ParameterSetName = "PathWithUpdate", ValueFromPipeline, ValueFromPipelineByPropertyName = $true)]
             [ValidateNotNullOrEmpty()]
             [string[]]
             $Path,
 
-            [parameter (mandatory = $true, ParameterSetName = "LiteralPath", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
-            [parameter (mandatory = $true, ParameterSetName = "LiteralPathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
-            [parameter (mandatory = $true, ParameterSetName = "LiteralPathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, ParameterSetName = "LiteralPath", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, ParameterSetName = "LiteralPathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
+            [parameter (Mandatory, ParameterSetName = "LiteralPathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $true)]
             [ValidateNotNullOrEmpty()]
             [Alias("PSPath")]
             [string[]]
             $LiteralPath,
 
-            [parameter (mandatory = $true,
+            [parameter (Mandatory,
                         Position = 1,
                         ValueFromPipeline = $false,
                         ValueFromPipelineByPropertyName = $false)]
@@ -110,13 +110,13 @@ Which ships with PowerShell Version 5 but will run under v3.
             [string]
             $CompressionLevel = "Optimal",
 
-            [parameter(mandatory = $true, ParameterSetName = "PathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
-            [parameter(mandatory = $true, ParameterSetName = "LiteralPathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
+            [parameter(Mandatory, ParameterSetName = "PathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
+            [parameter(Mandatory, ParameterSetName = "LiteralPathWithUpdate", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
             [switch]
             $Update = $false,
 
-            [parameter(mandatory = $true, ParameterSetName = "PathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
-            [parameter(mandatory = $true, ParameterSetName = "LiteralPathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
+            [parameter(Mandatory, ParameterSetName = "PathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
+            [parameter(Mandatory, ParameterSetName = "LiteralPathWithForce", ValueFromPipeline = $false, ValueFromPipelineByPropertyName = $false)]
             [switch]
             $Force = $false
         )

--- a/optional/Expand-Archive.ps1
+++ b/optional/Expand-Archive.ps1
@@ -57,17 +57,17 @@ Which ships with PowerShell Version 5 but will run under v3.
         param
         (
             [parameter (
-                        mandatory = $true,
+                        Mandatory,
                         Position = 0,
                         ParameterSetName = "Path",
-                        ValueFromPipeline = $true,
+                        ValueFromPipeline,
                         ValueFromPipelineByPropertyName = $true)]
             [ValidateNotNullOrEmpty()]
             [string]
             $Path,
 
             [parameter (
-                        mandatory = $true,
+                        Mandatory,
                         ParameterSetName = "LiteralPath",
                         ValueFromPipelineByPropertyName = $true)]
             [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
PowerShell v3 does not require `= $true` for  ValueFromPipeline and Mandatory

This addresses a lil pet peeve of mine