### PR TITLE
Test-DbaDbCompression fixes issue with non default schema

### DIFF
--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -440,16 +440,16 @@ DEALLOCATE cur;
 UPDATE ##testdbacompression
 SET
  [PercentScan] =
-	 case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
-	 ELSE i.range_scan_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
-	 END
+     case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
+     ELSE i.range_scan_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
+     END
  ,[PercentUpdate] =
-	case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
-	ELSE i.leaf_update_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
-	END
+    case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
+    ELSE i.leaf_update_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
+    END
 FROM sys.dm_db_index_operational_stats(db_id(), NULL, NULL, NULL) i
 INNER JOIN ##testdbacompression tmp
-	ON tmp.ObjectId = i.object_id
+    ON tmp.ObjectId = i.object_id
     AND tmp.IndexID = i.index_id;
 
 

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -245,6 +245,48 @@ function Test-DbaDbCompression {
 
         }
 
+        $sqlVersion = $(Get-DbaBuildReference -SqlInstance svtsqlrestore).Build.Major
+
+        $sqlVersionRestrictions = @()
+
+        if ($sqlVersion -ge 12) {
+            $sqlVersionRestrictions += "
+            BEGIN
+                -- remove memory optimized tables
+                DELETE tdc
+                FROM ##testdbacompression tdc
+                INNER JOIN sys.tables t
+                    ON SCHEMA_NAME(t.schema_id) = tdc.[Schema] COLLATE DATABASE_DEFAULT
+                    AND t.name = tdc.TableName COLLATE DATABASE_DEFAULT
+                WHERE t.is_memory_optimized = 1
+            END"
+        }
+        if ($sqlVersion -ge 13) {
+            $sqlVersionRestrictions += "
+            BEGIN
+                -- remove tables with encrypted columns
+                DELETE tdc
+                FROM ##testdbacompression tdc
+                INNER JOIN sys.tables t
+                    ON SCHEMA_NAME(t.schema_id) = tdc.[Schema] COLLATE DATABASE_DEFAULT
+                    AND t.name = tdc.TableName COLLATE DATABASE_DEFAULT
+                INNER JOIN sys.columns c
+                    ON t.object_id = c.object_id
+                WHERE encryption_type IS NOT NULL
+            END"
+        }
+        if ($sqlVersion -ge 14) {
+            $sqlVersionRestrictions += "
+            BEGIN
+                -- remove graph (node/edge) tables
+                DELETE tdc
+                FROM ##testdbacompression tdc
+                INNER JOIN sys.tables t
+                    ON tdc.[Schema] = SCHEMA_NAME(t.schema_id) COLLATE DATABASE_DEFAULT
+                    AND tdc.TableName = t.name COLLATE DATABASE_DEFAULT
+                WHERE (is_node = 1 OR is_edge = 1)
+            END"
+        }
         $sql = "SET NOCOUNT ON;
 
 IF OBJECT_ID('tempdb..##testdbacompression', 'U') IS NOT NULL
@@ -259,6 +301,7 @@ IF OBJECT_ID('tempdb..##tmpEstimatePage', 'U') IS NOT NULL
 CREATE TABLE ##testdbacompression (
     [Schema] SYSNAME
     ,[TableName] SYSNAME
+    ,[ObjectId] INT
     ,[IndexName] SYSNAME NULL
     ,[Partition] INT
     ,[IndexID] INT
@@ -298,6 +341,7 @@ CREATE TABLE ##tmpEstimatePage (
 INSERT INTO ##testdbacompression (
     [Schema]
     ,[TableName]
+    ,[ObjectId]
     ,[IndexName]
     ,[Partition]
     ,[IndexID]
@@ -307,6 +351,7 @@ INSERT INTO ##testdbacompression (
     )
     SELECT s.NAME AS [Schema]
     ,t.NAME AS [TableName]
+    ,t.OBJECT_ID AS [OBJECTID]
     ,x.NAME AS [IndexName]
     ,p.partition_number AS [Partition]
     ,x.Index_ID AS [IndexID]
@@ -327,40 +372,7 @@ ORDER BY [TableName] ASC;
 
 $sqlRestrict
 
