### PR TITLE
Fix PSUseDeclaredVarsMoreThanAssignments and PSAvoidTrailingWhitespace

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -3,10 +3,10 @@ function Add-DbaAgDatabase {
     <#
     .SYNOPSIS
         Adds a database to an availability group on a SQL Server instance.
-        
+
     .DESCRIPTION
         Adds a database to an availability group on a SQL Server instance.
-    
+
    .PARAMETER SqlInstance
         The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 
@@ -15,52 +15,52 @@ function Add-DbaAgDatabase {
 
     .PARAMETER Database
         The database or databases to add.
-    
+
     .PARAMETER AvailabilityGroup
         The availability group where the databases will be added.
-        
+
     .PARAMETER InputObject
         Enables piping from Get-DbaDatabase, Get-DbaDbSharePoint and more.
-        
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
-        
+
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: AvailabilityGroup, HA, AG
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Add-DbaAgDatabase
-        
+
     .EXAMPLE
         PS C:\> Add-DbaAgDatabase -SqlInstance sql2017a -AvailabilityGroup ag1 -Database db1, db2 -Confirm
-        
+
         Adds db1 and db2 to ag1 on sql2017a. Prompts for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaDatabase -SqlInstance sql2017a | Out-GridView -Passthru | Add-DbaAgDatabase -AvailabilityGroup ag1
-        
+
         Adds selected databases from sql2017a to ag1
-  
+
     .EXAMPLE
         PS C:\> Get-DbaDbSharePoint -SqlInstance sqlcluster | Add-DbaAgDatabase -AvailabilityGroup SharePoint
-        
+
         Adds SharePoint databases as found in SharePoint_Config on sqlcluster to ag1 on sqlcluster
-    
+
     .EXAMPLE
         PS C:\> Get-DbaDbSharePoint -SqlInstance sqlcluster -ConfigDatabase SharePoint_Config_2019 | Add-DbaAgDatabase -AvailabilityGroup SharePoint
-        
+
         Adds SharePoint databases as found in SharePoint_Config_2019 on sqlcluster to ag1 on sqlcluster
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
@@ -81,14 +81,14 @@ function Add-DbaAgDatabase {
                 return
             }
         }
-        
+
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
         }
