### PR TITLE
Fix for OnSuccessStepId in New-DbaAgentJobStep

### DIFF
--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -47,7 +47,7 @@ function New-DbaAgentJobStep {
         The text value van either be lowercase, uppercase or something in between as long as the text is correct.
 
     .PARAMETER OnFailStepId
-        The ID of the step in this job to execute if the step fails and OnFailAction is "GoToNextStep".
+        The ID of the step in this job to execute if the step fails and OnFailAction is "GoToStep".
 
     .PARAMETER Database
         The name of the database in which to execute a Transact-SQL step. The default is 'master'.
@@ -154,7 +154,7 @@ function New-DbaAgentJobStep {
         [int]$OnSuccessStepId = 0,
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnFailAction = 'QuitWithFailure',
-        [int]$OnFailStepId,
+        [int]$OnFailStepId = 0,
         [object]$Database,
         [string]$DatabaseUser,
         [int]$RetryAttempts,
@@ -170,13 +170,13 @@ function New-DbaAgentJobStep {
 
     begin {
         # Check the parameter on success step id
-        if (($OnSuccessAction -notin 'GoToStep', 'GoToNextStep') -and ($OnSuccessStepId -ge 1)) {
+        if (($OnSuccessAction -ne 'GoToStep') -and ($OnSuccessStepId -ge 1)) {
             Stop-Function -Message "Parameter OnSuccessStepId can only be used with OnSuccessAction 'GoToStep'." -Target $SqlInstance
             return
         }
 
         # Check the parameter on fail step id
-        if (($OnFailAction -notin 'GoToStep', 'GoToNextStep') -and ($OnFailStepId -ge 1)) {
+        if (($OnFailAction -ne 'GoToStep') -and ($OnFailStepId -ge 1)) {
             Stop-Function -Message "Parameter OnFailStepId can only be used with OnFailAction 'GoToStep'." -Target $SqlInstance
             return
         }

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -170,13 +170,13 @@ function New-DbaAgentJobStep {
 
     begin {
         # Check the parameter on success step id
-        if (($OnSuccessAction -in 'GoToStep', 'GoToNextStep') -and ($OnSuccessStepId -ge 1)) {
+        if (($OnSuccessAction -notin 'GoToStep', 'GoToNextStep') -and ($OnSuccessStepId -ge 1)) {
             Stop-Function -Message "Parameter OnSuccessStepId can only be used with OnSuccessAction 'GoToStep'." -Target $SqlInstance
             return
         }
 
-        # Check the parameter on success step id
-        if (($OnFailAction -in 'GoToStep', 'GoToNextStep') -and ($OnFailStepId -ge 1)) {
+        # Check the parameter on fail step id
+        if (($OnFailAction -notin 'GoToStep', 'GoToNextStep') -and ($OnFailStepId -ge 1)) {
             Stop-Function -Message "Parameter OnFailStepId can only be used with OnFailAction 'GoToStep'." -Target $SqlInstance
             return
         }


### PR DESCRIPTION
Recent change broke the functionality of New-DbaAgentJobStep. When specifying "-OnSuccessAction GoToStep -OnSuccessStepId 2" it would fail and say: "Parameter OnSuccessStepId can only be used with OnSuccessAction 'GoToStep'."

The line used to say "$OnSuccessAction -ne 'GoToStep'" but now says "$OnSuccessAction -in 'GoToStep', 'GoToNextStep'". When you choose GoToNextStep it will work with a OnSuccessStepId specified but it won't actually use it. 

I also updated some of the help info to match and set OnFailStepId = 0 to match how OnSucessStepId starts. 

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4312)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix #4312. Allow OnSuccessAction to use GoToStep again. 

### Approach
Revert to having a -ne comparison instead of -in. 

### Commands to test
New-DbaAgentJob -SqlInstance $myserver -Job "myTestJob"
New-DbaAgentJobStep -SqlInstance $myserver -Job "myTestJob" -StepId 1 -Subsystem TransactSql -StepName "myFirstStep" -Command "select 'oh, hello'" -OnSuccessAction GoToStep -OnSuccessStepId 2

