### PR TITLE
Invoke-DbaDbClone - Added support for additional parameters with DBCC command

### DIFF
--- a/functions/Invoke-DbaDbClone.ps1
+++ b/functions/Invoke-DbaDbClone.ps1
@@ -8,7 +8,9 @@
 
         This can be useful for testing query performance without requiring all the space needed for the data in the database.
 
-        Read more at sqlperformance: https://sqlperformance.com/2016/08/sql-statistics/expanding-dbcc-clonedatabase
+        Read more:
+            - https://sqlperformance.com/2016/08/sql-statistics/expanding-dbcc-clonedatabase
+            - https://support.microsoft.com/en-us/help/3177838/how-to-use-dbcc-clonedatabase-to-generate-a-schema-and-statistics-only
 
         Thanks to Microsoft Tiger Team for the code and idea https://github.com/Microsoft/tigertoolbox/
 
@@ -33,7 +35,7 @@
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Statistics, Performance
+        Tags: Statistics, Performance, Clone
         Author: Chrissy LeMaire (@cl), netnerds.net
 
         Website: https://dbatools.io
@@ -74,48 +76,47 @@
             Stop-Function -Message "You must specify a server name if you did not pipe a database"
         }
 
-        $updatestats = "declare @out table(id int identity(1,1),s sysname, o sysname, i sysname, stats_stream varbinary(max), rows bigint, pages bigint)
-                    declare @dbcc table(stats_stream varbinary(max), rows bigint, pages bigint)
-                    declare c cursor for
-                           select object_schema_name(object_id) s, object_name(object_id) o, name i
-                           from sys.indexes
-                           where type_desc in ('CLUSTERED COLUMNSTORE', 'NONCLUSTERED COLUMNSTORE')
-                    declare @s sysname, @o sysname, @i sysname
-                    open c
-                    fetch next from c into @s, @o, @i
-                    while @@FETCH_STATUS = 0 begin
-                           declare @showStats nvarchar(max) = N'DBCC SHOW_STATISTICS(""' + quotename(@s) + '.' + quotename(@o) + '"", ' + quotename(@i) + ') with stats_stream'
-                           insert @dbcc exec sp_executesql @showStats
-                           insert @out select @s, @o, @i, stats_stream, rows, pages from @dbcc
-                           delete @dbcc
-                           fetch next from c into @s, @o, @i
-                    end
-                    close c
-                    deallocate c
+        $sqlStats = "DECLARE @out TABLE(id INT IDENTITY(1,1), s SYSNAME, o SYSNAME, i SYSNAME, stats_stream VARBINARY(MAX), rows BIGINT, pages BIGINT)
+                    DECLARE @dbcc TABLE(stats_stream VARBINARY(MAX), rows BIGINT, pages BIGINT)
+                    DECLARE c CURSOR FOR
+                           SELECT OBJECT_SCHEMA_NAME(object_id) s, OBJECT_NAME(object_id) o, name i
+                           FROM sys.indexes
+                           WHERE type_desc IN ('CLUSTERED COLUMNSTORE', 'NONCLUSTERED COLUMNSTORE')
+                    DECLARE @s SYSNAME, @o SYSNAME, @i SYSNAME
+                    OPEN c
+                    FETCH NEXT FROM c INTO @s, @o, @i
+                    WHILE @@FETCH_STATUS = 0
+                    BEGIN
+                        DECLARE @showStats NVARCHAR(MAX) = N'DBCC SHOW_STATISTICS(""' + QUOTENAME(@s) + '.' + QUOTENAME(@o) + '"", ' + QUOTENAME(@i) + ') WITH stats_stream'
+                        INSERT @dbcc EXEC sp_executesql @showStats
+                        INSERT @out SELECT @s, @o, @i, stats_stream, rows, pages FROM @dbcc
+                        DELETE @dbcc
+                        FETCH NEXT FROM c INTO @s, @o, @i
+                    END
+                    CLOSE c
+                    DEALLOCATE c
 
 
-                    declare @sql nvarchar(max);
-                    declare @id int;
+                    DECLARE @sql NVARCHAR(MAX);
+                    DECLARE @id INT;
 
