### PR TITLE
Move formatting of dates and times to the begin block Fixes #4386

### DIFF
--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -398,6 +398,20 @@ function New-DbaAgentSchedule {
             Stop-Function -Message "End time $EndTime needs to match between '000000' and '235959'" -Target $SqlInstance
             return
         }
+
+        #Format dates and times
+        if ($StartDate) {
+            $StartDate = $StartDate.Insert(6, '-').Insert(4, '-')
+        }
+        if ($EndDate) {
+            $EndDate = $EndDate.Insert(6, '-').Insert(4, '-')
+        }
+        if ($StartTime) {
+            $StartTime = $StartTime.Insert(4, ':').Insert(2, ':')
+        }
+        if ($EndTime) {
+            $EndTime = $EndTime.Insert(4, ':').Insert(2, ':')
+        }
     }
 
     process {
@@ -485,25 +499,21 @@ function New-DbaAgentSchedule {
                         }
 
                         if ($StartDate) {
-                            $StartDate = $StartDate.Insert(6, '-').Insert(4, '-')
                             Write-Message -Message "Setting job schedule start date to $StartDate" -Level Verbose
                             $JobSchedule.ActiveStartDate = $StartDate
                         }
 
                         if ($EndDate) {
-                            $EndDate = $EndDate.Insert(6, '-').Insert(4, '-')
                             Write-Message -Message "Setting job schedule end date to $EndDate" -Level Verbose
                             $JobSchedule.ActiveEndDate = $EndDate
                         }
 
                         if ($StartTime) {
-                            $StartTime = $StartTime.Insert(4, ':').Insert(2, ':')
                             Write-Message -Message "Setting job schedule start time to $StartTime" -Level Verbose
                             $JobSchedule.ActiveStartTimeOfDay = $StartTime
                         }
 
                         if ($EndTime) {
-                            $EndTime = $EndTime.Insert(4, ':').Insert(2, ':')
                             Write-Message -Message "Setting job schedule end time to $EndTime" -Level Verbose
                             $JobSchedule.ActiveEndTimeOfDay = $EndTime
                         }
@@ -572,25 +582,21 @@ function New-DbaAgentSchedule {
                 }
 
                 if ($StartDate) {
-                    $StartDate = $StartDate.Insert(6, '-').Insert(4, '-')
                     Write-Message -Message "Setting job schedule start date to $StartDate" -Level Verbose
                     $JobSchedule.ActiveStartDate = $StartDate
                 }
 
                 if ($EndDate) {
-                    $EndDate = $EndDate.Insert(6, '-').Insert(4, '-')
                     Write-Message -Message "Setting job schedule end date to $EndDate" -Level Verbose
                     $JobSchedule.ActiveEndDate = $EndDate
                 }
 
                 if ($StartTime) {
-                    $StartTime = $StartTime.Insert(4, ':').Insert(2, ':')
                     Write-Message -Message "Setting job schedule start time to $StartTime" -Level Verbose
                     $JobSchedule.ActiveStartTimeOfDay = $StartTime
                 }
 
                 if ($EndTime) {
-                    $EndTime = $EndTime.Insert(4, ':').Insert(2, ':')
                     Write-Message -Message "Setting job schedule end time to $EndTime" -Level Verbose
                     $JobSchedule.ActiveEndTimeOfDay = $EndTime
                 }

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -315,6 +315,20 @@ function Set-DbaAgentSchedule {
             Stop-Function -Message "End time $EndTime needs to match between '000000' and '235959'" -Target $SqlInstance
             return
         }
+
+        #Format dates and times
+        if ($StartDate) {
+            $StartDate = $StartDate.Insert(6, '-').Insert(4, '-')
+        }
+        if ($EndDate) {
+            $EndDate = $EndDate.Insert(6, '-').Insert(4, '-')
+        }
+        if ($StartTime) {
+            $StartTime = $StartTime.Insert(4, ':').Insert(2, ':')
+        }
+        if ($EndTime) {
+            $EndTime = $EndTime.Insert(4, ':').Insert(2, ':')
+        }
     }
 
     process {
@@ -392,25 +406,21 @@ function Set-DbaAgentSchedule {
                         }
 
                         if ($StartDate) {
-                            $StartDate = $StartDate.Insert(6, '-').Insert(4, '-')
                             Write-Message -Message "Setting job schedule start date to $StartDate for schedule $ScheduleName" -Level Verbose
                             $JobSchedule.StartDate = $StartDate
                         }
 
                         if ($EndDate) {
-                            $EndDate = $EndDate.Insert(6, '-').Insert(4, '-')
                             Write-Message -Message "Setting job schedule end date to $EndDate for schedule $ScheduleName" -Level Verbose
                             $JobSchedule.EndDate = $EndDate
                         }
 
                         if ($StartTime) {
-                            $StartTime = $StartTime.Insert(4, ':').Insert(2, ':')
                             Write-Message -Message "Setting job schedule start time to $StartTime for schedule $ScheduleName" -Level Verbose
                             $JobSchedule.ActiveStartTimeOfDay = $StartTime
                         }
 
                         if ($EndTime) {
-                            $EndTime = $EndTime.Insert(4, ':').Insert(2, ':')
                             Write-Message -Message "Setting job schedule end time to $EndTime for schedule $ScheduleName" -Level Verbose
                             $JobSchedule.ActiveStartTimeOfDay = $EndTime
                         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4386)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When looping through servers or jobs the dashes and colons are inserted into dates and times multiple times resulting in bad formats

### Approach
The formatting code has been moved to the begin block

### Commands to test
sql1, sql2, sql3 | New-DbaAgentSchedule -Schedule daily -FrequencyType Daily -FrequencyInterval Everyday -StartTime '020000' -Force

sql1, sql2, sql3 | Set-DbaAgentSchedule -Job Job1 -ScheduleName 'daily' -FrequencyType Daily -FrequencyInterval Everyday -StartTime '020000'
