### PR TITLE
Read-DbaXEFile object disposal

### DIFF
--- a/functions/Read-DbaXEFile.ps1
+++ b/functions/Read-DbaXEFile.ps1
@@ -142,8 +142,8 @@ function Read-DbaXEFile {
                 }
 
                 [pscustomobject]$hash
+                $enum.dispose()
             }
-			$enum.dispose()   
         }
     }
 }

--- a/functions/Read-DbaXEFile.ps1
+++ b/functions/Read-DbaXEFile.ps1
@@ -142,8 +142,8 @@ function Read-DbaXEFile {
                 }
 
                 [pscustomobject]$hash
-                $enum.dispose()
             }
+            $enum.Dispose()
         }
     }
 }

--- a/functions/Read-DbaXEFile.ps1
+++ b/functions/Read-DbaXEFile.ps1
@@ -126,7 +126,7 @@ function Read-DbaXEFile {
             $columns = ($columns += $newcolumns) | Select-Object -Unique
 
             # Make it selectable, otherwise it's a weird enumeration
-            foreach ($event in (New-Object Microsoft.SqlServer.XEvent.Linq.QueryableXEventData($currentfile))) {
+            foreach ($event in $enum) {
                 $hash = [ordered]@{ }
 
                 foreach ($column in $columns) {
@@ -143,6 +143,7 @@ function Read-DbaXEFile {
 
                 [pscustomobject]$hash
             }
+			$enum.dispose()   
         }
     }
 }


### PR DESCRIPTION

## Type of Change
 - [ X] Bug fix (non-breaking change, fixes #4182)
 - [ X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 
### Purpose
Fixes #4182 disposing of Microsoft.SqlServer.XEvent.Linq.QueryableXEventData objects correctly to prevent file locking

### Approach
Re-uses exiting Microsoft.SqlServer.XEvent.Linq.QueryableXEventData rather than creating multiples and disposes of object when no longer required.

My first pull request for dbatools.  Apologies if I am not doing something correctly.  Have tried to follow documentation and guidelines.

### Commands to test
Read-DbaXEFile

