### PR TITLE
Test-DbaBuild, fixes #3896

### DIFF
--- a/functions/Test-DbaBuild.ps1
+++ b/functions/Test-DbaBuild.ps1
@@ -1,3 +1,4 @@
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Test-DbaBuild {
     <#
     .SYNOPSIS
@@ -216,7 +217,7 @@ function Test-DbaBuild {
             $targetSPName = $null
             $targetCUName = $null
             if ($BuildVersion.MatchType -eq 'Approximate') {
-                Stop-Function -Message "$($BuildVersion.Build) is not recognized as a correct version" -ErrorRecord $_ -Continue
+                Write-Message -Level Warning -Message "$($BuildVersion.Build) is not recognized as a correct version"
             }
             if ($MinimumBuild) {
                 Write-Message -Level Debug -Message "Comparing $MinimumBuild to $inputbuild"


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3896)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Reporting also on not Exact matches. The fix was so easy I'm embarassed the issue has been opened for such a long time.

### Approach
warn but continue reporting instead of warning and continue the next iteration of the loop.

### Commands to test
The ones on the original bug report are perfectly fine to reproduce
