### PR TITLE
Add surrounding parentheses

### DIFF
--- a/functions/Measure-DbaDiskSpaceRequirement.ps1
+++ b/functions/Measure-DbaDiskSpaceRequirement.ps1
@@ -217,7 +217,7 @@ function Measure-DbaDiskSpaceRequirement {
 
         foreach ($sourceFile in $sourceFiles) {
             foreach ($destFile in $destFiles) {
-                if ($found = ($sourceFile.Name -eq $destFile.Name)) {
+                if (($found = ($sourceFile.Name -eq $destFile.Name))) {
                     # Files found on both sides
                     [PSCustomObject]@{
                         SourceComputerName      = $sourceServer.ComputerName

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -314,7 +314,7 @@ function New-DbaLogin {
                 }
 
                 #verify if login exists on the server
-                if ($existingLogin = $server.Logins[$loginName]) {
+                if (($existingLogin = $server.Logins[$loginName])) {
                     if ($force) {
                         if ($Pscmdlet.ShouldProcess($existingLogin, "Dropping existing login $loginName on $instance because -Force was used")) {
                             try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4379 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix the issue raised by PSScriptAnalyzer.

### Approach
<!-- How does this change solve that purpose -->
After reading the rule documentation and reviewing the code, the code was correctly executing, but the PSSA rule was raised because the assignment was not surrounded in parentheses. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

` Invoke-ScriptAnalyzer -Path .\functions\ -IncludeRule PSPossibleIncorrectUsageOfAssignmentOperator `