-DECLARE @sqlVersion int
-SELECT @sqlVersion = substring(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')),0,CHARINDEX('.',(CONVERT(VARCHAR,SERVERPROPERTY('ProductVersion')))))
-IF @sqlVersion >= '12'
-    BEGIN
-        -- remove memory optimized tables
-        DELETE tdc
-        FROM ##testdbacompression tdc
-        INNER JOIN sys.tables t
-            ON SCHEMA_NAME(t.schema_id) = tdc.[Schema] COLLATE DATABASE_DEFAULT
-            AND t.name = tdc.TableName COLLATE DATABASE_DEFAULT
-        WHERE t.is_memory_optimized = 1
-    END
-IF @sqlVersion >= '13'
-    BEGIN
-        -- remove tables with encrypted columns
-        DELETE tdc
-        FROM ##testdbacompression tdc
-        INNER JOIN sys.tables t
-            ON SCHEMA_NAME(t.schema_id) = tdc.[Schema] COLLATE DATABASE_DEFAULT
-            AND t.name = tdc.TableName COLLATE DATABASE_DEFAULT
-        INNER JOIN sys.columns c
-            ON t.object_id = c.object_id
-        WHERE encryption_type IS NOT NULL
-    END
-IF @sqlVersion >= '14'
-    BEGIN
-        -- remove graph (node/edge) tables
-        DELETE tdc
-        FROM ##testdbacompression tdc
-        INNER JOIN sys.tables t
-            ON tdc.[Schema] = SCHEMA_NAME(t.schema_id) COLLATE DATABASE_DEFAULT
-            AND tdc.TableName = t.name COLLATE DATABASE_DEFAULT
-        WHERE (is_node = 1 OR is_edge = 1)
-    END
+$sqlVersionRestrictions
 
 DECLARE @schema SYSNAME
     ,@tbname SYSNAME
@@ -426,11 +438,20 @@ DEALLOCATE cur;
 
 --Update usage and partition_number - If database was restore the sys.dm_db_index_operational_stats will be empty until tables have accesses. Executing the sp_estimate_data_compression_savings first will make those entries appear
 UPDATE ##testdbacompression
-SET  [PercentScan] = i.range_scan_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
-    ,[PercentUpdate] = i.leaf_update_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
+SET
+ [PercentScan] =
+	 case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
+	 ELSE i.range_scan_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
+	 END
+ ,[PercentUpdate] =
+	case when (i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count) = 0 THEN 0
+	ELSE i.leaf_update_count * 100.0 / NULLIF((i.range_scan_count + i.leaf_insert_count + i.leaf_delete_count + i.leaf_update_count + i.leaf_page_merge_count + i.singleton_lookup_count), 0)
+	END
 FROM sys.dm_db_index_operational_stats(db_id(), NULL, NULL, NULL) i
-INNER JOIN ##testdbacompression tmp ON OBJECT_ID(tmp.TableName) = i.[object_id]
+INNER JOIN ##testdbacompression tmp
+	ON tmp.ObjectId = i.object_id
     AND tmp.IndexID = i.index_id;
+
 
 WITH tmp_cte (
     objname

--- a/tests/Test-DbaDbCompression.Tests.ps1
+++ b/tests/Test-DbaDbCompression.Tests.ps1
@@ -23,11 +23,12 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $dbname = "dbatoolsci_test_$(get-random)"
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $null = $server.Query("Create Database [$dbname]")
-        $null = $server.Query("select * into syscols from sys.all_columns
-                                select * into sysallparams from sys.all_parameters
-                                create clustered index CL_sysallparams on sysallparams (object_id)
+        $null = $server.Query("Create Schema test",$dbname)
+        $null = $server.Query(" select * into syscols from sys.all_columns
+                                select * into test.sysallparams from sys.all_parameters
+                                create clustered index CL_sysallparams on test.sysallparams (object_id)
                                 create nonclustered index NC_syscols on syscols (precision) include (collation_name)
-                                update sysallparams set is_xml_document = 1 where name = '@dbname'
+                                update test.sysallparams set is_xml_document = 1 where name = '@dbname'
                                 ",$dbname)
        }
     AfterAll {
@@ -42,6 +43,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $results.foreach{
             It "Should suggest ROW, PAGE or NO_GAIN for $($PSitem.TableName) - $($PSitem.IndexType) " {
                 $PSitem.CompressionTypeRecommendation | Should BeIn ("ROW","PAGE","NO_GAIN")
+            }
+            It "Should have values for PercentScan and PercentUpdate  $($PSitem.TableName) - $($PSitem.IndexType) " {
+                $PSitem.PercentUpdate | Should Not BeNullOrEmpty
+                $PSitem.PercentScan | Should Not BeNullOrEmpty
             }
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4099 #3698 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- #4099 - bad join to get index usage for objects not in dbo schema, fixed this.  Also changed logic so PercentScan and PercentUpdate return 0 instead of NULLs if there is no usage.  Added pester test to ensure this is the case.
- #3698 - Moved the logic out of the main SQL statement, now the version is determined in PowerShell and only valid SQL for that version is executed.
