### PR TITLE
fixing path check/create for script only

### DIFF
--- a/functions/Export-DbaSpConfigure.ps1
+++ b/functions/Export-DbaSpConfigure.ps1
@@ -85,7 +85,7 @@ function Export-DbaSpConfigure {
                 $mydocs = [Environment]::GetFolderPath('MyDocuments')
                 $filepath = "$mydocs\$($server.name.replace('\', '$'))-$timenow-sp_configure.sql"
             }
-            
+
             if (Test-Path $Path -PathType Container) {
                 $timenow= (Get-Date -uformat "%m%d%Y%H%M%S")
                 $filepath = Join-Path -Path $Path -ChildPath "$($server.name.replace('\', '$'))-$timenow-sp_configure.sql"
@@ -100,17 +100,17 @@ function Export-DbaSpConfigure {
                     $filepath = $Path
                 }
             }
-            
+
             If (-not $filepath) {
                 $filepath = $Path
             }
-            
+
             $topdir = Split-Path -Path $filepath
-            
+
             if (-not (Test-Path -Path $topdir)) {
-                New-Item -Path $topdir -ItemType Directory    
+                New-Item -Path $topdir -ItemType Directory
             }
-            
+
             $ShowAdvancedOptions = $server.Configuration.ShowAdvancedOptions.ConfigValue
 
             if($ShowAdvancedOptions -eq 0) {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -658,7 +658,7 @@ $BackupHistory | Restore-DbaDatabse -SqlInstance sql2000 -TrustDbBackupHistory
 
             try {
                 Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
-                $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true
+                $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
             }
             catch {
                 Stop-Function -ErrorRecord $_ -Message "Failure" -Continue

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -800,6 +800,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
     }
 
+    Context "Don't try to create/test folders with OutputScriptOnly (Issue 4046)"{
+        $null = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\RestoreTimeClean\RestoreTimeClean.bak -DestinationDataDirectory g:\DoesNtExist -OutputScriptOnly -WarningVariable warnvar
+        It "Should not raise a warning" {
+            ('' -eq $warnvar) | Should -Be $True
+        }
+    }
+
     if ($env:azurepasswd1) {
         Context "Restores to Azure" {
             BeforeAll {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4046 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
OutputScriptOnly wasn't shorting out the folder tests.

### Approach
Now it does skip them. An info message about the missing path is raised in the verbose stream


