### PR TITLE
Update the filters to match the description

### DIFF
--- a/bin/XEtemplates/Long Running Queries.xml
+++ b/bin/XEtemplates/Long Running Queries.xml
@@ -33,7 +33,7 @@
                <leaf>
                   <comparator name="greater_than_equal_uint64" package="package0" />
                   <event name="rpc_completed" package="sqlserver" field="duration" />
-                  <value>1000000</value>
+                  <value>10000000</value>
                </leaf>
             </and>
          </predicate>
@@ -61,7 +61,7 @@
                <leaf>
                   <comparator name="greater_than_equal_uint64" package="package0" />
                   <event name="sql_batch_completed" package="sqlserver" field="duration" />
-                  <value>500000</value>
+                  <value>10000000</value>
                </leaf>
             </and>
          </predicate>


### PR DESCRIPTION
According to the description the filters on duration should be set to 10000000 microseconds.

## Type of Change
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Update template definition to match description