### PR TITLE
Fixing up backup rebase functionality

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -215,9 +215,11 @@ function Format-DbaBackupInformation {
                 }
             }
             if ($null -ne $RebaseBackupFolder -and $History.FullName[0] -notmatch 'http') {
-                $History.FullName | ForEach-Object {
-                    $file = [System.IO.FileInfo]$_
-                    $_ = $RebaseBackupFolder + "\" + $file.BaseName + $file.Extension
+                for ($i = 0; $i -lt $History.count; $i++){
+                    for ($j = 0; $j -lt $History[$i].fullname.count; $j++){
+                        $file = [System.IO.FileInfo]$History[$i].fullname[$j]
+                        $History[$i].fullname[$j] = $RebaseBackupFolder + "\" + $file.BaseName + $file.Extension
+                    }
                 }
             }
             $History

--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -214,14 +214,16 @@ function Format-DbaBackupInformation {
                     }
                 }
             }
-            if ($null -ne $RebaseBackupFolder -and $History.FullName[0] -notmatch 'http') {
-                for ($i = 0; $i -lt $History.count; $i++){
-                    for ($j = 0; $j -lt $History[$i].fullname.count; $j++){
-                        $file = [System.IO.FileInfo]$History[$i].fullname[$j]
-                        $History[$i].fullname[$j] = $RebaseBackupFolder + "\" + $file.BaseName + $file.Extension
-                    }
+            if ('' -ne $RebaseBackupFolder -and $History.FullName[0] -notmatch 'http') {
+                Write-Message -Message 'Rebasing backup files' -Level Verbose
+
+                for ($j = 0; $j -lt $History.fullname.count; $j++){
+                    $file = [System.IO.FileInfo]($History.fullname[$j])
+                    $History.fullname[$j] = $RebaseBackupFolder + "\" + $file.BaseName + $file.Extension
                 }
+
             }
+
             $History
         }
     }

--- a/tests/Format-DbaBackupInformation.Tests.ps1
+++ b/tests/Format-DbaBackupInformation.Tests.ps1
@@ -122,7 +122,7 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
         $Output = Format-DbaBackupInformation -BackupHistory $History -RebaseBackupFolder c:\backups\
 
         It "Should not have moved all backup files to c:\backups" {
-            ($Output | Select-Object -ExpandProperty FullName | split-path | Where-Object {$_ -eq 'c:\backups'}).count | Should Be 0
+            ($Output | Select-Object -ExpandProperty FullName | split-path | Where-Object {$_ -eq 'c:\backups'}).count | Should Be $History.count
         }
 
     }
@@ -143,7 +143,7 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
             (($Output | Select-Object -ExpandProperty Filelist | Where-Object {$_.Type -eq 'L'}).PhysicalName | split-path | Where-Object {$_ -ne 'c:\logs'}).count | Should Be 0
         }
         It "Should not have moved all backup files to c:\backups" {
-            ($Output | Select-Object -ExpandProperty FullName | split-path | Where-Object {$_ -eq 'c:\backups'}).count | Should Be 0
+            ($Output | Select-Object -ExpandProperty FullName | split-path | Where-Object {$_ -eq 'c:\backups'}).count | Should Be $History.count
         }
 
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included (well, it works now).
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Reported in slack that the rebase functionality on Format-DbaBackupInformation wasn't working

### Approach
Made it work.

With the pass by copy a foreach loop wasn't working so switched to a for loop which allowed me to poke directly back into the array (can have multiple paths so needs to loop). 

Also fixed the pester test that was testing the opposite of what should have (ie it would fail if the backups were rebased)

### Learning
Check the test before assuming you can use it to prove things are working.