### PR TITLE
Issue3671

### DIFF
--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -112,14 +112,14 @@ CREATE TABLE #logshippingstatus
     DatabaseName VARCHAR(100) ,
     TimeSinceLastBackup INT ,
     LastBackupFile VARCHAR(255) ,
-    BackupThresshold INT ,
+    BackupThreshold INT ,
     IsBackupAlertEnabled BIT ,
     TimeSinceLastCopy INT ,
     LastCopiedFile VARCHAR(255) ,
     TimeSinceLastRestore INT ,
     LastRestoredFile VARCHAR(255) ,
     LastRestoredLatency INT ,
-    RestoreThresshold INT ,
+    RestoreThreshold INT ,
     IsRestoreAlertEnabled BIT
 );
 
@@ -130,14 +130,14 @@ INSERT INTO #logshippingstatus
     DatabaseName ,
     TimeSinceLastBackup ,
     LastBackupFile ,
-    BackupThresshold ,
+    BackupThreshold ,
     IsBackupAlertEnabled ,
     TimeSinceLastCopy ,
     LastCopiedFile ,
     TimeSinceLastRestore ,
     LastRestoredFile ,
     LastRestoredLatency ,
-    RestoreThresshold ,
+    RestoreThreshold ,
     IsRestoreAlertEnabled
 )
 EXEC master.sys.sp_help_log_shipping_monitor"
@@ -219,8 +219,8 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                             if (-not $result.TimeSinceLastBackup) {
                                 $statusDetails += "The backup has never been executed."
                             }
-                            elseif ($result.TimeSinceLastBackup -ge $result.BackupThresshold) {
-                                $statusDetails += "The backup has not been executed in the last $($result.BackupThresshold) minutes"
+                            elseif ($result.TimeSinceLastBackup -ge $result.BackupThreshold) {
+                                $statusDetails += "The backup has not been executed in the last $($result.BackupThreshold) minutes"
                             }
                         }
                         elseif (-not $result.IsPrimary) {
@@ -228,8 +228,8 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                             if ($null -eq $result.TimeSinceLastRestore) {
                                 $statusDetails += "The restore has never been executed."
                             }
-                            elseif ($result.TimeSinceLastRestore -ge $result.RestoreThresshold) {
-                                $statusDetails += "The restore has not been executed in the last $($result.RestoreThresshold) minutes"
+                            elseif ($result.TimeSinceLastRestore -ge $result.RestoreThreshold) {
+                                $statusDetails += "The restore has not been executed in the last $($result.RestoreThreshold) minutes"
                             }
                         }
                     }
@@ -262,6 +262,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                 }
 
                 # Set up the custom object
+                # Includes mispelled properties BackupThresshold and RestoreThresshold for backward compatiability.
                 $null = $collection.Add([PSCustomObject]@{
                         ComputerName          = $server.ComputerName
                         InstanceName          = $server.ServiceName
@@ -270,14 +271,16 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                         InstanceType          = switch ($result.IsPrimary) { $true { "Primary Instance" } $false { "Secondary Instance" } }
                         TimeSinceLastBackup   = $lastBackup
                         LastBackupFile        = $result.LastBackupFile
-                        BackupThresshold      = $result.BackupThresshold
+                        BackupThreshold       = $result.BackupThreshold
+                        BackupThresshold      = $result.BackupThreshold
                         IsBackupAlertEnabled  = $result.IsBackupAlertEnabled
                         TimeSinceLastCopy     = $lastCopy
                         LastCopiedFile        = $result.LastCopiedFile
                         TimeSinceLastRestore  = $lastRestore
                         LastRestoredFile      = $result.LastRestoredFile
                         LastRestoredLatency   = $result.LastRestoredLatency
-                        RestoreThresshold     = $result.RestoreThresshold
+                        RestoreThreshold      = $result.RestoreThreshold
+                        RestoreThresshold     = $result.RestoreThreshold
                         IsRestoreAlertEnabled = $result.IsRestoreAlertEnabled
                         Status                = $statusDetails -join ","
                     })
@@ -288,7 +291,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                 return $collection | Select-Object SqlInstance, Database, InstanceType, Status
             }
             else {
-                return $collection
+                return $collection | Select-DefaultView -ExcludeProperty BackupThreshold, RestoreThreshold
             }
         }
     }

--- a/functions/Test-DbaLogShippingStatus.ps1
+++ b/functions/Test-DbaLogShippingStatus.ps1
@@ -262,7 +262,6 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                 }
 
                 # Set up the custom object
-                # Includes mispelled properties BackupThresshold and RestoreThresshold for backward compatiability.
                 $null = $collection.Add([PSCustomObject]@{
                         ComputerName          = $server.ComputerName
                         InstanceName          = $server.ServiceName
@@ -272,7 +271,6 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                         TimeSinceLastBackup   = $lastBackup
                         LastBackupFile        = $result.LastBackupFile
                         BackupThreshold       = $result.BackupThreshold
-                        BackupThresshold      = $result.BackupThreshold
                         IsBackupAlertEnabled  = $result.IsBackupAlertEnabled
                         TimeSinceLastCopy     = $lastCopy
                         LastCopiedFile        = $result.LastCopiedFile
@@ -280,7 +278,6 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                         LastRestoredFile      = $result.LastRestoredFile
                         LastRestoredLatency   = $result.LastRestoredLatency
                         RestoreThreshold      = $result.RestoreThreshold
-                        RestoreThresshold     = $result.RestoreThreshold
                         IsRestoreAlertEnabled = $result.IsRestoreAlertEnabled
                         Status                = $statusDetails -join ","
                     })
@@ -291,7 +288,7 @@ EXEC master.sys.sp_help_log_shipping_monitor"
                 return $collection | Select-Object SqlInstance, Database, InstanceType, Status
             }
             else {
-                return $collection | Select-DefaultView -ExcludeProperty BackupThreshold, RestoreThreshold
+                return $collection
             }
         }
     }

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -38,7 +38,7 @@ function New-DbaLogShippingPrimaryDatabase {
         .PARAMETER CompressBackup
             Enables the use of backup compression
 
-        .PARAMETER ThressAlert
+        .PARAMETER ThresholdAlert
             Is the length of time, in minutes, when the alert is to be raised when the backup threshold is exceeded.
             The default is 14,420.
 
@@ -121,7 +121,7 @@ function New-DbaLogShippingPrimaryDatabase {
 
         [switch]$CompressBackup,
 
-        [int]$ThressAlert = 14420,
+        [int]ThresholdAlert = 14420,
 
         [int]$HistoryRetention = 14420,
 
@@ -241,7 +241,7 @@ function New-DbaLogShippingPrimaryDatabase {
     if ($MonitorServer) {
         $Query += ",@monitor_server = N'$MonitorServer'
             ,@monitor_server_security_mode = $MonitorServerSecurityMode
-            ,@threshold_alert = $ThressAlert
+            ,@threshold_alert = $ThresholdAlert
             ,@threshold_alert_enabled = $ThresholdAlertEnabled"
     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3671)
 - [ ] New feature (non-breaking change, adds functionality)
 - [X] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Changes ThressAlert to ThresholdAlert in internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
This is to match with other LogShipping commands. The parameter is never directly referenced in any calls and is an internal function so does not break any functionality.

Changes BackupThresshold /RestoreThresshold to BackupThreshold/RestoreThreshold in Test-DbaLogShippingStatus for consistency.
This could potentially break scripts as the returned objects now have different field names. 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
Test-DbaLogShippingStatus 

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
