### PR TITLE
Get-DbaDefaultPath fix

### DIFF
--- a/functions/Get-DbaDefaultPath.ps1
+++ b/functions/Get-DbaDefaultPath.ps1
@@ -42,8 +42,8 @@
 #>
     [CmdletBinding()]
     param (
-        [Parameter(ValueFromPipeline)]
-        [Alias("ServerInstance", "SqlServer")]
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "Instance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]
         [PSCredential]


### PR DESCRIPTION
The $SqlInstance parameter should be mandatory.

Without the fix when a user executes the cmdlet / function, he is not prompted for input. The cmdlet executes without error or output.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Running the Get-DbaDefaultPath cmdlet function without any piping or without using the "-SqlInstance" parameter would not yield any results at all. The user wans't prompted to fill in the missing SqlInstance value

### Approach
Extending the parameter attribute to handle the **Mandatory** configuration for the parameter
