### PR TITLE
New-DbaLogin - Removed unused variable from ScriptAnalyzer

### DIFF
--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -195,11 +195,6 @@
         }
         else {
             $loginCollection += $Login
-            $Login | ForEach-Object {
-                if ($_.IndexOf('\') -eq -1 -and $PsCmdlet.ParameterSetName -like "Password*" -and !($Password -or $HashedPassword)) {
-                    $passwordNotSpecified = $true
-                }
-            }
         }
         foreach ($instance in $SqlInstance) {
             try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
ScriptAnalyzer reported a variable that was declared but not used. I removed it, all tests still pass and still works.