### PR TITLE
Removing References to Alias of SqlInstance, Add Prompt to examples

### DIFF
--- a/functions/Invoke-DbaDbLogShipRecovery.ps1
+++ b/functions/Invoke-DbaDbLogShipRecovery.ps1
@@ -65,7 +65,7 @@ function Invoke-DbaDbLogShipRecovery {
             https://dbatools.io/Invoke-DbaDbLogShipRecovery
 
         .EXAMPLE
-            Invoke-DbaDbLogShipRecovery -SqlInstance server1
+            PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1
 
             Recovers all the databases on the instance that are enabled for log shipping
 

--- a/functions/Invoke-DbaDbLogShipRecovery.ps1
+++ b/functions/Invoke-DbaDbLogShipRecovery.ps1
@@ -65,27 +65,27 @@ function Invoke-DbaDbLogShipRecovery {
             https://dbatools.io/Invoke-DbaDbLogShipRecovery
 
         .EXAMPLE
-            Invoke-DbaDbLogShipRecovery -SqlServer server1
+            Invoke-DbaDbLogShipRecovery -SqlInstance server1
 
             Recovers all the databases on the instance that are enabled for log shipping
 
         .EXAMPLE
-            Invoke-DbaDbLogShipRecovery -SqlServer server1 -SqlCredential $cred -Verbose
+            PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -SqlCredential $cred -Verbose
 
             Recovers all the databases on the instance that are enabled for log shipping using a credential
 
         .EXAMPLE
-            Invoke-DbaDbLogShipRecovery -SqlServer server1 -database db_logship -Verbose
+            PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -database db_logship -Verbose
 
             Recovers the database "db_logship" to a normal status
 
         .EXAMPLE
-            db1, db2, db3, db4 | Invoke-DbaDbLogShipRecovery -SqlServer server1 -Verbose
+            PS C:\> db1, db2, db3, db4 | Invoke-DbaDbLogShipRecovery -SqlInstance server1 -Verbose
 
             Recovers the database db1, db2, db3, db4 to a normal status
 
         .EXAMPLE
-            Invoke-DbaDbLogShipRecovery -SqlServer server1 -WhatIf
+            PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -WhatIf
 
             Shows what would happen if the command were executed.
     #>

--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -1443,7 +1443,7 @@ function Invoke-DbaDbLogShipping {
                             Write-Message -Message "No path to the full backup is set. Trying to retrieve the last full backup for $db from $SourceSqlInstance" -Level Verbose
 
                             # Get the last full backup
-                            $LastBackup = Get-DbaBackupHistory -SqlServer $SourceSqlInstance -Databases $($db.Name) -LastFull -Credential $SourceSqlCredential
+                            $LastBackup = Get-DbaBackupHistory -SqlInstance $SourceSqlInstance -Databases $($db.Name) -LastFull -Credential $SourceSqlCredential
 
                             # Check if there was a last backup
                             if ($null -eq $LastBackup) {
@@ -1639,7 +1639,7 @@ function Invoke-DbaDbLogShipping {
                                 Write-Message -Message "Start database restore" -Level Verbose
                                 if ($NoRecovery -or (-not $Standby)) {
                                     if ($Force) {
-                                        $null = Restore-DbaDatabase -SqlServer $destInstance `
+                                        $null = Restore-DbaDatabase -SqlInstance $destInstance `
                                             -SqlCredential $DestinationSqlCredential `
                                             -Path $BackupPath `
                                             -DestinationFilePrefix $SecondaryDatabasePrefix `
@@ -1652,7 +1652,7 @@ function Invoke-DbaDbLogShipping {
                                             -WithReplace
                                     }
                                     else {
-                                        $null = Restore-DbaDatabase -SqlServer $destInstance `
+                                        $null = Restore-DbaDatabase -SqlInstance $destInstance `
                                             -SqlCredential $DestinationSqlCredential `
                                             -Path $BackupPath `
                                             -DestinationFilePrefix $SecondaryDatabasePrefix `
@@ -1672,7 +1672,7 @@ function Invoke-DbaDbLogShipping {
 
                                     # Check if credentials need to be used
                                     if ($DestinationSqlCredential) {
-                                        $null = Restore-DbaDatabase -ServerInstance $destInstance `
+                                        $null = Restore-DbaDatabase -SqlInstance $destInstance `
                                             -SqlCredential $DestinationSqlCredential `
                                             -Path $BackupPath `
                                             -DestinationFilePrefix $SecondaryDatabasePrefix `
@@ -1684,7 +1684,7 @@ function Invoke-DbaDbLogShipping {
                                             -StandbyDirectory $StandbyDirectory
                                     }
                                     else {
-                                        $null = Restore-DbaDatabase -ServerInstance $destInstance `
+                                        $null = Restore-DbaDatabase -SqlInstance $destInstance `
                                             -Path $BackupPath `
                                             -DestinationFilePrefix $SecondaryDatabasePrefix `
                                             -DestinationFileSuffix $SecondaryDatabaseSuffix `


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Minor changes to 2 functions to remove reference to Alias for SqlInstance (either SqlServer or ServerInstnce)
Also added prompt to some examples as per recent changes for other examples
