### PR TITLE
Resubmitting: Bill of Health - Export-DbaDiagnosticQuery - ScriptAnalyzer should be thumbs up now

### DIFF
--- a/functions/Export-DbaDiagnosticQuery.ps1
+++ b/functions/Export-DbaDiagnosticQuery.ps1
@@ -91,21 +91,6 @@
                 Stop-Function -Message "Failed to create directory $Path" -Continue
             }
         }
-
-        Function Remove-InvalidFileNameChars {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory,
-                    Position = 0,
-                    ValueFromPipeline,
-                    ValueFromPipelineByPropertyName = $true)]
-                [String]$Name
-            )
-            $Name = $Name.Replace(" ", "-")
-            $invalidChars = [IO.Path]::GetInvalidFileNameChars() -join ''
-            $re = "[{0}]" -f [RegEx]::Escape($invalidChars)
-            return ($Name -replace $re)
-        }
     }
 
     process {


### PR DESCRIPTION
Resubmitting #4222 because my fork was too far behind and caused merge issues

## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Purpose
Discovered the dbatools Bill of Health page, this PR should get a thumbs up for ScriptAnalyzer

Approach
I've removed a variable assignment which was no longer used.
And I removed a helper function which was also available as a central function.

Commands to test
Run ScriptAnalyzer, there should be no warnings for Export-DbaDiagnosticQuery