-        
+
         foreach ($db in $InputObject) {
             $ags = Get-DbaAvailabilityGroup -SqlInstance $db.Parent -AvailabilityGroup $AvailabilityGroup
-            
+
             foreach ($ag in $ags) {
                 if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Adding availability group $db to $($db.Parent.Name)")) {
                     try {

--- a/functions/Add-DbaAgListener.ps1
+++ b/functions/Add-DbaAgListener.ps1
@@ -3,10 +3,10 @@ function Add-DbaAgListener {
     <#
     .SYNOPSIS
         Adds a listener to an availability group on a SQL Server instance.
-        
+
     .DESCRIPTION
         Adds a listener to an availability group on a SQL Server instance.
-    
+
    .PARAMETER SqlInstance
         The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 
@@ -15,54 +15,54 @@ function Add-DbaAgListener {
 
     .PARAMETER AvailabilityGroup
         The Availability Group to which a listener will be bestowed upon.
-    
+
     .PARAMETER IPAddress
         Sets the IP address of the availability group listener.
-    
+
     .PARAMETER SubnetMask
         Sets the subnet IP mask of the availability group listener. Defaults to 255.255.255.0.
-    
+
     .PARAMETER Port
         Sets the port number used to communicate with the availability group. Defaults to 1433.
-    
+
     .PARAMETER Dhcp
         Indicates whether the listener uses DHCP.
-    
+
     .PARAMETER Passthru
         Don't create the listener, just pass thru an object that can be further customized before creation.
-    
+
     .PARAMETER InputObject
         Enables piping from Get-DbaAvailabilityGroup
-        
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
-        
+
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: AvailabilityGroup, HA, AG
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Add-DbaAgListener
-        
+
     .EXAMPLE
         PS C:\> Add-DbaAgListener -SqlInstance sql2017 -AvailabilityGroup SharePoint -IPAddress 10.0.20.20
-    
+
         Creates a listener on 10.0.20.20 port 1433 for the SharePoint availability group on sql2017.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaAvailabilityGroup -SqlInstance sql2017 -AvailabilityGroup availabilitygroup1 | Add-DbaAgListener -Dhcp
-        
+
         Creates a listener on port 1433 with a dynamic IP for the group1 availability group on sql2017.
 
 #>
@@ -85,11 +85,11 @@ function Add-DbaAgListener {
             Stop-Function -Message "You must specify one or more databases and one or more Availability Groups when using the SqlInstance parameter."
             return
         }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
         }
-        
+
         foreach ($ag in $InputObject) {
             if ((Test-Bound -Not -ParameterName Name)) {
                 $Name = $ag.Name
@@ -99,15 +99,15 @@ function Add-DbaAgListener {
                     $aglistener = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener -ArgumentList $ag, $Name
                     $aglistener.PortNumber = $Port
                     $listenerip = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityGroupListenerIPAddress -ArgumentList $aglistener
-                    
+
                     if (Test-Bound -ParameterName IPAddress) {
                         $listenerip.IPAddress = $IPAddress.IPAddressToString
                         $listenerip.SubnetMask = $SubnetMask.IPAddressToString
                     }
-                    
+
                     $listenerip.IsDHCP = $Dhcp
                     $aglistener.AvailabilityGroupListenerIPAddresses.Add($listenerip)
-                    
+
                     if ($Passthru) {
                         return $aglistener
                     } else {

--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -26,7 +26,7 @@ function Add-DbaAgReplica {
 
     .PARAMETER FailoverMode
         Sets the failover mode of the availability group replica. Options are Automatic and Manual. Automatic is default.
-    
+
     .PARAMETER BackupPriority
         Sets the backup priority availability group replica. Default is 50.
 
@@ -179,9 +179,9 @@ function Add-DbaAgReplica {
                     if ($Passthru) {
                         return $replica
                     }
-                    
+
                     $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'AvailabilityGroup', 'Name', 'Role', 'RollupSynchronizationState', 'AvailabilityMode', 'BackupPriority', 'EndpointUrl', 'SessionTimeout', 'FailoverMode', 'ReadonlyRoutingList'
-                    
+
                     $InputObject.AvailabilityReplicas.Add($replica)
                     $agreplica = $InputObject.AvailabilityReplicas[$Name]
                     Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name ComputerName -value $agreplica.Parent.ComputerName
@@ -189,7 +189,7 @@ function Add-DbaAgReplica {
                     Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name SqlInstance -value $agreplica.Parent.SqlInstance
                     Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name AvailabilityGroup -value $agreplica.Parent.Name
                     Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name Replica -value $agreplica.Name # backwards compat
-                    
+
                     Select-DefaultView -InputObject $agreplica -Property $defaults
                 } catch {
                     $msg = $_.Exception.InnerException.InnerException.Message

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -133,44 +133,44 @@ function Backup-DbaDbCertificate {
         [Alias('Silent')]
         [switch]$EnableException
     )
-    
+
     begin {
         if (-not $EncryptionPassword -and $DecryptionPassword) {
             Stop-Function -Message "If you specify an decryption password, you must also specify an encryption password" -Target $DecryptionPassword
         }
-        
+
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Backup-DbaDatabaseCertificate
-        
+
         function export-cert ($cert) {
             $certName = $cert.Name
             $db = $cert.Parent
             $server = $db.Parent
             $instance = $server.Name
             $actualPath = $Path
-            
+
             if ($null -eq $actualPath) {
                 $actualPath = Get-SqlDefaultPaths -SqlInstance $server -filetype Data
             }
-            
+
             $actualPath = "$actualPath".TrimEnd('\')
             $fullCertName = "$actualPath\$certName$Suffix"
             $exportPathKey = "$fullCertName.pvk"
-            
+
             if (!(Test-DbaPath -SqlInstance $server -Path $actualPath)) {
                 Stop-Function -Message "$SqlInstance cannot access $actualPath" -Target $actualPath
             }
-            
+
             if ($Pscmdlet.ShouldProcess($instance, "Exporting certificate $certName from $db on $instance to $actualPath")) {
                 Write-Message -Level Verbose -Message "Exporting Certificate: $certName to $fullCertName"
                 try {
-                    
+
                     $exportPathCert = "$fullCertName.cer"
-                    
+
                     # because the password shouldn't go to memory...
                     if ($EncryptionPassword.Length -gt 0 -and $DecryptionPassword.Length -gt 0) {
-                        
+
                         Write-Message -Level Verbose -Message "Both passwords passed in. Will export both cer and pvk."
-                        
+
                         $cert.export(
                             $exportPathCert,
                             $exportPathKey,
@@ -179,7 +179,7 @@ function Backup-DbaDbCertificate {
                         )
                     } elseif ($EncryptionPassword.Length -gt 0 -and $DecryptionPassword.Length -eq 0) {
                         Write-Message -Level Verbose -Message "Only encryption password passed in. Will export both cer and pvk."
-                        
+
                         $cert.export(
                             $exportPathCert,
                             $exportPathKey,
@@ -190,7 +190,7 @@ function Backup-DbaDbCertificate {
                         $exportPathKey = "Password required to export key"
                         $cert.export($exportPathCert)
                     }
-                    
+
                     [pscustomobject]@{
                         ComputerName   = $server.ComputerName
                         InstanceName   = $server.ServiceName
@@ -206,7 +206,7 @@ function Backup-DbaDbCertificate {
                         Status         = "Success"
                     } | Select-DefaultView -ExcludeProperty exportPathCert, exportPathKey, ExportPath, ExportKey
                 } catch {
-                    
+
                     if ($_.Exception.InnerException) {
                         $exception = $_.Exception.InnerException.ToString() -Split "System.Data.SqlClient.SqlException: "
                         $exception = ($exception[1] -Split "at Microsoft.SqlServer.Management.Common.ConnectionManager")[0]
@@ -232,14 +232,14 @@ function Backup-DbaDbCertificate {
             }
         }
     }
-    
+
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
-        
+
         foreach ($cert in $InputObject) {
             if ($cert.Name.StartsWith("##")) {
                 Write-Message -Level Output -Message "Skipping system cert $cert"

--- a/functions/Backup-DbaDbMasterKey.ps1
+++ b/functions/Backup-DbaDbMasterKey.ps1
@@ -94,7 +94,7 @@ function Backup-DbaDbMasterKey {
 
         foreach ($db in $InputObject) {
             $server = $db.Parent
-            
+
             if (Test-Bound -ParameterName Path -Not) {
                 $Path = $server.BackupDirectory
             }

--- a/functions/ConvertTo-DbaTimeline.ps1
+++ b/functions/ConvertTo-DbaTimeline.ps1
@@ -128,9 +128,6 @@ function ConvertTo-DbaTimeline {
     }
 
     process {
-        # build html container
-        $BaseObject = $InputObject.PsObject.BaseObject
-
         # create server list to support multiple servers
         if ($InputObject[0].SqlInstance -notin $servers) {
             $servers += $InputObject[0].SqlInstance

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -239,12 +239,13 @@ function Copy-DbaDatabase {
             Stop-Function -Message "-Continue cannot be used without -UseLastBackups"
             return
         }
-
+        <#
+        #Variable marked as unused by PSScriptAnalyzer
         if ($null -ne $NewName -or $null -ne $Prefix) {
             $ReplaceDbNameInFile = $true
         } else {
             $ReplaceDbNameInFile = $false
-        }
+        }#>
 
         function Join-Path {
             <#
@@ -265,7 +266,7 @@ function Copy-DbaDatabase {
                 }
             }
         }
-        
+
         function Join-AdminUnc {
             <#
         .SYNOPSIS

--- a/functions/Copy-DbaServerAudit.ps1
+++ b/functions/Copy-DbaServerAudit.ps1
@@ -168,7 +168,8 @@ function Copy-DbaServerAudit {
                         Write-Message -Level Verbose -Message "Force specified. Creating directory."
 
                         $destNetBios = Resolve-NetBiosName $destServer
-                        $path = Join-AdminUnc $destNetBios $currentAudit.Filepath
+                        #Variable marked as unused by PSScriptAnalyzer
+                        #$path = Join-AdminUnc $destNetBios $currentAudit.Filepath
                         $root = $currentAudit.Filepath.Substring(0, 3)
                         $rootUnc = Join-AdminUnc $destNetBios $root
 

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -108,13 +108,14 @@ function Copy-DbaSsisCatalog {
             )
             $result = Get-DbaService -ComputerName $Computer -Type SSIS
             if ($result) {
-                $running = $false
+                #Variable marked as unused by PSScriptAnalyzer
+                #$running = $false
                 foreach ($service in $result) {
                     if (!$service.State -eq "Running") {
                         Write-Message -Level Warning -Message "Service $($service.DisplayName) was found on the destination, but is currently not running."
                     } else {
                         Write-Message -Level Verbose -Message "Service $($service.DisplayName) was found running on the destination."
-                        $running = $true
+                        #$running = $true
                     }
                 }
             } else {

--- a/functions/Disable-DbaAgHadr.ps1
+++ b/functions/Disable-DbaAgHadr.ps1
@@ -43,7 +43,7 @@ function Disable-DbaAgHadr {
         PS C:\> Disable-DbaAgHadr -SqlInstance sql2016
 
         Sets Hadr service to disabled for the instance sql2016 but changes will not be applied until the next time the server restarts.
-    
+
     .EXAMPLE
         PS C:\> Disable-DbaAgHadr -SqlInstance sql2016 -Force
 
@@ -72,10 +72,13 @@ function Disable-DbaAgHadr {
             }
             $noChange = $false
 
+            <#
+            #Variable marked as unused by PSScriptAnalyzer
             switch ($instance.InstanceName) {
                 'MSSQLSERVER' { $agentName = 'SQLSERVERAGENT' }
                 default { $agentName = "SQLAgent`$$instanceName" }
             }
+            #>
 
             try {
                 Write-Message -Level Verbose -Message "Checking current Hadr setting for $computer"

--- a/functions/Disable-DbaForceNetworkEncryption.ps1
+++ b/functions/Disable-DbaForceNetworkEncryption.ps1
@@ -111,7 +111,8 @@ function Disable-DbaForceNetworkEncryption {
             $scriptblock = {
                 $regpath = "Registry::HKEY_LOCAL_MACHINE\$($args[0])\MSSQLServer\SuperSocketNetLib"
                 $cert = (Get-ItemProperty -Path $regpath -Name Certificate).Certificate
-                $oldvalue = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
+                #Variable marked as unused by PSScriptAnalyzer
+                #$oldvalue = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
                 Set-ItemProperty -Path $regpath -Name ForceEncryption -Value $false
                 $forceencryption = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
 

--- a/functions/Enable-DbaAgHadr.ps1
+++ b/functions/Enable-DbaAgHadr.ps1
@@ -43,7 +43,7 @@ function Enable-DbaAgHadr {
         PS C:\> Enable-DbaAgHadr -SqlInstance sql2016
 
         Sets Hadr service to enabled for the instance sql2016 but changes will not be applied until the next time the server restarts.
-    
+
     .EXAMPLE
         PS C:\> Enable-DbaAgHadr -SqlInstance sql2016 -Force
 
@@ -72,10 +72,13 @@ function Enable-DbaAgHadr {
             }
             $noChange = $false
 
+            <#
+            #Variable marked as unused by PSScriptAnalyzer
             switch ($instance.InstanceName) {
                 'MSSQLSERVER' { $agentName = 'SQLSERVERAGENT' }
                 default { $agentName = "SQLAgent`$$instanceName" }
             }
+            #>
 
             try {
                 Write-Message -Level Verbose -Message "Checking current Hadr setting for $computer"

--- a/functions/Enable-DbaForceNetworkEncryption.ps1
+++ b/functions/Enable-DbaForceNetworkEncryption.ps1
@@ -111,7 +111,8 @@ function Enable-DbaForceNetworkEncryption {
             $scriptblock = {
                 $regpath = "Registry::HKEY_LOCAL_MACHINE\$($args[0])\MSSQLServer\SuperSocketNetLib"
                 $cert = (Get-ItemProperty -Path $regpath -Name Certificate).Certificate
-                $oldvalue = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
+                #Variable marked as unused by PSScriptAnalyzer
+                #$oldvalue = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
                 Set-ItemProperty -Path $regpath -Name ForceEncryption -Value $true
                 $forceencryption = (Get-ItemProperty -Path $regpath -Name ForceEncryption).ForceEncryption
 

--- a/functions/Expand-DbaTLogResponsibly.ps1
+++ b/functions/Expand-DbaTLogResponsibly.ps1
@@ -370,7 +370,7 @@ function Expand-DbaTLogResponsibly {
                                                 $backup.MediaDescription = "Disk"
                                                 $dt = get-date -format yyyyMMddHHmmssms
                                                 $null = $backup.Devices.AddDevice($backupdirectory + "\" + $db + "_db_" + $dt + ".trn", 'File')
-                                                if ($DefaultCompression = $true) {
+                                                if ($DefaultCompression -eq $true) {
                                                     $backup.CompressionOption = 1
                                                 } else {
                                                     $backup.CompressionOption = 0

--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -114,7 +114,7 @@ function Find-DbaBackup {
             }
 
             switch ($Units) {
-                    #Variable marked as unused by PSScriptAnalyzer
+                #Variable marked as unused by PSScriptAnalyzer
                 'h' {<# $UnitString = 'Hours';#> [datetime]$ReturnDatetime = (Get-Date).AddHours( - $Value)  }
                 'd' {<# $UnitString = 'Days';#> [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value)   }
                 'w' {<# $UnitString = 'Weeks';#> [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value * 7) }

--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -114,10 +114,11 @@ function Find-DbaBackup {
             }
 
             switch ($Units) {
-                'h' { $UnitString = 'Hours'; [datetime]$ReturnDatetime = (Get-Date).AddHours( - $Value)  }
-                'd' { $UnitString = 'Days'; [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value)   }
-                'w' { $UnitString = 'Weeks'; [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value * 7) }
-                'm' { $UnitString = 'Months'; [datetime]$ReturnDatetime = (Get-Date).AddMonths( - $Value) }
+                    #Variable marked as unused by PSScriptAnalyzer
+                'h' {<# $UnitString = 'Hours';#> [datetime]$ReturnDatetime = (Get-Date).AddHours( - $Value)  }
+                'd' {<# $UnitString = 'Days';#> [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value)   }
+                'w' {<# $UnitString = 'Weeks';#> [datetime]$ReturnDatetime = (Get-Date).AddDays( - $Value * 7) }
+                'm' {<# $UnitString = 'Months';#> [datetime]$ReturnDatetime = (Get-Date).AddMonths( - $Value) }
             }
             $ReturnDatetime
         }

--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -270,8 +270,9 @@ function Find-DbaInstance {
                     $ports = @()
                     $browseResult = $null
                     $services = @()
-                    $serverObject = $null
-                    $browseFailed = $false
+                    #Variable marked as unused by PSScriptAnalyzer
+                    #$serverObject = $null
+                    #$browseFailed = $false
                     #endregion Null variables to prevent scope lookup on conditional existence
 
                     #region Gather data
@@ -303,7 +304,8 @@ function Find-DbaInstance {
                         try {
                             $browseResult = Get-SQLInstanceBrowserUDP -ComputerName $computer -EnableException
                         } catch {
-                            $browseFailed = $true
+                            #Variable marked as unused by PSScriptAnalyzer
+                            #$browseFailed = $true
                         }
                     }
 

--- a/functions/Find-DbaUserObject.ps1
+++ b/functions/Find-DbaUserObject.ps1
@@ -89,7 +89,8 @@ function Find-DbaUserObject {
                 $endPoints = $server.Endpoints | Where-Object { $_.Owner -ne $saname }
 
                 Write-Message -Level Verbose -Message "Gather data on Agent Jobs ownership"
-                $jobs = $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -ne $saname }
+                #Variable marked as unused by PSScriptAnalyzer
+                #$jobs = $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -ne $saname }
             } else {
                 Write-Message -Level Verbose -Message "Gathering data on instance objects"
                 $creds = $server.Credentials | Where-Object { $_.Identity -match $pattern }
@@ -97,7 +98,8 @@ function Find-DbaUserObject {
                 $endPoints = $server.Endpoints | Where-Object { $_.Owner -match $pattern }
 
                 Write-Message -Level Verbose -Message "Gather data on Agent Jobs ownership"
-                $jobs = $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -match $pattern }
+                #Variable marked as unused by PSScriptAnalyzer
+                #$jobs = $server.JobServer.Jobs | Where-Object { $_.OwnerLoginName -match $pattern }
             }
 
             ## dbs

--- a/functions/Get-DbaAgDatabase.ps1
+++ b/functions/Get-DbaAgDatabase.ps1
@@ -6,7 +6,7 @@ function Get-DbaAgDatabase {
 
     .DESCRIPTION
         Gets availability group databases from a SQL Server instance.
-    
+
         Default view provides most common set of properties for information on the database in an availability group.
 
         Information returned on the database will be specific to that replica, whether it is primary or a secondary.
@@ -16,7 +16,7 @@ function Get-DbaAgDatabase {
 
     .PARAMETER SqlCredential
         Login to the SqlInstance instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-    
+
     .PARAMETER AvailabilityGroup
         Specify the availability groups to query.
 
@@ -25,7 +25,7 @@ function Get-DbaAgDatabase {
 
     .PARAMETER InputObject
         Enables piped input from Get-DbaAvailabilityGroup.
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -72,7 +72,7 @@ function Get-DbaAgDatabase {
         if ($SqlInstance) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
         }
-        
+
         foreach ($db in $InputObject.AvailabilityDatabases) {
             if ($Database) {
                 if ($db.Name -notin $Database) { continue }
@@ -84,7 +84,7 @@ function Get-DbaAgDatabase {
             Add-Member -Force -InputObject $db -MemberType NoteProperty -Name Replica -value $server.ComputerName
             Add-Member -Force -InputObject $db -MemberType NoteProperty -Name DatabaseName -value $db.Name # for backwards compat
             Add-Member -Force -InputObject $db -MemberType NoteProperty -Name AvailabilityGroup -value $db.Parent.Name
-            
+
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'AvailabilityGroup', 'Replica', 'Name', 'SynchronizationState', 'IsFailoverReady', 'IsJoined', 'IsSuspended'
             Select-DefaultView -InputObject $db -Property $defaults
         }

--- a/functions/Get-DbaAgHadr.ps1
+++ b/functions/Get-DbaAgHadr.ps1
@@ -12,7 +12,7 @@ function Get-DbaAgHadr {
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-        
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Get-DbaAgListener.ps1
+++ b/functions/Get-DbaAgListener.ps1
@@ -12,7 +12,7 @@ function Get-DbaAgListener {
 
     .PARAMETER SqlCredential
         Login to the SqlInstance instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-        
+
     .PARAMETER AvailabilityGroup
         Specify the availability groups to query.
 
@@ -48,12 +48,12 @@ function Get-DbaAgListener {
 
         Returns all listeners found on sql2017a on sql2017a for the availability group AG-a
 
-    
+
     .EXAMPLE
         PS C:\> Get-DbaAvailabilityGroup -SqlInstance sql2017a -AvailabilityGroup OPP | Get-DbaAgListener
 
         Returns all listeners found on sql2017a on sql2017a for the availability group OPP
-    
+
 #>
     [CmdletBinding()]
     param (
@@ -69,13 +69,13 @@ function Get-DbaAgListener {
         if ($SqlInstance) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
         }
-        
+
         if (Test-Bound -ParameterName Listener) {
             $InputObject = $InputObject | Where-Object { $_.AvailabilityGroupListeners.Name -contains $Listener }
         }
-        
+
         $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'AvailabilityGroup', 'Name', 'PortNumber', 'ClusterIPConfiguration'
-        
+
         foreach ($aglistener in $InputObject.AvailabilityGroupListeners) {
             $server = $aglistener.Parent.Parent
             Add-Member -Force -InputObject $aglistener -MemberType NoteProperty -Name ComputerName -value $server.ComputerName

--- a/functions/Get-DbaAgReplica.ps1
+++ b/functions/Get-DbaAgReplica.ps1
@@ -18,10 +18,10 @@ function Get-DbaAgReplica {
 
     .PARAMETER Replica
         Return only specific replicas.
-    
+
     .PARAMETER InputObject
         Enables piped input from Get-DbaAvailabilityGroup.
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -68,21 +68,22 @@ function Get-DbaAgReplica {
         if ($SqlInstance) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
         }
-        
+
         if ($Replica) {
             $InputObject = $InputObject | Where-Object { $_.AvailabilityReplicas.Name -contains $Replica }
         }
-        
+
         $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'AvailabilityGroup', 'Name', 'Role', 'ConnectionState', 'RollupSynchronizationState', 'AvailabilityMode', 'BackupPriority', 'EndpointUrl', 'SessionTimeout', 'FailoverMode', 'ReadonlyRoutingList'
-        
+
         foreach ($agreplica in $InputObject.AvailabilityReplicas) {
-            $sever = $agreplica.Parent.Parent
+            #Variable marked as unused by PSScriptAnalyzer
+            #$sever = $agreplica.Parent.Parent
             Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name ComputerName -value $agreplica.Parent.ComputerName
             Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name InstanceName -value $agreplica.Parent.InstanceName
             Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name SqlInstance -value $agreplica.Parent.SqlInstance
             Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name AvailabilityGroup -value $agreplica.Parent.Name
             Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name Replica -value $agreplica.Name # backwards compat
-            
+
             Select-DefaultView -InputObject $agreplica -Property $defaults
         }
     }

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -6,7 +6,7 @@ function Get-DbaAvailabilityGroup {
 
     .DESCRIPTION
         Returns availability group objects from a SQL Server instance.
-    
+
         Default view provides most common set of properties for information on the Availability Group(s).
 
     .PARAMETER SqlInstance
@@ -84,9 +84,9 @@ function Get-DbaAvailabilityGroup {
             if (-not $server.IsHadrEnabled) {
                 Stop-Function -Message "Availability Group (HADR) is not configured for the instance: $instance." -Target $instance -Continue
             }
-            
+
             $ags = $server.AvailabilityGroups
-            
+
             if ($AvailabilityGroup) {
                 $ags = $ags | Where-Object Name -in $AvailabilityGroup
             }

--- a/functions/Get-DbaClientAlias.ps1
+++ b/functions/Get-DbaClientAlias.ps1
@@ -42,7 +42,7 @@ function Get-DbaClientAlias {
         PS C:\> Get-DbaClientAlias -ComputerName workstationx -Credential ad\sqldba
 
         Logs into workstationx as ad\sqldba then retrieves all SQL Server client aliases on Workstationx
-        
+
     .EXAMPLE
         PS C:\> 'Server1', 'Server2' | Get-DbaClientAlias
 

--- a/functions/Get-DbaDbCertificate.ps1
+++ b/functions/Get-DbaDbCertificate.ps1
@@ -3,64 +3,64 @@ function Get-DbaDbCertificate {
     <#
     .SYNOPSIS
         Gets database certificates
-        
+
     .DESCRIPTION
         Gets database certificates
-        
+
     .PARAMETER SqlInstance
         The target SQL Server instance
-        
+
     .PARAMETER SqlCredential
         Allows you to login to SQL Server using alternative credentials
-        
+
     .PARAMETER Database
         Get certificate from specific database
-        
+
     .PARAMETER ExcludeDatabase
         Database(s) to ignore when retrieving certificates
-    
+
     .PARAMETER InputObject
         Enables piping from Get-DbaDatabase
-    
+
     .PARAMETER Certificate
         Get specific certificate by name
-  
+
     .PARAMETER Certificate
         Get specific certificate by subject
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: Certificate
         Author: Chrissy LeMaire (@cl), netnerds.net
-        
+
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .EXAMPLE
         PS C:\> Get-DbaDbCertificate -SqlInstance sql2016
-        
+
         Gets all certificates
-        
+
     .EXAMPLE
         PS C:\> Get-DbaDbCertificate -SqlInstance Server1 -Database db1
-        
+
         Gets the certificate for the db1 database
-        
+
     .EXAMPLE
         PS C:\> Get-DbaDbCertificate -SqlInstance Server1 -Database db1 -Certificate cert1
-        
+
         Gets the cert1 certificate within the db1 database
 
     .EXAMPLE
         PS C:\> Get-DbaDbCertificate -SqlInstance Server1 -Database db1 -Subject 'Availability Group Cert'
-        
+
         Gets the cert1 certificate within the db1 database
-    
+
 #>
     [CmdletBinding()]
     param (
@@ -82,35 +82,36 @@ function Get-DbaDbCertificate {
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
-        
+
         foreach ($db in $InputObject) {
             if (!$db.IsAccessible) {
                 Write-Message -Level Warning -Message "$db is not accessible, skipping"
                 continue
             }
-            
-            $dbName = $db.Name
+
+            #Variable marked as unused by PSScriptAnalyzer
+            #$dbName = $db.Name
             $certs = $db.Certificates
-            
+
             if ($null -eq $certs) {
                 Write-Message -Message "No certificate exists in the $db database on $instance" -Target $db -Level Verbose
                 continue
             }
-            
+
             if ($Certificate) {
                 $certs = $certs | Where-Object Name -in $Certificate
             }
-            
+
             if ($Subject) {
                 $certs = $certs | Where-Object Subject -in $Subject
             }
-            
+
             foreach ($cert in $certs) {
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name ComputerName -value $db.ComputerName
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name InstanceName -value $db.InstanceName
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name SqlInstance -value $db.SqlInstance
                 Add-Member -Force -InputObject $cert -MemberType NoteProperty -Name Database -value $db.Name
-                
+
                 Select-DefaultView -InputObject $cert -Property ComputerName, InstanceName, SqlInstance, Database, Name, Subject, StartDate, ActiveForServiceBrokerDialog, ExpirationDate, Issuer, LastBackupDate, Owner, PrivateKeyEncryptionType, Serial
             }
         }

--- a/functions/Get-DbaDbCompatibility.ps1
+++ b/functions/Get-DbaDbCompatibility.ps1
@@ -69,16 +69,16 @@ function Get-DbaDbCompatibility {
             Write-Message -Level Warning -Message "You must specify either a SQL instance or pipe a database collection"
             continue
         }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
         }
-        
+
         foreach ($db in $InputObject) {
             $server = $db.Parent
             $ServerVersion = $server.VersionMajor
             Write-Message -Level Verbose -Message "SQL Server is using Version: $ServerVersion"
-            
+
             [PSCustomObject]@{
                 ComputerName  = $server.ComputerName
                 InstanceName  = $server.ServiceName

--- a/functions/Get-DbaDbMasterKey.ps1
+++ b/functions/Get-DbaDbMasterKey.ps1
@@ -21,7 +21,7 @@ function Get-DbaDbMasterKey {
 
     .PARAMETER InputObject
         Database object piped in from Get-DbaDatabase
-    
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed
 
@@ -63,30 +63,30 @@ function Get-DbaDbMasterKey {
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
-    
+
     process {
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
-        
+
         foreach ($db in $InputObject) {
             if (!$db.IsAccessible) {
                 Write-Message -Level Warning -Message "Database $db on $($db.Parent) is not accessible. Skipping."
                 continue
             }
-            
+
             $masterkey = $db.MasterKey
-            
+
             if (!$masterkey) {
                 Write-Message -Message "No master key exists in the $db database on $instance" -Target $db -Level Verbose
                 continue
             }
-            
+
             Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $db.Parent.ComputerName
             Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $db.Parent.ServiceName
             Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $db.Parent.DomainInstanceName
             Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $db.Name
-            
+
             Select-DefaultView -InputObject $masterkey -Property ComputerName, InstanceName, SqlInstance, Database, CreateDate, DateLastModified, IsEncryptedByServer
         }
     }

--- a/functions/Get-DbaDbMirror.ps1
+++ b/functions/Get-DbaDbMirror.ps1
@@ -69,7 +69,7 @@ function Get-DbaDbMirror {
                     4 { "PendingFailover" }
                     5 { "Synchronized" }
                 }
-                
+
                 foreach ($db in $witnessdb) {
                     Add-Member -InputObject $db -Force -MemberType NoteProperty -Name MirroringPartner -Value $witness.principal_server_name
                     Add-Member -InputObject $db -Force -MemberType NoteProperty -Name MirroringSafetyLevel -Value $witness.safety_level_desc

--- a/functions/Get-DbaEndpoint.ps1
+++ b/functions/Get-DbaEndpoint.ps1
@@ -94,7 +94,7 @@ function Get-DbaEndpoint {
                             }
                         }
                     }
-                    
+
                     $fqdn = "TCP://" + $dns + ":" + $end.Protocol.Tcp.ListenerPort
                 } else {
                     $fqdn = $null

--- a/functions/Get-DbaFile.ps1
+++ b/functions/Get-DbaFile.ps1
@@ -165,7 +165,8 @@ function Get-DbaFile {
     process {
         foreach ($instance in $SqlInstance) {
 
-            $paths = @()
+            #Variable marked as unused by PSScriptAnalyzer
+            #$paths = @()
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
             } catch {

--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -70,7 +70,7 @@ function Get-DbaLastGoodCheckDb {
         PS C:\> Get-DbaLastGoodCheckDb -SqlInstance sql2016 -ExcludeDatabase "TempDB" | Format-Table -AutoSize
 
         Returns a formatted table displaying Server, Database, DatabaseCreated, LastGoodCheckDb, DaysSinceDbCreated, DaysSinceLastGoodCheckDb, Status and DataPurityEnabled. All databases except for "TempDB" will be displayed in the output.
-        
+
 #>
     [CmdletBinding()]
     param (

--- a/functions/Get-DbaPfDataCollectorCounter.ps1
+++ b/functions/Get-DbaPfDataCollectorCounter.ps1
@@ -83,7 +83,8 @@ function Get-DbaPfDataCollectorCounter {
         [switch]$EnableException
     )
     begin {
-        $columns = 'ComputerName', 'Name', 'DataCollectorSet', 'Counters', 'DataCollectorType', 'DataSourceName', 'FileName', 'FileNameFormat', 'FileNameFormatPattern', 'LatestOutputLocation', 'LogAppend', 'LogCircular', 'LogFileFormat', 'LogOverwrite', 'SampleInterval', 'SegmentMaxRecords'
+        #Variable marked as unused by PSScriptAnalyzer
+        #$columns = 'ComputerName', 'Name', 'DataCollectorSet', 'Counters', 'DataCollectorType', 'DataSourceName', 'FileName', 'FileNameFormat', 'FileNameFormatPattern', 'LatestOutputLocation', 'LogAppend', 'LogCircular', 'LogFileFormat', 'LogOverwrite', 'SampleInterval', 'SegmentMaxRecords'
     }
     process {
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {

--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -76,6 +76,9 @@ function Get-DbaPrivilege {
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""); secedit /export /cfg $temp\secpolByDbatools.cfg > $NULL;
                         Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -match "SeBatchLogonRight" -or $_ -match 'SeManageVolumePrivilege' -or $_ -match 'SeLockMemoryPrivilege' }
                     }
+                    if ($Priv.count -eq 0) {
+                        Write-Message -Level Verbose -Message "No users with Batch Logon, Instant File Initialization, or Lock Pages in Memory Rights on $computer"
+                    }
 
                     Write-Message -Level Verbose -Message "Getting Batch Logon Privileges on $Computer"
                     $BL = Invoke-Command2 -Raw -ComputerName $computer -Credential $Credential -ArgumentList $ResolveSID -ScriptBlock {

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -95,9 +95,10 @@ function Get-DbaSpn {
                         } catch {
                             $port = $null
                         }
-                        if ($spn -match "\/") {
-                            $serviceclass = ($spn -Split "\/")[0]
-                        }
+                        #Variable marked as unused by PSScriptAnalyzer
+                        # if ($spn -match "\/") {
+                        #     $serviceclass = ($spn -Split "\/")[0]
+                        # }
                     }
                     [pscustomobject] @{
                         Input        = $Account

--- a/functions/Get-DbaWindowsLog.ps1
+++ b/functions/Get-DbaWindowsLog.ps1
@@ -283,7 +283,8 @@ function Get-DbaWindowsLog {
         $RunspacePool.Open()
 
         $countStarted = 0
-        $countReceived = 0
+        #Variable marked as unused by PSScriptAnalyzer
+        #$countReceived = 0
         #endregion Setup Runspace
     }
 

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -15,7 +15,7 @@ function Grant-DbaAgPermission {
 
     .PARAMETER Login
         The login or logins to modify.
-    
+
     .PARAMETER AvailabilityGroup
         Only modify specific availability groups.
 
@@ -130,7 +130,7 @@ function Grant-DbaAgPermission {
             if ($Type -contains "Endpoint") {
                 $server.Endpoints.Refresh()
                 $endpoint = $server.Endpoints | Where-Object EndpointType -eq DatabaseMirroring
-                
+
                 if (-not $endpoint) {
                     Stop-Function -Message "DatabaseMirroring endpoint does not exist on $server" -Target $server -Continue
                 }
@@ -158,7 +158,7 @@ function Grant-DbaAgPermission {
                     }
                 }
             }
-            
+
             if ($Type -contains "AvailabilityGroup") {
                 $ags = Get-DbaAvailabilityGroup -SqlInstance $account.Parent -AvailabilityGroup $AvailabilityGroup
                 foreach ($ag in $ags) {

--- a/functions/Import-DbaPfDataCollectorSetTemplate.ps1
+++ b/functions/Import-DbaPfDataCollectorSetTemplate.ps1
@@ -152,7 +152,8 @@ function Import-DbaPfDataCollectorSetTemplate {
         [switch]$EnableException
     )
     begin {
-        $metadata = Import-Clixml "$script:PSModuleRoot\bin\perfmontemplates\collectorsets.xml"
+        #Variable marked as unused by PSScriptAnalyzer
+        #$metadata = Import-Clixml "$script:PSModuleRoot\bin\perfmontemplates\collectorsets.xml"
 
         $setscript = {
             $setname = $args[0]; $templatexml = $args[1]
@@ -194,7 +195,7 @@ function Import-DbaPfDataCollectorSetTemplate {
                     Set-Variable -Name DisplayName -Value (Get-ChildItem -Path $file).BaseName
                 }
 
-                $Name = $DisplayNameUnresolved = $DisplayName
+                $Name = $DisplayName
 
                 Write-Message -Level Verbose -Message "Processing $file for $computer"
 

--- a/functions/Install-DbaWatchUpdate.ps1
+++ b/functions/Install-DbaWatchUpdate.ps1
@@ -60,7 +60,8 @@ function Install-DbaWatchUpdate {
                 $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).Date -RepetitionInterval (New-TimeSpan -Hours 1)
                 $principal = New-ScheduledTaskPrincipal -LogonType S4U -UserId (whoami)
                 $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([timespan]::Zero) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RunOnlyIfNetworkAvailable -DontStopOnIdleEnd
-                $task = Register-ScheduledTask -Principal $principal -TaskName 'dbatools version check' -Action $action -Trigger $trigger -Settings $settings -ErrorAction Stop
+                #Variable $Task marked as unused by PSScriptAnalyzer replaced with $null for catching output
+                $null = Register-ScheduledTask -Principal $principal -TaskName 'dbatools version check' -Action $action -Trigger $trigger -Settings $settings -ErrorAction Stop
             } catch {
                 # keep moving
             }

--- a/functions/Invoke-DbaAgFailover.ps1
+++ b/functions/Invoke-DbaAgFailover.ps1
@@ -3,19 +3,19 @@ function Invoke-DbaAgFailover {
     <#
     .SYNOPSIS
         Failover an availability group.
-        
+
     .DESCRIPTION
        Failover an availability group.
-        
+
     .PARAMETER SqlInstance
         The SQL Server instance. Server version must be SQL Server version 2012 or higher.
-        
+
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential).
-        
+
     .PARAMETER AvailabilityGroup
         Only failover specific availability groups.
-    
+
     .PARAMETER InputObject
         Enables piping from Get-DbaAvailabilityGroup
 
@@ -27,35 +27,35 @@ function Invoke-DbaAgFailover {
 
     .PARAMETER Force
         Force Failover and allow data loss
-    
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: AG, AvailabilityGroup, HA
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Invoke-DbaAgFailover
-        
+
     .EXAMPLE
         PS C:\> Invoke-DbaAgFailover -SqlInstance sql2017 -AvailabilityGroup SharePoint
-        
+
         Safely (no potential data loss) fails over the SharePoint AG on sql2017. Prompts for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaAvailabilityGroup -SqlInstance sql2017 | Out-GridView -Passthru | Invoke-DbaAgFailover -Confirm:$false
-        
+
         Safely (no potential data loss) fails over the selected availability groups on sql2017. Does not prompt for confirmation.
-    
+
     .EXAMPLE
         PS C:\> Invoke-DbaAgFailover -SqlInstance sql2017 -AvailabilityGroup SharePoint -Force
-        
+
         Forcefully (with potential data loss) fails over the SharePoint AG on sql2017. Prompts for confirmation.
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
@@ -74,11 +74,11 @@ function Invoke-DbaAgFailover {
             Stop-Function -Message "You must specify at least one availability group when using SqlInstance."
             return
         }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
         }
-        
+
         foreach ($ag in $InputObject) {
             $server = $ag.Parent
             if ($Force) {

--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -671,12 +671,15 @@ function Invoke-DbaDbLogShipping {
             $SourceInstanceName = "MSSQLSERVER"
         }
 
+        <#
+        #Variable marked as unused by PSScriptAnalyzer
         $IsSourceLocal = $false
 
         # Check if it's local or remote
         if ($SourceServerName -in ".", "localhost", $env:ServerName, "127.0.0.1") {
             $IsSourceLocal = $true
         }
+        #>
 
         # Set up regex strings for several checks
         $RegexDate = '(?<!\d)(?:(?:(?:1[6-9]|[2-9]\d)?\d{2})(?:(?:(?:0[13578]|1[02])31)|(?:(?:0[1,3-9]|1[0-2])(?:29|30)))|(?:(?:(?:(?:1[6-9]|[2-9]\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00)))0229)|(?:(?:1[6-9]|[2-9]\d)?\d{2})(?:(?:0?[1-9])|(?:1[0-2]))(?:0?[1-9]|1\d|2[0-8]))(?!\d)'
@@ -1686,7 +1689,8 @@ function Invoke-DbaDbLogShipping {
 
                             Write-Message -Message "Create backup job schedule $DatabaseBackupSchedule" -Level Verbose
 
-                            $BackupJobSchedule = New-DbaAgentSchedule -SqlInstance $SourceSqlInstance `
+                            #Variable $BackupJobSchedule marked as unused by PSScriptAnalyzer replaced with $null for catching output
+                            $null = New-DbaAgentSchedule -SqlInstance $SourceSqlInstance `
                                 -SqlCredential $SourceSqlCredential `
                                 -Job $DatabaseBackupJob `
                                 -Schedule $DatabaseBackupSchedule `
@@ -1742,8 +1746,8 @@ function Invoke-DbaDbLogShipping {
                                 -Force:$Force
 
                             Write-Message -Message "Create copy job schedule $DatabaseCopySchedule" -Level Verbose
-
-                            $CopyJobSchedule = New-DbaAgentSchedule -SqlInstance $destInstance `
+                            #Variable $CopyJobSchedule marked as unused by PSScriptAnalyzer replaced with $null for catching output
+                            $null = New-DbaAgentSchedule -SqlInstance $destInstance `
                                 -SqlCredential $DestinationSqlCredential `
                                 -Job $DatabaseCopyJob `
                                 -Schedule $DatabaseCopySchedule `
@@ -1761,7 +1765,8 @@ function Invoke-DbaDbLogShipping {
 
                             Write-Message -Message "Create restore job schedule $DatabaseRestoreSchedule" -Level Verbose
 
-                            $RestoreJobSchedule = New-DbaAgentSchedule -SqlInstance $destInstance `
+                            #Variable $RestoreJobSchedule marked as unused by PSScriptAnalyzer replaced with $null for catching output
+                            $null = New-DbaAgentSchedule -SqlInstance $destInstance `
                                 -SqlCredential $DestinationSqlCredential `
                                 -Job $DatabaseRestoreJob `
                                 -Schedule $DatabaseRestoreSchedule `

--- a/functions/Invoke-DbaDbMirroring.ps1
+++ b/functions/Invoke-DbaDbMirroring.ps1
@@ -271,9 +271,12 @@ function Invoke-DbaDbMirroring {
                 }
             }
 
+            <#
             if ($Witness) {
+                #Variable marked as unused by PSScriptAnalyzer
                 $witnessdb = Get-DbaDatabase -SqlInstance $witserver -Database $dbName
             }
+            #>
 
             $primaryendpoint = Get-DbaEndpoint -SqlInstance $source | Where-Object EndpointType -eq DatabaseMirroring
             $mirrorendpoint = Get-DbaEndpoint -SqlInstance $dest | Where-Object EndpointType -eq DatabaseMirroring

--- a/functions/Invoke-DbaXEReplay.ps1
+++ b/functions/Invoke-DbaXEReplay.ps1
@@ -78,7 +78,8 @@ function Invoke-DbaXeReplay {
     )
 
     begin {
-        $querycolumns = 'statement', 'batch_text'
+        #Variable marked as unused by PSScriptAnalyzer
+        #$querycolumns = 'statement', 'batch_text'
         $timestamp = (Get-Date -Format yyyyMMddHHmm)
         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
         $filename = "$temp\dbatools-replay-$timestamp.sql"
@@ -115,6 +116,7 @@ function Invoke-DbaXeReplay {
 
 
             if ($Raw) {
+                Write-Message -Message "Invoking XEReplay against $instance running on $($server.name) with raw output" -Level Verbose
                 if (Test-Bound -ParameterName SqlCredential) {
                     . $sqlcmd -S $instance -i $filename -U $SqlCredential.Username -P $SqlCredential.GetNetworkCredential().Password
                     continue
@@ -124,6 +126,7 @@ function Invoke-DbaXeReplay {
                 }
             }
 
+            Write-Message -Message "Invoking XEReplay against $instance running on $($server.name)" -Level Verbose
             if (Test-Bound -ParameterName SqlCredential) {
                 $output = . $sqlcmd -S $instance -i $filename -U $SqlCredential.Username -P $SqlCredential.GetNetworkCredential().Password
             } else {

--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -2,60 +2,60 @@ function Invoke-Sqlcmd2 {
     <#
     .SYNOPSIS
         Runs a T-SQL script.
-        
+
     .DESCRIPTION
         Runs a T-SQL script. Invoke-Sqlcmd2 runs the whole script and only captures the first selected result set, such as the output of PRINT statements when -verbose parameter is specified.
         Parameterized queries are supported.
-        
+
         Help details below borrowed from Invoke-Sqlcmd
-        
+
     .PARAMETER ServerInstance
         Specifies the SQL Server instance(s) to execute the query against.
-        
+
     .PARAMETER Database
         Specifies the name of the database to execute the query against. If specified, this database will be used in the ConnectionString when establishing the connection to SQL Server.
-        
+
         If a SQLConnection is provided, the default database for that connection is overridden with this database.
-        
+
     .PARAMETER Query
         Specifies one or more queries to be run. The queries can be Transact-SQL, XQuery statements, or sqlcmd commands. Multiple queries in a single batch may be separated by a semicolon.
-        
+
         Do not specify the sqlcmd GO separator (or, use the ParseGo parameter). Escape any double quotation marks included in the string.
-        
+
         Consider using bracketed identifiers such as [MyTable] instead of quoted identifiers such as "MyTable".
-        
+
     .PARAMETER InputFile
         Specifies the full path to a file to be used as the query input to Invoke-Sqlcmd2. The file can contain Transact-SQL statements, XQuery statements, sqlcmd commands and scripting variables.
-        
+
     .PARAMETER Credential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-        
+
         SECURITY NOTE: If you use the -Debug switch, the connectionstring including plain text password will be sent to the debug stream.
-        
+
     .PARAMETER Encrypt
         If this switch is enabled, the connection to SQL Server will be made using SSL.
-        
+
         This requires that the SQL Server has been set up to accept SSL requests. For information regarding setting up SSL on SQL Server, see https://technet.microsoft.com/en-us/library/ms189067(v=sql.105).aspx
-        
+
     .PARAMETER QueryTimeout
         Specifies the number of seconds before the queries time out.
-        
+
     .PARAMETER ConnectionTimeout
         Specifies the number of seconds before Invoke-Sqlcmd2 times out if it cannot successfully connect to an instance of the Database Engine. The timeout value must be an integer between 0 and 65534. If 0 is specified, connection attempts do not time out.
-        
+
     .PARAMETER As
         Specifies output type. Valid options for this parameter are 'DataSet', 'DataTable', 'DataRow', 'PSObject', and 'SingleValue'
-        
+
         PSObject output introduces overhead but adds flexibility for working with results: http://powershell.org/wp/forums/topic/dealing-with-dbnull/
-        
+
     .PARAMETER SqlParameters
         Specifies a hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
-        
+
         Example:
-        
+
     .PARAMETER AppendServerInstance
         If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
-        
+
     .PARAMETER ParseGo
         If this switch is enabled, "GO" statements will be handled automatically.
         Every "GO" will effectively run in a separate query, like if you issued multiple Invoke-SqlCmd2 commands.
@@ -69,55 +69,55 @@ function Invoke-Sqlcmd2 {
         and you call it via
         Invoke-SqlCmd2 -ServerInstance instance -Database msdb -Query ...
         you'll get back tables from msdb, not dbname.
-        
-        
+
+
     .PARAMETER SQLConnection
         Specifies an existing SQLConnection object to use in connecting to SQL Server. If the connection is closed, an attempt will be made to open it.
-        
+
     .INPUTS
         None
         You cannot pipe objects to Invoke-Sqlcmd2
-        
+
     .OUTPUTS
         As PSObject:     System.Management.Automation.PSCustomObject
         As DataRow:      System.Data.DataRow
         As DataTable:    System.Data.DataTable
         As DataSet:      System.Data.DataTableCollectionSystem.Data.DataSet
         As SingleValue:  Dependent on data type in first column.
-        
+
     .EXAMPLE
         Invoke-Sqlcmd2 -ServerInstance "MyComputer\MyInstance" -Query "SELECT login_time AS 'StartTime' FROM sysprocesses WHERE spid = 1"
-        
+
         Connects to a named instance of the Database Engine on a computer and runs a basic T-SQL query.
-        
+
         StartTime
         -----------
         2010-08-12 21:21:03.593
-        
+
     .EXAMPLE
         Invoke-Sqlcmd2 -ServerInstance "MyComputer\MyInstance" -InputFile "C:\MyFolder\tsqlscript.sql" | Out-File -filePath "C:\MyFolder\tsqlscript.rpt"
-        
+
         Reads a file containing T-SQL statements, runs the file, and writes the output to another file.
-        
+
     .EXAMPLE
         Invoke-Sqlcmd2  -ServerInstance "MyComputer\MyInstance" -Query "PRINT 'hello world'" -Verbose
-        
+
         Uses the PowerShell -Verbose parameter to return the message output of the PRINT command.
         VERBOSE: hello world
-        
+
     .EXAMPLE
         Invoke-Sqlcmd2 -ServerInstance MyServer\MyInstance -Query "SELECT ServerName, VCNumCPU FROM tblServerInfo" -as PSObject | ?{$_.VCNumCPU -gt 8}
         Invoke-Sqlcmd2 -ServerInstance MyServer\MyInstance -Query "SELECT ServerName, VCNumCPU FROM tblServerInfo" -as PSObject | ?{$_.VCNumCPU}
-        
+
         This example uses the PSObject output type to allow more flexibility when working with results.
-        
+
         If we used DataRow rather than PSObject, we would see the following behavior:
         Each row where VCNumCPU does not exist would produce an error in the first example
         Results would include rows where VCNumCPU has DBNull value in the second example
-        
+
     .EXAMPLE
         'Instance1', 'Server1/Instance1', 'Server2' | Invoke-Sqlcmd2 -query "Sp_databases" -as psobject -AppendServerInstance
-        
+
         This example lists databases for each instance.  It includes a column for the ServerInstance in question.
         DATABASE_NAME          DATABASE_SIZE REMARKS        ServerInstance
         -------------          ------------- -------        --------------
@@ -128,48 +128,48 @@ function Invoke-Sqlcmd2 {
         tempdb                        563200                Server1/Instance1
     ...
         OperationsManager           20480000                Server2
-        
+
     .EXAMPLE
         #Construct a query using SQL parameters
         $Query = "SELECT ServerName, VCServerClass, VCServerContact FROM tblServerInfo WHERE VCServerContact LIKE @VCServerContact AND VCServerClass LIKE @VCServerClass"
-        
+
         #Run the query, specifying values for SQL parameters
         Invoke-Sqlcmd2 -ServerInstance SomeServer\NamedInstance -Database ServerDB -query $query -SqlParameters @{ VCServerContact="%cookiemonster%"; VCServerClass="Prod" }
-        
+
         ServerName    VCServerClass VCServerContact
         ----------    ------------- ---------------
         SomeServer1   Prod          cookiemonster, blah
         SomeServer2   Prod          cookiemonster
         SomeServer3   Prod          blah, cookiemonster
-        
+
     .EXAMPLE
         Invoke-Sqlcmd2 -SQLConnection $Conn -Query "SELECT login_time AS 'StartTime' FROM sysprocesses WHERE spid = 1"
-        
+
         Uses an existing SQLConnection and runs a basic T-SQL query against it
-        
+
         StartTime
         -----------
         2010-08-12 21:21:03.593
-        
+
     .EXAMPLE
         Invoke-SqlCmd -SQLConnection $Conn -Query "SELECT ServerName FROM tblServerInfo WHERE ServerName LIKE @ServerName" -SqlParameters @{"ServerName = "c-is-hyperv-1"}
-        
+
         Executes a parameterized query against the existing SQLConnection, with a collection of one parameter to be passed to the query when executed.
-        
+
     .NOTES
         Changelog moved to CHANGELOG.md:
-        
+
         https://github.com/sqlcollaborative/Invoke-SqlCmd2/blob/master/CHANGELOG.md
-        
+
     .LINK
         https://github.com/sqlcollaborative/Invoke-SqlCmd2
-        
+
     .LINK
         https://github.com/RamblingCookieMonster/PowerShell
-        
+
     .FUNCTIONALITY
         SQL
-        
+
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Ins-Que')]

--- a/functions/Join-DbaAvailabilityGroup.ps1
+++ b/functions/Join-DbaAvailabilityGroup.ps1
@@ -15,7 +15,7 @@ function Join-DbaAvailabilityGroup {
 
     .PARAMETER AvailabilityGroup
         The availability group to join.
-    
+
     .PARAMETER InputObject
         Enables piped input from Get-DbaAvailabilityGroup.
 
@@ -74,19 +74,19 @@ function Join-DbaAvailabilityGroup {
         if ($InputObject) {
             $AvailabilityGroup += $InputObject.Name
         }
-        
+
         if (-not $AvailabilityGroup) {
             Stop-Function -Message "No availability group to add"
             return
         }
-        
+
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            
+
             foreach ($ag in $AvailabilityGroup) {
                 if ($Pscmdlet.ShouldProcess($server.Name, "Joining $ag")) {
                     try {

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -151,7 +151,7 @@ function New-DbaAgentProxy {
 
                 if ($Pscmdlet.ShouldProcess($instance, "Adding $proxyname with the $Credential credential")) {
                     # the new-object is stubborn and $true/$false has to be forced in
-                    $enabled = switch ($disabled) {
+                    switch (Test-Bound $disabled) {
                         $false {
                             $proxy = New-Object Microsoft.SqlServer.Management.Smo.Agent.ProxyAccount -ArgumentList $jobServer, $ProxyName, $Credential, $true, $Description
                         }

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -226,32 +226,32 @@ function New-DbaAvailabilityGroup {
         $stepCounter = 0
         $totalSteps = 9
         $activity = "Adding new availability group $name"
-        
+
         if ($Force -and $Secondary -and (-not $NetworkShare -and -not $UseLastBackups) -and ($SeedingMode -ne 'Automatic')) {
             Stop-Function -Message "NetworkShare or UseLastBackups is required when Force is used"
             return
         }
-        
+
         try {
             $server = Connect-SqlInstance -SqlInstance $Primary -SqlCredential $PrimarySqlCredential
         } catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Primary
             return
         }
-        
+
         if ($SeedingMode -eq 'Automatic' -and $server.VersionMajor -lt 13) {
             Stop-Function -Message "Automatic seeding mode only supported in SQL Server 2016 and above" -Target $Primary
             return
         }
-        
+
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Checking perquisites"
-        
+
         # Don't reuse $server here, it fails
         if (Get-DbaAvailabilityGroup -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name) {
             Stop-Function -Message "Availability group named $Name already exists on $Primary"
             return
         }
-        
+
         if ($Certificate) {
             $cert = Get-DbaDbCertificate -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Certificate $Certificate
             if (-not $cert) {
@@ -259,19 +259,19 @@ function New-DbaAvailabilityGroup {
                 return
             }
         }
-        
+
         if (($NetworkShare)) {
             if (-not (Test-DbaPath -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Path $NetworkShare)) {
                 Stop-Function -Continue -Message "Cannot access $NetworkShare from $Primary"
                 return
             }
         }
-        
+
         if ($Database -and -not $UseLastBackups -and -not $NetworkShare -and $Secondary -and $SeedingMode -ne 'Automatic') {
             Stop-Function -Continue -Message "You must specify a NetworkShare when adding databases to a manually seeded availability group"
             return
         }
-        
+
         if ($server.HostPlatform -eq "Linux") {
             # New to SQL Server 2017 (14.x) is the introduction of a cluster type for AGs. For Linux, there are two valid values: External and None.
             if ($ClusterType -notin "External", "None") {
@@ -284,7 +284,7 @@ function New-DbaAvailabilityGroup {
                 return
             }
         }
-        
+
         if ((Test-Bound -ParameterName ClusterType) -and $server.VersionMajor -lt 14) {
             Stop-Function -Message "ClusterType only supported in SQL Server 2017 and above"
             return
@@ -300,7 +300,7 @@ function New-DbaAvailabilityGroup {
                     return
                 }
             }
-            
+
             if ($SeedingMode -eq "Automatic") {
                 $primarypath = Get-DbaDefaultPath -SqlInstance $server
                 foreach ($second in $secondaries) {
@@ -314,23 +314,23 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         # database checks
         if ($Database) {
             $dbs += Get-DbaDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Database $Database
         }
-        
+
         foreach ($primarydb in $dbs) {
             if ($primarydb.MirroringStatus -ne "None") {
                 Stop-Function -Message "Cannot setup mirroring on database ($dbname) due to its current mirroring state: $($primarydb.MirroringStatus)"
                 return
             }
-            
+
             if ($primarydb.Status -ne "Normal") {
                 Stop-Function -Message "Cannot setup mirroring on database ($dbname) due to its current state: $($primarydb.Status)"
                 return
             }
-            
+
             if ($primarydb.RecoveryModel -ne "Full") {
                 if ((Test-Bound -ParameterName UseLastBackups)) {
                     Stop-Function -Message "$dbName not set to full recovery. UseLastBackups cannot be used."
@@ -340,9 +340,9 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Creating availability group named $Name on $Primary"
-        
+
         # Start work
         if ($Pscmdlet.ShouldProcess($Primary, "Setting up availability group named $Name and adding primary replica")) {
             try {
@@ -352,16 +352,16 @@ function New-DbaAvailabilityGroup {
                 $ag.HealthCheckTimeout = $HealthCheckTimeout
                 $ag.BasicAvailabilityGroup = $Basic
                 $ag.DatabaseHealthTrigger = $DatabaseHealthTrigger
-                
+
                 if ($server.VersionMajor -ge 14) {
                     $ag.ClusterType = $ClusterType
                 }
-                
+
                 if ($PassThru) {
                     $defaults = 'LocalReplicaRole', 'Name as AvailabilityGroup', 'PrimaryReplicaServerName as PrimaryReplica', 'AutomatedBackupPreference', 'AvailabilityReplicas', 'AvailabilityDatabases', 'AvailabilityGroupListeners'
                     return (Select-DefaultView -InputObject $ag -Property $defaults)
                 }
-                
+
                 $replicaparams = @{
                     InputObject                   = $ag
                     AvailabilityMode              = $AvailabilityMode
@@ -374,7 +374,7 @@ function New-DbaAvailabilityGroup {
                     ReadonlyRoutingConnectionUrl  = $ReadonlyRoutingConnectionUrl
                     Certificate                   = $Certificate
                 }
-                
+
                 $null = Add-DbaAgReplica @replicaparams -EnableException -SqlInstance $server
             } catch {
                 $msg = $_.Exception.InnerException.InnerException.Message
@@ -385,11 +385,11 @@ function New-DbaAvailabilityGroup {
                 return
             }
         }
-        
+
         # Add cluster permissions
         if ($ClusterType -eq 'Wsfc') {
             Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Adding endpoint connect permissions"
-            
+
             foreach ($second in $secondaries) {
                 if ($Pscmdlet.ShouldProcess($Primary, "Adding cluster permissions for availability group named $Name")) {
                     Write-Message -Level Verbose -Message "WSFC Cluster requires granting [NT AUTHORITY\SYSTEM] a few things. Setting now."
@@ -407,10 +407,10 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         # Add replicas
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Adding secondary replicas"
-        
+
         foreach ($second in $secondaries) {
             if ($Pscmdlet.ShouldProcess($second.Name, "Adding replica to availability group named $Name")) {
                 try {
@@ -421,7 +421,7 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         try {
             # something is up with .net create(), force a stop
             Invoke-Create -Object $ag
@@ -433,28 +433,28 @@ function New-DbaAvailabilityGroup {
             Stop-Function -Message $msg -ErrorRecord $_ -Target $Primary
             return
         }
-        
+
         # Add databases
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Adding databases"
-        
+
         $allbackups = @{ }
-        
+
         foreach ($db in $Database) {
             if ($SeedingMode -eq "Automatic") {
                 if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {
                     $null = $primarydb | Backup-DbaDatabase -BackupFileName NUL
                 }
             }
-            
+
             if ($Pscmdlet.ShouldProcess($Primary, "Adding $db to $Name")) {
                 $null = Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $db
             }
-            
+
             foreach ($second in $secondaries) {
                 if ($Pscmdlet.ShouldProcess($second.Name, "Adding $db to $Name")) {
                     $primarydb = Get-DbaDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Database $db
-                    $secondb = Get-DbaDatabase -SqlInstance $second -Database $db
-                    
+                    $seconddb = Get-DbaDatabase -SqlInstance $second -Database $db
+
                     if ((-not $seconddb -or $Force) -and $SeedingMode -ne 'Automatic') {
                         try {
                             if (-not $allbackups[$db]) {
@@ -479,10 +479,10 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         # Add listener
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Adding endpoint connect permissions"
-        
+
         if ($IPAddress) {
             if ($Pscmdlet.ShouldProcess($Primary, "Adding static IP listener for $Name to the Primary replica")) {
                 $null = Add-DbaAgListener -InputObject $ag -IPAddress $IPAddress -SubnetMask $SubnetMask -Port $Port -Dhcp:$Dhcp
@@ -496,9 +496,9 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Joining availability groups"
-        
+
         foreach ($second in $secondaries) {
             if ($Pscmdlet.ShouldProcess("Joining $($second.Name) to $Name")) {
                 try {
@@ -509,11 +509,11 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         # Grant permissions, but first, get all necessary service accounts
         $primaryserviceaccount = $server.ServiceAccount.Trim()
         $saname = ([DbaInstanceParameter]($server.DomainInstanceName)).ComputerName
-        
+
         if ($primaryserviceaccount) {
             if ($primaryserviceaccount.StartsWith("NT ")) {
                 $primaryserviceaccount = "$saname`$"
@@ -525,14 +525,14 @@ function New-DbaAvailabilityGroup {
                 $primaryserviceaccount = "$saname`$"
             }
         }
-        
+
         $serviceaccounts = @($primaryserviceaccount)
-        
+
         foreach ($second in $secondaries) {
             # If service account is empty, add the computer account instead
             $secondaryserviceaccount = $second.ServiceAccount.Trim()
             $saname = ([DbaInstanceParameter]($second.DomainInstanceName)).ComputerName
-            
+
             if ($secondaryserviceaccount) {
                 if ($secondaryserviceaccount.StartsWith("NT ")) {
                     $secondaryserviceaccount = "$saname`$"
@@ -544,16 +544,16 @@ function New-DbaAvailabilityGroup {
                     $secondaryserviceaccount = "$saname`$"
                 }
             }
-            
+
             if (-not $secondaryserviceaccount) {
                 $secondaryserviceaccount = "$saname`$"
             }
-            
+
             $serviceaccounts += $secondaryserviceaccount
         }
-        
+
         $serviceaccounts = $serviceaccounts | Select-Object -Unique
-        
+
         foreach ($second in $secondaries) {
             if ($Pscmdlet.ShouldProcess($second.Name, "Granting Connect permissions to service accounts: $serviceaccounts")) {
                 $null = Grant-DbaAgPermission -SqlInstance $server, $second -Login $serviceaccounts -Type Endpoint -Permission Connect
@@ -564,7 +564,7 @@ function New-DbaAvailabilityGroup {
                 }
             }
         }
-        
+
         # Get results
         Get-DbaAvailabilityGroup -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name
     }

--- a/functions/New-DbaClientAlias.ps1
+++ b/functions/New-DbaClientAlias.ps1
@@ -78,7 +78,8 @@ function New-DbaClientAlias {
         # This is a script block so cannot use messaging system
         $scriptblock = {
             $basekeys = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\MSSQLServer", "HKLM:\SOFTWARE\Microsoft\MSSQLServer"
-            $ServerName = $args[0]
+            #Variable marked as unused by PSScriptAnalyzer
+            #$ServerName = $args[0]
             $Alias = $args[1]
             $serverstring = $args[2]
 
@@ -105,11 +106,15 @@ function New-DbaClientAlias {
                     $null = New-Item -Path $connect -Force
                 }
 
+                <#
+                #Variable marked as unused by PSScriptAnalyzer
+                #Looks like it was once used for a Verbose Message
                 if ($basekey -like "*WOW64*") {
                     $architecture = "32-bit"
                 } else {
                     $architecture = "64-bit"
                 }
+                #>
 
                 # Write-Verbose "Creating/updating alias for $ComputerName for $architecture"
                 $null = New-ItemProperty -Path $connect -Name $Alias -Value $serverstring -PropertyType String -Force

--- a/functions/New-DbaConnectionString.ps1
+++ b/functions/New-DbaConnectionString.ps1
@@ -243,13 +243,15 @@ function New-DbaConnectionString {
 
                             if ($username -like "*\*") {
                                 $username = $username.Split("\")[1]
-                                $authtype = "Windows Authentication with Credential"
+                                #Variable marked as unused by PSScriptAnalyzer
+                                #$authtype = "Windows Authentication with Credential"
                                 $server.ConnectionContext.LoginSecure = $true
                                 $server.ConnectionContext.ConnectAsUser = $true
                                 $server.ConnectionContext.ConnectAsUserName = $username
                                 $server.ConnectionContext.ConnectAsUserPassword = ($Credential).GetNetworkCredential().Password
                             } else {
-                                $authtype = "SQL Authentication"
+                                #Variable marked as unused by PSScriptAnalyzer
+                                #$authtype = "SQL Authentication"
                                 $server.ConnectionContext.LoginSecure = $false
                                 $server.ConnectionContext.set_Login($username)
                                 $server.ConnectionContext.set_SecurePassword($Credential.Password)

--- a/functions/New-DbaDacOption.ps1
+++ b/functions/New-DbaDacOption.ps1
@@ -10,10 +10,10 @@ function New-DbaDacOption {
         https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.dacexportoptions.aspx
         https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.dac.dacextractoptions.aspx
         for more information
-        
+
     .PARAMETER Type
         Selecting the type of the export: Dacpac (default) or Bacpac.
-        
+
     .PARAMETER Action
         Choosing an intended action: Publish or Export.
 

--- a/functions/New-DbaDbMasterKey.ps1
+++ b/functions/New-DbaDbMasterKey.ps1
@@ -15,16 +15,16 @@ function New-DbaDbMasterKey {
 
     .PARAMETER Credential
         Enables easy creation of a secure password.
-    
+
     .PARAMETER Database
         The database where the master key will be created. Defaults to master.
 
     .PARAMETER Password
         Secure string used to create the key.
-    
+
     .PARAMETER InputObject
         Database object piped in from Get-DbaDatabase.
-    
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -49,12 +49,12 @@ function New-DbaDbMasterKey {
 
         You will be prompted to securely enter your password, then a master key will be created in the master database on server1 if it does not exist.
 
-    
+
     .EXAMPLE
         PS C:\> New-DbaDbMasterKey -SqlInstance Server1 -Credential usernamedoesntmatter
 
         You will be prompted by a credential interface to securely enter your password, then a master key will be created in the master database on server1 if it does not exist.
-    
+
     .EXAMPLE
         PS C:\> New-DbaDbMasterKey -SqlInstance Server1 -Database db1 -Confirm:$false
 
@@ -85,22 +85,22 @@ function New-DbaDbMasterKey {
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
-        
+
         foreach ($db in $InputObject) {
             if ($null -ne $db.MasterKey) {
                 Stop-Function -Message "Master key already exists in the $db database on $($db.Parent.Name)" -Target $db -Continue
             }
-            
+
             if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Creating master key for database '$($db.Name)'")) {
                 try {
                     $masterkey = New-Object Microsoft.SqlServer.Management.Smo.MasterKey $db
                     $masterkey.Create(([System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password))))
-                    
+
                     Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name ComputerName -value $db.Parent.ComputerName
                     Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name InstanceName -value $db.Parent.ServiceName
                     Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name SqlInstance -value $db.Parent.DomainInstanceName
                     Add-Member -Force -InputObject $masterkey -MemberType NoteProperty -Name Database -value $db.Name
-                    
+
                     Select-DefaultView -InputObject $masterkey -Property ComputerName, InstanceName, SqlInstance, Database, CreateDate, DateLastModified, IsEncryptedByServer
                 } catch {
                     Stop-Function -Message "Failed to create master key in $db on $instance. Exception: $($_.Exception.InnerException)" -Target $masterkey -ErrorRecord $_ -Continue

--- a/functions/New-DbaDbSnapshot.ps1
+++ b/functions/New-DbaDbSnapshot.ps1
@@ -298,7 +298,8 @@ function New-DbaDbSnapshot {
                             $Notes += 'SMO is probably trying to set a property on a read-only snapshot, run with -Debug to find out and report back'
                         }
                         if ($has_FSD) {
-                            $Status = 'Partial'
+                            #Variable marked as unused by PSScriptAnalyzer
+                            #$Status = 'Partial'
                             $Notes += 'Filestream groups are not viable for snapshot'
                         }
                         $Notes = $Notes -Join ';'

--- a/functions/New-DbaDirectory.ps1
+++ b/functions/New-DbaDirectory.ps1
@@ -85,7 +85,7 @@ function New-DbaDirectory {
         Write-Message -Level Debug -Message $sql
         if ($Pscmdlet.ShouldProcess($path, "Creating a new path on $($server.name)")) {
             try {
-                $query = $server.Query($sql)
+                $null = $server.Query($sql)
                 $Created = $true
             } catch {
                 $Created = $false

--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -9,7 +9,7 @@ function New-DbaEndpoint {
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
-    
+
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
@@ -33,7 +33,7 @@ function New-DbaEndpoint {
 
     .PARAMETER Certificate
         Database certificate used for authentication.
-    
+
     .PARAMETER EndpointEncryption
         Used to specify the state of encryption on the endpoint. Defaults to required.
         Disabled

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -107,7 +107,7 @@ function New-DbaLogin {
         PS C:\> New-DbaLogin -SqlInstance sql1 -Login domain\user
 
         Creates a new Windows Authentication backed login on sql1. The login will be part of the public server role.
-        
+
 #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Password", ConfirmImpact = "Low")]
     param (

--- a/functions/New-DbaXESmartReplay.ps1
+++ b/functions/New-DbaXESmartReplay.ps1
@@ -102,6 +102,7 @@ function New-DbaXESmartReplay {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if ($Pscmdlet.ShouldProcess($instance, "Creating new XESmartReply")) {
+                Write-Message -Message "Making a New XE SmartReplay for $Event against $instance running on $($server.name)" -Level Verbose
                 try {
                     $replay = New-Object -TypeName XESmartTarget.Core.Responses.ReplayResponse
                     $replay.ServerName = $instance

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -29,10 +29,10 @@ function Publish-DbaDacPackage {
 
     .PARAMETER GenerateDeploymentReport
         If this switch is enabled, the publish XML report  will be generated.
-        
+
     .PARAMETER Type
         Selecting the type of the export: Dacpac (default) or Bacpac.
-        
+
     .PARAMETER DacOption
         Export options for a corresponding export type. Can be created by New-DbaDacOption -Type Dacpac | Bacpac
 
@@ -272,7 +272,7 @@ function Publish-DbaDacPackage {
                 if ($connstring -notmatch 'Database=') {
                     $connstring = "$connstring;Database=$dbname"
                 }
-                
+
                 #Create services object
                 try {
                     $dacServices = New-Object Microsoft.SqlServer.Dac.DacServices $connstring

--- a/functions/Read-DbaAuditFile.ps1
+++ b/functions/Read-DbaAuditFile.ps1
@@ -64,10 +64,12 @@ function Read-DbaAuditFile {
 
             if ($file -is [System.String]) {
                 $currentfile = $file
-                $manualadd = $true
+                #Variable marked as unused by PSScriptAnalyzer
+                #$manualadd = $true
             } elseif ($file -is [System.IO.FileInfo]) {
                 $currentfile = $file.FullName
-                $manualadd = $true
+                #Variable marked as unused by PSScriptAnalyzer
+                #$manualadd = $true
             } else {
                 if ($file -isnot [Microsoft.SqlServer.Management.Smo.Audit]) {
                     Stop-Function -Message "Unsupported file type."

--- a/functions/Read-DbaXEFile.ps1
+++ b/functions/Read-DbaXEFile.ps1
@@ -66,10 +66,12 @@ function Read-DbaXEFile {
 
             if ($file -is [System.String]) {
                 $currentfile = $file
-                $manualadd = $true
+                #Variable marked as unused by PSScriptAnalyzer
+                #$manualadd = $true
             } elseif ($file -is [System.IO.FileInfo]) {
                 $currentfile = $file.FullName
-                $manualadd = $true
+                #Variable marked as unused by PSScriptAnalyzer
+                #$manualadd = $true
             } else {
                 if ($file -isnot [Microsoft.SqlServer.Management.XEvent.Session]) {
                     Stop-Function -Message "Unsupported file type."

--- a/functions/Remove-DbaAgDatabase.ps1
+++ b/functions/Remove-DbaAgDatabase.ps1
@@ -3,10 +3,10 @@ function Remove-DbaAgDatabase {
     <#
     .SYNOPSIS
         Removes a database from an availability group on a SQL Server instance.
-        
+
     .DESCRIPTION
         Removes a database from an availability group on a SQL Server instance.
-    
+
    .PARAMETER SqlInstance
         The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 
@@ -15,13 +15,13 @@ function Remove-DbaAgDatabase {
 
     .PARAMETER Database
         The database or databases to remove.
-    
+
     .PARAMETER AvailabilityGroup
         Only remove databases from specific availability groups.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
-        
+
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
@@ -32,25 +32,25 @@ function Remove-DbaAgDatabase {
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: AvailabilityGroup, HA, AG
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Remove-DbaAgDatabase
-        
+
     .EXAMPLE
         PS C:\> Remove-DbaAgDatabase -SqlInstance sqlserver2012 -AvailabilityGroup ag1, ag2 -Confirm:$false
-        
+
         Removes the ag1 and ag2 availability groups on sqlserver2012.  Does not prompt for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaAvailabilityGroup -SqlInstance sqlserver2012 -AvailabilityGroup availabilitygroup1 | Remove-DbaAgDatabase
-        
+
         Removes the availability groups returned from the Get-DbaAvailabilityGroup function. Prompts for confirmation.
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
@@ -72,17 +72,17 @@ function Remove-DbaAgDatabase {
                 return
             }
         }
-        
+
         if ($InputObject) {
             if ($InputObject[0].GetType().Name -eq 'Database') {
                 $Database += $InputObject.Name
             }
         }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaAgDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
         }
-        
+
         foreach ($db in $InputObject) {
             if ($Pscmdlet.ShouldProcess($db.Parent.Parent.Name, "Removing availability group database $db")) {
                 try {

--- a/functions/Remove-DbaAgListener.ps1
+++ b/functions/Remove-DbaAgListener.ps1
@@ -3,10 +3,10 @@ function Remove-DbaAgListener {
     <#
     .SYNOPSIS
         Removes a listener from an availability group on a SQL Server instance.
-        
+
     .DESCRIPTION
         Removes a listener from an availability group on a SQL Server instance.
-    
+
    .PARAMETER SqlInstance
         The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 
@@ -15,13 +15,13 @@ function Remove-DbaAgListener {
 
     .PARAMETER Listener
         The listener or listeners to remove.
-    
+
     .PARAMETER AvailabilityGroup
         Only remove listeners from specific availability groups.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
-        
+
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
@@ -32,25 +32,25 @@ function Remove-DbaAgListener {
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: AvailabilityGroup, HA, AG
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Remove-DbaAgListener
-            
+
     .EXAMPLE
         PS C:\> Remove-DbaAgListener -SqlInstance sqlserver2012 -AvailabilityGroup ag1, ag2 -Confirm:$false
-        
+
         Removes the ag1 and ag2 availability groups on sqlserver2012. Does not prompt for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaAvailabilityGroup -SqlInstance sqlserver2012 -AvailabilityGroup availabilitygroup1 | Remove-DbaAgListener
-        
+
         Removes the listeners returned from the Get-DbaAvailabilityGroup function. Prompts for confirmation.
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -117,26 +117,25 @@ function Remove-DbaAgentSchedule {
             }
 
             $server.JobServer.SharedSchedules.Refresh()
-
             $schedulename = $currentschedule.Name
             $jobCount = $server.JobServer.SharedSchedules[$currentschedule].JobCount
 
             # Check if the schedule is shared among other jobs
             if ($jobCount -ge 1 -and -not $Force) {
-                Stop-Function -Message "The schedule $currentschedule is shared connected to one or more jobs. If removal is neccesary use -Force." -Target $instance -Continue
+                Stop-Function -Message "The schedule $schedulename is shared connected to one or more jobs. If removal is neccesary use -Force." -Target $instance -Continue
             }
 
             # Remove the job schedule
             if ($PSCmdlet.ShouldProcess($instance, "Removing schedule $currentschedule on $instance")) {
                 # Loop through each of the schedules and drop them
-                Write-Message -Message "Removing schedule $currentschedule on $instance" -Level Verbose
+                Write-Message -Message "Removing schedule $schedulename on $instance" -Level Verbose
 
                 #Check if jobs use the schedule
                 if ($jobCount -ge 1) {
                     # Get the job object
                     $smoSchedules = $server.JobServer.SharedSchedules | Where-Object { ($_.Name -eq $currentschedule.Name) }
 
-                    Write-Message -Message "Schedule $currentschedule is used in one or more jobs. Removing it for each job." -Level Verbose
+                    Write-Message -Message "Schedule $schedulename is used in one or more jobs. Removing it for each job." -Level Verbose
 
                     # Loop through each if the schedules
                     foreach ($smoSchedule in ($smoSchedules)) {

--- a/functions/Remove-DbaAvailabilityGroup.ps1
+++ b/functions/Remove-DbaAvailabilityGroup.ps1
@@ -16,7 +16,7 @@ function Remove-DbaAvailabilityGroup {
         After the cluster regains quorum, you will need to drop the availability group again to remove it from the WSFC cluster.
 
         For more information: https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-availability-group-transact-sql
-   
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 

--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -6,7 +6,7 @@ function Remove-DbaBackup {
 
     .DESCRIPTION
         Removes SQL Server backups from disk.
-    
+
         Provides all of the same functionality for removing SQL backups from disk as a standard maintenance plan would.
 
         As an addition you have the ability to check the Archive bit on files before deletion. This will allow you to ensure backups have been archived to your archive location before removal.

--- a/functions/Remove-DbaDbCertificate.ps1
+++ b/functions/Remove-DbaDbCertificate.ps1
@@ -74,7 +74,7 @@ function Remove-DbaDbCertificate {
         foreach ($cert in $InputObject) {
             $db = $cert.Parent
             $server = $db.Parent
-            
+
             if ($Pscmdlet.ShouldProcess($server.Name, "Dropping the certificate named $cert for database $db")) {
                 try {
                     # erroractionprefs are not invoked for .net methods suddenly (??), so use Invoke-DbaQuery

--- a/functions/Remove-DbaDbMasterKey.ps1
+++ b/functions/Remove-DbaDbMasterKey.ps1
@@ -60,7 +60,7 @@ function Remove-DbaDbMasterKey {
         PS C:\> Get-DbaDbMasterKey -SqlInstance sql2017 -Database db1 | Remove-DbaDbMasterKey -Confirm:$false
 
         Suppresses all prompts to remove the master key in the 'db1' database and drops the key.
-    
+
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]
     param (
@@ -74,7 +74,7 @@ function Remove-DbaDbMasterKey {
         [Microsoft.SqlServer.Management.Smo.MasterKey[]]$InputObject,
         [switch]$EnableException
     )
-    
+
     process {
         if ($SqlInstance) {
             if (-not $Database -and -not $ExcludeDatabase -and -not $All) {
@@ -89,7 +89,7 @@ function Remove-DbaDbMasterKey {
                 }
             }
         }
-        
+
         foreach ($masterkey in $InputObject) {
             $server = $masterkey.Parent.Parent
             $db = $masterkey.Parent

--- a/functions/Remove-DbaEndpoint.ps1
+++ b/functions/Remove-DbaEndpoint.ps1
@@ -3,19 +3,19 @@ function Remove-DbaEndpoint {
     <#
     .SYNOPSIS
         Removes endpoints from a SQL Server instance.
-        
+
     .DESCRIPTION
         Removes endpoints from a SQL Server instance.
-        
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
-        
+
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-        
+
     .PARAMETER Endpoint
         Only remove specific endpoints.
-    
+
     .PARAMETER AllEndpoints
         Remove all endpoints on an instance.
 
@@ -24,7 +24,7 @@ function Remove-DbaEndpoint {
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
-        
+
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
@@ -32,30 +32,30 @@ function Remove-DbaEndpoint {
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: Endpoint
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Remove-DbaEndpoint
-        
+
     .EXAMPLE
         PS C:\> Remove-DbaEndpoint -SqlInstance sqlserver2012 -AllEndpoints
-        
+
         Removes all endpoints on the sqlserver2014 instance. Prompts for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Remove-DbaEndpoint -SqlInstance sqlserver2012 -Endpoint endpoint1,endpoint2 -Confirm:$false
-        
+
         Removes the endpoint1 and endpoint2 endpoints. Does not prompt for confirmation.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaEndpoint -SqlInstance sqlserver2012 -Endpoint endpoint1 | Remove-DbaEndpoint
-        
+
         Removes the endpoints returned from the Get-DbaEndpoint function. Prompts for confirmation.
 #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
@@ -76,7 +76,7 @@ function Remove-DbaEndpoint {
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -EndPoint $Endpoint
         }
-        
+
         foreach ($ep in $InputObject) {
             if ($Pscmdlet.ShouldProcess($ep.Parent.name, "Removing endpoint $ep")) {
                 try {

--- a/functions/Remove-DbaNetworkCertificate.ps1
+++ b/functions/Remove-DbaNetworkCertificate.ps1
@@ -114,7 +114,7 @@ function Remove-DbaNetworkCertificate {
                 $instancename = $args[2]
                 $vsname = $args[3]
 
-                $regpath = "Registry::HKEY_LOCAL_MACHINE\$($args[0])\MSSQLServer\SuperSocketNetLib"
+                $regpath = "Registry::HKEY_LOCAL_MACHINE\$($regroot)\MSSQLServer\SuperSocketNetLib"
                 $cert = (Get-ItemProperty -Path $regpath -Name Certificate).Certificate
                 Set-ItemProperty -Path $regpath -Name Certificate -Value $null
 

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -227,11 +227,13 @@ function Reset-DbaAdmin {
                 try {
                     if ($hostname -eq $env:COMPUTERNAME) {
                         $account = New-Object System.Security.Principal.NTAccount($args)
-                        $sid = $account.Translate([System.Security.Principal.SecurityIdentifier])
+                        #Variable $sid marked as unused by PSScriptAnalyzer replace with $null to catch output
+                        $null = $account.Translate([System.Security.Principal.SecurityIdentifier])
                     } else {
                         Invoke-Command -ErrorAction Stop -Session $session -ArgumentList $login -ScriptBlock {
                             $account = New-Object System.Security.Principal.NTAccount($args)
-                            $sid = $account.Translate([System.Security.Principal.SecurityIdentifier])
+                            #Variable $sid marked as unused by PSScriptAnalyzer replace with $null to catch output
+                            $null = $account.Translate([System.Security.Principal.SecurityIdentifier])
                         }
                     }
                 } catch {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -511,7 +511,8 @@ $BackupHistory | Restore-Dbadatabase -SqlInstance sql2000 -TrustDbBackupHistory
         $RestoreInstance.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
         #endregion Validation
 
-        $isLocal = [dbavalidate]::IsLocalHost($SqlInstance.ComputerName)
+        #Variable marked as unused by PSScriptAnalyzer
+        #$isLocal = [dbavalidate]::IsLocalHost($SqlInstance.ComputerName)
 
         if ($UseDestinationDefaultDirectories) {
             $DefaultPath = (Get-DbaDefaultPath -SqlInstance $RestoreInstance)
@@ -689,7 +690,8 @@ $BackupHistory | Restore-Dbadatabase -SqlInstance sql2000 -TrustDbBackupHistory
                     return
                 } else {
                     $WithReplace = $false
-                    $PageDb = ($FilteredBackupHistory.Database | select-Object -unique).Database
+                    #Variable marked as unused by PSScriptAnalyzer
+                    #$PageDb = ($FilteredBackupHistory.Database | select-Object -unique).Database
                 }
             }
             Write-Message -Message "Passing in to restore" -Level Verbose

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -78,20 +78,20 @@ function Restore-DbaDbCertificate {
             Stop-Function -Message "Failed to connect to: $SqlInstance" -Target $SqlInstance -ErrorRecord $_
             return
         }
-        
+
         foreach ($fullname in $Path) {
             if (-not $SqlInstance.IsLocalHost -and -not $fullname.StartsWith('\')) {
                 Stop-Function -Message "Path ($fullname) must be a UNC share when SQL instance is not local." -Continue -Target $fullname
             }
-            
+
             if (-not (Test-DbaPath -SqlInstance $server -Path $fullname)) {
                 Stop-Function -Message "$SqlInstance cannot access $fullname" -Continue -Target $fullname
             }
-            
+
             $directory = Split-Path $fullname
             $filename = Split-Path $fullname -Leaf
             $certname = [io.path]::GetFileNameWithoutExtension($filename)
-            
+
             if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
                 $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
                 $smocert.Name = $certname
@@ -103,7 +103,7 @@ function Restore-DbaDbCertificate {
                     Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
                     Write-Message -Level Verbose -Message "Private key: $privatekey"
                     $fromfile = $true
-                    
+
                     if ($EncryptionPassword) {
                         $smocert.Create($fullcertname, $fromfile, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($password)))
                     } else {
@@ -119,7 +119,7 @@ function Restore-DbaDbCertificate {
     }
     end {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Retore-DbaDatabaseCertificate
-        
+
     }
 }
 

--- a/functions/Revoke-DbaAgPermission.ps1
+++ b/functions/Revoke-DbaAgPermission.ps1
@@ -15,7 +15,7 @@ function Revoke-DbaAgPermission {
 
     .PARAMETER Login
         The login or logins to modify.
-    
+
     .PARAMETER AvailabilityGroup
         Only modify specific availability groups.
 
@@ -103,12 +103,12 @@ function Revoke-DbaAgPermission {
             Stop-Function -Message "You must specify one or more logins when using the SqlInstance parameter."
             return
         }
-        
+
         if ($Type -contains "AvailabilityGroup" -and -not $AvailabilityGroup) {
             Stop-Function -Message "You must specify at least one availability group when using the AvailabilityGroup type."
             return
         }
-        
+
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaLogin -SqlInstance $instance -SqlCredential $SqlCredential -Login $Login
             foreach ($account in $Login) {
@@ -117,7 +117,7 @@ function Revoke-DbaAgPermission {
                 }
             }
         }
-        
+
         foreach ($account in $InputObject) {
             $server = $account.Parent
             if ($Type -contains "Endpoint") {
@@ -125,7 +125,7 @@ function Revoke-DbaAgPermission {
                 if (-not $endpoint) {
                     Stop-Function -Message "DatabaseMirroring endpoint does not exist on $server" -Target $server -Continue
                 }
-                
+
                 foreach ($perm in $Permission) {
                     if ($Pscmdlet.ShouldProcess($server.Name, "Revoking $perm on $endpoint")) {
                         if ($perm -eq "CreateAnyDatabase") {
@@ -150,7 +150,7 @@ function Revoke-DbaAgPermission {
                     }
                 }
             }
-            
+
             if ($Type -contains "AvailabilityGroup") {
                 $ags = Get-DbaAvailabilityGroup -SqlInstance $account.Parent -AvailabilityGroup $AvailabilityGroup
                 foreach ($ag in $ags) {

--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -199,11 +199,13 @@ function Select-DbaBackupInformation {
                 #We have history so use this
                 [bigint]$LogBaseLsn = ($dbHistory | Sort-Object -Property LastLsn -Descending | select-object -First 1).lastLsn.ToString()
                 $FirstRecoveryForkID = $Full.FirstRecoveryForkID
+                Write-Message -Level Verbose -Message "Found LogBaseLsn: $LogBaseLsn and FirstRecoveryForkID: $FirstRecoveryForkID"
             } else {
                 Write-Message -Message "No full or diff, so attempting to pull from Continue informmation" -Level Verbose
                 try {
                     [bigint]$LogBaseLsn = ($ContinuePoints | Where-Object {$_.Database -eq $DatabaseFilter}).redo_start_lsn
                     $FirstRecoveryForkID = ($ContinuePoints | Where-Object {$_.Database -eq $DatabaseFilter}).FirstRecoveryForkID
+                    Write-Message -Level Verbose -Message "Found LogBaseLsn: $LogBaseLsn and FirstRecoveryForkID: $FirstRecoveryForkID from Continue information"
                 } catch {
                     Stop-Function -Message "Failed to find LSN or RecoveryForkID for $DatabaseFilter" -Category InvalidOperation -Target $DatabaseFilter
                 }

--- a/functions/Set-DbaDbCompatibility.ps1
+++ b/functions/Set-DbaDbCompatibility.ps1
@@ -17,7 +17,7 @@ function Set-DbaDbCompatibility {
 
     .PARAMETER TargetCompatibility
         The target compatibility level version. This is an int and follows Microsoft's versioning:
-    
+
         9 = SQL Server 2005
         10 = SQL Server 2008
         11 = SQL Server 2012
@@ -82,23 +82,23 @@ function Set-DbaDbCompatibility {
         [switch]$EnableException
     )
     process {
-        
+
         if (Test-Bound -not 'SqlInstance', 'InputObject') {
             Write-Message -Level Warning -Message "You must specify either a SQL instance or pipe a database collection"
             continue
         }
-        
+
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
         }
-        
+
         foreach ($db in $InputObject) {
             $server = $db.Parent
             $ServerVersion = $server.VersionMajor
             Write-Message -Level Verbose -Message "SQL Server is using Version: $ServerVersion"
-            
+
             $ogcompat = $db.CompatibilityLevel
-            $dbversion = switch ($db.CompatibilityLevel) {
+            $dbversion = switch ($ogcompat) {
                 "Version100" { 10 } # SQL Server 2008
                 "Version110" { 11 } # SQL Server 2012
                 "Version120" { 12 } # SQL Server 2014
@@ -107,7 +107,7 @@ function Set-DbaDbCompatibility {
                 "Version150" { 15 } # SQL Server 2019
                 default { 9 } # SQL Server 2005
             }
-            
+
             if (-not $TargetCompatibility) {
                 if ($dbversion -lt $ServerVersion) {
                     If ($Pscmdlet.ShouldProcess($server.Name, "Updating $db version from $dbversion to $ServerVersion")) {

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -99,7 +99,8 @@ function Set-DbaMaxDop {
     )
 
     begin {
-        $processed = New-Object System.Collections.ArrayList
+        #Variable marked as unused by PSScriptAnalyzer, maybe future improvement to replace $results = @()
+        #$processed = New-Object System.Collections.ArrayList
         $results = @()
     }
     process {

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -381,7 +381,8 @@ function Set-DbaStartupParameter {
         }
 
         $Scriptblock = {
-            $instance = $args[0]
+            #Variable marked as unused by PSScriptAnalyzer
+            #$instance = $args[0]
             $displayname = $args[1]
             $ParameterString = $args[2]
 
@@ -399,11 +400,13 @@ function Set-DbaStartupParameter {
         if ($pscmdlet.ShouldProcess("Setting Sql Server start parameters on $SqlInstance to $ParameterString")) {
             try {
                 if ($Credential) {
-                    $response = Invoke-ManagedComputerCommand -ComputerName $instance -Credential $Credential -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -EnableException
+                    #Variable $response marked as unused by PSScriptAnalyzer replace with $null to catch output
+                    $null = Invoke-ManagedComputerCommand -ComputerName $instance -Credential $Credential -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -EnableException
                     $output = Get-DbaStartupParameter -SqlInstance $server -Credential $Credential -EnableException
                     Add-Member -Force -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
                 } else {
-                    $response = Invoke-ManagedComputerCommand -ComputerName $instance -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -EnableException
+                    #Variable $response marked as unused by PSScriptAnalyzer replace with $null to catch output
+                    $null = Invoke-ManagedComputerCommand -ComputerName $instance -ScriptBlock $Scriptblock -ArgumentList $instance, $displayname, $ParameterString -EnableException
                     $output = Get-DbaStartupParameter -SqlInstance $server -EnableException
                     Add-Member -Force -InputObject $output -MemberType NoteProperty -Name OriginalStartupParameters -Value $originalparamstring
                 }
@@ -418,4 +421,3 @@ function Set-DbaStartupParameter {
         }
     }
 }
-

--- a/functions/Show-DbaDbList.ps1
+++ b/functions/Show-DbaDbList.ps1
@@ -41,7 +41,7 @@ function Show-DbaDbList {
         PS C:\> Show-DbaDbList -SqlInstance sqlserver2014a -SqlCredential $cred
 
         Shows a GUI list of databases using SQL credentials to connect to the SQL Server. Returns a string of the selected database.
-    
+
     .EXAMPLE
         PS C:\> Show-DbaDbList -SqlInstance sqlserver2014a -DefaultDb master
 
@@ -156,7 +156,8 @@ function Show-DbaDbList {
         [void]$stackpanel.Children.Add($image)
         [void]$stackpanel.Children.Add($textblock)
         $childitem.Header = $stackpanel
-        $databaseParent = $treeview.Items.Add($childitem)
+        #Variable marked as unused by PSScriptAnalyzer
+        #$databaseParent = $treeview.Items.Add($childitem)
 
         try {
             $databases = $sourceserver.databases.name

--- a/functions/Show-DbaServerFileSystem.ps1
+++ b/functions/Show-DbaServerFileSystem.ps1
@@ -19,7 +19,7 @@ function Show-DbaServerFileSystem {
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-    
+
     .NOTES
         Tags: Storage, FileSystem
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -133,17 +133,17 @@ function Show-DbaServerFileSystem {
         $foldericon = Convert-b64toimg "iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAU0SURBVEhLtZXpU5NXFIf9q/qto9bRuhc3xqUiUK3KoLYq6ihu1VIU1DpjRZ3BHVR8i6hUkDUJASNL2EJIWLKvBLJAAmHRpwfb6ai10Q/2w29u3pP3/p57zrn3vnOA/13/CkwMlzLuv0rMfYaoM59R+1ki1lwiFtHgGcIDuYT6fiZoPsWI6SSBnmyGeo4yZDxN2KEQHXr54H3Pdx5mNe6/QnzkGtMxNVNjeqK+AkLWQ/iMWdg7sxnz3uZ1vIrJSBnx0O9MhBQmggqxkRJC9hsEzFc+Dol5cpkcFaNXHbyasTMVNzARqWXEeZv+lh+xG/OIRWrgtU5ebxG1yu9meb+JEct57C+2fwLEe04g95mOPxJV8JphCcPUuBOHfg/6qm/pa8klNvyA6fFqZqbqZaxiZqKWQF8uVm3qp0LuMTNZyfREuUx+JuEo8agLe1smHTXpGLXSB3O+lKqMV5N1UtZypqJ/SCwHS2P6J0Iis5BqgTyR3tyVcIj4mAtL807aq1IxqLJwdR6TJhfL/xUCK3kjn/Ekg9rvPg6JevL/hlQJ5KmU4qGEg9IXCwNN22ir3ES3ap9AjjLqvU48/FBgN0SFeAzZDDSk3nnf852HWY25zxKPFEut/4JMRmcX5mM8bKJPm0bLs/V01e/B2X6IsPMyscAtRt2XRZdwdx1kQPsJ5Rp1nRGIZCKQqZhs09FiCTuJhQyYNFtoLl9HZ20mjtb9BK0XJJsrhG3nZJvn4Wr/AUfbEc+I/fFsI//xfAcwq4gjR0pTxPRkhQAeMh66zavpHkYDWoz1m3j5ZDWd1duxN+9muO80IVuejCcImI7h0W/F2boLtyFfrBJAwtZTjAdvMTn+VFZ/j7HADSbGahh2FGGoWYeuLImOynRsL3bg7zksgGP4DPvwdu2W52wp4wH6NJvFKgEkaP2J6LA0dKxMxruM+q9LFnfxmH+hu3oVTY+S0FekyFbdhrdzr1wnWXg6MnC1phBwVuOxqelvSBOrBJCRgWOM+a9JmUqI+AoJea4SlMY6pamdlStoVJbTVr6BQemPq22ngDJwNm/B3rSKgFuPzz0gmXwEEug7TMTzm5TpDkHXZYbtFxm2XsTenkX7s2VoS76m9cla+lUbcbxMlQxmAclYNEsIuzSE3N0CSRWrBBC/6RBB50XC3kICtl/xD+bh78/DIveWvnwJDQ8W0iJ96atNxtYoIN0GrA1JWOoX4Ler8Dq7MKu3iFUCiK/ngKw8Xy7EAnwDZ6UXOXjkGh/QZdL2dDHq+1/RXLoSc80aMV+LTbsKm3opHvU8buoqKdC1YFKliFUCiKdrr6w8B7/lAu7eUzi7j+PoPCIH8XtaHi9CXTyPZmUJpqqVDKq/wapZgUO9mKB2LqmlVSQ9bKG3fqNYJYA4O3bhMZ2QDHJxdGVj0x/E2rafXnW6QBaiKZ7LS2URpucrGFQtF8hyHJqlDGkXcLz0OnuVUno/loldvwO37He3MQebXB3W1n1yMe7BKBNnIeqiL9GVLHwDsaiWYdMsw6pehl1A7bXraK7birlhh1glgLi6T2Br24tZmyqr34BJvZn+xu1y2r+l9fF86m5+gbZ4PsbnazDXJ9OvXv9mNNUl45LSDck3x91bKFYJIF7TJWVQl6mYNGn6fl0WpoYMeupSaK9Yje7RcjmMqbSWZ9gNz9crxvotSq86TTHWpiiGmk2KUZWuOAyXlBG3Snnb8x3A2wp6m3b6rE+wtp+nq2oDL0oX01CaQndjAVZjbdGH5vyXPhj83Ppg8POKOX8Cx4yjZbQFLr4AAAAASUVORK5CYII="
         $dbatoolsicon = Convert-b64toimg "iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAO9SURBVEhL3VVdTFNXHO9MzPTF+OzDeBixFdTMINIWsAUK3AIVkFvAIQVFRLYZKR8Wi1IEKV9DYB8PGFAyEx8QScySabYY5+I2JvK18iWISKGk0JGhLzA3+e2c29uHtpcvH/0lv9yennN+v3vO/3fOFb2fCAg4vXWPNOmMRJ745TtTSskqeElviGXJ0XtkWvjJkyGLPoFAVQZoe/NkX/n6Mh/ysu4Qy7WZdJAutxRW6zT6LcNQaE4LiGgREH4cibpCMNqzCIk9hbScEoSSZ0zKOa7fRxG/k5d1h8ukvO4a5ubmMT1jw5E0vZcBZWzqOTS3dcB8tRXZeRX4/v5DZH5uIu0Wrn8NEzaNDjgYoUPd120oMjViX2iql8H6ZFd8DzE7eFl3iOWpuyQydlh44kbJroilSd8RuQ+cqh7wC9Z+JJaxY8KTN0gp+5Yk9DaREzYhb5FOBwZFZ6LlZifKa5ux//AxYTHCvSEp8A9O5n77B6dwqXS119guZ+GrGq9jfn4eM7ZZxB/PdxN2UfOpHq3kRWq/uoE8Yx3u/fQLzhSYUdN0g+tfN126z0oxNj6BJz0Dq0b4E2UawuJzuPhKyZmKYr/AocgMrk37VzWRBLGRdE/psuXqk9wkT/GNUCJLWqS3By/rDh9FxjaSrnahiZ7cq8wCUzKImLIJqC+Ngbk4gmjjIKKKB6Aq7l+OLBmfVF0YnlQZR1p4eSd2y5IiyEr+oyJ0CwIi0gUNKAOPmnG04Q0utf+DHweWkFjjQOyVWajLpsCUPkeUcRgqAzE09Dfz8k64aqI9YcDziUk87bMgOCZL0CQ0ux2J9UtIbXyFwall/PD0NeLKrU6DkhGymj8RXtRDjU7x8k64TKpJQmi6bLOzSEgv8DYhNWMujiK+9jU0VQs4Vm/H2MwSOh4vcP+rii2cQVh+F+IqbRJe3glyReuoSFBUJtpu3eWulv2h3ueE1iOu0g5N9QL3jLk8jerbdrz59y1yGoYQUdSLsII/CLscIsD9UPrLUz4myXhBhWjCPMVdPBBnhMbsIAZzSDDbcOvRIhyLy6i4+Qyq82QFxECR9xjK/K5OXtodNHo+CsW2tagunbxADbK+sXP16Bv/G7lNQ8hpHEX21UGoDb/j8NmfoSzoNvCymwdTPvMotsKGB32LaL1H0mS0oOHOFLpH/0L3iAOF3/YSk4dgTBMh/JTNgdVbtzNl1il12UuSpHE+SRayTb0IL3yCMP2vUJKtUuh/szNNK8Jfxw3BZNpiMoGjiKPJm54Ffw8gEv0PQRYX7wDAUKEAAAAASUVORK5CYII="
     }
-    
+
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         try {
             $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
-        
+
         # Create XAML form in Visual Studio, ensuring the ListView looks chromeless
         [xml]$xaml = '<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -127,17 +127,18 @@ function Start-DbaXESession {
                 $name = "XE Session Stop - $session"
                 if ($Pscmdlet.ShouldProcess("$Server", "Making New XEvent StopJob for $session")) {
                     # Setup the schedule time
-                    $time = ($StopAt).ToString("HHmmss")
+                    $time = $(($StopAt).ToString("HHmmss"))
 
                     # Create the schedule
-                    $schedule = New-DbaAgentSchedule -SqlInstance $server -Schedule $name -FrequencyType Once -StartTime ($StopAt).ToString("HHmmss") -Force
+                    $schedule = New-DbaAgentSchedule -SqlInstance $server -Schedule $name -FrequencyType Once -StartTime $time -Force
 
                     # Create the job and attach the schedule
                     $job = New-DbaAgentJob -SqlInstance $server -Job $name -Schedule $schedule -DeleteLevel Always -Force
 
                     # Create the job step
                     $sql = "ALTER EVENT SESSION [$session] ON SERVER STATE = stop;"
-                    $jobstep = New-DbaAgentJobStep -SqlInstance $server -Job $job -StepName 'T-SQL Stop' -Subsystem TransactSql -Command $sql -Force
+                    #Variable $jobstep marked as unused by PSScriptAnalyzer replace with $null to catch output
+                    $null = New-DbaAgentJobStep -SqlInstance $server -Job $job -StepName 'T-SQL Stop' -Subsystem TransactSql -Command $sql -Force
                 }
             }
         }

--- a/functions/Stop-DbaPfDataCollectorSet.ps1
+++ b/functions/Stop-DbaPfDataCollectorSet.ps1
@@ -79,7 +79,8 @@ function Stop-DbaPfDataCollectorSet {
         [switch]$EnableException
     )
     begin {
-        $sets = @()
+        #Variable marked as unused by PSScriptAnalyzer
+        #$sets = @()
         $wait = $NoWait -eq $false
 
         $setscript = {

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -85,7 +85,8 @@ function Test-DbaCmConnection {
     begin {
         #region Configuration Values
         $disable_cache = Get-DbatoolsConfigValue -Name "ComputerManagement.Cache.Disable.All" -Fallback $false
-        $disable_badcredentialcache = Get-DbatoolsConfigValue -Name "ComputerManagement.Cache.Disable.BadCredentialList" -Fallback $false
+        #Variable marked as unused by PSScriptAnalyzer
+        #$disable_badcredentialcache = Get-DbatoolsConfigValue -Name "ComputerManagement.Cache.Disable.BadCredentialList" -Fallback $false
         #endregion Configuration Values
 
         #region Helper Functions
@@ -100,7 +101,8 @@ function Test-DbaCmConnection {
             )
 
             try {
-                $os = $ComputerName.Connection.GetCimRMInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
+                #Variable $os marked as unused by PSScriptAnalyzer replace with $null to catch output
+                $null = $ComputerName.Connection.GetCimRMInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
 
                 New-Object PSObject -Property @{
                     Success       = "Success"
@@ -135,7 +137,8 @@ function Test-DbaCmConnection {
             )
 
             try {
-                $os = $ComputerName.Connection.GetCimDComInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
+                #Variable $os marked as unused by PSScriptAnalyzer replace with $null to catch output
+                $null = $ComputerName.Connection.GetCimDComInstance($Credential, "Win32_OperatingSystem", "root\cimv2")
 
                 New-Object PSObject -Property @{
                     Success       = "Success"
@@ -170,7 +173,8 @@ function Test-DbaCmConnection {
             )
 
             try {
-                $os = Get-WmiObject -ComputerName $ComputerName -Credential $Credential -Class Win32_OperatingSystem -ErrorAction Stop
+                #Variable $os marked as unused by PSScriptAnalyzer replace with $null to catch output
+                $null = Get-WmiObject -ComputerName $ComputerName -Credential $Credential -Class Win32_OperatingSystem -ErrorAction Stop
                 New-Object PSObject -Property @{
                     Success       = "Success"
                     Timestamp     = Get-Date
@@ -208,7 +212,8 @@ function Test-DbaCmConnection {
                     ErrorAction  = 'Stop'
                 }
                 if ($Credential) { $parameters["Credential"] = $Credential }
-                $os = Invoke-Command @parameters
+                #Variable $os marked as unused by PSScriptAnalyzer replace with $null to catch output
+                $null = Invoke-Command @parameters
 
                 New-Object PSObject -Property @{
                     Success       = "Success"
@@ -239,7 +244,8 @@ function Test-DbaCmConnection {
             #endregion Setup connection object
 
             #region Handle credentials
-            $BadCredentialsFound = $false
+            #Variable marked as unused by PSScriptAnalyzer
+            #$BadCredentialsFound = $false
             if ($con.DisableBadCredentialCache) { $con.KnownBadCredentials.Clear() }
             elseif ($con.IsBadCredential($Credential) -and (-not $Force)) {
                 Stop-Function -Message "[$Computer] The credentials supplied are on the list of known bad credentials, skipping. Use -Force to override this." -Continue -Category InvalidArgument -Target $Computer

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -116,7 +116,8 @@ function Test-DbaConnection {
 
             # SQL Server connection
             if ($instance.InstanceName -ne "MSSQLSERVER") {
-                $sqlport = "N/A"
+                #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
+                #$sqlport = "N/A"
             } else {
                 Write-Message -Level Verbose -Message "Testing raw socket connection to default SQL port"
                 $tcp = New-Object System.Net.Sockets.TcpClient
@@ -124,9 +125,11 @@ function Test-DbaConnection {
                     $tcp.Connect($baseaddress, 1433)
                     $tcp.Close()
                     $tcp.Dispose()
-                    $sqlport = $true
+                    #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
+                    #$sqlport = $true
                 } catch {
-                    $sqlport = $false
+                    #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
+                    #$sqlport = $false
                 }
             }
 

--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -201,9 +201,9 @@ function Test-DbaDiskAllocation {
                 Write-Message -Level Verbose -Message "Creating CimSession on $computer over WSMan failed. Creating CimSession on $computer over DCOM."
 
                 if (!$Credential) {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoptions -ErrorAction SilentlyContinue
                 } else {
-                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
+                    $cimsession = New-CimSession -ComputerName $Computer -SessionOption $sessionoptions -ErrorAction SilentlyContinue -Credential $Credential
                 }
             }
 

--- a/functions/Test-DbaEndpoint.ps1
+++ b/functions/Test-DbaEndpoint.ps1
@@ -3,67 +3,67 @@ function Test-DbaEndpoint {
     <#
     .SYNOPSIS
         Performs a simple connectivity test for TCP and SSL enabled endpoints.
-        
+
     .DESCRIPTION
         Performs a simple connectivity test for TCP and SSL enabled endpoints. Tests if port is accessible, not if endpoint is working.
-        
+
         Note that if an endpoint does not have a tcp listener port, it will be skipped.
-        
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-        
+
     .PARAMETER Endpoint
         Test only specific endpoint or endpoints.
-        
+
     .PARAMETER InputObject
         Enables piping from Get-DbaEndpoint.
-        
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-        
+
     .NOTES
         Tags: Endpoint
         Author: Chrissy LeMaire (@cl), netnerds.net
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
         License: MIT https://opensource.org/licenses/MIT
-        
+
     .LINK
         https://dbatools.io/Test-DbaEndpoint
-        
+
     .EXAMPLE
         PS C:\> Test-DbaEndpoint -SqlInstance localhost
-        
+
         Tests all endpoints on the local default SQL Server instance.
-        
+
         Note that if an endpoint does not have a tcp listener port, it will be skipped.
-        
+
     .EXAMPLE
         PS C:\> Get-DbaEndpoint -SqlInstance localhost, sql2016 -Endpoint Mirror | Test-DbaEndpoint
-        
+
         Tests all endpoints named Mirroring on sql2016 and localhost.
-        
+
         Note that if an endpoint does not have a tcp listener port, it will be skipped.
-        
+
     .EXAMPLE
         PS C:\> Test-DbaEndpoint -SqlInstance localhost, sql2016 -Endpoint Mirror
-        
+
         Tests all endpoints named Mirroring on sql2016 and localhost.
-        
+
         Note that if an endpoint does not have a tcp listener port, it will be skipped.
-        
+
     .EXAMPLE
         PS C:\> Test-DbaEndpoint -SqlInstance localhost -Verbose
-        
+
         Tests all endpoints on the local default SQL Server instance.
-        
+
         See all endpoints that were skipped due to not having a tcp listener port.
-        
+
 #>
     [CmdletBinding()]
     param (
@@ -78,13 +78,13 @@ function Test-DbaEndpoint {
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -Endpoint $Endpoint
         }
-        
+
         foreach ($end in $InputObject) {
             if (-not $end.Protocol.Tcp.ListenerPort) {
                 Write-Message -Level Verbose -Message "$end on $($end.Parent) does not have a tcp listener port"
             } else {
                 Write-Message "Connecting to port $($end.Protocol.Tcp.ListenerPort) on $($end.ComputerName) for endpoint $($end.Name)"
-                
+
                 try {
                     $tcp = New-Object System.Net.Sockets.TcpClient
                     $tcp.Connect($end.ComputerName, $end.Protocol.Tcp.ListenerPort)
@@ -94,7 +94,7 @@ function Test-DbaEndpoint {
                 } catch {
                     $connect = $_
                 }
-                
+
                 try {
                     $ssl = $end.Protocol.Tcp.SslPort
                     if ($ssl) {
@@ -109,7 +109,7 @@ function Test-DbaEndpoint {
                 } catch {
                     $sslconnect = $_
                 }
-                
+
                 [pscustomobject]@{
                     ComputerName  = $end.ComputerName
                     InstanceName  = $end.InstanceName

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -417,7 +417,8 @@ function Test-DbaLastBackup {
 
                                     ## Drop the database
                                     try {
-                                        $removeresult = Remove-DbaDatabase -SqlInstance $destserver -Database $dbname -Confirm:$false
+                                        #Variable $removeresult marked as unused by PSScriptAnalyzer replace with $null to catch output
+                                        $null = Remove-DbaDatabase -SqlInstance $destserver -Database $dbname -Confirm:$false
                                         Write-Message -Level Verbose -Message "Dropped $dbname Database on $destination."
                                     } catch {
                                         $destserver.Databases.Refresh()

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -83,7 +83,8 @@ function Test-DbaMaxDop {
     }
 
     process {
-        $hasScopedConfig = $false
+        #Variable marked as unused by PSScriptAnalyzer
+        #$hasScopedConfig = $false
 
         foreach ($instance in $SqlInstance) {
             try {
@@ -168,7 +169,8 @@ function Test-DbaMaxDop {
 
             # On SQL Server 2016 and higher, MaxDop can be set on a per-database level
             if ($server.VersionMajor -ge 13) {
-                $hasScopedConfig = $true
+                #Variable marked as unused by PSScriptAnalyzer
+                #$hasScopedConfig = $true
                 Write-Message -Level Verbose -Message "SQL Server 2016 or higher detected, checking each database's MaxDop."
 
                 $databases = $server.Databases | where-object {$_.IsSystemObject -eq $false}

--- a/functions/Watch-DbaXESession.ps1
+++ b/functions/Watch-DbaXESession.ps1
@@ -71,7 +71,7 @@ function Watch-DbaXESession {
     )
     process {
         if (-not $SqlInstance) {
-           
+
         } else {
             try {
                 $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -MinimumVersion 11
@@ -84,12 +84,12 @@ function Watch-DbaXESession {
             Write-Message -Level Verbose -Message "Getting XEvents Sessions on $SqlInstance."
             $InputObject += $XEStore.sessions | Where-Object Name -eq $Session
         }
-        
+
         foreach ($xesession in $InputObject) {
             $server = $xesession.Parent
             $sessionname = $xesession.Name
             Write-Message -Level Verbose -Message "Watching $sessionname on $($server.Name)."
-            
+
             if (-not $xesession.IsRunning -and -not $xesession.IsRunning) {
                 Stop-Function -Message "$($xesession.Name) is not running on $($server.Name)" -Continue
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4320 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Remove Variables that were flagged as being assigned, but not used.
Use Variables that seem to be mistyped, or created with code being executed.
Bonus: Cleanup Trailing whitespace

### Approach
<!-- How does this change solve that purpose -->
Commented out variables, with a message stating why it was commented out.
This was done so that if a cmdlet is doing something that was not clear it can quickly be replaced.
If the code is not needed it can be removed closer to V1.0
Otherwise this rule help spot mistyped variable names, or names that were not used, but should be.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-ScriptAnalyzer .\functions\ -IncludeRule PSUseShouldProcessForStateChangingFunctions`
