### PR TITLE
ShouldProcess updates

### DIFF
--- a/functions/Get-DbaDeprecatedFeature.ps1
+++ b/functions/Get-DbaDeprecatedFeature.ps1
@@ -36,7 +36,7 @@
     .EXAMPLE
         PS C:\> Get-DbaDeprecatedFeature -SqlInstance sql2008
 
-        Check deprecated features on server sql2008.    
+        Check deprecated features on server sql2008.
 
 #>
     [CmdletBinding()]

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -69,7 +69,7 @@
         Installs sp_WhoisActive to all servers within CMS
 #>
 
-    [CmdletBinding(SupportsShouldProcess)]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory, ValueFromPipeline, Position = 0)]
         [Alias("ServerInstance", "SqlServer")]

--- a/functions/Invoke-DbaWhoisActive.ps1
+++ b/functions/Invoke-DbaWhoisActive.ps1
@@ -195,7 +195,7 @@
         Similar to running sp_WhoIsActive @get_outer_command = 1, @find_block_leaders = 1
 
 #>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]

--- a/functions/New-DbaServiceMasterKey.ps1
+++ b/functions/New-DbaServiceMasterKey.ps1
@@ -44,7 +44,7 @@ function New-DbaServiceMasterKey {
         You will be prompted to securely enter your Service Key password, then a master key will be created in the master database on server1 if it does not exist.
 
 #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,

--- a/tests/Find-DbaDuplicateIndex.Tests.ps1
+++ b/tests/Find-DbaDuplicateIndex.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         $paramCount = 5
-        $defaultParamCount = 13
+        $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Find-DbaDuplicateIndex).Parameters.Keys
         $knownParameters = 'SqlInstance','SqlCredential','Database','IncludeOverlapping','EnableException'
         It "Should contain our specific parameters" {


### PR DESCRIPTION
small changes.

After looking at the docs, Find used to return some drop statements to be executed. We removed that but forgot to update the docs and shouldprocess. This whole command is read-only so I removed it. Not sure if whoisactive requires shouldprocess so I set its impact to low.