### PR TITLE
Add Pester Tests for cmdlets missing tests (Test-Dba*)

### DIFF
--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -23,71 +23,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test are custom to the command you are writing it for,
-        but something similar to below should be included if applicable.
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        It "Should return a result" {
+            $results = Test-DbaBuild -Build "12.00.4502" -MinimumBuild "12.0.4511" -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
 
-    The below examples are by no means set in stone and there are already
-        a number of test that you can pull examples from in how they are done.
-#>
-
-# # Add-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "XYZ is added properly" {
-#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
-
-#         It "Should show the proper LMN has been added" {
-#             $results.Property1 | Should Be "daper dan"
-#         }
-
-#         It "Should be in SomeSpecificLocation" {
-#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
-#         }
-#     }
-# }
-
-# # New-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Can generate/create a new XYZ" {
-#         BeforeAll {
-#             $results = New-DbaXyz <# your specific parameters #> -Silent
-#         }
-#         AfterAll {
-#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
-#         }
-#         It "Returns the right UGY" {
-#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
-#         }
-#     }
-# }
-
-# # Get-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Command actually works" {
-#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-
-#         It "Shows only one type of value" {
-#             foreach ($result in $results) {
-#                 $result.Property1 | Should BeLike "*FilterValue*"
-#             }
-#         }
-#     }
-# }
-
-# # Invoke-DbaNoun
-# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
-#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
-#     Context "Validate output" {
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-#         It "Should cycle instance error log" {
-#             $results.LogType | Should Be "instance"
-#         }
-#     }
-# }
+        It "Should return a result" {
+            $results = Test-DbaBuild -Build "12.0.5540" -MaxBehind "1SP 1CU" -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
+    }
+}

--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -1,0 +1,93 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 9
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Test-DbaBuild).Parameters.Keys
+        $knownParameters = 'Build','MinimumBuild','MaxBehind','Latest','SqlInstance','SqlCredential','Update','Quiet','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+<#
+    Integration test are custom to the command you are writing it for,
+        but something similar to below should be included if applicable.
+
+    The below examples are by no means set in stone and there are already
+        a number of test that you can pull examples from in how they are done.
+#>
+
+# # Add-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "XYZ is added properly" {
+#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
+
+#         It "Should show the proper LMN has been added" {
+#             $results.Property1 | Should Be "daper dan"
+#         }
+
+#         It "Should be in SomeSpecificLocation" {
+#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
+#         }
+#     }
+# }
+
+# # New-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Can generate/create a new XYZ" {
+#         BeforeAll {
+#             $results = New-DbaXyz <# your specific parameters #> -Silent
+#         }
+#         AfterAll {
+#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
+#         }
+#         It "Returns the right UGY" {
+#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
+#         }
+#     }
+# }
+
+# # Get-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Command actually works" {
+#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+
+#         It "Shows only one type of value" {
+#             foreach ($result in $results) {
+#                 $result.Property1 | Should BeLike "*FilterValue*"
+#             }
+#         }
+#     }
+# }
+
+# # Invoke-DbaNoun
+# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
+#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
+#     Context "Validate output" {
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+#         It "Should cycle instance error log" {
+#             $results.LogType | Should Be "instance"
+#         }
+#     }
+# }

--- a/tests/Test-DbaDbCompatibility.Tests.ps1
+++ b/tests/Test-DbaDbCompatibility.Tests.ps1
@@ -1,0 +1,93 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Test-DbaDbCompatibility).Parameters.Keys
+        $knownParameters = 'SqlInstance','Credential','Database','ExcludeDatabase','Detailed','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+<#
+    Integration test are custom to the command you are writing it for,
+        but something similar to below should be included if applicable.
+
+    The below examples are by no means set in stone and there are already
+        a number of test that you can pull examples from in how they are done.
+#>
+
+# # Add-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "XYZ is added properly" {
+#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
+
+#         It "Should show the proper LMN has been added" {
+#             $results.Property1 | Should Be "daper dan"
+#         }
+
+#         It "Should be in SomeSpecificLocation" {
+#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
+#         }
+#     }
+# }
+
+# # New-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Can generate/create a new XYZ" {
+#         BeforeAll {
+#             $results = New-DbaXyz <# your specific parameters #> -Silent
+#         }
+#         AfterAll {
+#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
+#         }
+#         It "Returns the right UGY" {
+#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
+#         }
+#     }
+# }
+
+# # Get-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Command actually works" {
+#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+
+#         It "Shows only one type of value" {
+#             foreach ($result in $results) {
+#                 $result.Property1 | Should BeLike "*FilterValue*"
+#             }
+#         }
+#     }
+# }
+
+# # Invoke-DbaNoun
+# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
+#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
+#     Context "Validate output" {
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+#         It "Should cycle instance error log" {
+#             $results.LogType | Should Be "instance"
+#         }
+#     }
+# }

