### PR TITLE
Rename Parameter; Add Code Coverage to Test

### DIFF
--- a/functions/Read-DbaTraceFile.ps1
+++ b/functions/Read-DbaTraceFile.ps1
@@ -33,8 +33,8 @@ function Read-DbaTraceFile {
     .PARAMETER ObjectType
         Search for results only with specific ObjectTypes. Uses IN for comparisons.
 
-    .PARAMETER ErrorID
-        Search for results only with specific Errors. Filters 'Error in ($ErrorID)'  Uses IN for comparisons.
+    .PARAMETER ErrorId
+        Search for results only with specific Errors. Filters 'Error in ($ErrorId)'  Uses IN for comparisons.
 
     .PARAMETER EventSequence
         Search for results only with specific EventSequences. Uses IN for comparisons.
@@ -168,7 +168,7 @@ function Read-DbaTraceFile {
         [int[]]$Spid,
         [string[]]$EventClass,
         [string[]]$ObjectType,
-        [int[]]$ErrorID,
+        [int[]]$ErrorId,
         [int[]]$EventSequence,
         [string[]]$TextData,
         [string[]]$ApplicationName,
@@ -182,7 +182,7 @@ function Read-DbaTraceFile {
         if ($where) {
             $Where = "where $where"
         }
-        elseif ($Database -or $Login -or $Spid -or $ApplicationName -or $EventClass -or $ObjectName -or $ObjectType -or $EventSequence -or $ErrorID) {
+        elseif ($Database -or $Login -or $Spid -or $ApplicationName -or $EventClass -or $ObjectName -or $ObjectType -or $EventSequence -or $ErrorId) {
 
             $tempwhere = @()
 
@@ -211,8 +211,8 @@ function Read-DbaTraceFile {
                 $tempwhere += "ObjectType in ($where)"
             }
 
-            if ($ErrorID) {
-                $where = $ErrorID -join ","
+            if ($ErrorId) {
+                $where = $ErrorId -join ","
                 $tempwhere += "Error in ($where)"
             }
 

--- a/functions/Read-DbaTraceFile.ps1
+++ b/functions/Read-DbaTraceFile.ps1
@@ -33,8 +33,8 @@ function Read-DbaTraceFile {
     .PARAMETER ObjectType
         Search for results only with specific ObjectTypes. Uses IN for comparisons.
 
-    .PARAMETER Error
-        Search for results only with specific Errors. Uses IN for comparisons.
+    .PARAMETER ErrorID
+        Search for results only with specific Errors. Filters 'Error in ($ErrorID)'  Uses IN for comparisons.
 
     .PARAMETER EventSequence
         Search for results only with specific EventSequences. Uses IN for comparisons.
@@ -168,7 +168,7 @@ function Read-DbaTraceFile {
         [int[]]$Spid,
         [string[]]$EventClass,
         [string[]]$ObjectType,
-        [int[]]$Error,
+        [int[]]$ErrorID,
         [int[]]$EventSequence,
         [string[]]$TextData,
         [string[]]$ApplicationName,
@@ -182,7 +182,7 @@ function Read-DbaTraceFile {
         if ($where) {
             $Where = "where $where"
         }
-        elseif ($Database -or $Login -or $Spid -or $ApplicationName -or $EventClass -or $ObjectName -or $ObjectType -or $EventSequence -or $Error) {
+        elseif ($Database -or $Login -or $Spid -or $ApplicationName -or $EventClass -or $ObjectName -or $ObjectType -or $EventSequence -or $ErrorID) {
 
             $tempwhere = @()
 
@@ -211,8 +211,8 @@ function Read-DbaTraceFile {
                 $tempwhere += "ObjectType in ($where)"
             }
 
-            if ($Error) {
-                $where = $Error -join ","
+            if ($ErrorID) {
+                $where = $ErrorID -join ","
                 $tempwhere += "Error in ($where)"
             }
 

--- a/tests/Read-DbaTraceFile.Tests.ps1
+++ b/tests/Read-DbaTraceFile.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         $paramCount = 15
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Read-DbaTraceFile).Parameters.Keys
-        $knownParameters = 'SqlInstance','SqlCredential','Path','Database','Login','Spid','EventClass','ObjectType','ErrorID','EventSequence','TextData','ApplicationName','ObjectName','Where','EnableException'
+        $knownParameters = 'SqlInstance','SqlCredential','Path','Database','Login','Spid','EventClass','ObjectType','ErrorId','EventSequence','TextData','ApplicationName','ObjectName','Where','EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -57,8 +57,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -Database Master -Login sa -Spid 7 -WarningAction SilentlyContinue -WarningVariable warn
             $warn | Should -Be $null
         }
-        It "Should execute using paramters EventClass, ObjectType, ErrorID" {
-            $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -EventClass 4 -ObjectType 4 -ErrorID 4 -WarningAction SilentlyContinue -WarningVariable warn
+        It "Should execute using paramters EventClass, ObjectType, ErrorId" {
+            $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -EventClass 4 -ObjectType 4 -ErrorId 4 -WarningAction SilentlyContinue -WarningVariable warn
             $warn | Should -Be $null
         }
         It "Should execute using paramters EventSequence, TextData, ApplicationName, ObjectName" {

--- a/tests/Read-DbaTraceFile.Tests.ps1
+++ b/tests/Read-DbaTraceFile.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         $paramCount = 15
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Read-DbaTraceFile).Parameters.Keys
-        $knownParameters = 'SqlInstance','SqlCredential','Path','Database','Login','Spid','EventClass','ObjectType','Error','EventSequence','TextData','ApplicationName','ObjectName','Where','EnableException'
+        $knownParameters = 'SqlInstance','SqlCredential','Path','Database','Login','Spid','EventClass','ObjectType','ErrorID','EventSequence','TextData','ApplicationName','ObjectName','Where','EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -51,4 +51,37 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $warn | Should -Be $null
         }
     }
+    Context "Verify Parameter Use" {
+
+        It "Should execute using paramters Database, Login, Spid" {
+            $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -Database Master -Login sa -Spid 7 -WarningAction SilentlyContinue -WarningVariable warn
+            $warn | Should -Be $null
+        }
+        It "Should execute using paramters EventClass, ObjectType, ErrorID" {
+            $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -EventClass 4 -ObjectType 4 -ErrorID 4 -WarningAction SilentlyContinue -WarningVariable warn
+            $warn | Should -Be $null
+        }
+        It "Should execute using paramters EventSequence, TextData, ApplicationName, ObjectName" {
+            $results = $script:instance1, $script:instance2 | Get-DbaTrace -Id 1 | Read-DbaTraceFile -EventSequence 4 -TextData "Text" -ApplicationName "Application" -ObjectName "Name" -WarningAction SilentlyContinue -WarningVariable warn
+            $warn | Should -Be $null
+        }
+
+    }
+    Context "Verify Failure with Mocks" {
+        It "Should Fail Connection to SqlInstance" {
+            mock Connect-SqlInstance {throw} -module dbatools
+            mock Stop-Function {"Failure"} -module dbatools
+            (Read-DbaTraceFile -SqlInstance "NotAnInstance" ) | Should -be "Failure"
+        }
+        It "Should try `$CurrentPath" {
+            #This mock forces line 257 to be tested
+            mock Test-Bound {$false} -module dbatools
+            (Read-DbaTraceFile -SqlInstance "$script:Instance2" ) | Should -Not -Be $null
+        }
+        It "Should Fail to find the Path" {
+            mock Test-DbaPath {$false} -module dbatools
+            mock Write-Message {"Path Does Not Exist"} -module dbatools
+            (Read-DbaTraceFile -SqlInstance "$script:Instance2" ) | Should -Be "Failure"
+        }
+        }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4248 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Remove the Parameter `-Error` from `Read-DbaTraceFile`
Replace with `-ErrorID` (This is not the value of the resultant table, but seemed the most logical name)
Add Code Coverage to existing Pester Test

### Approach
<!-- How does this change solve that purpose -->
Replaced Instances of `$Error` with `$ErrorID`
Gave a little more explanation in the parameter description

### Commands to test
<!-- if these are the examples in the help just note it as such -->
` Invoke-ScriptAnalyzer .\functions\Read-DbaTraceFile.ps1`
`Invoke-Pester .\Tests\Read-DbaTraceFile.Tests.ps1`


