### PR TITLE
Moved variables in Remove-DbaDbUser. Fixes #4184

### DIFF
--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -114,7 +114,7 @@
                 $db = $user.Parent
                 $server = $db.Parent
                 $ownedObjects = $false
-				$alterSchemas = @()
+                $alterSchemas = @()
                 $dropSchemas = @()
                 Write-Message -Level Verbose -Message "Removing User $user from Database $db on target $server"
 

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -110,16 +110,16 @@
             [CmdletBinding()]
             param ([Microsoft.SqlServer.Management.Smo.User[]]$users)
 
-            for ($i = 0; $i -lt $users.Count; $i++) {
-                $db = $users[$i].Parent
+            foreach ($user in $users) {
+                $db = $user.Parent
                 $server = $db.Parent
                 $ownedObjects = $false
-                Write-Message -Level Verbose -Message "Removing User $($users[$i]) from Database $db on target $server"
+                Write-Message -Level Verbose -Message "Removing User $user from Database $db on target $server"
 
                 # Drop Schemas owned by the user before droping the user
-                $schemaUrns = $users[$i].EnumOwnedObjects() | Where-Object Type -EQ Schema
+                $schemaUrns = $user.EnumOwnedObjects() | Where-Object Type -EQ Schema
                 if ($schemaUrns) {
-                    Write-Message -Level Verbose -Message "User $($users[$i]) owns $($schemaUrns.Count) schema(s)."
+                    Write-Message -Level Verbose -Message "User $user owns $($schemaUrns.Count) schema(s)."
 
                     # Need to gather up the schema changes so they can be done in a non-desctructive order
                     $alterSchemas = @()
@@ -129,7 +129,7 @@
                         $schema = $server.GetSmoObject($schemaUrn)
 
                         # Drop any schema that is the same name as the user
-                        if ($schema.Name -EQ $users[$i].Name) {
+                        if ($schema.Name -EQ $user.Name) {
                             # Check for owned objects early so we can exit before any changes are made
                             $ownedUrns = $schema.EnumOwnedObjects()
                             if (-Not $ownedUrns) {
@@ -139,21 +139,21 @@
                                 Write-Message -Level Warning -Message "User owns objects in the database and will not be removed."
                                 foreach ($ownedUrn in $ownedUrns) {
                                     $obj = $server.GetSmoObject($ownedUrn)
-                                    Write-Message -Level Warning -Message "User $($users[$i]) owns $($obj.GetType().Name) $obj"
+                                    Write-Message -Level Warning -Message "User $user owns $($obj.GetType().Name) $obj"
                                 }
                                 $ownedObjects = $true
                             }
                         }
 
                         # Change the owner of any schema not the same name as the user
-                        if ($schema.Name -NE $users[$i].Name) {
+                        if ($schema.Name -NE $user.Name) {
                             # Check for owned objects early so we can exit before any changes are made
                             $ownedUrns = $schema.EnumOwnedObjects()
                             if (($ownedUrns -And $Force) -Or (-Not $ownedUrns)) {
                                 $alterSchemas += $schema
                             }
                             else {
-                                Write-Message -Level Warning -Message "User $($users[$i]) owns the Schema $schema, which owns $($ownedUrns.Count) Object(s).  If you want to change the schemas' owner to [dbo] and drop the user anyway, use -Force parameter.  User $($users[$i]) will not be removed."
+                                Write-Message -Level Warning -Message "User $user owns the Schema $schema, which owns $($ownedUrns.Count) Object(s).  If you want to change the schemas' owner to [dbo] and drop the user anyway, use -Force parameter.  User $user will not be removed."
                                 $ownedObjects = $true
                             }
                         }
@@ -179,15 +179,15 @@
                         }
 
                         # Finally, Drop user
-                        if ($PSCmdlet.ShouldProcess($server, "Drop User $($users[$i]) from Database $db.")) {
-                            $users[$i].Drop()
+                        if ($PSCmdlet.ShouldProcess($server, "Drop User $user from Database $db.")) {
+                            $user.Drop()
                         }
 
                         $status = "Dropped"
 
                     }
                     catch {
-                        Write-Error -Message "Could not drop $($users[$i]) from Database $db on target $server"
+                        Write-Error -Message "Could not drop $user from Database $db on target $server"
                         $status = "Not Dropped"
                     }
 
@@ -196,7 +196,7 @@
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.name
-                        User         = $users[$i]
+                        User         = $user
                         Status       = $status
                     }
                 }

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -114,6 +114,8 @@
                 $db = $user.Parent
                 $server = $db.Parent
                 $ownedObjects = $false
+				$alterSchemas = @()
+                $dropSchemas = @()
                 Write-Message -Level Verbose -Message "Removing User $user from Database $db on target $server"
 
                 # Drop Schemas owned by the user before droping the user
@@ -122,9 +124,6 @@
                     Write-Message -Level Verbose -Message "User $user owns $($schemaUrns.Count) schema(s)."
 
                     # Need to gather up the schema changes so they can be done in a non-desctructive order
-                    $alterSchemas = @()
-                    $dropSchemas = @()
-
                     foreach ($schemaUrn in $schemaUrns) {
                         $schema = $server.GetSmoObject($schemaUrn)
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #4184 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Moved the variables $alterSchemas and $dropSchemas to an earlier point in the loop. This allows them to be cleared with each iteration. Previously they were only being cleared if the user owned a schema. This caused the variable to retain values through next iterations.
### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->
#Note that in this test, user2 must own a schema named user2 with no objects.
Remove-DbaDbUser -SqlInstance SRV-SQL01 -Database TestDBADatabase -User "user1", "user2", "user3"