--- a/tests/Test-DbaDbCompatibility.Tests.ps1
+++ b/tests/Test-DbaDbCompatibility.Tests.ps1
@@ -23,71 +23,21 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test are custom to the command you are writing it for,
-        but something similar to below should be included if applicable.
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        It "Should return a result" {
+            $results = Test-DbaDbCompatibility -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
 
-    The below examples are by no means set in stone and there are already
-        a number of test that you can pull examples from in how they are done.
-#>
+        It "Should return a result for a database" {
+            $results = Test-DbaDbCompatibility -Database Master -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
 
-# # Add-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "XYZ is added properly" {
-#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
-
-#         It "Should show the proper LMN has been added" {
-#             $results.Property1 | Should Be "daper dan"
-#         }
-
-#         It "Should be in SomeSpecificLocation" {
-#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
-#         }
-#     }
-# }
-
-# # New-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Can generate/create a new XYZ" {
-#         BeforeAll {
-#             $results = New-DbaXyz <# your specific parameters #> -Silent
-#         }
-#         AfterAll {
-#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
-#         }
-#         It "Returns the right UGY" {
-#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
-#         }
-#     }
-# }
-
-# # Get-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Command actually works" {
-#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-
-#         It "Shows only one type of value" {
-#             foreach ($result in $results) {
-#                 $result.Property1 | Should BeLike "*FilterValue*"
-#             }
-#         }
-#     }
-# }
-
-# # Invoke-DbaNoun
-# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
-#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
-#     Context "Validate output" {
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-#         It "Should cycle instance error log" {
-#             $results.LogType | Should Be "instance"
-#         }
-#     }
-# }
+        It "Should return a result excluding one database" {
+            $results = Test-DbaDbCompatibility -ExcludeDatabase Master -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
+    }
+}

--- a/tests/Test-DbaDeprecatedFeature.Tests.ps1
+++ b/tests/Test-DbaDeprecatedFeature.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
-. "$PSScriptRoot\Test-DbaDeprecatedFeature.ps1"
 . "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\functions\Test-DbaDeprecatedFeature.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
@@ -24,71 +24,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test are custom to the command you are writing it for,
-        but something similar to below should be included if applicable.
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        It "Should return a result" {
+            $results = Test-DbaDeprecatedFeature -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
 
-    The below examples are by no means set in stone and there are already
-        a number of test that you can pull examples from in how they are done.
-#>
-
-# # Add-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "XYZ is added properly" {
-#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
-
-#         It "Should show the proper LMN has been added" {
-#             $results.Property1 | Should Be "daper dan"
-#         }
-
-#         It "Should be in SomeSpecificLocation" {
-#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
-#         }
-#     }
-# }
-
-# # New-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Can generate/create a new XYZ" {
-#         BeforeAll {
-#             $results = New-DbaXyz <# your specific parameters #> -Silent
-#         }
-#         AfterAll {
-#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
-#         }
-#         It "Returns the right UGY" {
-#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
-#         }
-#     }
-# }
-
-# # Get-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Command actually works" {
-#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-
-#         It "Shows only one type of value" {
-#             foreach ($result in $results) {
-#                 $result.Property1 | Should BeLike "*FilterValue*"
-#             }
-#         }
-#     }
-# }
-
-# # Invoke-DbaNoun
-# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
-#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
-#     Context "Validate output" {
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-#         It "Should cycle instance error log" {
-#             $results.LogType | Should Be "instance"
-#         }
-#     }
-# }
+        It "Should return a result for a database" {
+            $results = Test-DbaDeprecatedFeature -SqlInstance $script:instance2 -Database Master
+            $results | Should -Not -Be $null
+        }
+    }
+}

