### PR TITLE
Spelling corrections, add handling for ? returned for compression type

### DIFF
--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -168,8 +168,8 @@
                     if ($CompressionType -eq "Recommended") {
                         if ($Pscmdlet.ShouldProcess($db, "Applying suggested compression using results from Test-DbaDbCompression")) {
                             Write-Message -Level Verbose -Message "Applying suggested compression settings using Test-DbaDbCompression"
-                            $results += $compressionSuggestion | Select-Object *, @{l = 'AlreadyProcesssed'; e = {"False"}}
-                            foreach ($obj in ($results | Where-Object {$_.CompressionTypeRecommendation -ne 'NO_GAIN' -and $_.PercentCompression -ge $PercentCompression} | Sort-Object PercentCompression -Descending)) {
+                            $results += $compressionSuggestion | Select-Object *, @{l = 'AlreadyProcessed'; e = {"False"}}
+                            foreach ($obj in ($results | Where-Object {$_.CompressionTypeRecommendation -notin @('NO_GAIN','?') -and $_.PercentCompression -ge $PercentCompression} | Sort-Object PercentCompression -Descending)) {
                                 if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
                                     break
@@ -179,14 +179,14 @@
                                     Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName)"
                                     $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
                                     $server.Databases[$obj.Database].Tables[$obj.TableName, $($obj.Schema)].Rebuild()
-                                    $obj.AlreadyProcesssed = "True"
+                                    $obj.AlreadyProcessed = "True"
                                 }
                                 else {
                                     ##nonclustered indexes
                                     Write-Message -Level Verbose -Message "Applying $($obj.CompressionTypeRecommendation) compression to $($obj.Database).$($obj.Schema).$($obj.TableName).$($obj.IndexName)"
                                     $($server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].PhysicalPartitions | Where-Object {$_.PartitionNumber -eq $obj.Partition}).DataCompression = $($obj.CompressionTypeRecommendation)
                                     $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName].Rebuild()
-                                    $obj.AlreadyProcesssed = "True"
+                                    $obj.AlreadyProcessed = "True"
                                 }
                                 $obj
                             }
@@ -223,7 +223,7 @@
                                         SizeCurrent                   = $null
                                         SizeRequested                 = $null
                                         PercentCompression            = $null
-                                        AlreadyProcesssed             = "True"
+                                        AlreadyProcessed             = "True"
                                     }
                                 }
 
@@ -266,7 +266,7 @@
                                             SizeCurrent                   = $null
                                             SizeRequested                 = $null
                                             PercentCompression            = $null
-                                            AlreadyProcesssed             = "True"
+                                            AlreadyProcessed             = "True"
                                         }
                                     }
                                 }
@@ -307,7 +307,7 @@
                                         SizeCurrent                   = $null
                                         SizeRequested                 = $null
                                         PercentCompression            = $null
-                                        AlreadyProcesssed             = "True"
+                                        AlreadyProcessed             = "True"
                                     }
                                 }
                             }

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -42,14 +42,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Command handles heaps and clustered indexes" {
         foreach ($row in $results | Where-Object {$_.IndexId -le 1}){
             It "Should process object $($row.TableName)" {
-                $row.AlreadyProcesssed | Should Be $True
+                $row.AlreadyProcessed | Should Be $True
             }
         }
     }
     Context "Command handles nonclustered indexes" {
         foreach ($row in $results | Where-Object {$_.IndexId -gt 1}){
             It "Should process nonclustered index $($row.IndexName)" {
-                $row.AlreadyProcesssed | Should Be $True
+                $row.AlreadyProcessed | Should Be $True
             }
         }
     }
@@ -67,7 +67,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         foreach ($row in $results) {
             It "Should process object $($row.TableName) from InputObject" {
-                $row.AlreadyProcesssed | Should Be $True
+                $row.AlreadyProcessed | Should Be $True
             }
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Some of my objects have returned `?` by `Test-DbaDBCompression for the `CompressionTypeRecommendation` and `Set-DbaDbCompression` throws an error when this is encountered.

Also fixed a spelling error in a field label.

### Approach
Handle `?` the same as `NO_GAIN` - don't attempt compression on the object at all.

### Commands to test
`Test-DbaDbCompression`