### PR TITLE
Bacpac handling and full SMO model support in Dac* commands

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -1,5 +1,5 @@
 ﻿function Export-DbaDacPackage {
-	<#
+    <#
     .SYNOPSIS
         Exports a dacpac from a server.
 
@@ -34,7 +34,7 @@
     .PARAMETER Table
         List of the tables to include into the export. Should be provided as an array of strings: dbo.Table1, Table2, Schema1.Table3.
     
-    .PARAMETER Options
+    .PARAMETER DacOption
         Export options for a corresponding export type. Can be created by New-DbaDacOption -Type Dacpac | Bacpac
 
     .PARAMETER ExtendedParameters
@@ -67,11 +67,13 @@
         Exports the dacpac for SharePoint_Config on sql2016 to $home\Documents\SharePoint_Config.dacpac
 
     .EXAMPLE
-        PS C:\> $moreprops = "/p:VerifyExtraction=$true /p:CommandTimeOut=10"
-        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config -Path C:\temp -ExtendedProperties $moreprops
+        PS C:\> $options = New-DbaDacOption -Type Dacpac
+        PS C:\> $options.ExtractAllTableData = $true
+        PS C:\> $options.CommandTimeout = 0
+        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options
 
-        Sets the CommandTimeout to 10 then extracts the dacpac for SharePoint_Config on sql2016 to C:\temp\SharePoint_Config.dacpac then verifies extraction.
-    
+        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to $home\Documents\DB1.dacpac including all table data.
+        
     .EXAMPLE
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -AllUserDatabases -ExcludeDatabase "DBMaintenance","DBMonitoring" C:\temp
 
@@ -81,231 +83,223 @@
         PS C:\> $moreparams = "/OverwriteFiles:$true /Quiet:$true"
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config -Path C:\temp -ExtendedParameters $moreparams
 
-        Using extended parameters to over-write the files and performs the extraction in quiet mode.
+        Using extended parameters to over-write the files and performs the extraction in quiet mode. Uses command line instead of SMO behind the scenes.
 #>
-	[CmdletBinding(DefaultParameterSetName = 'SMO')]
-	param
-	(
-		[parameter(Mandatory, ValueFromPipeline)]
-		[Alias("ServerInstance", "SqlServer")]
-		[DbaInstance[]]$SqlInstance,
-		[Alias("Credential")]
-		[PSCredential]$SqlCredential,
-		[object[]]$Database,
-		[object[]]$ExcludeDatabase,
-		[switch]$AllUserDatabases,
-		[string]$Path = "$home\Documents",
-		[parameter(ParameterSetName = 'SMO')]
-		[Alias('ExtractOptions', 'ExportOptions', 'DacExtractOptions', 'DacExportOptions')]
-		[object]$Options,
-		[parameter(ParameterSetName = 'CMD')]
-		[string]$ExtendedParameters,
-		[parameter(ParameterSetName = 'CMD')]
-		[string]$ExtendedProperties,
-		[ValidateSet('Dacpac', 'Bacpac')]
-		[string]$Type = 'Dacpac',
-		[parameter(ParameterSetName = 'SMO')]
-		[string[]]$Table,
-		[switch]$EnableException
-	)
+    [CmdletBinding(DefaultParameterSetName = 'SMO')]
+    param
+    (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstance[]]$SqlInstance,
+        [Alias("Credential")]
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [switch]$AllUserDatabases,
+        [string]$Path = "$home\Documents",
+        [parameter(ParameterSetName = 'SMO')]
+        [Alias('ExtractOptions', 'ExportOptions', 'DacExtractOptions', 'DacExportOptions', 'Options', 'Option')]
+        [object]$DacOption,
+        [parameter(ParameterSetName = 'CMD')]
+        [string]$ExtendedParameters,
+        [parameter(ParameterSetName = 'CMD')]
+        [string]$ExtendedProperties,
+        [ValidateSet('Dacpac', 'Bacpac')]
+        [string]$Type = 'Dacpac',
+        [parameter(ParameterSetName = 'SMO')]
+        [string[]]$Table,
+        [switch]$EnableException
+    )
 