--- a/tests/Test-DbaDeprecatedFeature.Tests.ps1
+++ b/tests/Test-DbaDeprecatedFeature.Tests.ps1
@@ -1,0 +1,94 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\Test-DbaDeprecatedFeature.ps1"
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Test-DbaDeprecatedFeature).Parameters.Keys
+        $knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','InputObject','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+<#
+    Integration test are custom to the command you are writing it for,
+        but something similar to below should be included if applicable.
+
+    The below examples are by no means set in stone and there are already
+        a number of test that you can pull examples from in how they are done.
+#>
+
+# # Add-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "XYZ is added properly" {
+#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
+
+#         It "Should show the proper LMN has been added" {
+#             $results.Property1 | Should Be "daper dan"
+#         }
+
+#         It "Should be in SomeSpecificLocation" {
+#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
+#         }
+#     }
+# }
+
+# # New-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Can generate/create a new XYZ" {
+#         BeforeAll {
+#             $results = New-DbaXyz <# your specific parameters #> -Silent
+#         }
+#         AfterAll {
+#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
+#         }
+#         It "Returns the right UGY" {
+#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
+#         }
+#     }
+# }
+
+# # Get-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Command actually works" {
+#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+
+#         It "Shows only one type of value" {
+#             foreach ($result in $results) {
+#                 $result.Property1 | Should BeLike "*FilterValue*"
+#             }
+#         }
+#     }
+# }
+
+# # Invoke-DbaNoun
+# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
+#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
+#     Context "Validate output" {
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+#         It "Should cycle instance error log" {
+#             $results.LogType | Should Be "instance"
+#         }
+#     }
+# }

--- a/tests/Test-DbaDiskAllocation.Tests.ps1
+++ b/tests/Test-DbaDiskAllocation.Tests.ps1
@@ -23,71 +23,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test are custom to the command you are writing it for,
-        but something similar to below should be included if applicable.
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        It "Should return a result" {
+            $results = Test-DbaDiskAllocation -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
 
-    The below examples are by no means set in stone and there are already
-        a number of test that you can pull examples from in how they are done.
-#>
-
-# # Add-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "XYZ is added properly" {
-#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
-
-#         It "Should show the proper LMN has been added" {
-#             $results.Property1 | Should Be "daper dan"
-#         }
-
-#         It "Should be in SomeSpecificLocation" {
-#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
-#         }
-#     }
-# }
-
-# # New-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Can generate/create a new XYZ" {
-#         BeforeAll {
-#             $results = New-DbaXyz <# your specific parameters #> -Silent
-#         }
-#         AfterAll {
-#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
-#         }
-#         It "Returns the right UGY" {
-#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
-#         }
-#     }
-# }
-
-# # Get-DbaNoun
-# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-#     Context "Command actually works" {
-#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-
-#         It "Shows only one type of value" {
-#             foreach ($result in $results) {
-#                 $result.Property1 | Should BeLike "*FilterValue*"
-#             }
-#         }
-#     }
-# }
-
-# # Invoke-DbaNoun
-# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
-#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
-#     Context "Validate output" {
-#         It "Should have correct properties" {
-#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
-#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
-#         }
-#         It "Should cycle instance error log" {
-#             $results.LogType | Should Be "instance"
-#         }
-#     }
-# }
+        It "Should return a result not using sql" {
+            $results = Test-DbaDiskAllocation -NoSqlCheck -SqlInstance $script:instance2
+            $results | Should -Not -Be $null
+        }
+    }
+}

