### PR TITLE
Replace -Detailed in Get-DbaTcpPort (#2217)

### DIFF
--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -66,148 +66,148 @@
         Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
 
 #>
-        [CmdletBinding()]
-        param (
-            [parameter(Mandatory, ValueFromPipeline)]
-            [Alias("ServerInstance", "SqlServer")]
-            [DbaInstanceParameter[]]$SqlInstance,
-            [Alias("Credential")]
-            [PSCredential]$SqlCredential,
-            [switch]$Detailed,
-            [switch]$AllTcpPort,
-            [Alias("Ipv4")]
-            [switch]$ExcludeIpv6,
-            [Alias('Silent')]
-            [switch]$EnableException
-        )
-        begin {
-            Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
-        }
-        process {
-            foreach ($instance in $SqlInstance) {
-                if ($AllTcpPort -eq $true) {
-                    try {
-                        $scriptblock = {
-                            $instance = $args[0]
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [Alias("Credential")]
+        [PSCredential]$SqlCredential,
+        [switch]$Detailed,
+        [switch]$AllTcpPort,
+        [Alias("Ipv4")]
+        [switch]$ExcludeIpv6,
+        [Alias('Silent')]
+        [switch]$EnableException
+    )
+    begin {
+        Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+    }
+    process {
+        foreach ($instance in $SqlInstance) {
+            if ($AllTcpPort -eq $true) {
+                try {
+                    $scriptblock = {
+                        $instance = $args[0]
 
-                            Add-Type -AssemblyName Microsoft.VisualBasic
+                        Add-Type -AssemblyName Microsoft.VisualBasic
 
-                            foreach ($servername in $wmi.ServerInstances) {
-                                $instanceName = $servername.Name
-                                $wmiinstance = $wmi.Services | Where-Object { $_.DisplayName -eq "SQL Server ($instanceName)" }
-                                $vsname = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'VSNAME' }).Value
+                        foreach ($servername in $wmi.ServerInstances) {
+                            $instanceName = $servername.Name
+                            $wmiinstance = $wmi.Services | Where-Object { $_.DisplayName -eq "SQL Server ($instanceName)" }
+                            $vsname = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'VSNAME' }).Value
 
-                                if ($vsname.length -eq 0) {
-                                    $vsname = "$instance\$instanceName"
+                            if ($vsname.length -eq 0) {
+                                $vsname = "$instance\$instanceName"
+                            }
+
+                            $vsname = $vsname.Replace("\MSSQLSERVER", "")
+
+                            try {
+                                $regroot = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'REGROOT' }).Value
+                                $dacport = (Get-ItemProperty "HKLM:\$regroot\MSSQLServer\SuperSocketNetLib\AdminConnection\Tcp").TcpDynamicPorts
+
+                                [PsCustomObject]@{
+                                    ComputerName = $instance
+                                    InstanceName = $instanceName
+                                    SqlInstance  = $vsname
+                                    IPAddress    = "0.0.0.0"
+                                    Port         = $dacport
+                                    Static       = $false
+                                    Type         = "DAC"
                                 }
+                            }
+                            catch {
+                                #Shouldn't have an empty catch block
+                                Write-Message -Level Verbose -Message "it's just not our day"
+                            }
 
-                                $vsname = $vsname.Replace("\MSSQLSERVER", "")
+                            $tcp = $servername.ServerProtocols | Where-Object Name -eq Tcp
+                            $ips = $tcp.IPAddresses
 
-                                try {
-                                    $regroot = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'REGROOT' }).Value
-                                    $dacport = (Get-ItemProperty "HKLM:\$regroot\MSSQLServer\SuperSocketNetLib\AdminConnection\Tcp").TcpDynamicPorts
+                            # This is a remote command so do not use Write-message
+                            Write-Verbose "Parsing information for $($ips.count) IP addresses."
+                            foreach ($ip in $ips) {
+                                $props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
 
-                                    [PsCustomObject]@{
-                                        ComputerName = $instance
-                                        InstanceName = $instanceName
-                                        SqlInstance  = $vsname
-                                        IPAddress    = "0.0.0.0"
-                                        Port         = $dacport
-                                        Static       = $false
-                                        Type         = "DAC"
-                                    }
-                                }
-                                catch {
-                                    #Shouldn't have an empty catch block
-                                    Write-Message -Level Verbose -Message "it's just not our day"
-                                }
-
-                                $tcp = $servername.ServerProtocols | Where-Object Name -eq Tcp
-                                $ips = $tcp.IPAddresses
-
-                                # This is a remote command so do not use Write-message
-                                Write-Verbose "Parsing information for $($ips.count) IP addresses."
-                                foreach ($ip in $ips) {
-                                    $props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
-
-                                    foreach ($prop in $props) {
-                                        if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
-                                            $port = $prop.value
-                                            if ($prop.name -eq 'TcpPort') {
-                                                $static = $true
-                                            }
-                                            else {
-                                                $static = $false
-                                            }
-                                            break
+                                foreach ($prop in $props) {
+                                    if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
+                                        $port = $prop.value
+                                        if ($prop.name -eq 'TcpPort') {
+                                            $static = $true
                                         }
+                                        else {
+                                            $static = $false
+                                        }
+                                        break
                                     }
+                                }
 
-                                    [PsCustomObject]@{
-                                        ComputerName = $instance
-                                        InstanceName = $instanceName
-                                        SqlInstance  = $vsname
-                                        IPAddress    = $ip.IPAddress.IPAddressToString
-                                        Port         = $port
-                                        Static       = $static
-                                        Type         = "Normal"
-                                    }
+                                [PsCustomObject]@{
+                                    ComputerName = $instance
+                                    InstanceName = $instanceName
+                                    SqlInstance  = $vsname
+                                    IPAddress    = $ip.IPAddress.IPAddressToString
+                                    Port         = $port
+                                    Static       = $static
+                                    Type         = "Normal"
                                 }
                             }
                         }
+                    }
 
-                        $computer = $instance.ComputerName
-                        $resolved = Resolve-DbaNetworkName -ComputerName $instance -Verbose:$false
-                        $computername = $resolved.FullComputerName
+                    $computer = $instance.ComputerName
+                    $resolved = Resolve-DbaNetworkName -ComputerName $instance -Verbose:$false
+                    $computername = $resolved.FullComputerName
 
-                        try {
-                            Write-Message -Level Verbose -Message "Trying with ComputerName ($computer)."
-                            $someIps = Invoke-ManagedComputerCommand -ComputerName $computer -ArgumentList $computer -ScriptBlock $scriptblock
-                        }
-                        catch {
-                            Write-Message -Level Verbose -Message "Trying with FullComputerName because ComputerName failed."
-                            $someIps = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $fqdn -ScriptBlock $scriptblock
-                        }
+                    try {
+                        Write-Message -Level Verbose -Message "Trying with ComputerName ($computer)."
+                        $someIps = Invoke-ManagedComputerCommand -ComputerName $computer -ArgumentList $computer -ScriptBlock $scriptblock
                     }
                     catch {
-                        Stop-Function -Message "Could not get all information." -Target $instance -ErrorRecord $_
-                    }
-
-                    $results = $someIps | Sort-Object IPAddress
-
-                    if ($ExcludeIpv6) {
-                        $octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
-                        [regex]$ipv4 = "^(?:$octet\.){3}$octet$"
-                        $results = $results | Where-Object { $_.IPAddress -match $ipv4 }
+                        Write-Message -Level Verbose -Message "Trying with FullComputerName because ComputerName failed."
+                        $someIps = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $fqdn -ScriptBlock $scriptblock
                     }
                 }
-                #Default Execution of Get-DbaTcpPort
-                if ($AllTcpPort -eq $false -or ($AllTcpPort -eq $true -and $null -eq $someIps)) {
-                    try {
-                        $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
-                    }
-                    catch {
-                        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $servername -Continue
-                    }
+                catch {
+                    Stop-Function -Message "Could not get all information." -Target $instance -ErrorRecord $_
+                }
 
-                    # WmiComputer can be unreliable :( Use T-SQL
-                    $sql = "SELECT local_net_address,local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
-                    $port = $server.Query($sql)
+                $results = $someIps | Sort-Object IPAddress
 
-                    $results = [PsCustomObject]@{
-                                ComputerName = $server.ComputerName
-                                InstanceName = $server.ServiceName
-                                SqlInstance  = $server.DomainInstanceName
-                                IPAddress    = $port.local_net_address
-                                Port         = $port.local_tcp_port
-                                Static       = $true
-                                Type         = "Normal"
-                               }
+                if ($ExcludeIpv6) {
+                    $octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
+                    [regex]$ipv4 = "^(?:$octet\.){3}$octet$"
+                    $results = $results | Where-Object { $_.IPAddress -match $ipv4 }
                 }
             }
-        }
-        end {
-            #return results
-            Select-DefaultView -InputObject $results -Property ComputerName, InstanceName, SqlInstance, IPAddress, Port
+            #Default Execution of Get-DbaTcpPort
+            if ($AllTcpPort -eq $false -or ($AllTcpPort -eq $true -and $null -eq $someIps)) {
+                try {
+                    $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
+                }
+                catch {
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $servername -Continue
+                }
+
+                # WmiComputer can be unreliable :( Use T-SQL
+                $sql = "SELECT local_net_address,local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
+                $port = $server.Query($sql)
+
+                $results = [PsCustomObject]@{
+                            ComputerName = $server.ComputerName
+                            InstanceName = $server.ServiceName
+                            SqlInstance  = $server.DomainInstanceName
+                            IPAddress    = $port.local_net_address
+                            Port         = $port.local_tcp_port
+                            Static       = $true
+                            Type         = "Normal"
+                            }
+            }
         }
     }
+    end {
+        #return results
+        Select-DefaultView -InputObject $results -Property ComputerName, InstanceName, SqlInstance, IPAddress, Port
+    }
+}

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -1,71 +1,71 @@
 ﻿function Get-DbaTcpPort {
-    <#
-        .SYNOPSIS
-            Returns the TCP port used by the specified SQL Server.
+<#
+    .SYNOPSIS
+        Returns the TCP port used by the specified SQL Server.
 
-        .DESCRIPTION
-            By default, this function returns just the TCP port used by the specified SQL Server.
+    .DESCRIPTION
+        By default, this function returns just the TCP port used by the specified SQL Server.
 
-            If -AllTcpPort is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
+        If -AllTcpPort is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
 
-            Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+        Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-        .PARAMETER SqlInstance
-            The target SQL Server instance or instances.
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
 
-        .PARAMETER SqlCredential
-            Allows you to connect to servers using alternate Windows credentials
+    .PARAMETER SqlCredential
+        Allows you to connect to servers using alternate Windows credentials
 
-            $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-        .PARAMETER AllTcpPort
-            If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
+    .PARAMETER AllTcpPort
+        If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
 
-        .PARAMETER Detailed
-            Output all properties, will be deprecated in 1.0.0 release. Use AllTcpPort instead.
+    .PARAMETER Detailed
+        Output all properties, will be deprecated in 1.0.0 release. Use AllTcpPort instead.
 
-        .PARAMETER ExcludeIpv6
-            If this switch is enabled, IPv6 information is excluded from AllTcpPort output.
+    .PARAMETER ExcludeIpv6
+        If this switch is enabled, IPv6 information is excluded from AllTcpPort output.
 
-        .PARAMETER EnableException
-            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-        .NOTES
-            Tags: SQLWMI, tcp
-            Author: Chrissy LeMaire (@cl), netnerds.net
+    .NOTES
+        Tags: SQLWMI, tcp
+        Author: Chrissy LeMaire (@cl), netnerds.net
 
-            Website: https://dbatools.io
-            Copyright: (c) 2018 by dbatools, licensed under MIT
-            License: MIT https://opensource.org/licenses/MIT
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
 
-        .LINK
-            https://dbatools.io/Get-DbaTcpPort
+    .LINK
+        https://dbatools.io/Get-DbaTcpPort
 
-        .EXAMPLE
-            PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a
+    .EXAMPLE
+        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a
 
-            Returns just the port number for the default instance on sqlserver2014a.
+        Returns just the port number for the default instance on sqlserver2014a.
 
-        .EXAMPLE
-            PS C:\> Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
+    .EXAMPLE
+        PS C:\> Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
 
-            Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
+        Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
 
-        .EXAMPLE
-            PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -AllTcpPort
+    .EXAMPLE
+        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -AllTcpPort
 
-            Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
+        Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
 
-            Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+        Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-        .EXAMPLE
-            PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -AllTcpPort
+    .EXAMPLE
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -AllTcpPort
 
-            Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
+        Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
 
-    #>
+#>
         [CmdletBinding()]
         param (
             [parameter(Mandatory, ValueFromPipeline)]

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -1,201 +1,213 @@
 ﻿function Get-DbaTcpPort {
-<#
-    .SYNOPSIS
-        Returns the TCP port used by the specified SQL Server.
+    <#
+        .SYNOPSIS
+            Returns the TCP port used by the specified SQL Server.
 
-    .DESCRIPTION
-        By default, this function returns just the TCP port used by the specified SQL Server.
+        .DESCRIPTION
+            By default, this function returns just the TCP port used by the specified SQL Server.
 
-        If -Detailed is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
+            If -AllTcpPort is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
 
-        Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+            Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-    .PARAMETER SqlInstance
-        The target SQL Server instance or instances.
+        .PARAMETER SqlInstance
+            The target SQL Server instance or instances.
 
-    .PARAMETER SqlCredential
-        Allows you to connect to servers using alternate Windows credentials
+        .PARAMETER SqlCredential
+            Allows you to connect to servers using alternate Windows credentials
 
-        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+            $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-    .PARAMETER Detailed
-        If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
+        .PARAMETER AllTcpPort
+            If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
 
-    .PARAMETER ExcludeIpv6
-        If this switch is enabled, IPv6 information is excluded from detailed output.
+        .PARAMETER Detailed
+            Output all properties, will be deprecated in 1.0.0 release. Use AllTcpPort instead.
 
-    .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+        .PARAMETER ExcludeIpv6
+            If this switch is enabled, IPv6 information is excluded from AllTcpPort output.
 
-    .NOTES
-        Tags: SQLWMI, tcp
-        Author: Chrissy LeMaire (@cl), netnerds.net
+        .PARAMETER EnableException
+            By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+            This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+            Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-        Website: https://dbatools.io
-        Copyright: (c) 2018 by dbatools, licensed under MIT
-        License: MIT https://opensource.org/licenses/MIT
+        .NOTES
+            Tags: SQLWMI, tcp
+            Author: Chrissy LeMaire (@cl), netnerds.net
 
-    .LINK
-        https://dbatools.io/Get-DbaTcpPort
+            Website: https://dbatools.io
+            Copyright: (c) 2018 by dbatools, licensed under MIT
+            License: MIT https://opensource.org/licenses/MIT
 
-    .EXAMPLE
-        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a
+        .LINK
+            https://dbatools.io/Get-DbaTcpPort
 
-        Returns just the port number for the default instance on sqlserver2014a.
+        .EXAMPLE
+            PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a
 
-    .EXAMPLE
-        PS C:\> Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
+            Returns just the port number for the default instance on sqlserver2014a.
 
-        Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
+        .EXAMPLE
+            PS C:\> Get-DbaTcpPort -SqlInstance winserver\sqlexpress, sql2016
 
-    .EXAMPLE
-        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -Detailed
+            Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
 
-        Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
+        .EXAMPLE
+            PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -AllTcpPort
 
-        Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
+            Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
 
-    .EXAMPLE
-        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -Detailed
+            Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
-        Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
+        .EXAMPLE
+            PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -AllTcpPort
 
-#>
-    [CmdletBinding()]
-    param (
-        [parameter(Mandatory, ValueFromPipeline)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
-        [Alias("Credential")]
-        [PSCredential]$SqlCredential,
-        [switch]$Detailed,
-        [Alias("Ipv4")]
-        [switch]$ExcludeIpv6,
-        [Alias('Silent')]
-        [switch]$EnableException
-    )
+            Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
 
-    process {
-        foreach ($instance in $SqlInstance) {
-            if ($detailed -eq $true) {
-                try {
-                    $scriptblock = {
-                        $instance = $args[0]
+    #>
+        [CmdletBinding()]
+        param (
+            [parameter(Mandatory, ValueFromPipeline)]
+            [Alias("ServerInstance", "SqlServer")]
+            [DbaInstanceParameter[]]$SqlInstance,
+            [Alias("Credential")]
+            [PSCredential]$SqlCredential,
+            [switch]$Detailed,
+            [switch]$AllTcpPort,
+            [Alias("Ipv4")]
+            [switch]$ExcludeIpv6,
+            [Alias('Silent')]
+            [switch]$EnableException
+        )
+        begin {
+            Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+        }
+        process {
+            foreach ($instance in $SqlInstance) {
+                if ($AllTcpPort -eq $true) {
+                    try {
+                        $scriptblock = {
+                            $instance = $args[0]
 
-                        Add-Type -AssemblyName Microsoft.VisualBasic
+                            Add-Type -AssemblyName Microsoft.VisualBasic
 
-                        foreach ($servername in $wmi.ServerInstances) {
-                            $instanceName = $servername.Name
-                            $wmiinstance = $wmi.Services | Where-Object { $_.DisplayName -eq "SQL Server ($instanceName)" }
-                            $vsname = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'VSNAME' }).Value
+                            foreach ($servername in $wmi.ServerInstances) {
+                                $instanceName = $servername.Name
+                                $wmiinstance = $wmi.Services | Where-Object { $_.DisplayName -eq "SQL Server ($instanceName)" }
+                                $vsname = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'VSNAME' }).Value
 
-                            if ($vsname.length -eq 0) {
-                                $vsname = "$instance\$instanceName"
-                            }
-
-                            $vsname = $vsname.Replace("\MSSQLSERVER", "")
-
-                            try {
-                                $regroot = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'REGROOT' }).Value
-                                $dacport = (Get-ItemProperty "HKLM:\$regroot\MSSQLServer\SuperSocketNetLib\AdminConnection\Tcp").TcpDynamicPorts
-
-                                [PsCustomObject]@{
-                                    ComputerName = $instance
-                                    InstanceName = $instanceName
-                                    SqlInstance  = $vsname
-                                    IPAddress    = "0.0.0.0"
-                                    Port         = $dacport
-                                    Static       = $false
-                                    Type         = "DAC"
+                                if ($vsname.length -eq 0) {
+                                    $vsname = "$instance\$instanceName"
                                 }
-                            }
-                            catch {
-                                # it's just not our day
-                            }
 
-                            $tcp = $servername.ServerProtocols | Where-Object Name -eq Tcp
-                            $ips = $tcp.IPAddresses
+                                $vsname = $vsname.Replace("\MSSQLSERVER", "")
 
-                            # This is a remote command so do not use Write-message
-                            Write-Verbose "Parsing information for $($ips.count) IP addresses."
-                            foreach ($ip in $ips) {
-                                $props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
+                                try {
+                                    $regroot = ($wmiinstance.AdvancedProperties | Where-Object { $_ -match 'REGROOT' }).Value
+                                    $dacport = (Get-ItemProperty "HKLM:\$regroot\MSSQLServer\SuperSocketNetLib\AdminConnection\Tcp").TcpDynamicPorts
 
-                                foreach ($prop in $props) {
-                                    if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
-                                        $port = $prop.value
-                                        if ($prop.name -eq 'TcpPort') {
-                                            $static = $true
-                                        }
-                                        else {
-                                            $static = $false
-                                        }
-                                        break
+                                    [PsCustomObject]@{
+                                        ComputerName = $instance
+                                        InstanceName = $instanceName
+                                        SqlInstance  = $vsname
+                                        IPAddress    = "0.0.0.0"
+                                        Port         = $dacport
+                                        Static       = $false
+                                        Type         = "DAC"
                                     }
                                 }
+                                catch {
+                                    #Shouldn't have an empty catch block
+                                    Write-Message -Level Verbose -Message "it's just not our day"
+                                }
 
-                                [PsCustomObject]@{
-                                    ComputerName = $instance
-                                    InstanceName = $instanceName
-                                    SqlInstance  = $vsname
-                                    IPAddress    = $ip.IPAddress.IPAddressToString
-                                    Port         = $port
-                                    Static       = $static
-                                    Type         = "Normal"
+                                $tcp = $servername.ServerProtocols | Where-Object Name -eq Tcp
+                                $ips = $tcp.IPAddresses
+
+                                # This is a remote command so do not use Write-message
+                                Write-Verbose "Parsing information for $($ips.count) IP addresses."
+                                foreach ($ip in $ips) {
+                                    $props = $ip.IPAddressProperties | Where-Object { $_.Name -eq "TcpPort" -or $_.Name -eq "TcpDynamicPorts" }
+
+                                    foreach ($prop in $props) {
+                                        if ([Microsoft.VisualBasic.Information]::IsNumeric($prop.value)) {
+                                            $port = $prop.value
+                                            if ($prop.name -eq 'TcpPort') {
+                                                $static = $true
+                                            }
+                                            else {
+                                                $static = $false
+                                            }
+                                            break
+                                        }
+                                    }
+
+                                    [PsCustomObject]@{
+                                        ComputerName = $instance
+                                        InstanceName = $instanceName
+                                        SqlInstance  = $vsname
+                                        IPAddress    = $ip.IPAddress.IPAddressToString
+                                        Port         = $port
+                                        Static       = $static
+                                        Type         = "Normal"
+                                    }
                                 }
                             }
                         }
-                    }
 
-                    $computer = $instance.ComputerName
-                    $resolved = Resolve-DbaNetworkName -ComputerName $instance -Verbose:$false
-                    $computername = $resolved.FullComputerName
+                        $computer = $instance.ComputerName
+                        $resolved = Resolve-DbaNetworkName -ComputerName $instance -Verbose:$false
+                        $computername = $resolved.FullComputerName
 
-                    try {
-                        Write-Message -Level Verbose -Message "Trying with ComputerName ($computer)."
-                        $someIps = Invoke-ManagedComputerCommand -ComputerName $computer -ArgumentList $computer -ScriptBlock $scriptblock
+                        try {
+                            Write-Message -Level Verbose -Message "Trying with ComputerName ($computer)."
+                            $someIps = Invoke-ManagedComputerCommand -ComputerName $computer -ArgumentList $computer -ScriptBlock $scriptblock
+                        }
+                        catch {
+                            Write-Message -Level Verbose -Message "Trying with FullComputerName because ComputerName failed."
+                            $someIps = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $fqdn -ScriptBlock $scriptblock
+                        }
                     }
                     catch {
-                        Write-Message -Level Verbose -Message "Trying with FullComputerName because ComputerName failed."
-                        $someIps = Invoke-ManagedComputerCommand -ComputerName $computername -ArgumentList $fqdn -ScriptBlock $scriptblock
+                        Stop-Function -Message "Could not get all information." -Target $instance -ErrorRecord $_
+                    }
+
+                    $results = $someIps | Sort-Object IPAddress
+
+                    if ($ExcludeIpv6) {
+                        $octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
+                        [regex]$ipv4 = "^(?:$octet\.){3}$octet$"
+                        $results = $results | Where-Object { $_.IPAddress -match $ipv4 }
                     }
                 }
-                catch {
-                    Stop-Function -Message "Could not get detailed information." -Target $instance -ErrorRecord $_
-                }
+                #Default Execution of Get-DbaTcpPort
+                if ($AllTcpPort -eq $false -or ($AllTcpPort -eq $true -and $null -eq $someIps)) {
+                    try {
+                        $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
+                    }
+                    catch {
+                        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $servername -Continue
+                    }
 
-                $cleanedUp = $someIps | Sort-Object IPAddress
+                    # WmiComputer can be unreliable :( Use T-SQL
+                    $sql = "SELECT local_net_address,local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
+                    $port = $server.Query($sql)
 
-                if ($ExcludeIpv6) {
-                    $octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
-                    [regex]$ipv4 = "^(?:$octet\.){3}$octet$"
-                    $cleanedUp = $cleanedUp | Where-Object { $_.IPAddress -match $ipv4 }
-                }
-
-                $cleanedUp
-            }
-
-            if ($Detailed -eq $false -or ($Detailed -eq $true -and $null -eq $someIps)) {
-                try {
-                    $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
-                }
-                catch {
-                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $servername -Continue
-                }
-
-                # WmiComputer can be unreliable :( Use T-SQL
-                $sql = "SELECT local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
-                $port = $server.Query($sql)
-
-                [PSCustomObject]@{
-                    ComputerName = $server.ComputerName
-                    InstanceName = $server.ServiceName
-                    SqlInstance  = $server.DomainInstanceName
-                    Port         = $port.local_tcp_port
+                    $results = [PsCustomObject]@{
+                                ComputerName = $server.ComputerName
+                                InstanceName = $server.ServiceName
+                                SqlInstance  = $server.DomainInstanceName
+                                IPAddress    = $port.local_net_address
+                                Port         = $port.local_tcp_port
+                                Static       = $true
+                                Type         = "Normal"
+                               }
                 }
             }
         }
+        end {
+            #return results
+            Select-DefaultView -InputObject $results -Property ComputerName, InstanceName, SqlInstance, IPAddress, Port
+        }
     }
-}

--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
         By default, this function returns just the TCP port used by the specified SQL Server.
 
-        If -AllTcpPort is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
+        If -All is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
 
         Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
@@ -18,14 +18,14 @@
 
         $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-    .PARAMETER AllTcpPort
+    .PARAMETER All
         If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
 
     .PARAMETER Detailed
-        Output all properties, will be deprecated in 1.0.0 release. Use AllTcpPort instead.
+        Output all properties, will be deprecated in 1.0.0 release. Use All instead.
 
     .PARAMETER ExcludeIpv6
-        If this switch is enabled, IPv6 information is excluded from AllTcpPort output.
+        If this switch is enabled, IPv6 information is excluded from All output.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -54,14 +54,14 @@
         Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
 
     .EXAMPLE
-        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -AllTcpPort
+        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -All
 
         Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
 
         Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
     .EXAMPLE
-        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -AllTcpPort
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -All
 
         Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
 
@@ -74,7 +74,7 @@
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
         [switch]$Detailed,
-        [switch]$AllTcpPort,
+        [switch]$All,
         [Alias("Ipv4")]
         [switch]$ExcludeIpv6,
         [Alias('Silent')]
@@ -85,7 +85,7 @@
     }
     process {
         foreach ($instance in $SqlInstance) {
-            if ($AllTcpPort -eq $true) {
+            if ($All -eq $true) {
                 try {
                     $scriptblock = {
                         $instance = $args[0]
@@ -182,7 +182,7 @@
                 }
             }
             #Default Execution of Get-DbaTcpPort
-            if ($AllTcpPort -eq $false -or ($AllTcpPort -eq $true -and $null -eq $someIps)) {
+            if ($All -eq $false -or ($All -eq $true -and $null -eq $someIps)) {
                 try {
                     $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
                 }

--- a/tests/Get-DbaTcpPort.Tests.ps1
+++ b/tests/Get-DbaTcpPort.Tests.ps1
@@ -14,7 +14,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         $paramCount = 6
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaTcpPort).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'AllTcpPort', 'ExcludeIpv6', 'EnableException', 'Detailed'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'All', 'ExcludeIpv6', 'EnableException', 'Detailed'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -33,12 +33,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Should Return Multiple Results" {
-            $server = Get-DbaTcpPort -SqlInstance $script:instance2 -AllTcpPort
+            $server = Get-DbaTcpPort -SqlInstance $script:instance2 -All
             $server.Count | Should BeGreaterThan 1
         }
 
         It "Should Throw an Error if SqlInstance doesn't exist" {
-            { Get-DbaTcpPort -SqlInstance "ThisIsNotAnInstance" -AllTcpPort | Should Throw }
+            { Get-DbaTcpPort -SqlInstance "ThisIsNotAnInstance" -All | Should Throw }
         }
     }
 }

--- a/tests/Get-DbaTcpPort.Tests.ps1
+++ b/tests/Get-DbaTcpPort.Tests.ps1
@@ -1,0 +1,44 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaTcpPort).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'AllTcpPort', 'ExcludeIpv6', 'EnableException', 'Detailed'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+
+    Context "Command actually works" {
+
+        It "Should Return a Result" {
+            $server = Get-DbaTcpPort -SqlInstance $script:instance2
+            $server | Should Not Be $null
+        }
+
+        It "Should Return Multiple Results" {
+            $server = Get-DbaTcpPort -SqlInstance $script:instance2 -AllTcpPort
+            $server.Count | Should BeGreaterThan 1
+        }
+
+        It "Should Throw an Error if SqlInstance doesn't exist" {
+            { Get-DbaTcpPort -SqlInstance "ThisIsNotAnInstance" -AllTcpPort | Should Throw }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2217 #3350 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Refactor Get-DbaTcpPort to not use `-Detailed` parameter
Add new descriptive parameter called `-AllTcpPort` to replace `-Detailed`
Include Test for cmdlet where one had not previously existed

### Approach
Tried to completely refactor the cmdlet, but realized it was being used by `Test-DbaConnection` in it's default form. Came up with a more suited parameter name to replace `-Detailed` (although I am completely up to changing it if it doesn't fit). `Select-DefaultView` returns the same properties regardless of if this new switch is used or not. 

### Commands to test
Get-DbaTcpPort -SqlInstance sqltestbed
Get-DbaTcpPort -SqlInstance sqltestbed -AllTcpPort

### Screenshots
Using Default Form
![tcp1](https://user-images.githubusercontent.com/13426972/46782241-7a8d4d00-ccf3-11e8-88ab-86afe87e1239.PNG)

Piping to Select *
![tcp2](https://user-images.githubusercontent.com/13426972/46782240-7a8d4d00-ccf3-11e8-805c-c5d9f7704b00.PNG)

