### PR TITLE
New command: Get-DbaDbMemoryUsage

### DIFF
--- a/functions/Get-DbaDbMemoryUsage.ps1
+++ b/functions/Get-DbaDbMemoryUsage.ps1
@@ -1,0 +1,142 @@
+﻿function Get-DbaDbMemoryUsage {
+    <#
+    .SYNOPSIS
+        Determine buffer pool usage by database.
+
+    .DESCRIPTION
+        This command can be utilized to determine which databases on a given instance are consuming buffer pool memory.
+
+        This command is based on query provided by Aaron Bertrand.
+        Reference: https://www.mssqltips.com/sqlservertip/2393/determine-sql-server-memory-use-by-database-and-object/
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential).
+
+    .PARAMETER Database
+        The database(s) to process - this list is auto-populated from the server. If unspecified, all databases will be processed.
+
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude.
+
+    .PARAMETER IncludeSystemDb
+        Switch to have the output include system database memory consumption.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Memory, Database
+        Author: Shawn Melton (@wsmelton), https://wsmelton.github.io
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaDbMemoryUsage
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbMemoryUsage -SqlInstance sqlserver2014a
+
+        Returns the buffer pool consumption for all user databases
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbMemoryUsage -SqlInstance sqlserver2014a -IncludeSystemDb
+
+        Returns the buffer pool consumption for all user databases and system databases
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbMemoryUsage -SqlInstance sql1 -IncludeSystemDb -Database tempdb
+
+        Returns the buffer pool consumption for tempdb database only
+
+    .EXAMPLE
+        PS C:\> Get-DbaMemoryUsage -SqlInstance sql2 -IncludeSystemDb -Exclude 'master','model','msdb','ResourceDb'
+
+        Returns the buffer pool consumption for all user databases and tempdb database
+#>
+    [CmdletBinding()]
+    param (
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer", "SqlServers")]
+        [DbaInstance[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [parameter(ValueFromPipelineByPropertyName = $true)]
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [switch]$IncludeSystemDb,
+        [switch]$EnableException
+    )
+
+    begin {
+        $sql = "DECLARE @total_buffer INT;
+            SELECT @total_buffer = cntr_value
+            FROM sys.dm_os_performance_counters
+            WHERE RTRIM([object_name]) LIKE '%Buffer Manager'
+            AND counter_name = 'Database Pages';
+
+            ;WITH src AS (
+                SELECT database_id, page_type, db_buffer_pages = COUNT_BIG(*)
+                FROM sys.dm_os_buffer_descriptors
+                GROUP BY database_id, page_type
+            )
+            SELECT [DatabaseName] = CASE [database_id] WHEN 32767 THEN 'ResourceDb' ELSE DB_NAME([database_id]) END,
+                page_type AS 'PageType',
+                db_buffer_pages AS 'PageCount',
+                (db_buffer_pages * 8)/1024 AS 'SizeMb',
+                CAST(db_buffer_pages * 100.0 / @total_buffer AS FLOAT) AS 'PercentUsed'
+            FROM src
+            ORDER BY [DatabaseName];"
+    }
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            try {
+                $results = $server.Query($sql)
+            }
+            catch {
+                Stop-Function -Message "Issue collecting data" -Target $instance -ErrorRecord $_
+            }
+            foreach ($row in $results) {
+                if (Test-Bound 'Database') {
+                    if ($row.DatabaseName -notin $Database) { continue }
+                }
+                if (Test-Bound 'ExcludeDatabase') {
+                    if ($row.DatabaseName -in $ExcludeDatabase) { continue }
+                }
+                if (Test-Bound -Not 'IncludeSystemDb') {
+                    if ($row.DatabaseName -in 'master', 'model', 'msdb', 'tempdb', 'ResourceDb') { continue }
+                }
+
+                if ($row.PercentUsed -is [System.DBNull]) {
+                    $percentUsed = 0
+                }
+                else {
+                    $percentUsed = [Math]::Round($row.PercentUsed)
+                }
+
+                [PSCustomObject]@{
+                    ComputerName = $server.ComputerName
+                    InstanceName = $server.ServiceName
+                    SqlInstance  = $server.DomainInstanceName
+                    Database     = $row.DatabaseName
+                    PageType     = $row.PageType
+                    PageCount    = [int]$row.PageCount
+                    Size         = [DbaSize]$row.SizeMb * 1024
+                    PercentUsed  = $percentUsed
+                } | Select-DefaultView -ExcludeProperty 'PageCount'
+            }
+        }
+    }
+}

--- a/tests/Get-DbaDbMemoryUsage.Tests.ps1
+++ b/tests/Get-DbaDbMemoryUsage.Tests.ps1
@@ -1,0 +1,48 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags "UnitTests" {
+    Context "Validate parameters" {
+        $defaultParamCount = 11
+        $command = Get-Command -Name $CommandName
+        [object[]]$params = $command.Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'IncludeSystemDb', 'Database', 'ExcludeDatabase'
+        $paramCount = $knownParameters.Count
+
+        It "Should contain our specific parameters" {
+            ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount
+        }
+
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $instance = Connect-DbaInstance -SqlInstance $script:instance2
+    }
+    Context "Functionality" {
+        It 'Returns data' {
+            $result = Get-DbaDbMemoryUsage -SqlInstance $instance -IncludeSystemDb
+            $result.Count | Should -BeGreaterOrEqual 1
+        }
+
+        It 'Accepts a list of databases' {
+            $result = Get-DbaDbMemoryUsage -SqlInstance $instance -Database 'ResourceDb' -IncludeSystemDb
+
+            $uniqueDbs = $result.Database | Select-Object -Unique
+            $uniqueDbs | Should -Be 'ResourceDb'
+        }
+
+        It 'Excludes databases' {
+            $result = Get-DbaDbMemoryUsage -SqlInstance $instance -IncludeSystemDb -ExcludeDatabase 'ResourceDb'
+
+            $uniqueDbs = $result.Database | Select-Object -Unique
+            $uniqueDbs | Should -Not -Contain 'ResourceDb'
+            $uniqueDbs | Should -Contain 'master'
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Command that outputs buffer pool consumption for each database.