### PR TITLE
List of valid options in help aligned

### DIFF
--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -79,8 +79,7 @@
         ResourceGovernor
         ServerAuditSpecifications
         CustomErrors
-        ServerRoles
-        SupportDbs
+        ServerRoles        
         AvailabilityGroups
         ReplicationSettings
 


### PR DESCRIPTION
SuportDbs is not a valid option any more

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Making sure that the list of options inside the help documentation is correct
