### PR TITLE
Find-DbaCommand, better examples gathering

### DIFF
--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -94,6 +94,10 @@ function Find-DbaCommand {
         [switch]$EnableException
     )
     begin {
+        function Get-DbaTrimmedString($Text) {
+            return $Text.Trim() -replace '(\r\n){2,}', "`n"
+        }
+
         $tagsRex = ([regex]'(?m)^[\s]{0,15}Tags:(.*)$')
         $authorRex = ([regex]'(?m)^[\s]{0,15}Author:(.*)$')
         $minverRex = ([regex]'(?m)^[\s]{0,15}MinimumVersion:(.*)$')
@@ -112,7 +116,7 @@ function Find-DbaCommand {
             $thebase.Description = $thishelp.Description.Text
 
             ## fetch examples
-            $thebase.Examples = $thishelp.Examples | Out-String -Width 120
+            $thebase.Examples = Get-DbaTrimmedString -Text ($thishelp.Examples | Out-String -Width 200)
 
             ## fetch help link
             $thebase.Links = ($thishelp.relatedLinks).NavigationLink.Uri
@@ -121,10 +125,10 @@ function Find-DbaCommand {
             $thebase.Synopsis = $thishelp.Synopsis
 
             ## fetch the syntax
-            $thebase.Syntax = $thishelp.Syntax | Out-String -Width 120
+            $thebase.Syntax = Get-DbaTrimmedString -Text ($thishelp.Syntax | Out-String -Width 600)
 
             ## store notes
-            $as = $thishelp.AlertSet | Out-String -Width 120
+            $as = $thishelp.AlertSet | Out-String -Width 600
 
             ## fetch the tags
             $tags = $tagsrex.Match($as).Groups[1].Value


### PR DESCRIPTION

## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
In order to comply with rendering, it's not useful to have examples and syntax cut out and having return codes within the code. 
If spacing/factoring/beautifying/readability is needed, multiline should be enforced in the CBH right in the source (prefixing every code line with `PS C:\>`)
