### PR TITLE
removing confusing alias RestoredDatababaseNamePrefix for RestoredDatabaseNamePrefix

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -358,7 +358,6 @@
         [parameter(ParameterSetName = "Restore")]
         [string]$DestinationFilePrefix = '',
         [parameter(ParameterSetName = "Restore")]
-        [Alias("RestoredDatababaseNamePrefix")]
         [string]$RestoredDatabaseNamePrefix,
         [parameter(ParameterSetName = "Restore")]
         [parameter(ParameterSetName = "RestorePage")]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Removing a confusing alias that pops up before the proper parameter, was correcting an earlier typo 

see https://sqlcommunity.slack.com/archives/C3EJ852JD/p1539850019000100 - for the details
