### PR TITLE
Fix Clear-DbaPlanCache  + example added

### DIFF
--- a/functions/Clear-DbaPlanCache.ps1
+++ b/functions/Clear-DbaPlanCache.ps1
@@ -55,6 +55,10 @@
         Logs into the SQL instance using the SQL Login 'sqladmin' and then Windows instance as 'ad\sqldba'
         and removes if Threshold over 100 MB.
 
+    .EXAMPLE    
+        PS C:\> Find-DbaInstance -ComputerName localhost | Get-DbaPlanCache | Clear-DbaPlanCache -Threshold 200
+
+        Scans localhost for instances using the browser service, traverses all instances and gets the plan cache for each, clears them out if they are above 200 MB.
 #>
     [CmdletBinding(SupportsShouldProcess)]
     param (
@@ -74,6 +78,13 @@
         foreach ($result in $InputObject) {
             if ($result.MB -ge $Threshold) {
                 if ($Pscmdlet.ShouldProcess($($result.SqlInstance), "Cleared SQL Plans plan cache")) {
+                    try {
+                        $server = Connect-SqlInstance -SqlInstance $result.SqlInstance -SqlCredential $SqlCredential
+                    }
+                    catch {
+                        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    }
+
                     $server.Query("DBCC FREESYSTEMCACHE('SQL Plans')")
                     [PSCustomObject]@{
                         ComputerName = $result.ComputerName

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -103,6 +103,11 @@
 
         Copies logins [Login1] and [Login2] from instance sql1 to instance sql2, but enforces password and expiration policies for the new logins. New logins will also have a default database set to [tempdb] and will be created in a disabled state.
 
+    .EXAMPLE
+        PS C:\> New-DbaLogin -SqlInstance sql1 -Login domain\user
+
+        Creates a new Windows Authentication backed login on sql1. The login will be part of the public server role.
+        
 #>
     [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = "Password")]
     param (


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix an issue with the $server variable not being initialized correctly.
Provide pipeline example for the users to see how to use it.

### Error description
If you use the cmdlet / function without having connected to any SQL Server instances earlier, it fails.
When piping in cache plans using the `Get-DbaPlanCache -SqlInstance localhost | Clear-DbaPlanCache -Threshold 200` it would also fail.

**The error reported is:**
```
PS C:\windows\system32> Get-DbaPlanCache -SqlInstance localhost | Clear-DbaPlanCache -Threshold 200
You cannot call a method on a null-valued expression.
At C:\Program Files\WindowsPowerShell\Modules\dbatools\0.9.472\allcommands.ps1:1809 char:21
+ ...                    $server.Query("DBCC FREESYSTEMCACHE('SQL Plans')")
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull
```



### Approach
The foreach loop that handles the $InputObject variable, doesn't take into account that there should be a $server variable declared, initialized and connected, before running the `$server.Query("DBCC FREESYSTEMCACHE('SQL Plans')")` code line.


### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![image](https://user-images.githubusercontent.com/8750181/46698616-df737500-cc17-11e8-9e01-037e47357e4c.png)
