### PR TITLE
Fixing up Azure credential handling in Backup and Restore

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -252,17 +252,20 @@ function Backup-DbaDatabase {
             }
             if ('' -ne $AzureBaseUrl) {
                 $AzureBaseUrl = $AzureBaseUrl.Trim("/")
-                if (Get-DbaCredential -SqlInstance $server -Name $AzureBaseUrl)
-                {
-                    Write-Message -Message "Found a SAS backup credental" -Level Verbose
+                if ('' -ne $AzureCredential){
+                    Write-Message -Message "Azure Credential name passed in, will proceed assuming it's value" -Level Verbose
+                    $FileCount = 1
                 }
                 else{
-                    if ($null -eq $AzureCredential) {
+                    Write-Message -Message "AzureUrl and no credential, testing for SAS credential"
+                    if (Get-DbaCredential -SqlInstance $server -Name $AzureBaseUrl)
+                    {
+                        Write-Message -Message "Found a SAS backup credental" -Level Verbose
+                    }
+                    else{
                         Stop-Function -Message "You must provide the credential name for the Azure Storage Account"
                         return
                     }
-
-                    $FileCount = 1
                 }
                 $BackupDirectory = $AzureBaseUrl
             }

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -251,12 +251,19 @@ function Backup-DbaDatabase {
                 }
             }
             if ('' -ne $AzureBaseUrl) {
-                if ($null -eq $AzureCredential) {
-                    Stop-Function -Message "You must provide the credential name for the Azure Storage Account"
-                    return
-                }
                 $AzureBaseUrl = $AzureBaseUrl.Trim("/")
-                $FileCount = 1
+                if (Get-DbaCredential -SqlInstance $server -Name $AzureBaseUrl)
+                {
+                    Write-Message -Message "Found a SAS backup credental" -Level Verbose
+                }
+                else{
+                    if ($null -eq $AzureCredential) {
+                        Stop-Function -Message "You must provide the credential name for the Azure Storage Account"
+                        return
+                    }
+
+                    $FileCount = 1
+                }
                 $BackupDirectory = $AzureBaseUrl
             }
 
@@ -364,7 +371,7 @@ function Backup-DbaDatabase {
 
             $backup.CopyOnly = $copyonly
             $backup.Action = $SMOBackupType
-            if ('' -ne $AzureBaseUrl) {
+            if ('' -ne $AzureBaseUrl -and $null -ne $AzureCredential) {
                 $backup.CredentialName = $AzureCredential
             }
 

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -252,17 +252,14 @@ function Backup-DbaDatabase {
             }
             if ('' -ne $AzureBaseUrl) {
                 $AzureBaseUrl = $AzureBaseUrl.Trim("/")
-                if ('' -ne $AzureCredential){
+                if ('' -ne $AzureCredential) {
                     Write-Message -Message "Azure Credential name passed in, will proceed assuming it's value" -Level Verbose
                     $FileCount = 1
-                }
-                else{
+                } else {
                     Write-Message -Message "AzureUrl and no credential, testing for SAS credential"
-                    if (Get-DbaCredential -SqlInstance $server -Name $AzureBaseUrl)
-                    {
+                    if (Get-DbaCredential -SqlInstance $server -Name $AzureBaseUrl) {
                         Write-Message -Message "Found a SAS backup credental" -Level Verbose
-                    }
-                    else{
+                    } else {
                         Stop-Function -Message "You must provide the credential name for the Azure Storage Account"
                         return
                     }
@@ -594,4 +591,3 @@ function Backup-DbaDatabase {
         }
     }
 }
-

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -99,7 +99,8 @@ function Backup-DbaDatabase {
         If specified, the only other parameters than can be used are "NoCopyOnly", "Type", "CompressBackup", "Checksum", "Verify", "AzureCredential", "CreateFolder".
 
     .PARAMETER AzureCredential
-        The name of the credential on the SQL instance that can write to the AzureBaseUrl.
+        The name of the credential on the SQL instance that can write to the AzureBaseUrl, only needed if using Storage access keys
+        If using SAS credentials, the command will look for a credential with a name matching the AzureBaseUrl
 
     .PARAMETER NoRecovery
         This is passed in to perform a tail log backup if needed
@@ -147,6 +148,11 @@ function Backup-DbaDatabase {
         PS C:\> Backup-DbaDatabase -SqlInstance sql2016 -AzureBaseUrl https://dbatoolsaz.blob.core.windows.net/azbackups/ -AzureCredential dbatoolscred -Type Full -CreateFolder
 
         Performs a full backup of all databases on the sql2016 instance to their own containers under the https://dbatoolsaz.blob.core.windows.net/azbackups/ container on Azure blog storage using the sql credential "dbatoolscred" registered on the sql2016 instance.
+
+    .EXAMPLE
+        PS C:\> Backup-DbaDatabase -SqlInstance sql2016 -AzureBaseUrl https://dbatoolsaz.blob.core.windows.net/azbackups/  -Type Full
+
+        Performs a full backup of all databases on the sql2016 instance to the https://dbatoolsaz.blob.core.windows.net/azbackups/ container on Azure blog storage using the Shared Access Signature sql credential "https://dbatoolsaz.blob.core.windows.net/azbackups" registered on the sql2016 instance.
 
     .EXAMPLE
         PS C:\> Backup-Dbadatabase -SqlInstance Server1\Prod -Database db1 -BackupDirectory \\filestore\backups\servername\instancename\dbname\backuptype -Type Full -ReplaceInName

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -363,7 +363,7 @@ function Restore-DbaDatabase {
         [parameter(Mandatory, ParameterSetName = "RestorePage")][object]$PageRestore,
         [parameter(Mandatory, ParameterSetName = "RestorePage")][string]$PageRestoreTailFolder,
         [int]$StatementTimeout = 0
-        
+
     )
     begin {
         Write-Message -Level InternalComment -Message "Starting"
@@ -379,7 +379,7 @@ function Restore-DbaDatabase {
         if ($PSCmdlet.ParameterSetName -eq "Restore") {
             $UseDestinationDefaultDirectories = $true
             $paramCount = 0
-            
+
             if (!(Test-Bound "AllowContinue") -and $true -ne $AllowContinue) {
                 $AllowContinue = $false
             }
@@ -400,7 +400,7 @@ function Restore-DbaDatabase {
                 Stop-Function -Category InvalidArgument -Message "To use ReplaceDbNameInFile you must specify DatabaseName"
                 return
             }
-            
+
             if ((Test-Bound "DestinationLogDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
                 Stop-Function -Category InvalidArgument -Message "The parameters DestinationLogDirectory and UseDestinationDefaultDirectories are mutually exclusive"
                 return
@@ -448,9 +448,9 @@ function Restore-DbaDatabase {
             if (!($PSBoundParameters.ContainsKey("DataBasename"))) {
                 $PipeDatabaseName = $true
             }
-            
+
         }
-        
+
         # changing statement timeout to $StatementTimeout
         if ($StatementTimeout -eq 0) {
             Write-Message -Level Verbose -Message "Changing statement timeout to infinity"
@@ -459,16 +459,16 @@ function Restore-DbaDatabase {
         }
         $RestoreInstance.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
         #endregion Validation
-        
+
         #Variable marked as unused by PSScriptAnalyzer
         #$isLocal = [dbavalidate]::IsLocalHost($SqlInstance.ComputerName)
-        
+
         if ($UseDestinationDefaultDirectories) {
             $DefaultPath = (Get-DbaDefaultPath -SqlInstance $RestoreInstance)
             $DestinationDataDirectory = $DefaultPath.Data
             $DestinationLogDirectory = $DefaultPath.Log
         }
-        
+
         $BackupHistory = @()
         #$UseDestinationDefaultDirectories = $true
     }
@@ -529,11 +529,23 @@ function Restore-DbaDatabase {
                             }
                         }
                     }
-                    if ($f.BackupPath -like 'http*' -and '' -eq $AzureCredential) {
-                        Stop-Function -Message "At least one Azure backup passed in, and no Credential supplied. Stopping"
-                        return
+
+                    if ($f.BackupPath -like 'http*'){
+                        if ('' -ne $AzureCredential){
+                            Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
+                            Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
+                        }
+                        else {
+                            $f.BackupPath -match 'https://.*/.*/'
+                            if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ){
+                                Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
+                            }
+                            else {
+                                Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
+                                return
+                            }
+                        }
                     }
-                    
                     $BackupHistory += $F | Select-Object *, @{
                         Name = "ServerName"; Expression = {
                             $_.SqlInstance
@@ -543,7 +555,7 @@ function Restore-DbaDatabase {
                             $_.Start -as [DateTime]
                         }
                     }
-                    
+
                 }
             } else {
                 $files = @()
@@ -584,12 +596,12 @@ function Restore-DbaDatabase {
                 if ($RestoreInstance.Databases[$DataBase].State -ne 'Existing') {
                     Write-Message -Message "$Database does not exist on $RestoreInstance" -level Warning
                     Continue
-                    
+
                 }
                 if ($RestoreInstance.Databases[$Database].Status -ne "Restoring") {
                     Write-Message -Message "$Database on $RestoreInstance is not in a Restoring State" -Level Warning
                     Continue
-                    
+
                 }
                 $RestoreComplete = $true
                 $RecoverSql = "RESTORE DATABASE $Database WITH RECOVERY"
@@ -629,34 +641,34 @@ function Restore-DbaDatabase {
             if ($StopAfterGetBackupInformation) {
                 return
             }
-            
+
             $null = $BackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatabaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping
-            
+
             if (Test-Bound -ParameterName FormatBackupInformation) {
                 Set-Variable -Name $FormatBackupInformation -Value $BackupHistory -Scope Global
             }
             if ($StopAfterFormatBackupInformation) {
                 return
             }
-            
+
             $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -IgnoreLogs:$IgnoreLogBackups -ContinuePoints $ContinuePoints -LastRestoreType $LastRestoreType -DatabaseName $DatabaseName
-            
+
             if (Test-Bound -ParameterName SelectBackupInformation) {
                 Write-Message -Message "Setting $SelectBackupInformation to FilteredBackupHistory" -Level Verbose
                 Set-Variable -Name $SelectBackupInformation -Value $FilteredBackupHistory -Scope Global
-                
+
             }
             if ($StopAfterSelectBackupInformation) {
                 return
             }
-            
+
             try {
                 Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
                 $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
             } catch {
                 Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
             }
-            
+
             if (Test-Bound -ParameterName TestBackupInformation) {
                 Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
             }
@@ -667,7 +679,7 @@ function Restore-DbaDatabase {
                     $_.IsVerified -eq $True
                 } | Select-Object -Property Database -Unique).Database -join ','
             Write-Message -Message "$DbVerfied passed testing" -Level Verbose
-            
+
             if (($FilteredBackupHistory | Where-Object {
                         $_.IsVerified -eq $True
                     }).count -lt $FilteredBackupHistory.count) {
@@ -681,7 +693,7 @@ function Restore-DbaDatabase {
                     return
                 }
             }
-            
+
             If ($PSCmdlet.ParameterSetName -eq "RestorePage") {
                 if (($FilteredBackupHistory.Database | select-Object -unique | Measure-Object).count -ne 1) {
                     Stop-Function -Message "Must only 1 database passed in for Page Restore. Sorry"
@@ -705,7 +717,7 @@ function Restore-DbaDatabase {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $RestoreInstance
             }
             if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                if ($RestoreInstace.Edition -like '*Enterprise*') {
+                if ($RestoreInstance.Edition -like '*Enterprise*') {
                     Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose
                     $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
                 }
@@ -713,7 +725,7 @@ function Restore-DbaDatabase {
                 $TailBackup | Restore-DbaDatabase -SqlInstance $RestoreInstance -TrustDbBackupHistory -NoRecovery -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -Continue
                 Restore-DbaDatabase -SqlInstance $RestoreInstance -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
             }
-            
+
         }
     }
 }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -130,7 +130,8 @@ function Restore-DbaDatabase {
         If a directory is specified the database(s) will be restored into a standby state, with the standby file placed into this directory (which must exist, and be writable by the target Sql Server instance)
 
     .PARAMETER AzureCredential
-        The name of the SQL Server credential to be used if restoring from an Azure hosted backup
+        The name of the SQL Server credential to be used if restoring from an Azure hosted backup using Storage Access Keys
+        If a backup path beginning http is passed in and this parameter is not specified then if a credential with a name matching the URL
 
     .PARAMETER ReplaceDbNameInFile
         If switch set and occurrence of the original database's name in a data or log file will be replace with the name specified in the DatabaseName parameter
@@ -243,6 +244,11 @@ function Restore-DbaDatabase {
 
         Will restore the backup held at  http://demo.blob.core.windows.net/backups/dbbackup.bak to server1\instance1. The connection to Azure will be made using the
         credential MyAzureCredential held on instance Server1\instance1
+
+    .EXAMPLE
+        PS C:\> Restore-DbaDatabase -SqlInstance server1\instance1 -Path http://demo.blob.core.windows.net/backups/dbbackup.bak
+
+        Will attempt to restore the backups from http://demo.blob.core.windows.net/backups/dbbackup.bak if a SAS credential with the name http://demo.blob.core.windows.net/backups exists on server1\instance1
 
     .EXAMPLE
         PS C:\> $File = Get-ChildItem c:\backups, \\server1\backups -recurse

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -530,17 +530,15 @@ function Restore-DbaDatabase {
                         }
                     }
 
-                    if ($f.BackupPath -like 'http*'){
-                        if ('' -ne $AzureCredential){
+                    if ($f.BackupPath -like 'http*') {
+                        if ('' -ne $AzureCredential) {
                             Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
                             Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
-                        }
-                        else {
+                        } else {
                             $f.BackupPath -match 'https://.*/.*/'
-                            if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ){
+                            if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ) {
                                 Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
-                            }
-                            else {
+                            } else {
                                 Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
                                 return
                             }
@@ -729,4 +727,3 @@ function Restore-DbaDatabase {
         }
     }
 }
-

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -160,7 +160,7 @@ function Test-DbaBackupInformation {
             $allpaths = $DbHistory | Select-Object -ExpandProperty FullName
             $allpaths_validity = Test-DbaPath -SqlInstance $RestoreInstance -Path $allpaths
             foreach ($path in $allpaths_validity) {
-                if ($path.FileExists -eq $false) {
+                if ($path.FileExists -eq $false -and ($path.FilePath -notlike 'http*')) {
                     Write-Message -Message "Backup File $($path.FilePath) cannot be read by $($RestoreInstance.Name). Does the service account ($($RestoreInstance.ServiceAccount)) have permission?" -Level Warning
                     $VerificationErrors++
                 }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -822,6 +822,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             It "Should restore cleanly" {
                 $results = Restore-DbaDatabase -SqlInstance $script:instance2 -WithReplace -DatabaseName dbatoolsci_azure -Path https://dbatools.blob.core.windows.net/sql/dbatoolsci_azure.bak
                 $results.BackupFile | Should -Be 'https://dbatools.blob.core.windows.net/sql/dbatoolsci_azure.bak'
+                $results.RestoreComplete | Should Be $True
             }
         }
     }
@@ -839,8 +840,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 Get-DbaDatabase -SqlInstance $script:instance2 -Database "dbatoolsci_azure" | Remove-DbaDatabase -Confirm:$false
             }
             It "Should restore cleanly" {
-                $results = @('https://dbatools.blob.core.windows.net/sql/az-1.bak','https://dbatools.blob.core.windows.net/sql/az-2.bak','https://azdbatools.blob.core.windows.net/sql/az-3.bak') | Restore-DbaDatabase -SqlInstance $script:instance2 -DatabaseName azstripetest -Verbose -AzureCredential dbatools_ci -WithReplace -ReplaceDbNameInFile
-                $results
+                $results = @('https://dbatools.blob.core.windows.net/sql/az-1.bak','https://dbatools.blob.core.windows.net/sql/az-2.bak','https://azdbatools.blob.core.windows.net/sql/az-3.bak') | Restore-DbaDatabase -SqlInstance $script:instance2 -DatabaseName azstripetest -AzureCredential dbatools_ci -WithReplace -ReplaceDbNameInFile
+                $results.RestoreComplete | Should Be $True
             }
         }
     }
@@ -860,6 +861,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 $results = Restore-DbaDatabase -SqlInstance $script:instance2 -WithReplace -DatabaseName dbatoolsci_azure -Path https://dbatools.blob.core.windows.net/legacy/dbatoolsci_azure.bak -AzureCredential dbatools_ci
                 $results.BackupFile | Should -Be 'https://dbatools.blob.core.windows.net/legacy/dbatoolsci_azure.bak'
                 $results.Script -match 'CREDENTIAL' | Should -Be $true
+                $results.RestoreComplete | Should Be $True
             }
         }
     }

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -394,7 +394,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
     }
-#>
+
     Context "RestoreTime point in time and continue with rename" {
         AfterAll {
             $null = Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeAllSystemDb | Remove-DbaDatabase -Confirm:$false
@@ -811,17 +811,21 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         Context "Restores From Azure using SAS" {
             BeforeAll {
                 $server = Connect-DbaInstance -SqlInstance $script:instance2
-                $sql = "CREATE CREDENTIAL [https://dbatools.blob.core.windows.net/sql] WITH IDENTITY = N'SHARED ACCESS SIGNATURE', SECRET = N'$env:azurepasswd'"
+                if (Get-DbaCredential -SqlInstance $script:instance2 -Name "[$script:azureblob]" ){
+                    $sql = "DROP CREDENTIAL [$script:azureblob]"
+                    $server.Query($sql)
+                }
+                $sql = "CREATE CREDENTIAL [$script:azureblob] WITH IDENTITY = N'SHARED ACCESS SIGNATURE', SECRET = N'$env:azurepasswd'"
                 $server.Query($sql)
                 $server.Query("CREATE DATABASE dbatoolsci_azure")
             }
             AfterAll {
-                $server.Query("DROP CREDENTIAL [https://dbatools.blob.core.windows.net/sql]")
+                $server.Query("DROP CREDENTIAL [$script:azureblob]")
                 Get-DbaDatabase -SqlInstance $script:instance2 -Database "dbatoolsci_azure" | Remove-DbaDatabase -Confirm:$false
             }
             It "Should restore cleanly" {
-                $results = Restore-DbaDatabase -SqlInstance $script:instance2 -WithReplace -DatabaseName dbatoolsci_azure -Path https://dbatools.blob.core.windows.net/sql/dbatoolsci_azure.bak
-                $results.BackupFile | Should -Be 'https://dbatools.blob.core.windows.net/sql/dbatoolsci_azure.bak'
+                $results = Restore-DbaDatabase -SqlInstance $script:instance2 -WithReplace -DatabaseName dbatoolsci_azure -Path $script:azureblob/dbatoolsci_azure.bak
+                $results.BackupFile | Should -Be "$script:azureblob/dbatoolsci_azure.bak"
                 $results.RestoreComplete | Should Be $True
             }
         }
@@ -831,16 +835,20 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         Context "Restores Striped backup From Azure using SAS" {
             BeforeAll {
                 $server = Connect-DbaInstance -SqlInstance $script:instance2
-                $sql = "CREATE CREDENTIAL [https://dbatools.blob.core.windows.net/sql] WITH IDENTITY = N'SHARED ACCESS SIGNATURE', SECRET = N'$env:azurepasswd'"
+                if (Get-DbaCredential -SqlInstance $script:instance2 -name "[$script:azureblob]" ) {
+                    $sql = "DROP CREDENTIAL [$script:azureblob]"
+                    $server.Query($sql)
+                }
+                $sql = "CREATE CREDENTIAL [$script:azureblob] WITH IDENTITY = N'SHARED ACCESS SIGNATURE', SECRET = N'$env:azurepasswd'"
                 $server.Query($sql)
                 $server.Query("CREATE DATABASE dbatoolsci_azure")
             }
             AfterAll {
-                $server.Query("DROP CREDENTIAL [https://dbatools.blob.core.windows.net/sql]")
+                $server.Query("DROP CREDENTIAL [$script:azureblob]")
                 Get-DbaDatabase -SqlInstance $script:instance2 -Database "dbatoolsci_azure" | Remove-DbaDatabase -Confirm:$false
             }
             It "Should restore cleanly" {
-                $results = @('https://dbatools.blob.core.windows.net/sql/az-1.bak','https://dbatools.blob.core.windows.net/sql/az-2.bak','https://azdbatools.blob.core.windows.net/sql/az-3.bak') | Restore-DbaDatabase -SqlInstance $script:instance2 -DatabaseName azstripetest -AzureCredential dbatools_ci -WithReplace -ReplaceDbNameInFile
+                $results = @("$script:azureblob/az-1.bak","$script:azureblob/az-2.bak","$script:azureblob/az-3.bak") | Restore-DbaDatabase -SqlInstance $script:instance2 -DatabaseName azstripetest  -WithReplace -ReplaceDbNameInFile
                 $results.RestoreComplete | Should Be $True
             }
         }
@@ -848,8 +856,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     if ($env:azurelegacypasswd) {
         Context "Restores from Azure using Access Key" {
             BeforeAll {
+                Get-DbaDatabase -SqlInstance $script:instance2 -Database "dbatoolsci_azure" | Remove-DbaDatabase -Confirm:$false
                 $server = Connect-DbaInstance -SqlInstance $script:instance2
-                $sql = "CREATE CREDENTIAL [dbatools_ci] WITH IDENTITY = N'dbatools', SECRET = N'$env:azurelegacypasswd'"
+                if (Get-DbaCredential -SqlInstance $script:instance2 -name dbatools_ci) {
+                    $sql = "DROP CREDENTIAL dbatools_ci"
+                    $server.Query($sql)
+                }
+                $sql = "CREATE CREDENTIAL [dbatools_ci] WITH IDENTITY = N'$script:azureblobaccount', SECRET = N'$env:azurelegacypasswd'"
                 $server.Query($sql)
                 $server.Query("CREATE DATABASE dbatoolsci_azure")
             }
@@ -865,6 +878,4 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             }
         }
     }
-
-
 }

--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -15,6 +15,8 @@ else {
     $script:appveyorlabrepo = "C:\github\appveyor-lab"
     $instances = @($script:instance1, $script:instance2)
     $ssisserver = "localhost\sql2016"
+    $script:azureblob = "https://dbatools.blob.core.windows.net/sql"
+    $script:azureblobaccount = "dbatools"
 }
 
 $PSDefaultParameterValues['*:WarningAction' ] = 'SilentlyContinue'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4322)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing up the issues with Azure Credential handling from #4322 
### Approach
Test-DbaBackupInformation now doesn't try to path check 'files' begining http

Backup-DbaDatabase now checks for a SAS credential before complaining if a URL is passed in. Allows all allowed backup features when using SAS for backup to URL

Restore-DbaDatabase uses the same SAS/Key testing as well.

Got the Azure backup integration tests working

Added test for striping with restore from URL with SAS

Paramterised the tests for Azure Restore/Backup so people can modify a local constants.ps1 if they want to check locally than blocking appveyor time.