-	process {
-		if ((Test-Bound -Not -ParameterName Database) -and (Test-Bound -Not -ParameterName ExcludeDatabase) -and (Test-Bound -Not -ParameterName AllUserDatabases)) {
-			Stop-Function -Message "You must specify databases to execute against using either -Database, -ExcludeDatabase or -AllUserDatabases"
-			return
-		}
+    process {
+        if ((Test-Bound -Not -ParameterName Database) -and (Test-Bound -Not -ParameterName ExcludeDatabase) -and (Test-Bound -Not -ParameterName AllUserDatabases)) {
+            Stop-Function -Message "You must specify databases to execute against using either -Database, -ExcludeDatabase or -AllUserDatabases"
+            return
+        }
 
-		if (-not (Test-Path $Path)) {
-			Write-Message -Level Verbose "Assuming that $Path is a file path"
-			$parentFolder = Split-Path $path -Parent
-			if (-not (Test-Path $parentFolder)) {
-				Stop-Function -Message "$parentFolder doesn't exist or access denied"
-				return
-			}
-			$leaf = Split-Path $path -Leaf
-			$fileName = Join-Path (Get-Item $parentFolder) $leaf
-		}
-		else {
-			$fileItem = Get-Item $Path
-			if ($fileItem -is [System.IO.DirectoryInfo]) {
-				$parentFolder = $fileItem.FullName
-			}
-			elseif ($fileItem -is [System.IO.FileInfo]) {
-				$fileName = $fileItem.FullName
-			}
-		}
+        if (-not (Test-Path $Path)) {
+            Write-Message -Level Verbose "Assuming that $Path is a file path"
+            $parentFolder = Split-Path $path -Parent
+            if (-not (Test-Path $parentFolder)) {
+                Stop-Function -Message "$parentFolder doesn't exist or access denied"
+                return
+            }
+            $leaf = Split-Path $path -Leaf
+            $fileName = Join-Path (Get-Item $parentFolder) $leaf
+        }
+        else {
+            $fileItem = Get-Item $Path
+            if ($fileItem -is [System.IO.DirectoryInfo]) {
+                $parentFolder = $fileItem.FullName
+            }
+            elseif ($fileItem -is [System.IO.FileInfo]) {
+                $fileName = $fileItem.FullName
+            }
+        }
 
-		if (Test-Bound -Not -ParameterName 'DacfxPath') {
-			$dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
-		}
-		if ((Test-Path $dacfxPath) -eq $false) {
-			Stop-Function -Message 'No usable version of Dac Fx found.' -EnableException $EnableException
-			return
-		}
-		else {
-			try {
-				Add-Type -Path $dacfxPath
-				Write-Message -Level Verbose -Message "Dac Fx loaded."
-			}
-			catch {
-				Stop-Function -Message 'No usable version of Dac Fx found.' -ErrorRecord $_
-				return
-			}
-		}
+        $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
+        if ((Test-Path $dacfxPath) -eq $false) {
+            Stop-Function -Message 'Dac Fx library not found.' -EnableException $EnableException
+            return
+        }
+        else {
+            try {
+                Add-Type -Path $dacfxPath
+                Write-Message -Level Verbose -Message "Dac Fx loaded."
+            }
+            catch {
+                Stop-Function -Message 'No usable version of Dac Fx found.' -ErrorRecord $_
+                return
+            }
+        }
         
-		#check that at least one of the DB selection parameters was specified
-		if (!$AllUserDatabases -and !$Database) {
-			Stop-Function -Message "Either -Database or -AllUserDatabases should be specified" -Continue
-		}    
-		#Check Option object types - should have a specific type
-		if ($Type -eq 'Dacpac') {
-			if ($Options -and $Options -isnot [Microsoft.SqlServer.Dac.DacExtractOptions]) {
-				Stop-Function -Message "Microsoft.SqlServer.Dac.DacExtractOptions object type is expected - got $($Options.GetType())."
-				return
-			}
-		}
-		elseif ($Type -eq 'Bacpac') {
-			if ($Options -and $Options -isnot [Microsoft.SqlServer.Dac.DacExportOptions]) {
-				Stop-Function -Message "Microsoft.SqlServer.Dac.DacExportOptions object type is expected - got $($Options.GetType())."
-				return
-			}
-		}
+        #check that at least one of the DB selection parameters was specified
+        if (!$AllUserDatabases -and !$Database) {
+            Stop-Function -Message "Either -Database or -AllUserDatabases should be specified" -Continue
+        }
+        #Check Option object types - should have a specific type
+        if ($Type -eq 'Dacpac') {
+            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.DacExtractOptions]) {
+                Stop-Function -Message "Microsoft.SqlServer.Dac.DacExtractOptions object type is expected - got $($DacOption.GetType())."
+                return
+            }
+        }
+        elseif ($Type -eq 'Bacpac') {
+            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.DacExportOptions]) {
+                Stop-Function -Message "Microsoft.SqlServer.Dac.DacExportOptions object type is expected - got $($DacOption.GetType())."
+                return
+            }
+        }
         
-		#Create a tuple to be used as a table filter
-		if ($Table) {
-			$tblList = New-Object 'System.Collections.Generic.List[Tuple[String, String]]'
-			foreach ($tableItem in $Table) {
-				$tableSplit = $tableItem.Split('.')
-				if ($tableSplit.Count -gt 1) {
-					$tblName = $tableSplit[-1]
-					$schemaName = $tableSplit[-2]
-				}
-				else {
-					$tblName = [string]$tableSplit
-					$schemaName = 'dbo'
-				}
-				$tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName, $tblName))
-			}
-		}
-		else {
-			$tblList = $null
-		}
+        #Create a tuple to be used as a table filter
+        if ($Table) {
+            $tblList = New-Object 'System.Collections.Generic.List[Tuple[String, String]]'
+            foreach ($tableItem in $Table) {
+                $tableSplit = $tableItem.Split('.')
+                if ($tableSplit.Count -gt 1) {
+                    $tblName = $tableSplit[-1]
+                    $schemaName = $tableSplit[-2]
+                }
+                else {
+                    $tblName = [string]$tableSplit
+                    $schemaName = 'dbo'
+                }
+                $tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName, $tblName))
+            }
+        }
+        else {
+            $tblList = $null
+        }
 
