### PR TITLE
Restore-DbaDbCertificate - add parameter, fix some formatting

### DIFF
--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -18,6 +18,9 @@ function Restore-DbaDbCertificate {
         .PARAMETER Password
             Secure string used to decrypt the private key.
 
+        .PARAMETER EncryptionPassword
+            If specified this will be used to encrypt the private key.
+
         .PARAMETER Database
             The database where the certificate imports into. Defaults to master.
 
@@ -28,23 +31,28 @@ function Restore-DbaDbCertificate {
             Prompts you for confirmation before executing any changing operations within the command.
 
         .PARAMETER EnableException
-                By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-                This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-                Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
         .NOTES
-        Tags: Migration, Certificate
-        Author: Jess Pomfret (@jpomfret)
+            Tags: Migration, Certificate
+            Author: Jess Pomfret (@jpomfret), jesspomfret.com
 
-        Website: https://dbatools.io
-        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-        License: MIT https://opensource.org/licenses/MIT
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+            License: MIT https://opensource.org/licenses/MIT
 
         .EXAMPLE
-        Restore-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -password (ConvertTo-SecureString -force -AsPlainText GoodPass1234!!)
-        Imports all the certificates in the specified path.
+            Restore-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -Password (ConvertTo-SecureString -Force -AsPlainText GoodPass1234!!)
 
-        #>
+            Restores all the certificates in the specified path, password is used to both decrypt and encrypt the private key.
+
+        .EXAMPLE
+            Restore-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates\DatabaseTDE.cer -EncryptionType MasterKey -Password (ConvertTo-SecureString -force -AsPlainText GoodPass1234!!)
+
+            Restores the DatabaseTDE certificate to Server1 and uses the MasterKey to encrypt the private key.
+    #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory)]
@@ -54,6 +62,7 @@ function Restore-DbaDbCertificate {
         [PSCredential]$SqlCredential,
         [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$Path,
+        [Security.SecureString]$EncryptionPassword,
         [object]$Database = "master",
         [Security.SecureString]$Password = (Read-Host "Password" -AsSecureString),
         [Alias('Silent')]
@@ -63,39 +72,19 @@ function Restore-DbaDbCertificate {
     begin {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Retore-DbaDatabaseCertificate
 
-        function new-smocert ($directory, $certname) {
-            if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
-                $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
-                $smocert.Name = $certname
-                $smocert.Parent = $server.Databases[$Database]
-                Write-Message -Level Verbose -Message "Creating Certificate: $certname"
-                try {
-                    $fullcertname = "$directory\$certname.cer"
-                    $privatekey = "$directory\$certname.pvk"
-                    Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
-                    Write-Message -Level Verbose -Message "Private key: $privatekey"
-                    $fromfile = 1
-                    $smocert.Create($fullcertname, $fromfile, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)))
-                    $smocert
-                }
-                catch {
-                    Write-Message -Level Warning -Message $_ -ErrorRecord $_ -Target $instance
-                }
-            }
-        }
-
-        try {
-            Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $sqlcredential
-        }
-        catch {
-            Stop-Function -Message "Failed to connect to: $SqlInstance" -Target $SqlInstance -InnerErrorRecord $_
-            return
-        }
     }
 
     process {
         if (Test-FunctionInterrupt) { return }
+
+            try {
+                Write-Message -Level Verbose -Message "Connecting to $SqlInstance"
+                $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failed to connect to: $SqlInstance" -Target $SqlInstance -InnerErrorRecord $_
+                return
+            }
 
         foreach ($fullname in $path) {
 
@@ -109,8 +98,30 @@ function Restore-DbaDbCertificate {
 
             $directory = Split-Path $fullname
             $filename = Split-Path $fullname -Leaf
-            $basename = [io.path]::GetFileNameWithoutExtension($filename)
-            $cert = new-smocert -directory $directory -certname $basename
+            $certname = [io.path]::GetFileNameWithoutExtension($filename)
+
+            if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
+                $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
+                $smocert.Name = $certname
+                $smocert.Parent = $server.Databases[$Database]
+                Write-Message -Level Verbose -Message "Creating Certificate: $certname"
+                try {
+                    $fullcertname = "$directory\$certname.cer"
+                    $privatekey = "$directory\$certname.pvk"
+                    Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
+                    Write-Message -Level Verbose -Message "Private key: $privatekey"
+                    $fromfile = 1
+                    if($EncryptionPassword) {
+                        $smocert.Create($fullcertname, $fromfile, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)))
+                    }else {
+                        $smocert.Create($fullcertname, $fromfile, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)))
+                    }
+                    $cert = $smocert
+                }
+                catch {
+                    Write-Message -Level Warning -Message $_ -ErrorRecord $_ -Target $instance
+                }
+            }
             Get-DbaDbCertificate -SqlInstance $server -Database $Database -Certificate $cert.Name
         }
     }

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -1,50 +1,50 @@
 function Restore-DbaDbCertificate {
     <#
-.SYNOPSIS
-Imports certificates from .cer files using SMO.
+        .SYNOPSIS
+            Imports certificates from .cer files using SMO.
 
-.DESCRIPTION
-Imports certificates from.cer files using SMO.
+        .DESCRIPTION
+            Imports certificates from.cer files using SMO.
 
-.PARAMETER SqlInstance
-The SQL Server to create the certificates on.
+        .PARAMETER SqlInstance
+            The SQL Server to create the certificates on.
 
-.PARAMETER Path
-The Path the contains the certificate and private key files. The path can be a directory or a specific certificate.
+        .PARAMETER Path
+            The Path the contains the certificate and private key files. The path can be a directory or a specific certificate.
 
-.PARAMETER SqlCredential
-Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
+        .PARAMETER SqlCredential
+            Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
-.PARAMETER Password
-Secure string used to decrypt the private key.
+        .PARAMETER Password
+            Secure string used to decrypt the private key.
 
-.PARAMETER Database
-The database where the certificate imports into. Defaults to master.
+        .PARAMETER Database
+            The database where the certificate imports into. Defaults to master.
 
-.PARAMETER WhatIf
-Shows what would happen if the command were to run. No actions are actually performed.
+        .PARAMETER WhatIf
+            Shows what would happen if the command were to run. No actions are actually performed.
 
-.PARAMETER Confirm
-Prompts you for confirmation before executing any changing operations within the command.
+        .PARAMETER Confirm
+            Prompts you for confirmation before executing any changing operations within the command.
 
-.PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER EnableException
+                By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+                This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+                Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-.NOTES
-Tags: Migration, Certificate
-Author: Jess Pomfret (@jpomfret)
+        .NOTES
+        Tags: Migration, Certificate
+        Author: Jess Pomfret (@jpomfret)
 
-Website: https://dbatools.io
-Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
-License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+        License: MIT https://opensource.org/licenses/MIT
 
-.EXAMPLE
-Restore-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -password (ConvertTo-SecureString -force -AsPlainText GoodPass1234!!)
-Imports all the certificates in the specified path.
+        .EXAMPLE
+        Restore-DbaDbCertificate -SqlInstance Server1 -Path \\Server1\Certificates -password (ConvertTo-SecureString -force -AsPlainText GoodPass1234!!)
+        Imports all the certificates in the specified path.
 
-#>
+        #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
     param (
         [Parameter(Mandatory)]
@@ -64,7 +64,7 @@ Imports all the certificates in the specified path.
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Retore-DbaDatabaseCertificate
 
         function new-smocert ($directory, $certname) {
-            if ($Pscmdlet.ShouldProcess("$cert on $SqlInstance", "Importing Certificate")) {
+            if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
                 $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
                 $smocert.Name = $certname
                 $smocert.Parent = $server.Databases[$Database]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Added the -EncryptionPassword parameter, previously certificates were being restored to the server and then encrypted with the Decryption password. Now If you specify an encryption password it will use that, however if you don't it will be encrypted using the master key which I believe would be preferable behaviour (at least it is in my shop).

### Approach
<!-- How does this change solve that purpose -->
Adds `-EncryptionPassword` parameter

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
#encrypts using master key
Restore-DbaDbCertificate -SqlInstance $server -Path $path -Password $password

#encrypts using password
Restore-DbaDbCertificate -SqlInstance $server -Path $path -Password $password -EncryptionPassword $password
```