### PR TITLE
Update functions/Get-DbaSsisExecutionHistory.ps1

### DIFF
--- a/functions/Get-DbaSsisExecutionHistory.ps1
+++ b/functions/Get-DbaSsisExecutionHistory.ps1
@@ -62,7 +62,7 @@ function Get-DbaSsisExecutionHistory {
         Shows what would happen if the command were executed and would return the SQL statement that would be executed per instance.
 
 #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Update the example to reflect current parameters. `-ContinueAfterDbccError` is no longer a valid parameter option. Unable to create a new example.