### PR TITLE
Set-DbaLogin Updates

### DIFF
--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -178,10 +178,9 @@ function Set-DbaLogin {
             switch ($Password.GetType().Name) {
                 "PSCredential" { $newPassword = $Password.Password }
                 "SecureString" { $newPassword = $Password }
-            }
-
-            if ($Password.GetType().Name -notin @('PSCredential', 'SecureString')) {
-                Stop-Function -Message "Password must be a PSCredential or SecureString" -Target $Login
+                default {
+                    Stop-Function -Message "Password must be a PSCredential or SecureString" -Target $Login
+                }
             }
         }
 

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -165,7 +165,6 @@ function Set-DbaLogin {
     )
 
     begin {
-
         # Check the parameters
         if ($Login -eq $NewName) {
             Stop-Function -Message 'Login name is the same as the value in -NewName' -Target $Login -Continue
@@ -207,7 +206,7 @@ function Set-DbaLogin {
             catch {
                 Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            $InputObject += Get-DbaLogin -SqlInstance $server -Login $Login | Where-Object { ($_.IsSystemObject -eq $false) -and ($_.Name -notlike '##*') }
+            $InputObject += Get-DbaLogin -SqlInstance $server -Login $Login -NoSystem -ExcludeFilter '##*'
         }
 
         # Loop through all the logins

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -166,20 +166,23 @@ function Set-DbaLogin {
 
     begin {
         # Check the parameters
-        if ($Login -eq $NewName) {
+        if ((Test-Bound -ParameterName 'SqlInstance') -and (Test-Bound -ParameterName 'Login' -Not)) {
+            Stop-Function -Message 'You must specify a Login when using SqlInstance'
+        }
+
+        if ((Test-Bound -ParameterName 'NewName') -and $Login -eq $NewName) {
             Stop-Function -Message 'Login name is the same as the value in -NewName' -Target $Login -Continue
         }
 
-        if ($Disable -and $Enable) {
+        if ((Test-Bound -ParameterName 'Disable') -and (Test-Bound -ParameterName 'Enable')) {
             Stop-Function -Message 'You cannot use both -Enable and -Disable together' -Target $Login -Continue
         }
 
-        if ($GrantLogin -and $DenyLogin) {
+        if ((Test-Bound -ParameterName 'GrantLogin') -and (Test-Bound -ParameterName 'DenyLogin')) {
             Stop-Function -Message 'You cannot use both -GrantLogin and -DenyLogin together' -Target $Login -Continue
         }
 
-        # Check the password
-        if ($Password) {
+        if (Test-bound -ParameterName 'Password') {
             switch ($Password.GetType().Name) {
                 'PSCredential' { $newPassword = $Password.Password }
                 'SecureString' { $newPassword = $Password }
@@ -187,10 +190,6 @@ function Set-DbaLogin {
                     Stop-Function -Message 'Password must be a PSCredential or SecureString' -Target $Login
                 }
             }
-        }
-
-        if ((Test-Bound -ParameterName SqlInstance) -And (Test-Bound -ParameterName Login -Not)) {
-            Stop-Function -Message 'You must specify a Login when using SqlInstance'
         }
     }
 
@@ -217,7 +216,7 @@ function Set-DbaLogin {
             $notes = @()
 
             # Change the name
-            if ($NewName) {
+            if (Test-Bound -ParameterName 'NewName') {
                 $allLogins = Get-DbaLogin -SqlInstance $server
 
                 # Check if the new name doesn't already exist
@@ -237,7 +236,7 @@ function Set-DbaLogin {
             }
 
             # Change the password
-            if ($Password) {
+            if (Test-Bound -ParameterName 'Password') {
                 try {
                     $l.ChangePassword($newPassword, $Unlock, $MustChange)
                     $passwordChanged = $true
@@ -250,7 +249,7 @@ function Set-DbaLogin {
             }
 
             # Disable the login
-            if ($Disable) {
+            if (Test-Bound -ParameterName 'Disable') {
                 if ($l.IsDisabled) {
                     Write-Message -Message "Login $l is already disabled" -Level Verbose
                 }
@@ -266,7 +265,7 @@ function Set-DbaLogin {
             }
 
             # Enable the login
-            if ($Enable) {
+            if (Test-Bound -ParameterName 'Enable') {
                 if (-not $l.IsDisabled) {
                     Write-Message -Message "Login $l is already enabled" -Level Verbose
                 }
@@ -282,7 +281,7 @@ function Set-DbaLogin {
             }
 
             # Deny access
-            if ($DenyLogin) {
+            if (Test-Bound -ParameterName 'DenyLogin') {
                 if ($l.DenyWindowsLogin) {
                     Write-Message -Message "Login $l already has login access denied" -Level Verbose
                 }
@@ -292,7 +291,7 @@ function Set-DbaLogin {
             }
 
             # Grant access
-            if ($GrantLogin) {
+            if (Test-Bound -ParameterName 'GrantLogin') {
                 if (-not $l.DenyWindowsLogin) {
                     Write-Message -Message "Login $l already has login access granted" -Level Verbose
                 }
@@ -302,7 +301,7 @@ function Set-DbaLogin {
             }
 
             # Enforce password policy
-            if (Test-Bound PasswordPolicyEnforced) {
+            if (Test-Bound -ParameterName 'PasswordPolicyEnforced') {
                 if ($l.PasswordPolicyEnforced -eq $PasswordPolicyEnforced) {
                     Write-Message -Message "Login $l password policy is already set to $($l.PasswordPolicyEnforced)" -Level Verbose
                 }

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -131,6 +131,12 @@ function Set-DbaLogin {
 
     Remove the server role "bulkadmin" to the login
 
+    .EXAMPLE
+    $login = Get-DbaLogin -SqlInstance sql1 -Login test
+    $login | Set-DbaLogin -Disable
+
+    Disable the login from the pipeline
+
 #>
 
     [CmdletBinding()]

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -212,6 +212,7 @@ function Set-DbaLogin {
         # Loop through all the logins
         foreach ($l in $InputObject) {
             $server = $l.Parent
+
             # Create the notes
             $notes = @()
 
@@ -303,7 +304,7 @@ function Set-DbaLogin {
             # Enforce password policy
             if (Test-Bound PasswordPolicyEnforced) {
                 if ($l.PasswordPolicyEnforced -eq $PasswordPolicyEnforced) {
-                    Write-Message -Message ("Login $l password policy is already set to " + $l.PasswordPolicyEnforced) -Level Verbose
+                    Write-Message -Message "Login $l password policy is already set to $($l.PasswordPolicyEnforced)" -Level Verbose
                 }
                 else {
                     $l.PasswordPolicyEnforced = $PasswordPolicyEnforced
@@ -352,22 +353,23 @@ function Set-DbaLogin {
             else {
                 $notes = $null
             }
+
             # Return the results
-                [PSCustomObject]@{
-                    ComputerName           = $server.ComputerName
-                    InstanceName           = $server.ServiceName
-                    SqlInstance            = $server.DomainInstanceName
-                    LoginName              = $l.Name
-                    DenyLogin              = $l.DenyWindowsLogin
-                    IsDisabled             = $l.IsDisabled
-                    IsLocked               = $l.IsLocked
-                    PasswordPolicyEnforced = $l.PasswordPolicyEnforced
-                    MustChangePassword     = $l.MustChangePassword
-                    PasswordChanged        = $passwordChanged
-                    ServerRole             = $roles.Role -join ','
-                    Notes                  = $notes
-                } | Select-DefaultView -ExcludeProperty Login
-                # Change output and update tests when there's time
+            [PSCustomObject]@{
+                ComputerName           = $server.ComputerName
+                InstanceName           = $server.ServiceName
+                SqlInstance            = $server.DomainInstanceName
+                LoginName              = $l.Name
+                DenyLogin              = $l.DenyWindowsLogin
+                IsDisabled             = $l.IsDisabled
+                IsLocked               = $l.IsLocked
+                PasswordPolicyEnforced = $l.PasswordPolicyEnforced
+                MustChangePassword     = $l.MustChangePassword
+                PasswordChanged        = $passwordChanged
+                ServerRole             = $roles.Role -join ','
+                Notes                  = $notes
+            } | Select-DefaultView -ExcludeProperty Login
+            # Change output and update tests when there's time
             # Get-DbaLogin -SqlInstance $server -Login $l.Name
         }
     }

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -353,23 +353,21 @@ function Set-DbaLogin {
                 $notes = $null
             }
 
-            # Return the results
-            [PSCustomObject]@{
-                ComputerName           = $server.ComputerName
-                InstanceName           = $server.ServiceName
-                SqlInstance            = $server.DomainInstanceName
-                LoginName              = $l.Name
-                DenyLogin              = $l.DenyWindowsLogin
-                IsDisabled             = $l.IsDisabled
-                IsLocked               = $l.IsLocked
-                PasswordPolicyEnforced = $l.PasswordPolicyEnforced
-                MustChangePassword     = $l.MustChangePassword
-                PasswordChanged        = $passwordChanged
-                ServerRole             = $roles.Role -join ','
-                Notes                  = $notes
-            } | Select-DefaultView -ExcludeProperty Login
-            # Change output and update tests when there's time
-            # Get-DbaLogin -SqlInstance $server -Login $l.Name
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'ComputerName' -Value $server.ComputerName
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'InstanceName' -Value $server.ServiceName
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'SqlInstance' -Value $server.DomainInstanceName
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'PasswordChanged' -Value $passwordChanged
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'ServerRole' -Value ($roles.Role -join ',')
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'Notes' -Value $notes
+
+            # backwards compatibility: LoginName, DenyLogin
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'LoginName' -Value $l.Name
+            Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'DenyLogin' -Value $l.DenyWindowsLogin
+
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'LoginName', 'DenyLogin', 'IsDisabled', 'IsLocked',
+                'PasswordPolicyEnforced', 'MustChangePassword', 'PasswordChanged', 'ServerRole', 'Notes'
+
+            Select-DefaultView -InputObject $l -Property $defaults
         }
     }
 }

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -135,7 +135,7 @@ function Set-DbaLogin {
 
     [CmdletBinding()]
     param (
-        [Alias("ServerInstance", "SqlServer")]
+        [Alias('ServerInstance', 'SqlServer')]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Login,
@@ -148,9 +148,9 @@ function Set-DbaLogin {
         [switch]$DenyLogin,
         [switch]$GrantLogin,
         [switch]$PasswordPolicyEnforced,
-        [ValidateSet("bulkadmin", "dbcreator", "diskadmin", "processadmin", "public", "securityadmin", "serveradmin", "setupadmin", "sysadmin")]
+        [ValidateSet('bulkadmin', 'dbcreator', 'diskadmin', 'processadmin', 'public', 'securityadmin', 'serveradmin', 'setupadmin', 'sysadmin')]
         [string[]]$AddRole,
-        [ValidateSet("bulkadmin", "dbcreator", "diskadmin", "processadmin", "public", "securityadmin", "serveradmin", "setupadmin", "sysadmin")]
+        [ValidateSet('bulkadmin', 'dbcreator', 'diskadmin', 'processadmin', 'public', 'securityadmin', 'serveradmin', 'setupadmin', 'sysadmin')]
         [string[]]$RemoveRole,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Login[]]$InputObject,
@@ -162,30 +162,30 @@ function Set-DbaLogin {
 
         # Check the parameters
         if ($Login -eq $NewName) {
-            Stop-Function -Message "Login name is the same as the value in -NewName" -Target $Login -Continue
+            Stop-Function -Message 'Login name is the same as the value in -NewName' -Target $Login -Continue
         }
 
         if ($Disable -and $Enable) {
-            Stop-Function -Message "You cannot use both -Enable and -Disable together" -Target $Login -Continue
+            Stop-Function -Message 'You cannot use both -Enable and -Disable together' -Target $Login -Continue
         }
 
         if ($GrantLogin -and $DenyLogin) {
-            Stop-Function -Message "You cannot use both -GrantLogin and -DenyLogin together" -Target $Login -Continue
+            Stop-Function -Message 'You cannot use both -GrantLogin and -DenyLogin together' -Target $Login -Continue
         }
 
         # Check the password
         if ($Password) {
             switch ($Password.GetType().Name) {
-                "PSCredential" { $newPassword = $Password.Password }
-                "SecureString" { $newPassword = $Password }
+                'PSCredential' { $newPassword = $Password.Password }
+                'SecureString' { $newPassword = $Password }
                 default {
-                    Stop-Function -Message "Password must be a PSCredential or SecureString" -Target $Login
+                    Stop-Function -Message 'Password must be a PSCredential or SecureString' -Target $Login
                 }
             }
         }
 
         if ((Test-Bound -ParameterName SqlInstance) -And (Test-Bound -ParameterName Login -Not)) {
-            Stop-Function -Message "You must specify a Login when using SqlInstance"
+            Stop-Function -Message 'You must specify a Login when using SqlInstance'
         }
     }
 
@@ -194,12 +194,12 @@ function Set-DbaLogin {
 
         foreach ($instance in $sqlinstance) {
             # Try connecting to the instance
-            Write-Message -Message "Connecting to $instance" -Level Verbose
+            Write-Message -Message 'Connecting to $instance' -Level Verbose
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             }
             catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $InputObject += Get-DbaLogin -SqlInstance $server -Login $Login | Where-Object { ($_.IsSystemObject -eq $false) -and ($_.Name -notlike '##*') }
         }
@@ -225,7 +225,7 @@ function Set-DbaLogin {
                     }
                 }
                 else {
-                    $notes += "New login name already exists"
+                    $notes += 'New login name already exists'
                     Write-Message -Message "New login name $NewName already exists on $instance" -Level Verbose
                 }
             }
@@ -359,7 +359,7 @@ function Set-DbaLogin {
                     PasswordPolicyEnforced = $l.PasswordPolicyEnforced
                     MustChangePassword     = $l.MustChangePassword
                     PasswordChanged        = $passwordChanged
-                    ServerRole             = $roles.Role -join ","
+                    ServerRole             = $roles.Role -join ','
                     Notes                  = $notes
                 } | Select-DefaultView -ExcludeProperty Login
                 # Change output and update tests when there's time


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x?] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Added help example for pipeline
Fix formatting
Fix code styling proposed by @wsmelton
Change output to SMO Login object
Cache logins by instance to improve performance

### Approach
* Fix formatting - Changed some double quotes to single quotes, removed some extra white space, etc.
* Fix code styling proposed by @wsmelton - Moved Stop-Function to default portion of switch instead of an additional if
* Change output to SMO Login object - Changed output to SMO Login using Get-DbaDatabase as an example. I kept LoginName and DenyLogin to prevent it from being a breaking change (new names on SMO Login object are Name and DenyWindowsLogin)
* Cache logins by instance to improve performance - Keep a hash table of all logins on each instance and lookup against that instead of looking up for the instance for every login

### Commands to test
Pester tests are pretty inclusive.

### Learning
This one always bites me - to get the actual SQL instance from a DbaInstanceParameter object you need to call .ToString().

This is not true:
```powershell
[DbaInstanceParameter]'Server1' -eq 'Server1'
```

This is true:
```powershell
([DbaInstanceParameter]'Server1').ToString() -eq 'Server1'
```