-                    select top 1 @id=id,@sql=
-                    'UPDATE STATISTICS ' + quotename(s) + '.' + quotename(o)  + '(' + quotename(i)
-                    + ') with stats_stream = ' + convert(nvarchar(max), stats_stream, 1)
-                    + ', rowcount = ' + convert(nvarchar(max), rows) + ', pagecount = '  + convert(nvarchar(max), pages)
-                    from @out
+                    SELECT TOP 1 @id=id,@sql=
+                    'UPDATE STATISTICS ' + QUOTENAME(s) + '.' + QUOTENAME(o)  + '(' + QUOTENAME(i)
+                    + ') WITH stats_stream = ' + CONVERT(NVARCHAR(MAX), stats_stream, 1)
+                    + ', rowcount = ' + CONVERT(NVARCHAR(MAX), rows) + ', pagecount = '  + CONVERT(NVARCHAR(MAX), pages)
+                    FROM @out
 
                     WHILE (@@ROWCOUNT <> 0)
                     BEGIN
-                        exec sp_executesql @sql
-                        delete @out where id = @id
-                        select top 1 @id=id,@sql=
-                        'UPDATE STATISTICS ' + quotename(s) + '.' + quotename(o)  + '(' + quotename(i)
-                        + ') with stats_stream = ' + convert(nvarchar(max), stats_stream, 1)
-                        + ', rowcount = ' + convert(nvarchar(max), rows) + ', pagecount = '  + convert(nvarchar(max), pages)
-                        from @out
+                        EXEC sp_executesql @sql
+                        DELETE @out WHERE id = @id
+                        SELECT TOP 1 @id=id,@sql=
+                        'UPDATE STATISTICS ' + QUOTENAME(s) + '.' + QUOTENAME(o)  + '(' + QUOTENAME(i)
+                        + ') WITH stats_stream = ' + CONVERT(NVARCHAR(MAX), stats_stream, 1)
+                        + ', rowcount = ' + CONVERT(NVARCHAR(MAX), rows) + ', pagecount = '  + CONVERT(NVARCHAR(MAX), pages)
+                        FROM @out
                     END"
-
     }
-
     process {
         if (Test-FunctionInterrupt) { return }
 
@@ -131,7 +132,6 @@
             $sql2012min = [version]"11.0.7001.0" # SQL 2012 SP4
             $sql2014min = [version]"12.0.5000.0" # SQL 2014 SP2
             $sql2016min = [version]"13.0.4001.0" # SQL 2016 SP1
-
 
             if ($server.VersionMajor -eq 11 -and $server.Version -lt $sql2012min) {
                 Stop-Function -Message "Unsupported version for $instance. SQL Server 2012 SP4 and above required." -Target $server -Continue
@@ -153,21 +153,21 @@
                 Stop-Function -Message "Only user databases are supported" -Target $instance -Continue
             }
 
-            if (-not $Database.name) {
+            if (-not $Database.Name) {
                 Stop-Function -Message "Database not found" -Target $instance -Continue
             }
 
             if ($UpdateStatistics) {
                 try {
                     Write-Message -Level Verbose -Message "Updating statistics"
-                    $null = $database.Query($updatestats)
+                    $null = $database.Query($sqlStats)
                 }
                 catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Target $server -Continue
                 }
             }
 
-            $dbname = $database.Name
+            $dbName = $database.Name
 
             foreach ($db in $CloneDatabase) {
                 Write-Message -Level Verbose -Message "Cloning $db from $database"
@@ -176,7 +176,7 @@
                 }
                 else {
                     try {
-                        $sql = "dbcc clonedatabase('$dbname','$db')"
+                        $sql = "DBCC CLONEDATABASE('$dbName','$db')"
                         $null = $database.Query($sql)
                         $server.Databases.Refresh()
                         Get-DbaDatabase -SqlInstance $server -Database $db

--- a/functions/Invoke-DbaDbClone.ps1
+++ b/functions/Invoke-DbaDbClone.ps1
@@ -217,7 +217,6 @@
                         $sql = "DBCC CLONEDATABASE('$dbName','$db') $sqlWith"
                         Write-Message -Level Debug -Message "Sql Statement: $sql"
                         $null = $database.Query($sql)
-                        # $server.Databases.Refresh()
                         Get-DbaDatabase -SqlInstance $server -Database $db
                     }
                     catch {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
Fixes #4199 

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The `DBCC CLONEDATABASE` has additional parameters to exclude stats or the query store from being cloned as well. The issue has details on where the build limit is, and validation has been added to cover both scenarios.

There is no update to the test as right now...if no one else comes back to it I can eventually but will take a bit to gather the code to validate query store and stats object is truly empty. Note that using `NO_STATISTICS` does still bring over the stats object, it just contains no data in it.

I tested this against 2017 container and all worked as expected handling a database with stats and query store configured.