-		foreach ($instance in $sqlinstance) {
-			try {
-				$server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-			}
-			catch {
-				Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-			}
-			$cleaninstance = $instance.ToString().Replace('\', '-')
+        foreach ($instance in $sqlinstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            }
+            catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+            $cleaninstance = $instance.ToString().Replace('\', '-')
 
-			$dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -ExcludeAllSystemDb -Database $Database -ExcludeDatabase $ExcludeDatabase
-			if (-not $dbs) {
-				Stop-Function -Message "Databases not found on $instance" -Target $instance -Continue
-			}
+            $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -ExcludeAllSystemDb -Database $Database -ExcludeDatabase $ExcludeDatabase
+            if (-not $dbs) {
+                Stop-Function -Message "Databases not found on $instance" -Target $instance -Continue
+            }
 
-			foreach ($db in $dbs) {
-				$dbname = $db.name
-				$connstring = $server.ConnectionContext.ConnectionString
-				if ($connstring -notmatch 'Database=') {
-					$connstring = "$connstring;Database=$dbname"
-				}
-				if ($fileName) {
-					$currentFileName = $fileName
-				}
-				else {
-					if ($Type -eq 'Dacpac') { $ext = 'dacpac' }
-					elseif ($Type -eq 'Bacpac') { $ext = 'bacpac' }
-					$currentFileName = Join-Path $parentFolder "$cleaninstance-$dbname.$ext"
-				}
-				Write-Message -Level Verbose -Message "Using connection string $connstring"
+            foreach ($db in $dbs) {
+                $dbname = $db.name
+                $connstring = $server.ConnectionContext.ConnectionString
+                if ($connstring -notmatch 'Database=') {
+                    $connstring = "$connstring;Database=$dbname"
+                }
+                if ($fileName) {
+                    $currentFileName = $fileName
+                }
+                else {
+                    if ($Type -eq 'Dacpac') { $ext = 'dacpac' }
+                    elseif ($Type -eq 'Bacpac') { $ext = 'bacpac' }
+                    $currentFileName = Join-Path $parentFolder "$cleaninstance-$dbname.$ext"
+                }
+                Write-Message -Level Verbose -Message "Using connection string $connstring"
                 
-				#using SMO by default
-				if ($PsCmdlet.ParameterSetName -eq 'SMO') {
-					try {
-						$dacSvc = New-Object -TypeName Microsoft.SqlServer.Dac.DacServices -ArgumentList $connstring -ErrorAction Stop
-					}
-					catch {
-						Stop-Function -Message "Could not connect to the connection string $connstring" -Target $instance -Continue
-					}
-					if ($Type -eq 'Dacpac') {
-						Write-Message -Level Verbose -Message "Initiating Dacpac extract to $currentFileName"
-						if (!$Options) {
-							$opts = New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
-						}
-						else {
-							$opts = $Options
-						}
-						#not sure how to extract that info from the existing DAC application, leaving 1.0.0.0 for now
-						$version = New-Object System.Version -ArgumentList '1.0.0.0'
-						try {
-							$dacSvc.Extract($currentFileName, $dbname, $dbname, $version, $null, $tblList, $opts, $null)
-						}
-						catch {
-							Stop-Function -Message "DacServices extraction failure" -ErrorRecord $_ -Continue
-						}
-					}
-					elseif ($Type -eq 'Bacpac') {
-						Write-Message -Level Verbose -Message "Initiating Bacpac export to $currentFileName"
-						if (!$Options) {
-							$opts = New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
-						}
-						else {
-							$opts = $Options
-						}
-						try {
-							$dacSvc.ExportBacpac($currentFileName, $dbname, $opts, $tblList, $null)
-						}
-						catch {
-							Stop-Function -Message "DacServices export failure" -ErrorRecord $_ -Continue
-						}
-					}
-				}
-				elseif ($PsCmdlet.ParameterSetName -eq 'CMD') {
-					if ($Type -eq 'Dacpac') { $action = 'Extract' }
-					elseif ($Type -eq 'Bacpac') { $action = 'Export' }
-					$cmdConnString = $connstring.Replace('"', "'")
+                #using SMO by default
+                if ($PsCmdlet.ParameterSetName -eq 'SMO') {
+                    try {
+                        $dacSvc = New-Object -TypeName Microsoft.SqlServer.Dac.DacServices -ArgumentList $connstring -ErrorAction Stop
+                    }
+                    catch {
+                        Stop-Function -Message "Could not connect to the connection string $connstring" -Target $instance -Continue
+                    }
+                    if (!$DacOption) {
+                        $opts = New-DbaDacOption -Type $Type
+                    }
+                    else {
+                        $opts = $DacOption
+                    }
+                    if ($Type -eq 'Dacpac') {
+                        Write-Message -Level Verbose -Message "Initiating Dacpac extract to $currentFileName"
+                        #not sure how to extract that info from the existing DAC application, leaving 1.0.0.0 for now
+                        $version = New-Object System.Version -ArgumentList '1.0.0.0'
+                        try {
+                            $dacSvc.Extract($currentFileName, $dbname, $dbname, $version, $null, $tblList, $opts, $null)
+                        }
+                        catch {
+                            Stop-Function -Message "DacServices extraction failure" -ErrorRecord $_ -Continue
+                        }
+                    }
+                    elseif ($Type -eq 'Bacpac') {
+                        Write-Message -Level Verbose -Message "Initiating Bacpac export to $currentFileName"
+                        try {
+                            $dacSvc.ExportBacpac($currentFileName, $dbname, $opts, $tblList, $null)
+                        }
+                        catch {
+                            Stop-Function -Message "DacServices export failure" -ErrorRecord $_ -Continue
+                        }
+                    }
+                }
+                elseif ($PsCmdlet.ParameterSetName -eq 'CMD') {
+                    if ($Type -eq 'Dacpac') { $action = 'Extract' }
+                    elseif ($Type -eq 'Bacpac') { $action = 'Export' }
+                    $cmdConnString = $connstring.Replace('"', "'")
 
-					$sqlPackageArgs = "/action:$action /tf:""$currentFileName"" /SourceConnectionString:""$cmdConnString"" $ExtendedParameters $ExtendedProperties"
-					$resultstime = [diagnostics.stopwatch]::StartNew()
+                    $sqlPackageArgs = "/action:$action /tf:""$currentFileName"" /SourceConnectionString:""$cmdConnString"" $ExtendedParameters $ExtendedProperties"
+                    $resultstime = [diagnostics.stopwatch]::StartNew()
 
-					try {
-						$startprocess = New-Object System.Diagnostics.ProcessStartInfo
-						$startprocess.FileName = "$script:PSModuleRoot\bin\smo\sqlpackage.exe"
-						$startprocess.Arguments = $sqlPackageArgs
-						$startprocess.RedirectStandardError = $true
-						$startprocess.RedirectStandardOutput = $true
-						$startprocess.UseShellExecute = $false
-						$startprocess.CreateNoWindow = $true
-						$process = New-Object System.Diagnostics.Process
-						$process.StartInfo = $startprocess
-						$process.Start() | Out-Null
-						$stdout = $process.StandardOutput.ReadToEnd()
-						$stderr = $process.StandardError.ReadToEnd()
-						$process.WaitForExit()
-						Write-Message -level Verbose -Message "StandardOutput: $stdout"
-					}
-					catch {
-						Stop-Function -Message "SQLPackage Failure" -ErrorRecord $_ -Continue
-					}
+                    try {
+                        $startprocess = New-Object System.Diagnostics.ProcessStartInfo
+                        $startprocess.FileName = "$script:PSModuleRoot\bin\smo\sqlpackage.exe"
+                        $startprocess.Arguments = $sqlPackageArgs
+                        $startprocess.RedirectStandardError = $true
+                        $startprocess.RedirectStandardOutput = $true
+                        $startprocess.UseShellExecute = $false
+                        $startprocess.CreateNoWindow = $true
+                        $process = New-Object System.Diagnostics.Process
+                        $process.StartInfo = $startprocess
+                        $process.Start() | Out-Null
+                        $stdout = $process.StandardOutput.ReadToEnd()
+                        $stderr = $process.StandardError.ReadToEnd()
+                        $process.WaitForExit()
+                        Write-Message -level Verbose -Message "StandardOutput: $stdout"
+                    }
+                    catch {
+                        Stop-Function -Message "SQLPackage Failure" -ErrorRecord $_ -Continue
+                    }
 
-					if ($process.ExitCode -ne 0) {
-						Stop-Function -Message "Standard output - $stderr" -Continue
-					}
-				}
-				[pscustomobject]@{
-					ComputerName = $server.ComputerName
-					InstanceName = $server.ServiceName
-					SqlInstance  = $server.DomainInstanceName
-					Database     = $dbname
-					Path         = $currentFileName
-					Elapsed      = [prettytimespan]($resultstime.Elapsed)
-				} | Select-DefaultView -ExcludeProperty ComputerName, InstanceName
-			}
-		}
-	}
-	end {
-		Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Export-DbaDacpac
-	}
+                    if ($process.ExitCode -ne 0) {
+                        Stop-Function -Message "Standard output - $stderr" -Continue
+                    }
+                }
+                [pscustomobject]@{
+                    ComputerName = $server.ComputerName
+                    InstanceName = $server.ServiceName
+                    SqlInstance  = $server.DomainInstanceName
+                    Database     = $dbname
+                    Path         = $currentFileName
+                    Elapsed      = [prettytimespan]($resultstime.Elapsed)
+                } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName
+            }
+        }
+    }
+    end {
+        Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Export-DbaDacpac
+    }
 }

