### PR TITLE
Invoke-TlsWebRequest, fixes #4250

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -101,17 +101,17 @@ function Get-DbaComputerSystem {
                 }
 
                 if ($IncludeAws) {
-                    $isAws = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ScriptBlock { ((Invoke-WebRequest -TimeoutSec 15 -Uri 'http://169.254.169.254').StatusCode) -eq 200 } -Raw
+                    $isAws = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ScriptBlock { ((Invoke-TlsWebRequest -TimeoutSec 15 -Uri 'http://169.254.169.254').StatusCode) -eq 200 } -Raw
 
                     if ($isAws) {
                         $scriptBlock = {
                             [PSCustomObject]@{
-                                AmiId                 = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/ami-id').Content
-                                IamRoleArn            = ((Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/iam/info').Content | ConvertFrom-Json).InstanceProfileArn
-                                InstanceId            = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/instance-id').Content
-                                InstanceType          = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/instance-type').Content
-                                AvailabilityZone      = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/placement/availability-zone').Content
-                                PublicHostname        = (Invoke-WebRequest -Uri 'http://169.254.169.254/latest/meta-data/public-hostname').Content
+                                AmiId            = (Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/ami-id').Content
+                                IamRoleArn       = ((Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/iam/info').Content | ConvertFrom-Json).InstanceProfileArn
+                                InstanceId       = (Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/instance-id').Content
+                                InstanceType     = (Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/instance-type').Content
+                                AvailabilityZone = (Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/placement/availability-zone').Content
+                                PublicHostname   = (Invoke-TlsWebRequest -Uri 'http://169.254.169.254/latest/meta-data/public-hostname').Content
                             }
                         }
                         $awsProps = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ScriptBlock $scriptBlock
@@ -121,23 +121,23 @@ function Get-DbaComputerSystem {
                     }
                 }
                 $inputObject = [PSCustomObject]@{
-                    ComputerName                 = $computerResolved
-                    Domain                       = $computerSystem.Domain
-                    DomainRole                   = $domainRole
-                    Manufacturer                 = $computerSystem.Manufacturer
-                    Model                        = $computerSystem.Model
-                    SystemFamily                 = $computerSystem.SystemFamily
-                    SystemSkuNumber              = $computerSystem.SystemSKUNumber
-                    SystemType                   = $computerSystem.SystemType
-                    NumberLogicalProcessors      = $computerSystem.NumberOfLogicalProcessors
-                    NumberProcessors             = $computerSystem.NumberOfProcessors
-                    IsHyperThreading             = $isHyperThreading
-                    TotalPhysicalMemory          = [DbaSize]$computerSystem.TotalPhysicalMemory
-                    IsDaylightSavingsTime        = $computerSystem.EnableDaylightSavingsTime
-                    DaylightInEffect             = $computerSystem.DaylightInEffect
-                    DnsHostName                  = $computerSystem.DNSHostName
-                    IsSystemManagedPageFile      = $computerSystem.AutomaticManagedPagefile
-                    AdminPasswordStatus          = $adminPasswordStatus
+                    ComputerName            = $computerResolved
+                    Domain                  = $computerSystem.Domain
+                    DomainRole              = $domainRole
+                    Manufacturer            = $computerSystem.Manufacturer
+                    Model                   = $computerSystem.Model
+                    SystemFamily            = $computerSystem.SystemFamily
+                    SystemSkuNumber         = $computerSystem.SystemSKUNumber
+                    SystemType              = $computerSystem.SystemType
+                    NumberLogicalProcessors = $computerSystem.NumberOfLogicalProcessors
+                    NumberProcessors        = $computerSystem.NumberOfProcessors
+                    IsHyperThreading        = $isHyperThreading
+                    TotalPhysicalMemory     = [DbaSize]$computerSystem.TotalPhysicalMemory
+                    IsDaylightSavingsTime   = $computerSystem.EnableDaylightSavingsTime
+                    DaylightInEffect        = $computerSystem.DaylightInEffect
+                    DnsHostName             = $computerSystem.DNSHostName
+                    IsSystemManagedPageFile = $computerSystem.AutomaticManagedPagefile
+                    AdminPasswordStatus     = $adminPasswordStatus
                 }
                 if ($IncludeAws -and $isAws) {
                     Add-Member -Force -InputObject $inputObject -MemberType NoteProperty -Name AwsAmiId -Value $awsProps.AmiId

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -143,19 +143,16 @@ function Install-DbaFirstResponderKit {
                 Write-Message -Level Verbose -Message "Downloading and unzipping the First Responder Kit zip file."
 
                 try {
-                    $oldSslSettings = [System.Net.ServicePointManager]::SecurityProtocol
-                    [System.Net.ServicePointManager]::SecurityProtocol = "Tls12"
+
                     try {
-                        $wc = New-Object System.Net.WebClient
-                        $wc.DownloadFile($url, $zipfile)
+                        Invoke-TlsWebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
                     }
                     catch {
                         # Try with default proxy and usersettings
-                        $wc = New-Object System.Net.WebClient
-                        $wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
-                        $wc.DownloadFile($url, $zipfile)
+                        (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+                        Invoke-TlsWebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
                     }
-                    [System.Net.ServicePointManager]::SecurityProtocol = $oldSslSettings
+
 
                     # Unblock if there's a block
                     Unblock-File $zipfile -ErrorAction SilentlyContinue

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -91,7 +91,7 @@
 
         if ($LocalFile -eq $null -or $LocalFile.Length -eq 0) {
             $baseUrl = "http://whoisactive.com/downloads"
-            $latest = ((Invoke-WebRequest -UseBasicParsing -uri http://whoisactive.com/downloads).Links | where-object { $PSItem.href -match "who_is_active" } | Select-Object href -First 1).href
+            $latest = ((Invoke-TlsWebRequest -UseBasicParsing -uri http://whoisactive.com/downloads).Links | where-object { $PSItem.href -match "who_is_active" } | Select-Object href -First 1).href
             $LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath $latest;
 
             if ((Test-Path -Path $LocalCachedCopy -PathType Leaf) -and (-not $Force)) {
@@ -106,13 +106,13 @@
                         Write-Message -Level Verbose -Message "Downloading sp_WhoisActive zip file, unzipping and installing."
                         $url = $baseUrl + "/" + $latest
                         try {
-                            Invoke-WebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
+                            Invoke-TlsWebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
                             Copy-Item -Path $zipfile -Destination $LocalCachedCopy
                         }
                         catch {
                             #try with default proxy and usersettings
                             (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
-                            Invoke-WebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
+                            Invoke-TlsWebRequest $url -OutFile $zipfile -ErrorAction Stop -UseBasicParsing
                         }
                     }
                     catch {
@@ -175,10 +175,10 @@
 
             $matchString = 'Who Is Active? v'
 
-            If ($sql  -like "*$matchString*"){
+            If ($sql -like "*$matchString*") {
                 $posStart = $sql.IndexOf("$matchString")
                 $PosEnd = $sql.IndexOf(")", $PosStart)
-                $versionWhoIsActive = $sql.Substring($posStart+$matchString.Length, $posEnd - ($posStart + $matchString.Length)+ 1).TrimEnd()
+                $versionWhoIsActive = $sql.Substring($posStart + $matchString.Length, $posEnd - ($posStart + $matchString.Length) + 1).TrimEnd()
             }
             Else {
                 $versionWhoIsActive = ''

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -141,7 +141,7 @@ function Invoke-DbaQuery {
         Write-Message -Level Debug -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
 
         $splatInvokeDbaSqlAsync = @{
-            As      = $As
+            As = $As
         }
 
         if (Test-Bound -ParameterName "SqlParameters") {
@@ -199,7 +199,13 @@ function Invoke-DbaQuery {
                             "http" {
                                 $tempfile = "$env:TEMP\$temporaryFilesPrefix-$temporaryFilesCount.sql"
                                 try {
-                                    Invoke-WebRequest -Uri $item -OutFile $tempfile -ErrorAction Stop
+                                    try {
+                                        Invoke-TlsWebRequest -Uri $item -OutFile $tempfile -ErrorAction Stop
+                                    }
+                                    catch {
+                                        (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+                                        Invoke-TlsWebRequest -Uri $item -OutFile $tempfile -ErrorAction Stop
+                                    }
                                     $files += $tempfile
                                     $temporaryFilesCount++
                                     $temporaryFiles += $tempfile

--- a/functions/Save-DbaDiagnosticQueryScript.ps1
+++ b/functions/Save-DbaDiagnosticQueryScript.ps1
@@ -44,11 +44,17 @@
     function Get-WebData {
         param ($uri)
         try {
-            $data = (Invoke-WebRequest -uri $uri -ErrorAction Stop)
+            try {
+                $data = (Invoke-TlsWebRequest -uri $uri -ErrorAction Stop)
+            }
+            catch {
+                (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+                $data = (Invoke-TlsWebRequest -uri $uri -ErrorAction Stop)
+            }
             return $data
         }
         catch {
-            Stop-Function -Message "Invoke-WebRequest failed: $_" -Target $data -ErrorRecord $_
+            Stop-Function -Message "Invoke-TlsWebRequest failed: $_" -Target $data -ErrorRecord $_
             return
         }
     }
@@ -91,7 +97,7 @@
         try {
             Write-Message -Level Output -Message "Downloading $($doc.URL)"
             $filename = "{0}\SQLServerDiagnosticQueries_{1}_{2}.sql" -f $Path, $doc.SQLVersion, "$($doc.FileYear)$($doc.FileMonth)"
-            Invoke-WebRequest -Uri $doc.URL -OutFile $filename -ErrorAction Stop
+            Invoke-TlsWebRequest -Uri $doc.URL -OutFile $filename -ErrorAction Stop
         }
         catch {
             Stop-Function -Message "Requesting and writing file failed: $_" -Target $filename -ErrorRecord $_

--- a/internal/functions/Invoke-TlsWebRequest.ps1
+++ b/internal/functions/Invoke-TlsWebRequest.ps1
@@ -1,0 +1,19 @@
+function Invoke-TlsWebRequest {
+    <#
+    Internal utility that mimics invoke-webrequest
+    but enables all tls available version
+    rather than the default, which on a lot
+    of standard installations is just TLS 1.0
+
+    #>
+    $currentVersionTls = [Net.ServicePointManager]::SecurityProtocol
+    $currentSupportableTls = [Math]::Max($currentVersionTls.value__, [Net.SecurityProtocolType]::Tls.value__)
+    $availableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -gt $currentSupportableTls }
+    $availableTls | ForEach-Object {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_
+    }
+
+    Invoke-WebRequest @Args
+
+    [Net.ServicePointManager]::SecurityProtocol = $currentVersionTls
+}


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #4250)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Invoke-WebRequest (and all .net, really) use defaults that conflicts with recent algorithms used by https sites. This (Invoke-TlsWebRequest) is a pure wrapper that extends to whatever is possible to negotiate the defaults in order to have https sites reliabily invoked.

### Approach
Splats, `@args` and a sane dose of stackoverflow. 

Also, every command using invoke-webrequest or any other .net has been rewritten to use invoke-tlswebrequest.
