### PR TITLE
Issue3822

### DIFF
--- a/functions/Export-DbaSpConfigure.ps1
+++ b/functions/Export-DbaSpConfigure.ps1
@@ -16,12 +16,11 @@ function Export-DbaSpConfigure {
         .PARAMETER Path
             Specifies the path to a file which will contain the sp_configure queries necessary to replicate the configuration settings on another instance. This file is suitable for input into Import-DbaSPConfigure.
 
-    
         .PARAMETER EnableException
             By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
             This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
             Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-    
+
         .NOTES
             Tags: SpConfig, Configure, Configuration
             Website: https://dbatools.io
@@ -53,39 +52,50 @@ function Export-DbaSpConfigure {
             catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            
+
             if (-not (Test-Bound -ParameterName Path)) {
                 $timenow = (Get-Date -uformat "%m%d%Y%H%M%S")
                 $mydocs = [Environment]::GetFolderPath('MyDocuments')
                 $path = "$mydocs\$($server.name.replace('\', '$'))-$timenow-sp_configure.sql"
             }
-            
+
+            $ShowAdvancedOptions = $server.Configuration.ShowAdvancedOptions.ConfigValue
+
             try {
                 Set-Content -Path $path "EXEC sp_configure 'show advanced options' , 1;  RECONFIGURE WITH OVERRIDE"
             }
             catch {
                 Stop-Function -Message "Can't write to $path" -ErrorRecord $_ -Continue
             }
-            
-            $server.Configuration.ShowAdvancedOptions.ConfigValue = $true
-            $server.Configuration.Alter($true)
+
+            if($ShowAdvancedOptions -eq 0) {
+                try {
+                    $server.Configuration.ShowAdvancedOptions.ConfigValue = $true
+                    $server.Configuration.Alter($true)
+                }
+                catch {
+                    Stop-Function -Message "Can't set 'show advanced options' to 1 on instance $instance" -ErrorRecord $_ -Continue
+                }
+            }
             foreach ($sourceprop in $server.Configuration.Properties) {
                 $displayname = $sourceprop.DisplayName
                 $configvalue = $sourceprop.ConfigValue
                 Add-Content -Path $path "EXEC sp_configure '$displayname' , $configvalue;"
             }
-            Add-Content -Path $path "EXEC sp_configure 'show advanced options' , 0;"
-            Add-Content -Path $Path "RECONFIGURE WITH OVERRIDE"
-            $server.Configuration.ShowAdvancedOptions.ConfigValue = $false
-            $server.Configuration.Alter($true)
+            IF($ShowAdvancedOptions -eq 0) {
+                Add-Content -Path $path "EXEC sp_configure 'show advanced options' , 0;"
+                Add-Content -Path $Path "RECONFIGURE WITH OVERRIDE"
+
+                $server.Configuration.ShowAdvancedOptions.ConfigValue = $false
+                $server.Configuration.Alter($true)
+            }
             Get-ChildItem -Path $path
         }
     }
-    
+
     end {
-        If ($Pscmdlet.ShouldProcess("console", "Showing finished message")) {
-            Write-Message -Level Verbose -Message "Server configuration export finished"
-        }
+        Write-Message -Level Verbose -Message "Server configuration export finished"
+
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Export-SqlSpConfigure
     }
 }