--- a/functions/New-DbaDacOption.ps1
+++ b/functions/New-DbaDacOption.ps1
@@ -13,6 +13,9 @@
         
     .PARAMETER Type
         Selecting the type of the export: Dacpac (default) or Bacpac.
+        
+    .PARAMETER Action
+        Choosing an intended action: Publish or Export.
 
     .NOTES
         Tags: Migration, Database, Dacpac
@@ -36,7 +39,10 @@
 #>
     Param (
         [ValidateSet('Dacpac', 'Bacpac')]
-        [string]$Type = 'Dacpac'
+        [string]$Type = 'Dacpac',
+        [Parameter(Mandatory)]
+        [ValidateSet('Publish', 'Export')]
+        [string]$Action
     )
     $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
     if ((Test-Path $dacfxPath) -eq $false) {
@@ -53,10 +59,21 @@
             return
         }
     }
-    if ($Type -eq 'Dacpac') {
-        New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
+    # Pick proper option object depending on type and action
+    if ($Action -eq 'Export') {
+        if ($Type -eq 'Dacpac') {
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
+        }
+        elseif ($Type -eq 'Bacpac') {
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
+        }
     }
-    elseif ($Type -eq 'Bacpac') {
-        New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
+    elseif ($Action -eq 'Publish') {
+        if ($Type -eq 'Dacpac') {
+            New-Object -TypeName Microsoft.SqlServer.Dac.PublishOptions
+        }
+        elseif ($Type -eq 'Bacpac') {
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacImportOptions
+        }
     }
 }

--- a/functions/New-DbaDacOption.ps1
+++ b/functions/New-DbaDacOption.ps1
@@ -1,0 +1,62 @@
+﻿function New-DbaDacOption {
+    <#
+    .SYNOPSIS
+        Creates a new Microsoft.SqlServer.Dac.DacExtractOptions/DacExportOptions object depending on the chosen Type
+
+    .DESCRIPTION
+        Creates a new Microsoft.SqlServer.Dac.DacExtractOptions/DacExportOptions object that can be used during DacPackage extract. Basically saves you the time from remembering the SMO assembly name ;)
+
+        See:
+        https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.dacexportoptions.aspx
+        https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.dacextractoptions.aspx
+        for more information
+        
+    .PARAMETER Type
+        Selecting the type of the export: Dacpac (default) or Bacpac.
+
+    .NOTES
+        Tags: Migration, Database, Dacpac
+        Author: Kirill Kravtsov (@nvarscar), nvarscar.wordpress.com
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/New-DbaScriptingOption
+
+    .EXAMPLE
+        PS C:\> $options = New-DbaDacOption -Type Dacpac
+        PS C:\> $options.ExtractAllTableData = $true
+        PS C:\> $options.CommandTimeout = 0
+        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options
+
+        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for SharePoint_Config on sql2016 to C:\temp\SharePoint_Config.dacpac including all table data.
+
+#>
+    Param (
+        [ValidateSet('Dacpac', 'Bacpac')]
+        [string]$Type = 'Dacpac'
+    )
+    $dacfxPath = "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Dac.dll"
+    if ((Test-Path $dacfxPath) -eq $false) {
+        Stop-Function -Message 'Dac Fx library not found.' -EnableException $EnableException
+        return
+    }
+    else {
+        try {
+            Add-Type -Path $dacfxPath
+            Write-Message -Level Verbose -Message "Dac Fx loaded."
+        }
+        catch {
+            Stop-Function -Message 'No usable version of Dac Fx found.' -ErrorRecord $_
+            return
+        }
+    }
+    if ($Type -eq 'Dacpac') {
+        New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
+    }
+    elseif ($Type -eq 'Bacpac') {
+        New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
+    }
+}

