### PR TITLE
Fixed a bug with setting Array properties

### DIFF
--- a/functions/Start-DbaXESmartTarget.ps1
+++ b/functions/Start-DbaXESmartTarget.ps1
@@ -202,9 +202,17 @@
                     $newResponder = New-Object -TypeName $typename
                     foreach ($property in $responder.PSObject.Properties) {
                         if ($property.Value) {
-                            $name = $property.Name
-                            $newResponder.$name = $property.Value
+                            if($property.Value -is [Array]) {
+                                "$($property.Name) is Array" 
+                                $name = $property.Name
+                                $newResponder.$name = [object[]]$property.Value
+                            }
+                            else {
+                                $name = $property.Name
+                                $newResponder.$name = $property.Value   
+                            }
                         }
+
                     }
                     $params["Responder"] += $newResponder
                 }

--- a/functions/Start-DbaXESmartTarget.ps1
+++ b/functions/Start-DbaXESmartTarget.ps1
@@ -203,7 +203,6 @@
                     foreach ($property in $responder.PSObject.Properties) {
                         if ($property.Value) {
                             if($property.Value -is [Array]) {
-                                "$($property.Name) is Array" 
                                 $name = $property.Name
                                 $newResponder.$name = [object[]]$property.Value
                             }


### PR DESCRIPTION
Array properties ended up being passed a single string value with all values concatenated.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fix a bug with array properties of XESmartTarget Response types. They ened up being treated as a single string value with all values concatenated.
Example:

```
$columns = "name", "collection_time", "client_app_name", "server_principal_name", "client_hostname", "database_name"
$response = New-DbaXESmartTableWriter -SqlInstance "MyServer" -Database dba -Table loginaudit -OutputColumn $columns -UploadIntervalSeconds 10 
Start-DbaXESmartTarget -SqlInstance "MyServer" -Session srvloginaudit -Responder $response 
```

In this case, when the background job is created, OutputColumns becomes a single string:
`"name collection_time client_app_name server_principal_name client_hostname database_name"`

### Approach
All properties are tested for `-is [Array]` and, in case, casted to Array.

### Commands to test
```
$columns = "name", "collection_time", "client_app_name", "server_principal_name", "client_hostname", "database_name"
$response = New-DbaXESmartTableWriter -SqlInstance "MyServer" -Database dba -Table loginaudit -OutputColumn $columns -UploadIntervalSeconds 10 
Start-DbaXESmartTarget -SqlInstance "MyServer" -Session srvloginaudit -Responder $response 
```