### PR TITLE
Test-DbLastBackup Max size now working as expected

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -447,19 +447,19 @@ function Test-DbaLastBackup {
                             }
 
                             #Cleanup BackupFiles if -CopyFile and backup was moved to destination
-                            if ($CopyFile) {
-                                Write-Message -Level Verbose -Message "Removing copied backup file from $destination."
-                                try {
-                                    $removearray | Remove-item -ErrorAction Stop
-                                }
-                                catch {
-                                    Write-Message -Level Warning -Message $_ -ErrorRecord $_ -Target $instance
-                                }
-                            }
 
                             $destserver.Databases.Refresh()
                             if ($destserver.Databases[$dbname] -and !$NoDrop) {
                                 Write-Message -Level Warning -Message "$dbname was not dropped."
+                            }
+                        }
+                        if ($CopyFile) {
+                            Write-Message -Level Verbose -Message "Removing copied backup file from $destination."
+                            try {
+                                $removearray | Remove-item -ErrorAction Stop
+                            }
+                            catch {
+                                Write-Message -Level Warning -Message $_ -ErrorRecord $_ -Target $instance
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3968)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix the user requirements

### Approach
reset the results parameter properly on each loop
Move the cleanup outside of the success section so it works when things fail

The trailing space fails are because someone committed them into dev.