--- a/functions/New-DbaDacOption.ps1
+++ b/functions/New-DbaDacOption.ps1
@@ -62,18 +62,21 @@
     # Pick proper option object depending on type and action
     if ($Action -eq 'Export') {
         if ($Type -eq 'Dacpac') {
-            New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacExtractOptions
         }
         elseif ($Type -eq 'Bacpac') {
-            New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacExportOptions
         }
     }
     elseif ($Action -eq 'Publish') {
         if ($Type -eq 'Dacpac') {
-            New-Object -TypeName Microsoft.SqlServer.Dac.PublishOptions
+            $output = New-Object -TypeName Microsoft.SqlServer.Dac.PublishOptions
+            $output.DeployOptions = New-Object -TypeName Microsoft.SqlServer.Dac.DacDeployOptions
+            $output.GenerateDeploymentScript = $false
+            $output
         }
         elseif ($Type -eq 'Bacpac') {
-            New-Object -TypeName Microsoft.SqlServer.Dac.DacImportOptions
+            New-Object -TypeName Microsoft.SqlServer.Dac.DacImportOptions
         }
     }
 }

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -107,7 +107,6 @@
         [switch]$GenerateDeploymentScript,
         [parameter(ParameterSetName = 'Xml')]
         [switch]$GenerateDeploymentReport,
-        [parameter(ParameterSetName = 'Xml')]
         [Switch]$ScriptOnly,
         [ValidateSet('Dacpac', 'Bacpac')]
         [string]$Type = 'Dacpac',
