### PR TITLE
Get-DbaDatabase, faster enum

### DIFF
--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -283,7 +283,7 @@ function Get-DbaDatabase {
 
             $inputObject = @()
             foreach($dt in $backed_info) {
-                $inputObject += $server.Databases[$dt.name]
+                $inputObject += $server.Databases | Where-Object Name -ceq $dt.name
             }
             $inputobject = $inputObject |
                 Where-Object {


### PR DESCRIPTION
for whatever reason, recent SMOs have a very unspeedy behaviour when selecting from a "keyed dictionary"