### PR TITLE
added example for using -FileMapping

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -11,7 +11,6 @@ function Restore-DbaDatabase {
         The function defaults to working on a remote instance. This means that all paths passed in must be relative to the remote instance.
         XpDirTree will be used to perform the file scans
 
-
         Various means can be used to pass in a list of files to be considered. The default is to non recursively scan the folder
         passed in.
 

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -291,12 +291,23 @@ function Restore-DbaDatabase {
 
         $BackupHistory = Get-DbaBackupInformation -SqlInstance sql2005 -Path \\backups\sql2000\ProdDb
         $BackupHistory | Restore-DbaDatabse -SqlInstance sql2000 -TrustDbBackupHistory
+    
     .EXAMPLE
         Restore-DbaDatabase -SqlInstance server1\instance1 -Path "C:\Temp\devops_prod_full.bak" -DatabaseName "DevOps_DEV" -ReplaceDbNameInFile
         Rename-DbaDatabase -SqlInstance server1\instance1 -Database "DevOps_DEV" -LogicalName "<DBN>_<FT>"
 
         This will restore the database from the "C:\Temp\devops_prod_full.bak" file, with the new name "DevOps_DEV" and store the different physical files with the new name. It will use the system default configured data and log locations.
         After the restore the logical names of the database files will be renamed with the "DevOps_DEV_ROWS" for MDF/NDF and "DevOps_DEV_LOG" for LDF
+    
+    .EXAMPLE
+        $FileStructure = @{
+            'database_data' = 'C:\Data\database_data.mdf'
+            'database_log' = 'C:\Log\database_log.ldf'
+        }
+        Restore-DbaDatabase -SqlInstance server1 -Path \\ServerName\ShareName\File -DatabaseName database -FileMapping $FileStructure
+
+        Restores 'database' to 'server1' and moves the files to new locations. The format for the $FileStructure HashTable is the file logical name as the Key, and the new location as the Value.
+
     .NOTES
         Tags: DisasterRecovery, Backup, Restore
         Author: Stuart Moore (@napalmgram), stuart-moore.com


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add an example for using the -FileMapping parameter to move files during restore.

### Approach
<!-- How does this change solve that purpose -->
 
```
.EXAMPLE
        $FileStructure = @{
            'database_data' = 'C:\Data\database_data.mdf'
            'database_log' = 'C:\Log\database_log.ldf'
        }
        Restore-DbaDatabase -SqlInstance server1 -Path \\ServerName\ShareName\File -DatabaseName database -FileMapping $FileStructure

        Restores 'database' to 'server1' and moves the files to new locations. The format for the $FileStructure HashTable is the file logical name as the Key, and the new location as the Value.
```