@@ -298,6 +297,12 @@
                     #Perform proper action depending on the Type
                     if ($Type -eq 'Dacpac') {
                         if ($ScriptOnly) {
+                            if (!$options.GenerateDeploymentScript) {
+                                Stop-Function -Message "GenerateDeploymentScript option should be specified when running with -ScriptOnly" -EnableException $true
+                            }
+                            if (!$options.DatabaseScriptPath) {
+                                Stop-Function -Message "DatabaseScriptPath option should be specified when running with -ScriptOnly" -EnableException $true
+                            }
                             Write-Message -Level Verbose -Message "Generating script."
                             $result = $dacServices.Script($dacPackage, $dbname, $options)
                         }
@@ -312,7 +317,7 @@
                     }
                 }
                 catch [Microsoft.SqlServer.Dac.DacServicesException] {
-                    Stop-Function -Message "Deployment failed" -ErrorRecord $_ -EnableException $true
+                    Stop-Function -Message "Deployment failed" -ErrorRecord $_ -Continue
                 }
                 finally {
                     Unregister-Event -SourceIdentifier "msg"
@@ -322,7 +327,7 @@
                     }
                     if ($GenerateDeploymentScript) {
                         Write-Message -Level Verbose -Message "Database change script - $DatabaseScriptPath."
-                        if ((Test-Path $MasterDbScriptPath)) {
+                        if ((Test-Path $options.MasterDbScriptPath)) {
                             Write-Message -Level Verbose -Message "Master database change script - $($result.MasterDbScript)."
                         }
                     }

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -331,7 +331,6 @@
                         Write-Message -Level Warning -Message "Seems like the attempt to publish/script may have failed. If scripts have not generated load dacpac into Visual Studio to check SQL is valid."
                     }
                     $server = [dbainstance]$instance
-                    $deployOptions = $options.DeployOptions | Select-Object -Property * -ExcludeProperty "SqlCommandVariableValues"
                     if ($Type -eq 'Dacpac') {
                         $output = [pscustomobject]@{
                             ComputerName         = $server.ComputerName
@@ -345,7 +344,7 @@
                             DatabaseScriptPath   = $options.DatabaseScriptPath
                             MasterDbScriptPath   = $options.MasterDbScriptPath
                             DeploymentReport     = $DeploymentReport
-                            DeployOptions        = $deployOptions
+                            DeployOptions        = $options.DeployOptions | Select-Object -Property * -ExcludeProperty "SqlCommandVariableValues"
                             SqlCmdVariableValues = $options.DeployOptions.SqlCommandVariableValues.Keys
                         }
                     }
@@ -358,7 +357,7 @@
                             Result           = $resultoutput
                             Bacpac           = $Path
                             ConnectionString = $connstring
-                            DeployOptions    = $deployOptions
+                            DeployOptions    = $options
                         }
                     }
                     $output | Select-DefaultView -Property $defaultcolumns

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -57,6 +57,15 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                     Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
                 }
             }
