### PR TITLE
Fix PSAvoidUsingCmdletAliases

### DIFF
--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -187,7 +187,7 @@ function Get-DbaAgentJobHistory {
                     }
                     elseif ($tok -eq 'JOBID') {
                         # convert(binary(16), ?)
-                        $repl = @('0x') + @($exec.JobID.ToByteArray() | foreach { $_.ToString('X2') }) -join ''
+                        $repl = @('0x') + @($exec.JobID.ToByteArray() | ForEach-Object -Process { $_.ToString('X2') }) -join ''
                         $repl = Resolve-TokenEscape -method $EscMethod -value $repl
                         $outfile = $outfile.Replace($x.Value, $repl)
                     }

--- a/functions/Get-DbaDbPartitionFunction.ps1
+++ b/functions/Get-DbaDbPartitionFunction.ps1
@@ -95,7 +95,7 @@
                     continue
                 }
 
-                $partitionfunctions | foreach {
+                $partitionfunctions | ForEach-Object {
 
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName

--- a/functions/Get-DbaDbPartitionScheme.ps1
+++ b/functions/Get-DbaDbPartitionScheme.ps1
@@ -95,7 +95,7 @@
                     continue
                 }
 
-                $PartitionSchemes | foreach {
+                $PartitionSchemes | ForEach-Object {
 
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName

--- a/functions/Get-DbaDbUdf.ps1
+++ b/functions/Get-DbaDbUdf.ps1
@@ -103,7 +103,7 @@
                     $UserDefinedFunctions = $UserDefinedFunctions | Where-Object { $_.IsSystemObject -eq $false }
                 }
 
-                $UserDefinedFunctions | foreach {
+                $UserDefinedFunctions | ForEach-Object {
 
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName

--- a/functions/Get-DbaDbUser.ps1
+++ b/functions/Get-DbaDbUser.ps1
@@ -103,7 +103,7 @@
                     $users = $users | Where-Object { $_.IsSystemObject -eq $false }
                 }
 
-                $users | foreach {
+                $users | ForEach-Object {
 
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -193,7 +193,7 @@
                         $datefile = [DateTime]::ParseExact($base, 'yyyyMMdd_HHmmss', $null)
                     }
                     catch {
-                        $datefile = Get-ItemProperty -Path $l | select -ExpandProperty CreationTime
+                        $datefile = Get-ItemProperty -Path $l | Select-Object -ExpandProperty CreationTime
                     }
                     if ($datefile -gt $since) {
                         $filteredlogs += $l

--- a/functions/Import-DbaSpConfigure.ps1
+++ b/functions/Import-DbaSpConfigure.ps1
@@ -154,7 +154,7 @@
     process {
         if ($Path.length -eq 0) {
             if ($Pscmdlet.ShouldProcess($destination, "Export sp_configure")) {
-                $sqlfilename = Export-SqlSpConfigure $sourceserver
+                $sqlfilename = Export-DbaSpConfigure $sourceserver
             }
 
             if ($sourceserver.versionMajor -ne $destserver.versionMajor -and $force -eq $false) {

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -199,7 +199,7 @@
 
             if (-not $Database) {
                 if ($PSCmdlet.ShouldProcess($instance, "Prompting with GUI list of databases")) {
-                    $Database = Show-DbaDatabaseList -SqlInstance $server -Title "Install sp_WhoisActive" -Header "To deploy sp_WhoisActive, select a database or hit cancel to quit." -DefaultDb "master"
+                    $Database = Show-DbaDbList -SqlInstance $server -Title "Install sp_WhoisActive" -Header "To deploy sp_WhoisActive, select a database or hit cancel to quit." -DefaultDb "master"
 
                     if (-not $Database) {
                         Stop-Function -Message "You must select a database to install the procedure." -Target $Database

--- a/tests/Get-DbaDbPartitionFunction.Tests.ps1
+++ b/tests/Get-DbaDbPartitionFunction.Tests.ps1
@@ -16,8 +16,45 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll{
+        $tempguid = [guid]::newguid();
+        $PFName = "dbatoolssci_$($tempguid.guid)"
+        $CreateTestPartitionFunction = "CREATE PARTITION FUNCTION [$PFName] (int)  AS RANGE LEFT FOR VALUES (1, 100, 1000, 10000, 100000);"
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $CreateTestPartitionFunction -Database master
+    }
+    AfterAll{
+        $DropTestPartitionFunction = "DROP PARTITION FUNCTION [$PFName];"
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $DropTestPartitionFunction -Database master
+    }
+
+    Context "Partition Functions are correctly located" {
+        $results1 = Get-DbaDbPartitionFunction -SqlInstance $script:instance2 -Database master | Select-Object *
+        $results2 = Get-DbaDbPartitionFunction -SqlInstance $script:instance2
+
+        It "Should execute and return results"{
+            $results2 | Should -Not -Be $null
+        }
+
+        It "Should execute against Master and return results"{
+            $results1 | Should -Not -Be $null
+        }
+
+        It "Should have matching name $PFName" {
+            $results1.name | Should -Be $PFName
+        }
+
+        It "Should have range values of @(1, 100, 1000, 10000, 100000)" {
+            $results1.rangeValues | Should -Be @(1, 100, 1000, 10000, 100000)
+        }
+
+        It "Should have PartitionFunctionParameters of Int" {
+            $results1.PartitionFunctionParameters | Should -Be "[int]"
+        }
+
+        It "Should not Throw an Error" {
+            {Get-DbaDbPartitionFunction -SqlInstance $script:instance2 -ExcludeDatabase master } | Should -not -Throw
+        }
+    }
+}

--- a/tests/Get-DbaDbPartitionScheme.Tests.ps1
+++ b/tests/Get-DbaDbPartitionScheme.Tests.ps1
@@ -16,8 +16,56 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll{
+        $tempguid = [guid]::newguid();
+        $PFName = "dbatoolssci_$($tempguid.guid)"
+        $PFScheme  = "dbatoolssci_PFScheme"
+
+        $CreateTestPartitionScheme = @"
+CREATE PARTITION FUNCTION [$PFName] (int)  AS RANGE LEFT FOR VALUES (1, 100, 1000, 10000, 100000);
+GO
+CREATE PARTITION SCHEME $PFScheme AS PARTITION [$PFName] ALL TO ( [PRIMARY] );
+"@
+
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $CreateTestPartitionScheme -Database master -ParseGo
+    }
+    AfterAll{
+        $DropTestPartitionScheme = @"
+DROP PARTITION SCHEME [$PFScheme];
+GO
+DROP PARTITION FUNCTION [$PFName];
+"@
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $DropTestPartitionScheme -Database master -ParseGo
+    }
+
+    Context "Partition Functions are correctly located" {
+        $results1 = Get-DbaDbPartitionScheme -SqlInstance $script:instance2 -Database master | Select-Object *
+        $results2 = Get-DbaDbPartitionScheme -SqlInstance $script:instance2
+
+        It "Should execute and return results"{
+            $results2 | Should -Not -Be $null
+        }
+
+        It "Should execute against Master and return results"{
+            $results1 | Should -Not -Be $null
+        }
+
+        It "Should have matching name $PFScheme" {
+            $results1.name | Should -Be $PFScheme
+        }
+
+        It "Should have PartitionFunction of $PFName " {
+            $results1.PartitionFunction | Should -Be $PFName
+        }
+
+        It "Should have FileGroups of [Primary]" {
+            $results1.FileGroups | Should -Be @('PRIMARY', 'PRIMARY', 'PRIMARY', 'PRIMARY', 'PRIMARY', 'PRIMARY')
+        }
+
+        It "Should not Throw an Error" {
+            {Get-DbaDbPartitionScheme -SqlInstance $script:instance2 -ExcludeDatabase master } | Should -not -Throw
+        }
+    }
+}

--- a/tests/Get-DbaDbUdf.Tests.ps1
+++ b/tests/Get-DbaDbUdf.Tests.ps1
@@ -16,8 +16,65 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll{
+#Test Function adapted from examples at:
+#https://docs.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-2017#examples
+$CreateTestUDFunction = @"
+CREATE FUNCTION dbo.dbatoolssci_ISOweek (@DATE datetime)
+RETURNS int
+WITH EXECUTE AS CALLER
+AS
+BEGIN
+     DECLARE @ISOweek int;
+     SET @ISOweek= DATEPART(wk,@DATE)+1
+          -DATEPART(wk,CAST(DATEPART(yy,@DATE) as CHAR(4))+'0104');
+--Special cases: Jan 1-3 may belong to the previous year
+     IF (@ISOweek=0)
+          SET @ISOweek=dbo.ISOweek(CAST(DATEPART(yy,@DATE)-1
+               AS CHAR(4))+'12'+ CAST(24+DATEPART(DAY,@DATE) AS CHAR(2)))+1;
+--Special case: Dec 29-31 may belong to the next year
+     IF ((DATEPART(mm,@DATE)=12) AND
+          ((DATEPART(dd,@DATE)-DATEPART(dw,@DATE))>= 28))
+          SET @ISOweek=1;
+     RETURN(@ISOweek);
+END;
+"@
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $CreateTestUDFunction -Database master
+    }
+    AfterAll{
+        $DropTestUDFunction = "DROP FUNCTION dbo.dbatoolssci_ISOweek;"
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $DropTestUDFunction -Database master
+    }
+
+    Context "Partition Functions are correctly located" {
+        $results1 = Get-DbaDbUdf -SqlInstance $script:instance2 -Database master | Where-object {$_.name -eq 'dbatoolssci_ISOweek'} | Select-Object *
+        $results2 = Get-DbaDbUdf -SqlInstance $script:instance2
+
+        It "Should execute and return results"{
+            $results2 | Should -Not -Be $null
+        }
+
+        It "Should execute against Master and return results"{
+            $results1 | Should -Not -Be $null
+        }
+
+        It "Should have matching name dbo.dbatoolssci_ISOweek" {
+            $results1.name | Should -Be 'dbatoolssci_ISOweek'
+            $results1.schema | Should -Be 'dbo'
+        }
+
+        It "Should have a function type of Scalar " {
+            $results1.FunctionType | Should -Be 'Scalar'
+        }
+
+        It "Should have Parameters of [@Date]" {
+            $results1.Parameters | Should -Be "[@Date]"
+        }
+
+        It "Should not Throw an Error" {
+            {Get-DbaDbUdf -SqlInstance $script:instance2 -ExcludeDatabase master -ExcludeSystemUdf } | Should -not -Throw
+        }
+    }
+}

--- a/tests/Get-DbaDbUser.Tests.ps1
+++ b/tests/Get-DbaDbUser.Tests.ps1
@@ -16,8 +16,56 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll{
+        $tempguid = [guid]::newguid();
+        $DBUserName = "dbatoolssci_$($tempguid.guid)"
+$CreateTestUser = @"
+CREATE LOGIN [$DBUserName]
+    WITH PASSWORD = '$($tempguid.guid)';
+USE Master;
+CREATE USER [$DBUserName] FOR LOGIN [$DBUserName]
+    WITH DEFAULT_SCHEMA = dbo;
+"@
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $CreateTestUser -Database master
+    }
+    AfterAll{
+        $DropTestUser = "DROP User [$DBUserName];"
+        Invoke-Sqlcmd2 -ServerInstance $script:instance2 -Query $DropTestUser -Database master
+    }
+
+    Context "Partition Functions are correctly located" {
+        $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database master | Where-object {$_.name -eq "$DBUserName"} | Select-Object *
+        $results2 = Get-DbaDbUser -SqlInstance $script:instance2
+
+        It "Should execute and return results"{
+            $results2 | Should -Not -Be $null
+        }
+
+        It "Should execute against Master and return results"{
+            $results1 | Should -Not -Be $null
+        }
+
+        It "Should have matching login and username of $DBUserName" {
+            $results1.name | Should -Be "$DBUserName"
+            $results1.login | Should -Be "$DBUserName"
+        }
+
+        It "Should have a login type of SqlLogin" {
+            $results1.LoginType | Should -Be 'SqlLogin'
+        }
+
+        It "Should have DefaultSchema of dbo" {
+            $results1.DefaultSchema | Should -Be "dbo"
+        }
+
+        It "Should have database access" {
+            $results1.HasDBAccess | Should -Be $true
+        }
+
+        It "Should not Throw an Error" {
+            {Get-DbaDbUser -SqlInstance $script:instance2 -ExcludeDatabase master -ExcludeSystemUser } | Should -not -Throw
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4233 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix Dbatools cmdlets using aliases instead of the full cmdlet name
Add Integration tests for the `Get` cmdlets that didn't have one currently

### Approach
<!-- How does this change solve that purpose -->
Execute the following to identify the cmdlets:
 `Invoke-ScriptAnalyzer .\Functions\ | Where-Object {$_.RuleName -eq 'PSAvoidUsingCmdletAliases'}` 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Execute the Pester Tests for each cmdlet, or the `Invoke-ScriptAnalyzer` above
