### PR TITLE
Replace -Detailed in Get-DbaTcpPort (Attempt 2)

### DIFF
--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -6,7 +6,7 @@
     .DESCRIPTION
         By default, this function returns just the TCP port used by the specified SQL Server.
 
-        If -Detailed is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
+        If -All is specified, the server name, IPAddress (ipv4 and ipv6), port number and an indicator of whether or not the port assignment is static are returned.
 
         Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
@@ -18,11 +18,14 @@
 
         $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
-    .PARAMETER Detailed
+    .PARAMETER All
         If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
 
+    .PARAMETER Detailed
+        Output all properties, will be deprecated in 1.0.0 release. Use All instead.
+
     .PARAMETER ExcludeIpv6
-        If this switch is enabled, IPv6 information is excluded from detailed output.
+        If this switch is enabled, IPv6 information is excluded from All output.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -51,14 +54,14 @@
         Returns an object with server name and port number for the sqlexpress on winserver and the default instance on sql2016.
 
     .EXAMPLE
-        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -Detailed
+        PS C:\> Get-DbaTcpPort -SqlInstance sqlserver2014a, sql2016 -All
 
         Returns an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for sqlserver2014a and sql2016.
 
         Remote sqlwmi is used by default. If this doesn't work, then remoting is used. If neither work, it defaults to T-SQL which can provide only the port.
 
     .EXAMPLE
-        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -Detailed
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaTcpPort -ExcludeIpv6 -All
 
         Returns an object with server name, IPAddress (just ipv4), port and static ($true/$false) for every server listed in the Central Management Server on sql2014.
 
@@ -71,15 +74,18 @@
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
         [switch]$Detailed,
+        [switch]$All,
         [Alias("Ipv4")]
         [switch]$ExcludeIpv6,
         [Alias('Silent')]
         [switch]$EnableException
     )
-
+    begin {
+        Test-DbaDeprecation -DeprecatedOn 1.0.0 -Parameter Detailed
+    }
     process {
         foreach ($instance in $SqlInstance) {
-            if ($detailed -eq $true) {
+            if ($All -eq $true) {
                 try {
                     $scriptblock = {
                         $instance = $args[0]
@@ -112,7 +118,8 @@
                                 }
                             }
                             catch {
-                                # it's just not our day
+                                #Shouldn't have an empty catch block
+                                Write-Message -Level Verbose -Message "it's just not our day"
                             }
 
                             $tcp = $servername.ServerProtocols | Where-Object Name -eq Tcp
@@ -163,21 +170,19 @@
                     }
                 }
                 catch {
-                    Stop-Function -Message "Could not get detailed information." -Target $instance -ErrorRecord $_
+                    Stop-Function -Message "Could not get all information." -Target $instance -ErrorRecord $_
                 }
 
-                $cleanedUp = $someIps | Sort-Object IPAddress
+                $results = $someIps | Sort-Object IPAddress
 
                 if ($ExcludeIpv6) {
                     $octet = '(?:0?0?[0-9]|0?[1-9][0-9]|1[0-9]{2}|2[0-5][0-5]|2[0-4][0-9])'
                     [regex]$ipv4 = "^(?:$octet\.){3}$octet$"
-                    $cleanedUp = $cleanedUp | Where-Object { $_.IPAddress -match $ipv4 }
+                    $results = $results | Where-Object { $_.IPAddress -match $ipv4 }
                 }
-
-                $cleanedUp
             }
-
-            if ($Detailed -eq $false -or ($Detailed -eq $true -and $null -eq $someIps)) {
+            #Default Execution of Get-DbaTcpPort
+            if ($All -eq $false -or ($All -eq $true -and $null -eq $someIps)) {
                 try {
                     $server = Connect-SqlInstance -SqlInstance "TCP:$instance" -SqlCredential $SqlCredential -MinimumVersion 9
                 }
@@ -186,16 +191,23 @@
                 }
 
                 # WmiComputer can be unreliable :( Use T-SQL
-                $sql = "SELECT local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
+                $sql = "SELECT local_net_address,local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID"
                 $port = $server.Query($sql)
 
-                [PSCustomObject]@{
-                    ComputerName = $server.ComputerName
-                    InstanceName = $server.ServiceName
-                    SqlInstance  = $server.DomainInstanceName
-                    Port         = $port.local_tcp_port
-                }
+                $results = [PsCustomObject]@{
+                            ComputerName = $server.ComputerName
+                            InstanceName = $server.ServiceName
+                            SqlInstance  = $server.DomainInstanceName
+                            IPAddress    = $port.local_net_address
+                            Port         = $port.local_tcp_port
+                            Static       = $true
+                            Type         = "Normal"
+                            }
             }
         }
+    }
+    end {
+        #return results
+        Select-DefaultView -InputObject $results -Property ComputerName, InstanceName, SqlInstance, IPAddress, Port
     }
 }

--- a/tests/Get-DbaTcpPort.Tests.ps1
+++ b/tests/Get-DbaTcpPort.Tests.ps1
@@ -1,0 +1,44 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaTcpPort).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'All', 'ExcludeIpv6', 'EnableException', 'Detailed'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+
+    Context "Command actually works" {
+
+        It "Should Return a Result" {
+            $server = Get-DbaTcpPort -SqlInstance $script:instance2
+            $server | Should Not Be $null
+        }
+
+        It "Should Return Multiple Results" {
+            $server = Get-DbaTcpPort -SqlInstance $script:instance2 -All
+            $server.Count | Should BeGreaterThan 1
+        }
+
+        It "Should Throw an Error if SqlInstance doesn't exist" {
+            { Get-DbaTcpPort -SqlInstance "ThisIsNotAnInstance" -All | Should Throw }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Bug fix (non-breaking change, fixes #2217 #3350 )
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Refactor Get-DbaTcpPort to not use `-Detailed` parameter
Add new descriptive parameter called `-AllTcpPort` to replace `-Detailed`
Include Test for cmdlet where one had not previously existed

### Approach
Tried to completely refactor the cmdlet, but realized it was being used by `Test-DbaConnection` in it's default form. Came up with a more suited parameter name to replace `-Detailed` (although I am completely up to changing it if it doesn't fit). `Select-DefaultView` returns the same properties regardless of if this new switch is used or not. 

### Commands to test
Get-DbaTcpPort -SqlInstance sqltestbed
Get-DbaTcpPort -SqlInstance sqltestbed -AllTcpPort

### Screenshots
Using Default Form
![tcp1](https://user-images.githubusercontent.com/13426972/46782241-7a8d4d00-ccf3-11e8-88ab-86afe87e1239.PNG)

Piping to Select *
![tcp2](https://user-images.githubusercontent.com/13426972/46782240-7a8d4d00-ccf3-11e8-805c-c5d9f7704b00.PNG)

