### PR TITLE
stalebot settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+issues:
+  daysUntilStale: 60
+  daysUntilClose: 30
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. If you would like this issue to remain open:
+      * Verify that you can still reproduce the issue in the latest version of dbatools
+      * Comment that the issue is still reproducible and include:
+         * What version of dbatools you reproduced the issue on
+         * What OS and version you reproduced the issue on
+         * What steps you followed to reproduce the issue
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the
+    last three months. If this issue is still valid, please add a comment
+  exemptLabels:
+    - Feature
+    - Availability Groups
+    - Discussion
+    - Documentation
+    - Question


### PR DESCRIPTION
As discussed on #dbatools-dev : 
 - 60 days till it gets marked as stale
 - 30 more days to get closed automatically
 - only applied to issues (just relabelled all bugs as such, so questions, features, discussions, documentation issues for the moment won't be touched)

Once this is in, we can add the bot. Once we get acquainted, I feel we should turn it on also on features... but that's for another discussion (and another time)