--- a/functions/Export-DbaSpConfigure.ps1
+++ b/functions/Export-DbaSpConfigure.ps1
@@ -8,7 +8,7 @@ function Export-DbaSpConfigure {
             Exports advanced sp_configure global configuration options to sql file.
 
         .PARAMETER SqlInstance
-            SqlInstance name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline inpu
+            SqlInstance name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input.
             You must have sysadmin access if needs to set 'show advanced options' to 1 and server version must be SQL Server version 2005 or higher.
 
         .PARAMETER SqlCredential

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -8,8 +8,7 @@ function Get-DbaSpConfigure {
             The data includes the default value for each configuration, for quick identification of values that may have been changed.
 
         .PARAMETER SqlInstance
-            SQL Server name or SMO object representing the SQL Server to connect to. This can be a
-            collection and receive pipeline input
+            SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input
 
         .PARAMETER SqlCredential
             Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -36,6 +36,12 @@ function Get-DbaSpConfigure {
         .LINK
             https://dbatools.io/Get-DbaSpConfigure
 
+        .INPUTS
+            A DbaInstanceParameter representing an array of SQL Server instances.
+
+        .OUTPUTS
+            Returns pscustomobject with properties ServerName, ComputerName, InstanceName, SqlInstance, Name, Description, IsAdvanced, IsDynamic, MinValue, MaxValue, ConfiguredValue, RunningValue, DefaultValue, IsRunningDefaultValue
+
         .EXAMPLE
             Get-DbaSpConfigure -SqlInstance localhost
 

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -45,7 +45,7 @@ function Get-DbaSpConfigure {
         .EXAMPLE
             Get-DbaSpConfigure -SqlInstance localhost
 
-            Returns server level configuration data on the localhost (ServerName, Name, DisplayName, Description, IsAdvanced, IsDynamic, MinValue, MaxValue, ConfiguredValue, RunningValue, DefaultValue, IsRunningDefaultValue)
+            Returns all system configuration information on the localhost.
 
         .EXAMPLE
             'localhost','localhost\namedinstance' | Get-DbaSpConfigure
@@ -60,7 +60,7 @@ function Get-DbaSpConfigure {
         .EXAMPLE
             Get-DbaSpConfigure -SqlInstance sql2012 -ExcludeName 'max server memory (MB)', 'remote access' | Out-GridView
 
-            Returns server level configuration data on sql2012 but excludes for 'max server memory (MB)' and 'remote access'. Values returned in GridView
+            Returns system configuration information on sql2012 but excludes for 'max server memory (MB)' and 'remote access'. Values returned in GridView
         #>
     [CmdletBinding()]
     Param (

--- a/functions/Get-DbaSpConfigure.ps1
+++ b/functions/Get-DbaSpConfigure.ps1
@@ -61,6 +61,12 @@ function Get-DbaSpConfigure {
             Get-DbaSpConfigure -SqlInstance sql2012 -ExcludeName 'max server memory (MB)', RemoteAccess | Out-GridView
 
             Returns system configuration information on sql2012 but excludes for 'max server memory (MB)' and 'remote access'. Values returned in GridView
+
+        .EXAMPLE
+            $cred = Get-Credential SqlCredential
+            'sql2012' | Get-DbaSpConfigure -SqlCredential $cred -Name RemoteAccess, 'max server memory (MB)' -ExcludeName 'remote access' | Out-GridView
+
+            Returns system configuration information on sql2012 using SQL Server Authentication. Only MaxServerMemory is returned as RemoteAccess was also excluded.
         #>
     [CmdletBinding()]
     Param (

--- a/functions/Import-DbaSpConfigure.ps1
+++ b/functions/Import-DbaSpConfigure.ps1
@@ -166,9 +166,9 @@ function Import-DbaSpConfigure {
 
             If ($Pscmdlet.ShouldProcess($destination, "Execute sp_configure")) {
                 $sourceserver.Configuration.ShowAdvancedOptions.ConfigValue = $true
-                $sourceserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null
+                $sourceserver.Configuration.Alter($true)
                 $destserver.Configuration.ShowAdvancedOptions.ConfigValue = $true
-                $destserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null
+                $sourceserver.Configuration.Alter($true)
 
                 $destprops = $destserver.Configuration.Properties
 
@@ -179,7 +179,7 @@ function Import-DbaSpConfigure {
                     if ($null -ne $destprop) {
                         try {
                             $destprop.configvalue = $sourceprop.configvalue
-                            $destserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null
+                            $null = $destserver.Query("RECONFIGURE WITH OVERRIDE")
                             Write-Message -Level Output -Message "updated $($destprop.displayname) to $($sourceprop.configvalue)."
                         }
                         catch {
@@ -195,9 +195,9 @@ function Import-DbaSpConfigure {
                 }
 
                 $sourceserver.Configuration.ShowAdvancedOptions.ConfigValue = $false
-                $sourceserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null
+                $sourceserver.Configuration.Alter($true)
                 $destserver.Configuration.ShowAdvancedOptions.ConfigValue = $false
-                $destserver.Query("RECONFIGURE WITH OVERRIDE") | Out-Null
+                $destserver.Configuration.Alter($true)
 
                 if ($needsrestart -eq $true) {
                     Write-Message -Level Warning -Message "Some configuration options will be updated once SQL Server is restarted."

--- a/functions/Import-DbaSpConfigure.ps1
+++ b/functions/Import-DbaSpConfigure.ps1
@@ -115,7 +115,7 @@ function Import-DbaSpConfigure {
             }
 
             if (!(Test-SqlSa -SqlInstance $sourceserver -SqlCredential $SourceSqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $sourceserver. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $sourceserver. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
             }
 
             try {
@@ -128,7 +128,7 @@ function Import-DbaSpConfigure {
             }
 
             if (!(Test-SqlSa -SqlInstance $destserver -SqlCredential $DestinationSqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $destserver. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $destserver. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
             }
 
             $source = $sourceserver.DomainInstanceName
@@ -144,7 +144,7 @@ function Import-DbaSpConfigure {
             }
 
             if (!(Test-SqlSa -SqlInstance $server -SqlCredential $SqlCredential)) {
-                Stop-Function -Message "Not a sysadmin on $server. Skipping." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Not a sysadmin on $server. Quitting." -Category PermissionDenied -ErrorRecord $_ -Target $server -Continue
             }
 
             if ((Test-Path $Path) -eq $false) {

--- a/functions/Import-DbaSpConfigure.ps1
+++ b/functions/Import-DbaSpConfigure.ps1
@@ -73,12 +73,12 @@ function Import-DbaSpConfigure {
         .EXAMPLE
             Import-DbaSpConfigure -Source sqlserver -Destination sqlcluster -SourceSqlCredential $SourceSqlCredential -DestinationSqlCredential $DestinationSqlCredential
 
-            Imports the sp_configure settings from the source server sqlserver and sets them on the sqlcluster server using the SQL credentials stored in the variables using the SQL credential stored in the variables $SourceSqlCredential and $DestinationSqlCredential
+            Imports the sp_configure settings from the source server sqlserver and sets them on the sqlcluster server using the SQL credentials stored in the variables $SourceSqlCredential and $DestinationSqlCredential
 
         .EXAMPLE
             Import-DbaSpConfigure -SqlInstance sqlserver -Path .\spconfig.sql -SqlCredential $SqlCredential
 
-            Imports the sp_configure settings from the file .\spconfig.sql and sets them on the sqlserver server using the SQL credential stored in the variables $SourceSqlCredential and $DestinationSqlCredential
+            Imports the sp_configure settings from the file .\spconfig.sql and sets them on the sqlserver server using the SQL credential stored in the variable $SqlCredential
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]

--- a/internal/functions/Get-SqlDefaultSpConfigure.ps1
+++ b/internal/functions/Get-SqlDefaultSpConfigure.ps1
@@ -34,7 +34,7 @@ function Get-SqlDefaultSpConfigure {
             [pscustomobject]@{
                 "affinity mask"                  = 0
                 "allow updates"                  = 0
-                "aweenabled"                     = 0
+                "awe enabled"                    = 0
                 "c2 audit mode"                  = 0
                 "cost threshold for parallelism" = 5
                 "Cross DB Ownership Chaining"    = 0
@@ -52,21 +52,21 @@ function Get-SqlDefaultSpConfigure {
                 "media retention"                = 0
                 "min memory per query (KB)"      = 1024
                 "min server memory (MB)"         = 0
-                "Using Nested Triggers"          = 1
+                "nested triggers"                = 1
                 "network packet size (B)"        = 4096
                 "open objects"                   = 0
                 "priority boost"                 = 0
                 "query governor cost limit"      = 0
                 "query wait (s)"                 = -1
                 "recovery interval (min)"        = 0
-                "remoteaccess"                   = 1
-                "remotelogin timeout"            = 20
+                "remote access"                  = 1
+                "remote login timeout (s)"       = 20
                 "remote proc trans"              = 0
                 "remote query timeout (s)"       = 600
                 "scan for startup procs"         = 0
                 "set working set size"           = 0
                 "show advanced options"          = 0
-                "two digityear cutoff"           = 2049
+                "two digit year cutoff"          = 2049
                 "user connections"               = 0
                 "user options"                   = 0
             }
@@ -84,7 +84,7 @@ function Get-SqlDefaultSpConfigure {
                 "Agent XPs"                          = 0
                 "allow updates"                      = 0
                 "awe enabled"                        = 0
-                "blocked process threshold (s)"      = 0
+                "blocked process threshold"          = 0
                 "c2 audit mode"                      = 0
                 "clr enabled"                        = 0
                 "common criteria compliance enabled" = 0
@@ -153,7 +153,7 @@ function Get-SqlDefaultSpConfigure {
             [pscustomobject]@{
                 "access check cache bucket count"    = 0
                 "access check cache quota"           = 0
-                "ad hoc distributed queries"         = 0
+                "Ad Hoc Distributed Queries"         = 0
                 "affinity I/O mask"                  = 0
                 "affinity64 I/O mask"                = 0
                 "affinity mask"                      = 0
@@ -232,7 +232,7 @@ function Get-SqlDefaultSpConfigure {
             [pscustomobject]@{
                 "access check cache bucket count"    = 0
                 "access check cache quota"           = 0
-                "ad hoc distributed queries"         = 0
+                "Ad Hoc Distributed Queries"         = 0
                 "affinity I/O mask"                  = 0
                 "affinity64 I/O mask"                = 0
                 "affinity mask"                      = 0
@@ -277,7 +277,7 @@ function Get-SqlDefaultSpConfigure {
                 "Ole Automation Procedures"          = 0
                 "open objects"                       = 0
                 "optimize for ad hoc workloads"      = 0
-                "PH_timeou"                          = 60
+                "PH timeout (s)"                     = 60
                 "precompute rank"                    = 0
                 "priority boost"                     = 0
                 "query governor cost limit"          = 0
@@ -297,6 +297,8 @@ function Get-SqlDefaultSpConfigure {
                 "transform noise words"              = 0
                 "two digit year cutoff"              = 2049
                 "user connections"                   = 0
+                "User Instance Timeout"              = 60
+                "user instances enabled"             = 0
                 "user options"                       = 0
                 "xp_cmdshell"                        = 0
             }
@@ -308,7 +310,7 @@ function Get-SqlDefaultSpConfigure {
             [pscustomobject]@{
                 "access check cache bucket count"    = 0
                 "access check cache quota"           = 0
-                "ad hoc distributed queries"         = 0
+                "Ad Hoc Distributed Queries"         = 0
                 "affinity I/O mask"                  = 0
                 "affinity64 I/O mask"                = 0
                 "affinity mask"                      = 0
@@ -374,6 +376,8 @@ function Get-SqlDefaultSpConfigure {
                 "transform noise words"              = 0
                 "two digit year cutoff"              = 2049
                 "user connections"                   = 0
+                "User Instance Timeout"              = 60
+                "user instances enabled"             = 0
                 "user options"                       = 0
                 "xp_cmdshell"                        = 0
             }
@@ -383,93 +387,12 @@ function Get-SqlDefaultSpConfigure {
         #region SQL2016
         13 {
             [pscustomobject]@{
-                "access check cache bucket count"        = 0
-                "access check cache quota"               = 0
-                "ad hoc distributed queries"             = 0
-                "affinity I/O mask"                      = 0
-                "affinity64 I/O mask"                    = 0
-                "affinity mask"                          = 0
-                "affinity64 mask"                        = 0
-                "Agent XPs"                              = 0
-                "allow updates"                          = 0
-                "automatic soft-NUMA disabled"           = 0
-                "backup checksum default"                = 0
-                "backup compression default"             = 0
-                "blocked process threshold (s)"          = 0
-                "c2 audit mode"                          = 0
-                "clr enabled"                            = 0
-                "common criteria compliance enabled"     = 0
-                "contained database authentication"      = 0
-                "cost threshold for parallelism"         = 5
-                "cross db ownership chaining"            = 0
-                "cursor threshold"                       = -1
-                "Database Mail XPs"                      = 0
-                "default full-text language"             = 1033
-                "default language"                       = 0
-                "default trace enabled"                  = 1
-                "disallow results from triggers"         = 0
-                "EKM provider enabled"                   = 0
-                "external scripts enabled"               = 0
-                "filestream access level"                = 0
-                "fill factor (%)"                        = 0
-                "ft crawl bandwidth (max)"               = 100
-                "ft crawl bandwidth (min)"               = 0
-                "ft notify bandwidth (max)"              = 100
-                "ft notify bandwidth (min)"              = 0
-                "index create memory (KB)"               = 0
-                "in-doubt xact resolution"               = 0
-                "lightweight pooling"                    = 0
-                "locks"                                  = 0
-                "max degree of parallelism"              = 0
-                "max full-text crawl range"              = 4
-                "max server memory (MB)"                 = 2147483647
-                "max text repl size (B)"                 = 65536
-                "max worker threads"                     = 0
-                "media retention"                        = 0
-                "min memory per query (KB)"              = 1024
-                "min server memory (MB)"                 = 0
-                "nested triggers"                        = 1
-                "network packet size (B)"                = 4096
-                "Ole Automation Procedures"              = 0
-                "open objects"                           = 0
-                "optimize for ad hoc workloads"          = 0
-                "PH timeout (s)"                         = 60
-                "PolyBase Hadoop and Azure blob storage" = 0
-                "precompute rank"                        = 0
-                "priority boost"                         = 0
-                "query governor cost limit"              = 0
-                "query wait (s)"                         = -1
-                "recovery interval (min)"                = 0
-                "remote access"                          = 1
-                "remote admin connections"               = 0
-                "remote data archive"                    = 0
-                "remote login timeout (s)"               = 10
-                "remote proc trans"                      = 0
-                "remote query timeout (s)"               = 0
-                "Replication XPs"                        = 0
-                "scan for startup procs"                 = 0
-                "server trigger recursion"               = 1
-                "set working set size"                   = 0
-                "show advanced options"                  = 0
-                "SMO and DMO XPs"                        = 1
-                "transform noise words"                  = 0
-                "two digit year cutoff"                  = 2049
-                "user connections"                       = 0
-                "user options"                           = 0
-                "xp_cmdshell"                            = 0
-            }
-        }
-        #endregion SQL2016
-
-        #region SQL2017
-        14 {
-            [pscustomobject]@{
                 "access check cache bucket count"    = 0
                 "access check cache quota"           = 0
                 "Ad Hoc Distributed Queries"         = 0
-                "affinity I / O mask"                = 0
+                "affinity I/O mask"                  = 0
+                "affinity64 I/O mask"                = 0
                 "affinity mask"                      = 0
-                "affinity64 I / O mask"              = 0
                 "affinity64 mask"                    = 0
                 "Agent XPs"                          = 0
                 "allow polybase export"              = 0
@@ -480,7 +403,6 @@ function Get-SqlDefaultSpConfigure {
                 "blocked process threshold (s)"      = 0
                 "c2 audit mode"                      = 0
                 "clr enabled"                        = 0
-                "clr strict security"                = 1
                 "common criteria compliance enabled" = 0
                 "contained database authentication"  = 0
                 "cost threshold for parallelism"     = 5
@@ -494,7 +416,7 @@ function Get-SqlDefaultSpConfigure {
                 "EKM provider enabled"               = 0
                 "external scripts enabled"           = 0
                 "filestream access level"            = 0
-                "fill factor ( % )"                  = 0
+                "fill factor (%)"                    = 0
                 "ft crawl bandwidth (max)"           = 100
                 "ft crawl bandwidth (min)"           = 0
                 "ft notify bandwidth (max)"          = 100
@@ -539,6 +461,94 @@ function Get-SqlDefaultSpConfigure {
                 "transform noise words"              = 0
                 "two digit year cutoff"              = 2049
                 "user connections"                   = 0
+                "User Instance Timeout"              = 60
+                "user instances enabled"             = 0
+                "user options"                       = 0
+                "xp_cmdshell"                        = 0
+            }
+        }
+        #endregion SQL2016
+
+        #region SQL2017
+        14 {
+            [pscustomobject]@{
+                "access check cache bucket count"    = 0
+                "access check cache quota"           = 0
+                "Ad Hoc Distributed Queries"         = 0
+                "affinity I/O mask"                  = 0
+                "affinity mask"                      = 0
+                "affinity64 I/O mask"                = 0
+                "affinity64 mask"                    = 0
+                "Agent XPs"                          = 0
+                "allow polybase export"              = 0
+                "allow updates"                      = 0
+                "automatic soft-NUMA disabled"       = 0
+                "backup checksum default"            = 0
+                "backup compression default"         = 0
+                "blocked process threshold (s)"      = 0
+                "c2 audit mode"                      = 0
+                "clr enabled"                        = 0
+                "clr strict security"                = 1
+                "common criteria compliance enabled" = 0
+                "contained database authentication"  = 0
+                "cost threshold for parallelism"     = 5
+                "cross db ownership chaining"        = 0
+                "cursor threshold"                   = -1
+                "Database Mail XPs"                  = 0
+                "default full-text language"         = 1033
+                "default language"                   = 0
+                "default trace enabled"              = 1
+                "disallow results from triggers"     = 0
+                "EKM provider enabled"               = 0
+                "external scripts enabled"           = 0
+                "filestream access level"            = 0
+                "fill factor (%)"                    = 0
+                "ft crawl bandwidth (max)"           = 100
+                "ft crawl bandwidth (min)"           = 0
+                "ft notify bandwidth (max)"          = 100
+                "ft notify bandwidth (min)"          = 0
+                "hadoop connectivity"                = 0
+                "index create memory (KB)"           = 0
+                "in-doubt xact resolution"           = 0
+                "lightweight pooling"                = 0
+                "locks"                              = 0
+                "max degree of parallelism"          = 0
+                "max full-text crawl range"          = 4
+                "max server memory (MB)"             = 2147483647
+                "max text repl size (B)"             = 65536
+                "max worker threads"                 = 0
+                "media retention"                    = 0
+                "min memory per query (KB)"          = 1024
+                "min server memory (MB)"             = 0
+                "nested triggers"                    = 1
+                "network packet size (B)"            = 4096
+                "Ole Automation Procedures"          = 0
+                "open objects"                       = 0
+                "optimize for ad hoc workloads"      = 0
+                "PH timeout (s)"                     = 60
+                "polybase network encryption"        = 1
+                "precompute rank"                    = 0
+                "priority boost"                     = 0
+                "query governor cost limit"          = 0
+                "query wait (s)"                     = -1
+                "recovery interval (min)"            = 0
+                "remote access"                      = 1
+                "remote admin connections"           = 0
+                "remote data archive"                = 0
+                "remote login timeout (s)"           = 10
+                "remote proc trans"                  = 0
+                "remote query timeout (s)"           = 600
+                "Replication XPs"                    = 0
+                "scan for startup procs"             = 0
+                "server trigger recursion"           = 1
+                "set working set size"               = 0
+                "show advanced options"              = 0
+                "SMO and DMO XPs"                    = 1
+                "transform noise words"              = 0
+                "two digit year cutoff"              = 2049
+                "user connections"                   = 0
+                "User Instance Timeout"              = 60
+                "user instances enabled"             = 0
                 "user options"                       = 0
                 "xp_cmdshell"                        = 0
 

--- a/tests/Get-DbaSpConfigure.Tests.ps1
+++ b/tests/Get-DbaSpConfigure.Tests.ps1
@@ -2,24 +2,44 @@
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = 5
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaSpConfigure).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential','Name','ExcludeName','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Get configuration" {
         $server = Connect-DbaInstance -SqlInstance $script:instance1
         $configs = $server.Query("sp_configure")
         $remotequerytimeout = $configs | Where-Object name -match 'remote query timeout'
 
-        It "returns equal to or more results than the straight T-SQL query" {
+        It "returns equal to results of the straight T-SQL query" {
             $results = Get-DbaSpConfigure -SqlInstance $script:instance1
-            $results.count -ge $configs.count
+            $results.count -eq $configs.count
         }
 
         It "returns two results" {
-            $results = Get-DbaSpConfigure -SqlInstance $script:instance1 -ConfigName RemoteQueryTimeout, AllowUpdates
+            $results = Get-DbaSpConfigure -SqlInstance $script:instance1 -Name RemoteQueryTimeout, AllowUpdates
             $results.Count | Should Be 2
         }
 
+        It "returns two results less than all data" {
+            $results = Get-DbaSpConfigure -SqlInstance $script:instance1 -ExcludeName "remote query timeout (s)", AllowUpdates
+            $results.Count -eq $configs.count -2
+        }
+
         It "matches the output of sp_configure " {
-            $results = Get-DbaSpConfigure -SqlInstance $script:instance1 -ConfigName RemoteQueryTimeout
+            $results = Get-DbaSpConfigure -SqlInstance $script:instance1 -Name RemoteQueryTimeout
             $results.ConfiguredValue -eq $remotequerytimeout.config_value | Should Be $true
             $results.RunningValue -eq $remotequerytimeout.run_value | Should Be $true
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #3822 #3756 #3237)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issues around sp_configure commands

Fix issues raised in #3822 and 3237
Have also added ExcludeName parameter as per 2387

Have fixed issues raised in #3756
Fixed some bugs found in the internal function Get-SqlDefaultSpConfigure 

The Import-DbaSpConfigure command has been modified to use the normal messaging system and also include checks for SysAdmin access

There is an issue #3351 related to Export-DbaSpConfigure. If this is considered valid then this can be easily included.

### Commands to test
Get-DbaSpConfigure
Export-DbaSpConfigure
Import-DbaSpConfigure

