### PR TITLE
Get-DbaProductKey, fixes #4020

### DIFF
--- a/functions/Get-DbaRegistryRoot.ps1
+++ b/functions/Get-DbaRegistryRoot.ps1
@@ -77,7 +77,7 @@ Gets the registry root for all instances on server1
                 if ([System.String]::IsNullOrEmpty($vsname)) {
                     $vsname = $computer
                     if ($instancename -ne "MSSQLSERVER") {
-                        $vsname = "$computer\$instancename"
+                        $vsname = "$($computer.ComputerName)\$instancename"
                     }
                 }
 


### PR DESCRIPTION
Do not merge yet, I still need to test on a broader range of setups (but feel free to try).

First and foremost, this function IMHO needs to either target a live instance, or a computer. If for each passed instance every other instance details are fetched, then it should target ComputerName, not SqlInstance.

Fixed things ATM:
 - the original failed to reset product key when multiple instances were found (didn't get properly reset within the loop)
 - it seems that "recent" sql installs (e.g. on WS2016) the regpath is ClientSetup rather than Setup. So for every installable version on "WS2016" now it tries both Setup and ClientSetup
 - it fetched for -gt 2012 the productid of the ClientTools package rather than the instance itself, so I switched the base search to the instance regroot
 - given we have Get-DbaRegistryRoot already, to avoid code duplication, now we use that to get available regroots
 - Get-DbaregistryRoot returned bad instances names due to wrong concatenation, so I fixed that as well
 