### PR TITLE
New Get-DbaServerRoleMember Function

### DIFF
--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -62,7 +62,7 @@ function Get-DbaServerRoleMember {
 			Returns all members of the sysadmin or dbcreator roles on localhost.
 
 		.EXAMPLE
-			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ExcludeRole 'sysadmin'
+			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ExcludeServerRole 'sysadmin'
 
 			Returns all members of server-level roles other than sysadmin.
 

--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -1,10 +1,10 @@
 function Get-DbaServerRoleMember {
-	<#
-		.SYNOPSIS
-			Get members of server roles for each instance(s) of SQL Server.
+    <#
+        .SYNOPSIS
+            Get members of server roles for each instance(s) of SQL Server.
 
-		.DESCRIPTION
-			The Get-DbaServerRoleMember returns connected SMO object for server roles for each instance(s) of SQL Server.
+        .DESCRIPTION
+            The Get-DbaServerRoleMember returns connected SMO object for server roles for each instance(s) of SQL Server.
 
         .PARAMETER SqlInstance
             SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
@@ -12,16 +12,16 @@ function Get-DbaServerRoleMember {
         .PARAMETER SqlCredential
             Login to the target instance using alternate Windows or SQL Login Authentication. Accepts credential objects (Get-Credential).
 
-		.PARAMETER ServerRole
-			The role(s) to process. If unspecified, all roles will be processed.
+        .PARAMETER ServerRole
+            The role(s) to process. If unspecified, all roles will be processed.
 
-		.PARAMETER ExcludeServerRole
-			The role(s) to exclude.
+        .PARAMETER ExcludeServerRole
+            The role(s) to exclude.
 
-		.PARAMETER Login
-			The login(s) to process. If unspecified, all logins will be processed.
+        .PARAMETER Login
+            The login(s) to process. If unspecified, all logins will be processed.
 
-		.PARAMETER ExcludeFixedRole
+        .PARAMETER ExcludeFixedRole
             Filter the fixed server-level roles. Only applies to SQL Server 2017 that supports creation of server-level roles.
 
         .PARAMETER EnableException
@@ -40,121 +40,121 @@ function Get-DbaServerRoleMember {
         .LINK
             https://dbatools.io/Get-DbaServerRoleMember
 
-		.EXAMPLE
-			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost
+        .EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance localhost
 
-			Returns all members of all server roles on the local default SQL Server instance
+            Returns all members of all server roles on the local default SQL Server instance
 
         .EXAMPLE
             PS C:\> Get-DbaServerRoleMember -SqlInstance localhost, sql2016
 
-			Returns all members of all server roles on the local and sql2016 SQL Server instances
+            Returns all members of all server roles on the local and sql2016 SQL Server instances
 
         .EXAMPLE
             PS C:\> $servers = Get-Content C:\servers.txt
             PS C:\> $servers | Get-DbaServerRoleMember
 
-			Returns all members of all server roles for every server in C:\servers.txt
+            Returns all members of all server roles for every server in C:\servers.txt
 
-		.EXAMPLE
-			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ServerRole 'sysadmin', 'dbcreator'
+        .EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ServerRole 'sysadmin', 'dbcreator'
 
-			Returns all members of the sysadmin or dbcreator roles on localhost.
+            Returns all members of the sysadmin or dbcreator roles on localhost.
 
-		.EXAMPLE
-			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ExcludeServerRole 'sysadmin'
+        .EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ExcludeServerRole 'sysadmin'
 
-			Returns all members of server-level roles other than sysadmin.
+            Returns all members of server-level roles other than sysadmin.
 
-		.EXAMPLE
+        .EXAMPLE
             PS C:\> Get-DbaServerRoleMember -SqlInstance sql2017a -ExcludeFixedRole
 
-			Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
+            Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
 
-		.EXAMPLE
-			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -Login 'MyFriendlyDeveloper'
+        .EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -Login 'MyFriendlyDeveloper'
 
-			Returns all server-level role(s) for the MyFriendlyDeveloper login on localhost.
+            Returns all server-level role(s) for the MyFriendlyDeveloper login on localhost.
     #>
-	[CmdletBinding()]
-	param (
-		[parameter(Position = 0, Mandatory, ValueFromPipeline)]
-		[Alias('ServerInstance', 'SqlServer')]
-		[DbaInstance[]]$SqlInstance,
-		[Alias('Credential')]
-		[PSCredential]$SqlCredential,
-		[string[]]$ServerRole,
-		[string[]]$ExcludeServerRole,
-		[object[]]$Login,
-		[switch]$ExcludeFixedRole,
-		[Alias('Silent')]
-		[switch]$EnableException
-	)
+    [CmdletBinding()]
+    param (
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias('ServerInstance', 'SqlServer')]
+        [DbaInstance[]]$SqlInstance,
+        [Alias('Credential')]
+        [PSCredential]$SqlCredential,
+        [string[]]$ServerRole,
+        [string[]]$ExcludeServerRole,
+        [object[]]$Login,
+        [switch]$ExcludeFixedRole,
+        [Alias('Silent')]
+        [switch]$EnableException
+    )
 
-	process {
-		foreach ($instance in $SqlInstance) {
-			Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+    process {
+        foreach ($instance in $SqlInstance) {
+            Write-Message -Level Verbose -Message "Attempting to connect to $instance"
 
-			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-			}
-			catch {
-				Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            }
+            catch {
+                Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
-			$roles = $server.Roles
+            $roles = $server.Roles
 
-			if (Test-Bound -ParameterName 'Login') {
-				$logins = Get-DbaLogin -SqlInstance $instance -Login $Login
-				Write-Message -Level 'Verbose' -Message "Filtering by logins: $($logins -join ', ')"
+            if (Test-Bound -ParameterName 'Login') {
+                $logins = Get-DbaLogin -SqlInstance $instance -Login $Login
+                Write-Message -Level 'Verbose' -Message "Filtering by logins: $($logins -join ', ')"
 
-				foreach ($l in $logins) {
-					$loginRoles += $l.ListMembers()
-				}
+                foreach ($l in $logins) {
+                    $loginRoles += $l.ListMembers()
+                }
 
-				$loginRoles = $loginRoles | Select-Object -Unique
-				Write-Message -Level 'Verbose' -Message "Filtering by roles: $($loginRoles -join ', ')"
+                $loginRoles = $loginRoles | Select-Object -Unique
+                Write-Message -Level 'Verbose' -Message "Filtering by roles: $($loginRoles -join ', ')"
 
-				$roles = $roles | Where-Object { $_.Name -in $loginRoles }
-			}
+                $roles = $roles | Where-Object { $_.Name -in $loginRoles }
+            }
 
-			if (Test-Bound -ParameterName 'ServerRole') {
-				$roles = $roles | Where-Object { $_.Name -in $ServerRole }
-			}
+            if (Test-Bound -ParameterName 'ServerRole') {
+                $roles = $roles | Where-Object { $_.Name -in $ServerRole }
+            }
 
-			if (Test-Bound -ParameterName 'ExcludeServerRole') {
-				$roles = $roles | Where-Object { $_.Name -notin $ExcludeServerRole }
-			}
+            if (Test-Bound -ParameterName 'ExcludeServerRole') {
+                $roles = $roles | Where-Object { $_.Name -notin $ExcludeServerRole }
+            }
 
-			if (Test-Bound -ParameterName 'ExcludeFixedRole') {
-				$roles = $roles | Where-Object { $_.IsFixedRole -eq $false }
-			}
+            if (Test-Bound -ParameterName 'ExcludeFixedRole') {
+                $roles = $roles | Where-Object { $_.IsFixedRole -eq $false }
+            }
 
-			foreach ($role in $roles) {
-				Write-Message -Level 'Verbose' -Message "Getting Server Role Members for $role on $instance"
+            foreach ($role in $roles) {
+                Write-Message -Level 'Verbose' -Message "Getting Server Role Members for $role on $instance"
 
-				$members = $role.EnumMemberNames()
-				Write-Message -Level 'Verbose' -Message "$role members: $($members -join ', ')"
+                $members = $role.EnumMemberNames()
+                Write-Message -Level 'Verbose' -Message "$role members: $($members -join ', ')"
 
-				if (Test-Bound -ParameterName 'Login') {
-					Write-Message -Level 'Verbose' -Message "Only returning results for $($logins.Name -join ', ')"
-					$members = $members | Where-Object { $_ -in $logins.Name }
-				}
+                if (Test-Bound -ParameterName 'Login') {
+                    Write-Message -Level 'Verbose' -Message "Only returning results for $($logins.Name -join ', ')"
+                    $members = $members | Where-Object { $_ -in $logins.Name }
+                }
 
-				foreach ($member in $members) {
-					$l = $server.Logins | Where-Object { $_.Name -eq $member }
+                foreach ($member in $members) {
+                    $l = $server.Logins | Where-Object { $_.Name -eq $member }
 
-					if ($l) {
-						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'ComputerName' -Value $server.ComputerName
-						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'InstanceName' -Value $server.ServiceName
-						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'SqlInstance' -Value $server.DomainInstanceName
-						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'Role' -Value $role
+                    if ($l) {
+                        Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'ComputerName' -Value $server.ComputerName
+                        Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'InstanceName' -Value $server.ServiceName
+                        Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'SqlInstance' -Value $server.DomainInstanceName
+                        Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'Role' -Value $role
 
-						Select-DefaultView -InputObject $l -Property 'ComputerName', 'InstanceName', 'SqlInstance', 'Role', 'Name'
-					}
-				}
+                        Select-DefaultView -InputObject $l -Property 'ComputerName', 'InstanceName', 'SqlInstance', 'Role', 'Name'
+                    }
+                }
 
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -18,6 +18,9 @@ function Get-DbaServerRoleMember {
 		.PARAMETER ExcludeServerRole
 			The role(s) to exclude.
 
+		.PARAMETER Login
+			The login(s) to process. If unspecified, all logins will be processed.
+
 		.PARAMETER ExcludeFixedRole
             Filter the fixed server-level roles. Only applies to SQL Server 2017 that supports creation of server-level roles.
 
@@ -66,7 +69,12 @@ function Get-DbaServerRoleMember {
 		.EXAMPLE
             PS C:\> Get-DbaServerRoleMember -SqlInstance sql2017a -ExcludeFixedRole
 
-            Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
+			Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
+
+		.EXAMPLE
+			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -Login 'MyFriendlyDeveloper'
+
+			Returns all server-level role(s) for the MyFriendlyDeveloper login on localhost.
     #>
 	[CmdletBinding()]
 	param (

--- a/functions/Get-DbaServerRoleMember.ps1
+++ b/functions/Get-DbaServerRoleMember.ps1
@@ -1,0 +1,152 @@
+function Get-DbaServerRoleMember {
+	<#
+		.SYNOPSIS
+			Get members of server roles for each instance(s) of SQL Server.
+
+		.DESCRIPTION
+			The Get-DbaServerRoleMember returns connected SMO object for server roles for each instance(s) of SQL Server.
+
+        .PARAMETER SqlInstance
+            SQL Server name or SMO object representing the SQL Server to connect to. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+        .PARAMETER SqlCredential
+            Login to the target instance using alternate Windows or SQL Login Authentication. Accepts credential objects (Get-Credential).
+
+		.PARAMETER ServerRole
+			The role(s) to process. If unspecified, all roles will be processed.
+
+		.PARAMETER ExcludeServerRole
+			The role(s) to exclude.
+
+		.PARAMETER ExcludeFixedRole
+            Filter the fixed server-level roles. Only applies to SQL Server 2017 that supports creation of server-level roles.
+
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+        .NOTES
+            Tags: ServerRole, Security, Login
+            Author: Klaas Vandenberghe (@PowerDBAKlaas)
+
+            Website: https://dbatools.io
+            Copyright: (C) Chrissy LeMaire, clemaire@gmail.com
+-           License: MIT https://opensource.org/licenses/MIT
+
+        .LINK
+            https://dbatools.io/Get-DbaServerRoleMember
+
+		.EXAMPLE
+			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost
+
+			Returns all members of all server roles on the local default SQL Server instance
+
+        .EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance localhost, sql2016
+
+			Returns all members of all server roles on the local and sql2016 SQL Server instances
+
+        .EXAMPLE
+            PS C:\> $servers = Get-Content C:\servers.txt
+            PS C:\> $servers | Get-DbaServerRoleMember
+
+			Returns all members of all server roles for every server in C:\servers.txt
+
+		.EXAMPLE
+			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ServerRole 'sysadmin', 'dbcreator'
+
+			Returns all members of the sysadmin or dbcreator roles on localhost.
+
+		.EXAMPLE
+			PS C:\> Get-DbaServerRoleMember -SqlInstance localhost -ExcludeRole 'sysadmin'
+
+			Returns all members of server-level roles other than sysadmin.
+
+		.EXAMPLE
+            PS C:\> Get-DbaServerRoleMember -SqlInstance sql2017a -ExcludeFixedRole
+
+            Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
+    #>
+	[CmdletBinding()]
+	param (
+		[parameter(Position = 0, Mandatory, ValueFromPipeline)]
+		[Alias('ServerInstance', 'SqlServer')]
+		[DbaInstance[]]$SqlInstance,
+		[Alias('Credential')]
+		[PSCredential]$SqlCredential,
+		[string[]]$ServerRole,
+		[string[]]$ExcludeServerRole,
+		[object[]]$Login,
+		[switch]$ExcludeFixedRole,
+		[Alias('Silent')]
+		[switch]$EnableException
+	)
+
+	process {
+		foreach ($instance in $SqlInstance) {
+			Write-Message -Level Verbose -Message "Attempting to connect to $instance"
+
+			try {
+				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+			}
+			catch {
+				Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+			}
+
+			$roles = $server.Roles
+
+			if (Test-Bound -ParameterName 'Login') {
+				$logins = Get-DbaLogin -SqlInstance $instance -Login $Login
+				Write-Message -Level 'Verbose' -Message "Filtering by logins: $($logins -join ', ')"
+
+				foreach ($l in $logins) {
+					$loginRoles += $l.ListMembers()
+				}
+
+				$loginRoles = $loginRoles | Select-Object -Unique
+				Write-Message -Level 'Verbose' -Message "Filtering by roles: $($loginRoles -join ', ')"
+
+				$roles = $roles | Where-Object { $_.Name -in $loginRoles }
+			}
+
+			if (Test-Bound -ParameterName 'ServerRole') {
+				$roles = $roles | Where-Object { $_.Name -in $ServerRole }
+			}
+
+			if (Test-Bound -ParameterName 'ExcludeServerRole') {
+				$roles = $roles | Where-Object { $_.Name -notin $ExcludeServerRole }
+			}
+
+			if (Test-Bound -ParameterName 'ExcludeFixedRole') {
+				$roles = $roles | Where-Object { $_.IsFixedRole -eq $false }
+			}
+
+			foreach ($role in $roles) {
+				Write-Message -Level 'Verbose' -Message "Getting Server Role Members for $role on $instance"
+
+				$members = $role.EnumMemberNames()
+				Write-Message -Level 'Verbose' -Message "$role members: $($members -join ', ')"
+
+				if (Test-Bound -ParameterName 'Login') {
+					Write-Message -Level 'Verbose' -Message "Only returning results for $($logins.Name -join ', ')"
+					$members = $members | Where-Object { $_ -in $logins.Name }
+				}
+
+				foreach ($member in $members) {
+					$l = $server.Logins | Where-Object { $_.Name -eq $member }
+
+					if ($l) {
+						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'ComputerName' -Value $server.ComputerName
+						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'InstanceName' -Value $server.ServiceName
+						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'SqlInstance' -Value $server.DomainInstanceName
+						Add-Member -Force -InputObject $l -MemberType 'NoteProperty' -Name 'Role' -Value $role
+
+						Select-DefaultView -InputObject $l -Property 'ComputerName', 'InstanceName', 'SqlInstance', 'Role', 'Name'
+					}
+				}
+
+			}
+		}
+	}
+}

--- a/tests/Get-DbaServerRoleMember.Tests.ps1
+++ b/tests/Get-DbaServerRoleMember.Tests.ps1
@@ -3,72 +3,72 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {
-	Context "Validate parameters" {
-		$defaultParamCount = 11
-		$command = Get-Command -Name $CommandName
-		[object[]]$params = $command.Parameters.Keys
-		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'ExcludeFixedRole', 'ServerRole', 'ExcludeServerRole', 'Login'
-		$paramCount = $knownParameters.Count
+    Context "Validate parameters" {
+        $defaultParamCount = 11
+        $command = Get-Command -Name $CommandName
+        [object[]]$params = $command.Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'ExcludeFixedRole', 'ServerRole', 'ExcludeServerRole', 'Login'
+        $paramCount = $knownParameters.Count
 
-		It "Should contain our specific parameters" {
-			((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
-		}
+        It "Should contain our specific parameters" {
+            ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
+        }
 
-		It "Should only contain $paramCount parameters" {
-			$params.Count - $defaultParamCount | Should Be $paramCount
-		}
-	}
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-	BeforeAll {
-		$instance = Connect-DbaInstance -SqlInstance $script:instance2
+    BeforeAll {
+        $instance = Connect-DbaInstance -SqlInstance $script:instance2
 
-		$password1 = ConvertTo-SecureString 'password1' -AsPlainText -Force
-		$testLogin = 'getDbaServerRoleMemberLogin'
-		$null = New-DbaLogin -SqlInstance $instance -Login $testLogin -Password $password1
-		$null = Set-DbaLogin -SqlInstance $instance -Login $testLogin -AddRole 'dbcreator'
-	}
+        $password1 = ConvertTo-SecureString 'password1' -AsPlainText -Force
+        $testLogin = 'getDbaServerRoleMemberLogin'
+        $null = New-DbaLogin -SqlInstance $instance -Login $testLogin -Password $password1
+        $null = Set-DbaLogin -SqlInstance $instance -Login $testLogin -AddRole 'dbcreator'
+    }
 
-	Context "Functionality" {
-		It 'Returns all role membership for server roles' {
-			$result = Get-DbaServerRoleMember -SqlInstance $instance
+    Context "Functionality" {
+        It 'Returns all role membership for server roles' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance
 
-			# should have at least $testLogin and a sysadmin
-			$result.Count | Should -BeGreaterOrEqual 2
-		}
+            # should have at least $testLogin and a sysadmin
+            $result.Count | Should -BeGreaterOrEqual 2
+        }
 
-		It 'Accepts a list of roles' {
-			$result = Get-DbaServerRoleMember -SqlInstance $instance -ServerRole 'sysadmin'
+        It 'Accepts a list of roles' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance -ServerRole 'sysadmin'
 
-			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
-			$uniqueRoles | Should -Be 'sysadmin'
-		}
+            $uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+            $uniqueRoles | Should -Be 'sysadmin'
+        }
 
-		It 'Excludes roles' {
-			$result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeServerRole 'dbcreator'
+        It 'Excludes roles' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeServerRole 'dbcreator'
 
-			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
-			$uniqueRoles | Should -Not -Contain 'dbcreator'
-			$uniqueRoles | Should -Contain 'sysadmin'
-		}
+            $uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+            $uniqueRoles | Should -Not -Contain 'dbcreator'
+            $uniqueRoles | Should -Contain 'sysadmin'
+        }
 
-		It 'Excludes fixed roles' {
-			$result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeFixedRole
-			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
-			$uniqueRoles | Should -Not -Contain 'sysadmin'
-		}
+        It 'Excludes fixed roles' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeFixedRole
+            $uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+            $uniqueRoles | Should -Not -Contain 'sysadmin'
+        }
 
-		It 'Filters by a specific login' {
-			$result = Get-DbaServerRoleMember -SqlInstance $instance -Login $testLogin
+        It 'Filters by a specific login' {
+            $result = Get-DbaServerRoleMember -SqlInstance $instance -Login $testLogin
 
-			$uniqueLogins = $result.Name | Select-Object -Unique
-			$uniqueLogins.Count | Should -BeExactly 1
-			$uniqueLogins | Should -Contain $testLogin
-		}
-	}
+            $uniqueLogins = $result.Name | Select-Object -Unique
+            $uniqueLogins.Count | Should -BeExactly 1
+            $uniqueLogins | Should -Contain $testLogin
+        }
+    }
 
-	AfterAll {
-		Remove-DbaLogin -SqlInstance $instance -Login $testLogin -Force -Confirm:$false
-	}
+    AfterAll {
+        Remove-DbaLogin -SqlInstance $instance -Login $testLogin -Force -Confirm:$false
+    }
 }

--- a/tests/Get-DbaServerRoleMember.Tests.ps1
+++ b/tests/Get-DbaServerRoleMember.Tests.ps1
@@ -1,0 +1,74 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags "UnitTests" {
+	Context "Validate parameters" {
+		$defaultParamCount = 11
+		$command = Get-Command -Name $CommandName
+		[object[]]$params = $command.Parameters.Keys
+		$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'ExcludeFixedRole', 'ServerRole', 'ExcludeServerRole', 'Login'
+		$paramCount = $knownParameters.Count
+
+		It "Should contain our specific parameters" {
+			((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
+		}
+
+		It "Should only contain $paramCount parameters" {
+			$params.Count - $defaultParamCount | Should Be $paramCount
+		}
+	}
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+	BeforeAll {
+		$instance = Connect-DbaInstance -SqlInstance $script:instance2
+
+		$password1 = ConvertTo-SecureString 'password1' -AsPlainText -Force
+		$testLogin = 'getDbaServerRoleMemberLogin'
+		$null = New-DbaLogin -SqlInstance $instance -Login $testLogin -Password $password1
+		$null = Set-DbaLogin -SqlInstance $instance -Login $testLogin -AddRole 'dbcreator'
+	}
+
+	Context "Functionality" {
+		It 'Returns all role membership for server roles' {
+			$result = Get-DbaServerRoleMember -SqlInstance $instance
+
+			# should have at least $testLogin and a sysadmin
+			$result.Count | Should -BeGreaterOrEqual 2
+		}
+
+		It 'Accepts a list of roles' {
+			$result = Get-DbaServerRoleMember -SqlInstance $instance -ServerRole 'sysadmin'
+
+			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+			$uniqueRoles | Should -Be 'sysadmin'
+		}
+
+		It 'Excludes roles' {
+			$result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeServerRole 'dbcreator'
+
+			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+			$uniqueRoles | Should -Not -Contain 'dbcreator'
+			$uniqueRoles | Should -Contain 'sysadmin'
+		}
+
+		It 'Excludes fixed roles' {
+			$result = Get-DbaServerRoleMember -SqlInstance $instance -ExcludeFixedRole
+			$uniqueRoles = $result.Role | Select-Object -ExpandProperty 'Name' -Unique
+			$uniqueRoles | Should -Not -Contain 'sysadmin'
+		}
+
+		It 'Filters by a specific login' {
+			$result = Get-DbaServerRoleMember -SqlInstance $instance -Login $testLogin
+
+			$uniqueLogins = $result.Name | Select-Object -Unique
+			$uniqueLogins.Count | Should -BeExactly 1
+			$uniqueLogins | Should -Contain $testLogin
+		}
+	}
+
+	AfterAll {
+		Remove-DbaLogin -SqlInstance $instance -Login $testLogin -Force -Confirm:$false
+	}
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Server level role membership function described in Issue #4128. This is one of two functions needed to replace Get-DbaRoleMember.

### Approach
<!-- How does this change solve that purpose -->
Server level role membership function described in Issue #4128. This is one of two functions needed to replace Get-DbaRoleMember.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Returns all members of the sysadmin or dbcreator roles on localhost.
```powershell
Get-DbaServerRoleMember -SqlInstance localhost -ServerRole 'sysadmin', 'dbcreator'
```

Returns all members of server-level roles other than sysadmin.
```powershell
Get-DbaServerRoleMember -SqlInstance localhost -ExcludeRole 'sysadmin'
```

Returns all members of server-level role(s) that are not fixed roles on sql2017a instance.
```powershell
Get-DbaServerRoleMember -SqlInstance sql2017a -ExcludeFixedRole
```

Returns all server-level role(s) for the MyFriendlyDeveloper login on localhost.
```powershell
Get-DbaServerRoleMember -SqlInstance localhost -Login 'MyFriendlyDeveloper'
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/7840633/46511343-19a9d480-c81c-11e8-9c31-6acf022388ec.png)