+            It "uses EXE to extract dacpac" {
+                $exportProperties = "/p:ExtractAllTableData=True"
+                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -ExtendedProperties $exportProperties
+                $results.Path | Should -Not -BeNullOrEmpty
+                Test-Path $results.Path | Should -Be $true
+                if (($results).Path) {
+                    Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
+                }
+            }
         }
     }
     Context "Extract bacpac" {
@@ -70,7 +79,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         if ((Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table example)) {
             # Sometimes appveyor bombs
-            It "exports a dacpac" {
+            It "exports a bacpac" {
                 $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Type Bacpac
                 $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
@@ -78,11 +87,20 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                     Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
                 }
             }
-            It "exports dacpac with a table list" {
-                $relativePath = '.\extract.dacpac'
-                $expectedPath = Join-Path (Get-Item .) 'extract.dacpac'
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Path $relativePath -Table example  -Type Bacpac
+            It "exports bacpac with a table list" {
+                $relativePath = '.\extract.bacpac'
+                $expectedPath = Join-Path (Get-Item .) 'extract.bacpac'
+                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Path $relativePath -Table example -Type Bacpac
                 $results.Path | Should -Be $expectedPath
+                Test-Path $results.Path | Should -Be $true
+                if (($results).Path) {
+                    Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
+                }
+            }
+            It "uses EXE to extract bacpac" {
+                $exportProperties = "/p:TargetEngineVersion=Default"
+                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -ExtendedProperties $exportProperties -Type Bacpac
+                $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
                     Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -9,9 +9,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $null = $server.Query("Create Database [$dbname]")
             $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
-            $null = $db.Query("CREATE TABLE dbo.example (id int);
+            $null = $db.Query("CREATE TABLE dbo.example (id int, PRIMARY KEY (id));
             INSERT dbo.example
-            SELECT top 100 1
+            SELECT top 100 object_id
             FROM sys.objects")
         }
         catch { } # No idea why appveyor can't handle this
@@ -40,7 +40,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
                     Remove-Item -Confirm:$false -Path ($results).Path -ErrorAction SilentlyContinue
                 }
             }
-            It "exports to the correct directory" { 
+            It "exports to the correct directory" {
                 $relativePath = '.\'
                 $expectedPath = (Resolve-Path $relativePath).Path
                 $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Path $relativePath

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -3,10 +3,16 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Unit Tests" -Tag "UnitTests" {
-    It "Returns dacpac options" {
-        New-DbaDacOption | Should -Not -BeNullOrEmpty
+    It "Returns dacpac export options" {
+        New-DbaDacOption -Action Export | Should -Not -BeNullOrEmpty
     }
-    It "Returns bacpac options" {
-        New-DbaDacOption -Type Bacpac | Should -Not -BeNullOrEmpty
+    It "Returns bacpac export options" {
+        New-DbaDacOption -Action Export -Type Bacpac | Should -Not -BeNullOrEmpty
+    }
+    It "Returns dacpac publish options" {
+        New-DbaDacOption -Action Publish  | Should -Not -BeNullOrEmpty
+    }
+    It "Returns bacpac publish options" {
+        New-DbaDacOption -Action Publish -Type Bacpac | Should -Not -BeNullOrEmpty
     }
 }

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -3,6 +3,12 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$commandname Unit Tests" -Tag "UnitTests" {
+    BeforeAll {
+        $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database whatever -Path C:\temp
+    }
+    AfterAll {
+        Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
+    }
     It "Returns dacpac export options" {
         New-DbaDacOption -Action Export | Should -Not -BeNullOrEmpty
     }
@@ -11,6 +17,9 @@ Describe "$commandname Unit Tests" -Tag "UnitTests" {
     }
     It "Returns dacpac publish options" {
         New-DbaDacOption -Action Publish  | Should -Not -BeNullOrEmpty
+    }
+    It "Returns dacpac publish options from an xml" {
+        New-DbaDacOption -Action Publish -PublishXml $publishprofile.FileName -EnableException | Should -Not -BeNullOrEmpty
     }
     It "Returns bacpac publish options" {
         New-DbaDacOption -Action Publish -Type Bacpac | Should -Not -BeNullOrEmpty

--- a/tests/New-DbaDacOption.Tests.ps1
+++ b/tests/New-DbaDacOption.Tests.ps1
@@ -1,0 +1,12 @@
+﻿$commandname = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$commandname Unit Tests" -Tag "UnitTests" {
+    It "Returns dacpac options" {
+        New-DbaDacOption | Should -Not -BeNullOrEmpty
+    }
+    It "Returns bacpac options" {
+        New-DbaDacOption -Type Bacpac | Should -Not -BeNullOrEmpty
+    }
+}

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -10,23 +10,53 @@ if (-not $env:appveyor) {
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $null = $server.Query("Create Database [$dbname]")
             $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
-            $null = $db.Query("CREATE TABLE dbo.example (id int);
-            INSERT dbo.example
-            SELECT top 100 1
-            FROM sys.objects")
+			$null = $db.Query("CREATE TABLE dbo.example (id int, PRIMARY KEY (id));
+                INSERT dbo.example
+                SELECT top 100 object_id
+                FROM sys.objects")
             $publishprofile = New-DbaDacProfile -SqlInstance $script:instance1 -Database $dbname -Path C:\temp
-            $dacpac = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname
         }
         AfterAll {
             Remove-DbaDatabase -SqlInstance $script:instance1, $script:instance2 -Database $dbname -Confirm:$false
             Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
-        }
-        
-        It "shows that the update is complete" {
-            $results = $dacpac | Publish-DbaDacPackage -PublishXml $publishprofile.FileName -Database $dbname -SqlInstance $script:instance2
-            $results.Result -match 'Update complete.' | Should Be $true
-            if (($dacpac).Path) {
+            if (Test-Path $dacpac.Path) {
                 Remove-Item -Confirm:$false -Path ($dacpac).Path -ErrorAction SilentlyContinue
+            }
+        }
+        AfterEach {
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false
+        }
+        Context "Dacpac tests" {
+            BeforeAll {
+                $extractOptions = New-DbaDacOption -Action Export
+                $extractOptions.ExtractAllTableData = $true
+                $dacpac = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -DacOption $extractOptions
+            }
+            It "Performs an xml-based deployment" {
+                $results = $dacpac | Publish-DbaDacPackage -PublishXml $publishprofile.FileName -Database $dbname -SqlInstance $script:instance2
+                $results.Result -match 'Update complete.' | Should Be $true
+                $ids = Invoke-DbaQuery -Database $dbname -SqlInstance $script:instance2 -Query 'SELECT id FROM dbo.example'
+                $ids.id | Should -Not -BeNullOrEmpty
+            }
+            It "Performs an SMO-based deployment" {
+                $options = New-DbaDacOption -Action Publish
+                $results = $dacpac | Publish-DbaDacPackage -DacOption $options -Database $dbname -SqlInstance $script:instance2
+                $results.Result -match 'Update complete.' | Should Be $true
+                $ids = Invoke-DbaQuery -Database $dbname -SqlInstance $script:instance2 -Query 'SELECT id FROM dbo.example'
+                $ids.id | Should -Not -BeNullOrEmpty
+            }
+        }
+        Context "Bacpac tests" {
+            BeforeAll {
+                $extractOptions = New-DbaDacOption -Action Export -Type Bacpac
+                $bacpac = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -DacOption $extractOptions -Type Bacpac
+            }
+            It "Performs an SMO-based deployment" {
+                $options = New-DbaDacOption -Action Publish -Type Bacpac
+                $results = $bacpac | Publish-DbaDacPackage -Type Bacpac -DacOption $options -Database $dbname -SqlInstance $script:instance2
+                $results.Result -match 'Updating database \(Complete\)' | Should Be $true
+                $ids = Invoke-DbaQuery -Database $dbname -SqlInstance $script:instance2 -Query 'SELECT id FROM dbo.example'
+                $ids.id | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -19,9 +19,6 @@ if (-not $env:appveyor) {
         AfterAll {
             Remove-DbaDatabase -SqlInstance $script:instance1, $script:instance2 -Database $dbname -Confirm:$false
             Remove-Item -Confirm:$false -Path $publishprofile.FileName -ErrorAction SilentlyContinue
-            if (Test-Path $dacpac.Path) {
-                Remove-Item -Confirm:$false -Path ($dacpac).Path -ErrorAction SilentlyContinue
-            }
         }
         AfterEach {
             Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Confirm:$false
@@ -31,6 +28,11 @@ if (-not $env:appveyor) {
                 $extractOptions = New-DbaDacOption -Action Export
                 $extractOptions.ExtractAllTableData = $true
                 $dacpac = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -DacOption $extractOptions
+            }
+            AfterAll {
+                if (Test-Path $dacpac.Path) {
+                    Remove-Item -Confirm:$false -Path ($dacpac).Path -ErrorAction SilentlyContinue
+                }
             }
             It "Performs an xml-based deployment" {
                 $results = $dacpac | Publish-DbaDacPackage -PublishXml $publishprofile.FileName -Database $dbname -SqlInstance $script:instance2
@@ -50,6 +52,11 @@ if (-not $env:appveyor) {
             BeforeAll {
                 $extractOptions = New-DbaDacOption -Action Export -Type Bacpac
                 $bacpac = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -DacOption $extractOptions -Type Bacpac
+            }
+            AfterAll {
+                if (Test-Path $bacpac.Path) {
+                    Remove-Item -Confirm:$false -Path ($bacpac).Path -ErrorAction SilentlyContinue
+                }
             }
             It "Performs an SMO-based deployment" {
                 $options = New-DbaDacOption -Action Publish -Type Bacpac

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -53,6 +53,7 @@ if (-not $env:appveyor) {
                 $results.DatabaseScriptPath | Should -Not -BeNullOrEmpty
                 Test-Path ($results.DatabaseScriptPath) | Should -Be $true
                 Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Should -BeNullOrEmpty
+                Remove-Item $results.DatabaseScriptPath
             }
             It "Should throw when the script output is not specified" {
                 $opts = New-DbaDacOption -Action Publish

--- a/tests/Publish-DbaDacPackage.Tests.ps1
+++ b/tests/Publish-DbaDacPackage.Tests.ps1
@@ -10,7 +10,7 @@ if (-not $env:appveyor) {
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $null = $server.Query("Create Database [$dbname]")
             $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
-			$null = $db.Query("CREATE TABLE dbo.example (id int, PRIMARY KEY (id));
+            $null = $db.Query("CREATE TABLE dbo.example (id int, PRIMARY KEY (id));
                 INSERT dbo.example
                 SELECT top 100 object_id
                 FROM sys.objects")


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Adding support for Bacpacs
- Introducing a non-xml-based deployment scenario that uses SMO objects
- No extra options/files needed by default - generates a default deployment template when not specified

### Approach
- New command: New-DbaDacOption that returns a proper options object for the deployment - @potatoqualitee plz add it to the psd1 once the PR is reviewed , the tests gonna fail miserably otherwise.
- New parameters: Type (bacpac/dacpac), DacOption and a few others

### Commands to test
From help:
```powershell
        PS C:\> $options = New-DbaDacOption -Type Dacpac -Action Export
        PS C:\> $options.ExtractAllTableData = $true
        PS C:\> $options.CommandTimeout = 0
        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options $options

        PS C:\> $options = New-DbaDacOption -Type Dacpac -Action Publish
        PS C:\> $options.DeployOptions.DropObjectsNotInSource = $true
        PS C:\> Publish-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options $options -Path c:\temp\db.dacpac
```

### Screenshots
![image](https://user-images.githubusercontent.com/30303784/47229287-fdb24100-d38c-11e8-9b2f-4445622f261b.png)

### Learning
Dacfx dll is not being loaded by default here, (apparently, to support different versions of the libraries. What if we only loaded the libraries needed for the commands we execute using some kind of internal function that knew which library to load for which function? Like, loading only Microsoft.SqlServer.Smo.dll by default and for functions that depend on other SMOs perform a call to the internal function to load missing DLLs. That could theoretically speed up import time.
Just a thought though.
