### PR TITLE
CI, parallelize tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ configuration: "Debug"
 
 before_build:
   - nuget restore bin\projects\dbatools\dbatools.sln
-  
+
 build:
   project: bin\projects\dbatools\dbatools.sln
 
@@ -13,7 +13,7 @@ after_build:
     # Removed to prevent credential exposure
     # - ps: Push-AppveyorArtifact msbuild.binlog
     # - ps: Push-AppveyorArtifact msbuild.log
-    
+
 version: 0.9.{build}
 
 cache:
@@ -25,7 +25,7 @@ cache:
 shallow_clone: true
 
 # Set build info
-environment: 
+environment:
   environment: development
   version: 0.9.$(appveyor_build_number)
   #appveyor_rdp_password: 2odCuiKmYiem
@@ -33,21 +33,46 @@ environment:
     secure: ZnF3fWSDfHraMCWlHaekvWrXf3sDqY5M28HMK4236PBbNSoqP29wEhsWMQioSSYGomzgIp9vuiwR8Fc9ViNLoqq0bVcErxEojBFTaPMEzOg2ZwO9OnOTiuUEc5JkoLBv6rEBBWef/DvkFfhr1r0K0xQu6OAPYHVTCRajTZbBRNfCTUM2X2o41t+cSa7681rtnJQnB/8cAfVVnPtJ+97s8w==
   azurelegacypasswd:
     secure: ud4yZN6kPf+VWhgpgJhbEMCoUJKHTiH9uvv71ybTlu+45+V12M+B07YjysoXGC1qnGBwVy4DDGJfh2VkPWxamK0IpsEimsRS/CCEZlb6unYC4dqEm980QwP4/zwcTSK1
-    
+
   matrix:
     - scenario: 2008R2
+      part: 1/2
+      main_instance: localhost\SQL2008R2SP2
+      setup_scripts: \tests\appveyor.SQL2008R2SP2.ps1
+    - scenario: 2008R2
+      part: 2/2
       main_instance: localhost\SQL2008R2SP2
       setup_scripts: \tests\appveyor.SQL2008R2SP2.ps1
     - scenario: 2016
+      part: 1/2
+      main_instance: localhost\SQL2016
+      setup_scripts: \tests\appveyor.SQL2016.ps1
+    - scenario: 2016
+      part: 2/2
       main_instance: localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2016.ps1
     - scenario: service_restarts
+      part: 1/2
+      main_instance: localhost\SQL2017,localhost\SQL2016
+      setup_scripts: \tests\appveyor.SQL2017.ps1,\tests\appveyor.SQL2016.ps1
+    - scenario: service_restarts
+      part: 2/2
       main_instance: localhost\SQL2017,localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2017.ps1,\tests\appveyor.SQL2016.ps1
     - scenario: 2016_2017
+      part: 1/2
+      main_instance: localhost\SQL2017,localhost\SQL2016
+      setup_scripts: \tests\appveyor.SQL2017.ps1,\tests\appveyor.SQL2016.ps1
+    - scenario: 2016_2017
+      part: 2/2
       main_instance: localhost\SQL2017,localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2017.ps1,\tests\appveyor.SQL2016.ps1
     - scenario: default
+      part: 1/2
+      main_instance: localhost\SQL2008R2SP2,localhost\SQL2016
+      setup_scripts: \tests\appveyor.SQL2008R2SP2.ps1,\tests\appveyor.SQL2016.ps1
+    - scenario: default
+      part: 2/2
       main_instance: localhost\SQL2008R2SP2,localhost\SQL2016
       setup_scripts: \tests\appveyor.SQL2008R2SP2.ps1,\tests\appveyor.SQL2016.ps1
 

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -292,9 +292,11 @@ if (-not $Finalize) {
     if ($env:PART) {
         try {
             [int]$num, [int]$denom = $env:PART.Split('/')
-            Write-Host -ForegroundColor DarkGreen "Test Parts   : part $($env:PART) on total $($AllScenarioTests.Count)"
-            $scenarioParts = Split-ArrayInParts -array $AllScenarioTests -parts $denom
-            $AllScenarioTests = $scenarioParts[$num-1]
+            Write-Host -ForegroundColor DarkGreen "Test Parts    : part $($env:PART) on total $($AllScenarioTests.Count)"
+            #shuffle things a bit (i.e. with natural sorting most of the *get* fall into the first part, all the *set* in the last, etc)
+            $AllScenarioTestsShuffled = $AllScenarioTests | Sort-Object -Property @{Expression={ $_.Name.Split('-')[-1].Replace('Dba', '') }; Ascending = $true}
+            $scenarioParts = Split-ArrayInParts -array $AllScenarioTestsShuffled -parts $denom
+            $AllScenarioTests = $scenarioParts[$num-1] | Sort-Object -Property Name
         } catch {
         }
     }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [x] Build system
 

### Purpose
Make an appropriate usage of the capabilities of dbatools's appveyor concurrent builds 

### Approach
Added "part" env variable. For now it's just a mere split by two for every scenario but as it can be easily figured out, its assignment capabilities are dynamic (should we ever find ourselves in the need of directing more "power" towards a scenario rather than another one)

----

If this works at the very first commit, I'd be amazed, so refrain from merging "as fast as one can"