### PR TITLE
Speedup Copy-DbaDatabase

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1292,15 +1292,15 @@
                             }
                         }
                     }
-                    $destServer.Databases.Refresh()
+                    $NewDatabase = Get-DbaDatabase -SqlInstance $destServer -database $DestinationdbName
 
                     # restore potentially lost settings
                     if ($destServer.VersionMajor -ge 9 -and $NoRecovery -eq $false) {
-                        if ($sourceDbOwnerChaining -ne $destServer.Databases[$DestinationdbName].DatabaseOwnershipChaining) {
+                        if ($sourceDbOwnerChaining -ne $$NewDatabase.DatabaseOwnershipChaining) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Updating DatabaseOwnershipChaining on $DestinationdbName")) {
                                 try {
-                                    $destServer.Databases[$DestinationdbName].DatabaseOwnershipChaining = $sourceDbOwnerChaining
-                                    $destServer.Databases[$DestinationdbName].Alter()
+                                    $NewDatabase.DatabaseOwnershipChaining = $sourceDbOwnerChaining
+                                    $NewDatabase.Alter()
                                     Write-Message -Level Verbose -Message "Successfully updated DatabaseOwnershipChaining for $sourceDbOwnerChaining on $DestinationdbName on $destinstance."
                                 }
                                 catch {
@@ -1311,11 +1311,11 @@
                             }
                         }
 
-                        if ($sourceDbTrustworthy -ne $destServer.Databases[$DestinationdbName].Trustworthy) {
+                        if ($sourceDbTrustworthy -ne $NewDatabase.Trustworthy) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Updating Trustworthy on $DestinationdbName")) {
                                 try {
-                                    $destServer.Databases[$DestinationdbName].Trustworthy = $sourceDbTrustworthy
-                                    $destServer.Databases[$DestinationdbName].Alter()
+                                    $NewDatabase.Trustworthy = $sourceDbTrustworthy
+                                    $NewDatabase.Alter()
                                     Write-Message -Level Verbose -Message "Successfully updated Trustworthy to $sourceDbTrustworthy for $DestinationdbName on $destinstance"
                                 }
                                 catch {
@@ -1326,11 +1326,11 @@
                             }
                         }
 
-                        if ($sourceDbBrokerEnabled -ne $destServer.Databases[$DestinationdbName].BrokerEnabled) {
+                        if ($sourceDbBrokerEnabled -ne $NewDatabase.BrokerEnabled) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Updating BrokerEnabled on $dbName")) {
                                 try {
-                                    $destServer.Databases[$DestinationdbName].BrokerEnabled = $sourceDbBrokerEnabled
-                                    $destServer.Databases[$DestinationdbName].Alter()
+                                    $NewDatabase.BrokerEnabled = $sourceDbBrokerEnabled
+                                    $NewDatabase.Alter()
                                     Write-Message -Level Verbose -Message "Successfully updated BrokerEnabled to $sourceDbBrokerEnabled for $DestinationdbName on $destinstance."
                                 }
                                 catch {
@@ -1342,7 +1342,7 @@
                         }
                     }
 
-                    if ($sourceDbReadOnly -ne $destServer.Databases[$DestinationdbName].ReadOnly -and $NoRecovery -eq $false) {
+                    if ($sourceDbReadOnly -ne $NewDatabase.ReadOnly -and $NoRecovery -eq $false) {
                         if ($Pscmdlet.ShouldProcess($destinstance, "Updating ReadOnly status on $DestinationdbName")) {
                             $update = Update-SqldbReadOnly -SqlInstance $destServer -dbname $DestinationdbName -readonly $sourceDbReadOnly
                             if ($update -eq $true) {

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -1296,7 +1296,7 @@
 
                     # restore potentially lost settings
                     if ($destServer.VersionMajor -ge 9 -and $NoRecovery -eq $false) {
-                        if ($sourceDbOwnerChaining -ne $$NewDatabase.DatabaseOwnershipChaining) {
+                        if ($sourceDbOwnerChaining -ne $NewDatabase.DatabaseOwnershipChaining) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Updating DatabaseOwnershipChaining on $DestinationdbName")) {
                                 try {
                                     $NewDatabase.DatabaseOwnershipChaining = $sourceDbOwnerChaining


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
On instances with large numbers of databases, the call to `$destServer.databases.refresh()` can take a long time but only the new database needs to be refreshed (for comparison against properties of the source DB)

### Approach
Replaced refreshing all databases on the instance with getting a reference to just the new database that was restored.

On my test instance with 300+ databases, this was approx. a 10% speed improvement.

### Commands to test
`Copy-DbaDatabase`

