### PR TITLE
Set-DbaLogin -Allow pipeline from Get-DbaLogin

### DIFF
--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -128,11 +128,6 @@ function Set-DbaLogin {
 
     Remove the server role "bulkadmin" to the login
 
-    .EXAMPLE
-    Get-DbaLogin -SqlInstance sql1 -Login test | Set-DbaLogin -RemoveRole bulkadmin
-
-    Remove the server role "bulkadmin" from the login test on sql1
-
 #>
 
     [CmdletBinding(DefaultParameterSetName = "Default")]

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -344,9 +344,23 @@ function Set-DbaLogin {
             else {
                 $notes = $null
             }
-
-            Get-DbaLogin -SqlInstance $server -Login $l.Name
-
+            # Return the results
+                [PSCustomObject]@{
+                    ComputerName           = $server.ComputerName
+                    InstanceName           = $server.ServiceName
+                    SqlInstance            = $server.DomainInstanceName
+                    LoginName              = $l.Name
+                    DenyLogin              = $l.DenyWindowsLogin
+                    IsDisabled             = $l.IsDisabled
+                    IsLocked               = $l.IsLocked
+                    PasswordPolicyEnforced = $l.PasswordPolicyEnforced
+                    MustChangePassword     = $l.MustChangePassword
+                    PasswordChanged        = $passwordChanged
+                    ServerRole             = $roles.Role -join ","
+                    Notes                  = $notes
+                } | Select-DefaultView -ExcludeProperty Login
+                # Change output and update tests when there's time
+            # Get-DbaLogin -SqlInstance $server -Login $l.Name
         }
     }
 }

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -74,6 +74,18 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             $result.DenyLogin | Should -Be $false
         }
 
+        It "Enforces password policy on login" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced
+
+            $result.PasswordPolicyEnforced | Should Be $true
+        }
+
+        It "Disables enforcing password policy on login" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced:$false
+
+            $result.PasswordPolicyEnforced | Should Be $false
+        }
+
         It "Add roles to login" {
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -AddRole serveradmin, processadmin
 

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 14
         [object[]]$params = (Get-ChildItem function:\Set-DbaLogin).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'Password', 'Unlock', 'MustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'AddRole', 'RemoveRole', 'EnableException'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'Password', 'Unlock', 'MustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'AddRole', 'RemoveRole', 'EnableException', 'InputObject'
+        $paramCount = $knownParameters.Count
         It "Contains our specific parameters" {
-            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+            ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
         }
     }
 }
@@ -26,26 +26,12 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
         }
 
         It "Does test login exist" {
-            $logins = Get-DbaLogin -SqlInstance $script:instance2 | Where-Object {$_.Name -eq "testlogin"} | Select-Object Name
+            $logins = Get-DbaLogin -SqlInstance $script:instance2 | Where-Object { $_.Name -eq "testlogin" } | Select-Object Name
             $logins.Name | Should -Be "testlogin"
         }
 
         It "Change the password"{
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Password $password2
-
-            $result.PasswordChanged | Should -Be $true
-        }
-
-        It "Change the password via SqlInstance pipeline" {
-            $instance = Connect-DbaInstance -SqlInstance $script:instance2
-            $result = $instance | Set-DbaLogin -Login 'testLogin' -Password $password2
-
-            $result.PasswordChanged | Should -Be $true
-        }
-
-        It "Change the password via Get-DbaLogin pipeline" {
-            $login = Get-DbaLogin -SqlInstance $script:instance2 -Login testLogin
-            $result = $login | Set-DbaLogin -Password $password2
 
             $result.PasswordChanged | Should -Be $true
         }

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -36,6 +36,20 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             $result.PasswordChanged | Should -Be $true
         }
 
+        It "Change the password via SqlInstance pipeline" {
+            $instance = Connect-DbaInstance -SqlInstance $script:instance2
+            $result = $instance | Set-DbaLogin -Login 'testLogin' -Password $password2
+
+            $result.PasswordChanged | Should -Be $true
+        }
+
+        It "Change the password via Get-DbaLogin pipeline" {
+            $login = Get-DbaLogin -SqlInstance $script:instance2 -Login testLogin
+            $result = $login | Set-DbaLogin -Password $password2
+
+            $result.PasswordChanged | Should -Be $true
+        }
+
         It "Disable the login" {
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Disable
 
@@ -58,18 +72,6 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -GrantLogin
 
             $result.DenyLogin | Should -Be $false
-        }
-
-        It "Enforces password policy on login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced
-
-            $result.PasswordPolicyEnforced | Should Be $true
-        }
-
-        It "Disables enforcing password policy on login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced:$false
-
-            $result.PasswordPolicyEnforced | Should Be $false
         }
 
         It "Add roles to login" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Accept Get-DbaLogin as input to Set-DbaLogin on the pipeline.

### Approach
<!-- How does this change solve that purpose -->
Get-DbaLogin outputs SqlInstance, Name. On Set-DbaLogin I added ValueFromPipelineByPropertyName to the SqlInstance and Login parameters. I also had to add an alias of Name to the Login parameter.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```powershell
Get-DbaLogin -SqlInstance sql1 -Login test | Set-DbaLogin -RemoveRole bulkadmin
```