### PR TITLE
Fix nouns and verbs

### DIFF
--- a/functions/Clear-DbaConnectionPool.ps1
+++ b/functions/Clear-DbaConnectionPool.ps1
@@ -82,4 +82,3 @@ function Clear-DbaConnectionPool {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Clear-DbaSqlConnectionPool
     }
 }
-

--- a/functions/Clear-DbaLatchStatistics.ps1
+++ b/functions/Clear-DbaLatchStatistics.ps1
@@ -56,7 +56,7 @@ function Clear-DbaLatchStatistics {
         Connects using sqladmin credential and clears latch statistics on servers sql2008 and sqlserver2012
 #>
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Singular Noun doesn't make sense")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
@@ -93,4 +93,3 @@ function Clear-DbaLatchStatistics {
         }
     }
 }
-

--- a/functions/Clear-DbaLatchStatistics.ps1
+++ b/functions/Clear-DbaLatchStatistics.ps1
@@ -56,6 +56,7 @@ function Clear-DbaLatchStatistics {
         Connects using sqladmin credential and clears latch statistics on servers sql2008 and sqlserver2012
 #>
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -46,6 +46,7 @@ function Clear-DbaWaitStatistics {
 
 #>
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]

--- a/functions/Clear-DbaWaitStatistics.ps1
+++ b/functions/Clear-DbaWaitStatistics.ps1
@@ -46,7 +46,7 @@ function Clear-DbaWaitStatistics {
 
 #>
     [CmdletBinding(ConfirmImpact = 'High', SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Singular Noun doesn't make sense")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer", "SqlServers")]
@@ -82,4 +82,3 @@ function Clear-DbaWaitStatistics {
         }
     }
 }
-

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -69,6 +69,7 @@ function Copy-DbaLinkedServer {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -69,7 +69,7 @@ function Copy-DbaLinkedServer {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter]$Source,
@@ -262,4 +262,3 @@ function Copy-DbaLinkedServer {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Copy-SqlLinkedServer
     }
 }
-

--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -198,6 +198,7 @@ function Find-DbaInstance {
 
 #>
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
     param (
         [Parameter(Mandatory, ParameterSetName = 'Computer', ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,

--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -198,7 +198,7 @@ function Find-DbaInstance {
 
 #>
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification = "Internal functions are ignored")]
     param (
         [Parameter(Mandatory, ParameterSetName = 'Computer', ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
@@ -967,4 +967,3 @@ function Find-DbaInstance {
         $steppablePipeline.End()
     }
 }
-

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -49,7 +49,7 @@ function Find-DbaLoginInGroup {
 
 #>
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
@@ -150,4 +150,3 @@ function Find-DbaLoginInGroup {
         }
     }
 }
-

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -49,6 +49,7 @@ function Find-DbaLoginInGroup {
 
 #>
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -143,7 +143,7 @@ function Get-DbaDatabase {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
@@ -352,4 +352,3 @@ function Get-DbaDatabase {
         }
     }
 }
-

--- a/functions/Get-DbaDatabase.ps1
+++ b/functions/Get-DbaDatabase.ps1
@@ -143,6 +143,7 @@ function Get-DbaDatabase {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Position = 0, Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -69,7 +69,7 @@ function Get-DbaMaintenanceSolutionLog {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
@@ -251,4 +251,3 @@ function Get-DbaMaintenanceSolutionLog {
         }
     }
 }
-

--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -69,6 +69,7 @@ function Get-DbaMaintenanceSolutionLog {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -50,7 +50,7 @@ function Get-DbaSpn {
 
 #>
     [cmdletbinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification = "Internal functions are ignored")]
     param (
         [Parameter(Mandatory = $false, ValueFromPipeline)]
         [string[]]$ComputerName,
@@ -166,4 +166,3 @@ function Get-DbaSpn {
         }
     }
 }
-

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -50,6 +50,7 @@ function Get-DbaSpn {
 
 #>
     [cmdletbinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
     param (
         [Parameter(Mandatory = $false, ValueFromPipeline)]
         [string[]]$ComputerName,

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -178,6 +178,7 @@ function Import-DbaCsvToSql {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [string[]]$Csv,
         [Parameter(Mandatory)]

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -178,7 +178,7 @@ function Import-DbaCsvToSql {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [string[]]$Csv,
         [Parameter(Mandatory)]
@@ -1303,4 +1303,3 @@ function Import-DbaCsvToSql {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Import-CsvToSql
     }
 }
-

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -104,7 +104,7 @@ function Install-DbaMaintenanceSolution {
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]
@@ -378,4 +378,3 @@ function Install-DbaMaintenanceSolution {
         Write-Message -Level Output -Message "Installation complete."
     }
 }
-

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -104,6 +104,7 @@ function Install-DbaMaintenanceSolution {
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias('ServerInstance', 'SqlServer')]

--- a/functions/Invoke-DbaBalanceDataFiles.ps1
+++ b/functions/Invoke-DbaBalanceDataFiles.ps1
@@ -84,7 +84,7 @@ function Invoke-DbaBalanceDataFiles {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Singular Noun doesn't make sense")]
     param (
         [parameter(ParameterSetName = "Pipe", Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -356,4 +356,3 @@ function Invoke-DbaBalanceDataFiles {
         } # end process
     }
 }
-

--- a/functions/Invoke-DbaBalanceDataFiles.ps1
+++ b/functions/Invoke-DbaBalanceDataFiles.ps1
@@ -84,6 +84,7 @@ function Invoke-DbaBalanceDataFiles {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Singular Noun doesn't make sense")]
     param (
         [parameter(ParameterSetName = "Pipe", Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,

--- a/functions/Register-DbatoolsConfig.ps1
+++ b/functions/Register-DbatoolsConfig.ps1
@@ -56,6 +56,7 @@ function Register-DbatoolsConfig {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
     param (
         [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Configuration.Config[]]$Config,

--- a/functions/Register-DbatoolsConfig.ps1
+++ b/functions/Register-DbatoolsConfig.ps1
@@ -56,7 +56,7 @@ function Register-DbatoolsConfig {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification = "Internal functions are ignored")]
     param (
         [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Configuration.Config[]]$Config,
@@ -165,4 +165,3 @@ function Register-DbatoolsConfig {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Register-DbaConfig
     }
 }
-

--- a/functions/Remove-DbaXESession.ps1
+++ b/functions/Remove-DbaXESession.ps1
@@ -66,6 +66,7 @@ function Remove-DbaXESession {
 
 #>
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess, ConfirmImpact = 'High')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]

--- a/functions/Remove-DbaXESession.ps1
+++ b/functions/Remove-DbaXESession.ps1
@@ -66,7 +66,7 @@ function Remove-DbaXESession {
 
 #>
     [CmdletBinding(DefaultParameterSetName = 'Session', SupportsShouldProcess, ConfirmImpact = 'High')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]
@@ -137,4 +137,3 @@ function Remove-DbaXESession {
         }
     }
 }
-

--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -69,6 +69,7 @@ function Start-DbaXESession {
 
 #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Session')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]

--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -69,7 +69,7 @@ function Start-DbaXESession {
 
 #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Session')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]
@@ -170,4 +170,3 @@ function Start-DbaXESession {
         }
     }
 }
-

--- a/functions/Stop-DbaXESession.ps1
+++ b/functions/Stop-DbaXESession.ps1
@@ -61,7 +61,7 @@ function Stop-DbaXESession {
 
 #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Session')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]
@@ -134,4 +134,3 @@ function Stop-DbaXESession {
         }
     }
 }
-

--- a/functions/Stop-DbaXESession.ps1
+++ b/functions/Stop-DbaXESession.ps1
@@ -61,6 +61,7 @@ function Stop-DbaXESession {
 
 #>
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Session')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="Internal functions are ignored")]
     param (
         [parameter(Position = 1, Mandatory, ParameterSetName = 'Session')]
         [parameter(Position = 1, Mandatory, ParameterSetName = 'All')]

--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -44,7 +44,7 @@ function Update-Dbatools {
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="It is the proper noun of the cmdlet")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "It is the proper noun of the cmdlet")]
     param(
         [parameter(Mandatory = $false)]
         [Alias("dev", "devbranch")]
@@ -66,4 +66,3 @@ function Update-Dbatools {
         }
     }
 }
-

--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -44,6 +44,7 @@ function Update-Dbatools {
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="It is the proper noun of the cmdlet")]
     param(
         [parameter(Mandatory = $false)]
         [Alias("dev", "devbranch")]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4346 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Include rules for PSScriptAnalyzer to Ignore rules in specific situations

### Approach
<!-- How does this change solve that purpose -->
added:
`[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns","",Justification="It is the proper noun of the cmdlet")]`
`[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs","",Justification="Internal functions are ignored")]`


### Commands to test
<!-- if these are the examples in the help just note it as such -->

