### PR TITLE
Correct filter for DB filter on Get-DbaAgDatabase

### DIFF
--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -88,7 +88,7 @@
             foreach ($ag in $ags) {
                 $agDatabases = $ag.AvailabilityDatabases
                 foreach ($agDb in $agDatabases) {
-                    if ($Database -and $agDb.Name -notmatch $Database) {
+                    if ($Database -and $agDb.Name -notin $Database) {
                         continue
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3619 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
Fixing filter being that `[object[]]$Database` is an array, the filter on line should be `-NotIn` instead of `NotMatch`.