--- a/tests/Test-DbaDiskAllocation.Tests.ps1
+++ b/tests/Test-DbaDiskAllocation.Tests.ps1
@@ -1,0 +1,93 @@
+﻿$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 13
+        [object[]]$params = (Get-ChildItem function:\Test-DbaDiskAllocation).Parameters.Keys
+        $knownParameters = 'ComputerName','NoSqlCheck','SqlCredential','Credential','Detailed','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+<#
+    Integration test are custom to the command you are writing it for,
+        but something similar to below should be included if applicable.
+
+    The below examples are by no means set in stone and there are already
+        a number of test that you can pull examples from in how they are done.
+#>
+
+# # Add-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "XYZ is added properly" {
+#         $results = Add-DbaXyz <# your specific parameters and values #> -Confirm:$false
+
+#         It "Should show the proper LMN has been added" {
+#             $results.Property1 | Should Be "daper dan"
+#         }
+
+#         It "Should be in SomeSpecificLocation" {
+#             $results.PSParentPath | Should Be "51??16'25.7 N + 30??13'37.7 E"
+#         }
+#     }
+# }
+
+# # New-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Can generate/create a new XYZ" {
+#         BeforeAll {
+#             $results = New-DbaXyz <# your specific parameters #> -Silent
+#         }
+#         AfterAll {
+#             Remove-DbaXyz <# your specific parameters #> -Confirm:$false
+#         }
+#         It "Returns the right UGY" {
+#             "$($results.Property1)" -match 'SqlServer' | Should Be $true
+#         }
+#     }
+# }
+
+# # Get-DbaNoun
+# Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+#     Context "Command actually works" {
+#         $results = Get-DbaXyz -ComputerName $script:instance1, $script:instance2
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Property1,Property2,Property3'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+
+#         It "Shows only one type of value" {
+#             foreach ($result in $results) {
+#                 $result.Property1 | Should BeLike "*FilterValue*"
+#             }
+#         }
+#     }
+# }
+
+# # Invoke-DbaNoun
+# Describe "$CommandName Integration Test" -Tag "IntegrationTests" {
+#     $results = Invoke-DbaXyz -SqlInstance $script:instance1 -Type SpecialValue
+#     Context "Validate output" {
+#         It "Should have correct properties" {
+#             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,LogType,IsSuccessful,Notes'.Split(',')
+#             ($results.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+#         }
+#         It "Should cycle instance error log" {
+#             $results.LogType | Should Be "instance"
+#         }
+#     }
+# }

--- a/tests/Test-DbaLoginPassword.Tests.ps1
+++ b/tests/Test-DbaLoginPassword.Tests.ps1
@@ -1,6 +1,7 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\internal\functions\Get-PasswordHash.ps1"
 
 Describe "$CommandName Unit Tests" -Tag UnitTests, Get-DbaLogin {
     Context "Validate parameters" {
@@ -13,7 +14,7 @@ Describe "$CommandName Unit Tests" -Tag UnitTests, Get-DbaLogin {
         #>
         $paramCount = 6
         $defaultParamCount = 11
-        [object[]]$params = (Get-ChildItem function:\Test-DbaDbCompatibility).Parameters.Keys
+        [object[]]$params = (Get-ChildItem function:\Test-DbaLoginPassword).Parameters.Keys
         $knownParameters = 'SqlInstance','SqlCredential','Dictionary','Login','InputObject','EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount

--- a/tests/Test-DbaLoginPassword.Tests.ps1
+++ b/tests/Test-DbaLoginPassword.Tests.ps1
@@ -3,6 +3,25 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$CommandName Unit Tests" -Tag UnitTests, Get-DbaLogin {
+    Context "Validate parameters" {
+        <#
+            The $paramCount is adjusted based on the parameters your command will have.
+
+            The $defaultParamCount is adjusted based on what type of command you are writing the test for:
+                - Commands that *do not* include SupportShouldProcess, set defaultParamCount    = 11
+                - Commands that *do* include SupportShouldProcess, set defaultParamCount        = 13
+        #>
+        $paramCount = 6
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Test-DbaDbCompatibility).Parameters.Keys
+        $knownParameters = 'SqlInstance','SqlCredential','Dictionary','Login','InputObject','EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
     Context "$Command Name Input" {
         $Params = (Get-Command Get-DbaLogin).Parameters
         It "Should have a mandatory parameter SQLInstance" {
@@ -19,6 +38,7 @@ Describe "$CommandName Unit Tests" -Tag UnitTests, Get-DbaLogin {
             $Params['EnableException'].Count | Should Be 1
         }
     }
+
 }
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3350 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Create Tests for cmdlets that do not currently have them.
Focus on cmdlets starting with `Test-` verb
Rename an existing test which had `test.ps1` instead of `Tests.ps1`

### Approach
<!-- How does this change solve that purpose -->
Used a script to generate the `UnitTest` tag in accordance with the template
Used existing examples to create the `IntegrationTests` tag for each test

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Running Invoke-Pester against each test created.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![test1](https://user-images.githubusercontent.com/13426972/46921507-4ef7b480-cfca-11e8-872c-4b3f3457b187.PNG)
![test2](https://user-images.githubusercontent.com/13426972/46921508-50c17800-cfca-11e8-84a6-a1b476c56d93.PNG)
![test3](https://user-images.githubusercontent.com/13426972/46921509-51f2a500-cfca-11e8-9847-4b14ba3389b4.PNG)
