### PR TITLE
Fixed relative path issue in Export-DbaDacPackage (#4053)

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -91,6 +91,11 @@ function Export-DbaDacPackage {
             Stop-Function -Message "$Path doesn't exist or access denied"
         }
 
+        # Convert $Path to absolute path because relative paths are problematic when you mix PowerShell commands
+        # and System.IO.
+        # This must happen after Test-Path because Resolve-Path will throw an exception if a path does not exist.
+        $Path = (Resolve-Path $Path).Path
+        
         if ((Get-Item $path) -isnot [System.IO.DirectoryInfo]) {
             Stop-Function -Message "Path must be a directory"
         }

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -28,5 +28,23 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                 Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
             }
         }
+
+        It "exports to the correct directory" {
+            $testFolder = 'C:\Temp\dacpacs'
+            New-Item $testFolder -ItemType Directory
+
+            Push-Location $testFolder
+            try {
+                $relativePath = '.\'
+                $expectedPath = (Resolve-Path $relativePath).Path
+
+                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Path $relativePath
+                $results.Path | Split-Path | Should -Be $expectedPath
+            }
+            finally {
+                Pop-Location
+                Remove-Item $testFolder -Force -Recurse
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4053
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix for #4053

### Approach
Converts relative paths to absolute paths.

### Commands to test
Export-DbaDacPackage -Path .\

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
