### PR TITLE
Fix PSUsePSCredentialType

### DIFF
--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -536,7 +536,7 @@ function Find-DbaInstance {
             [CmdletBinding()]
             param (
                 [string]$DomainController,
-                [object]$Credential,
+                [Pscredential]$Credential,
                 [string]$ComputerName = "*",
                 [switch]$GetSPN
             )

--- a/functions/Get-DbaWindowsLog.ps1
+++ b/functions/Get-DbaWindowsLog.ps1
@@ -253,7 +253,7 @@ function Get-DbaWindowsLog {
                 [DateTime]
                 $End,
 
-                [object]
+                [PSCredential]
                 $Credential,
 
                 [int]

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -15,7 +15,7 @@ function New-DbaAgentProxy {
     .PARAMETER Name
         The name of the proxy or proxies you want to create
 
-    .PARAMETER Credential
+    .PARAMETER ProxyCredential
         The associated SQL Server Credential. The credential must be created prior to creating the Proxy.
 
     .PARAMETER SubSystem
@@ -76,13 +76,13 @@ function New-DbaAgentProxy {
         https://dbatools.io/New-DbaAgentProxy
 
     .EXAMPLE
-        PS C:\> New-DbaAgentProxy -SqlInstance sql2016 -Name STIG -Credential 'PowerShell Proxy'
+        PS C:\> New-DbaAgentProxy -SqlInstance sql2016 -Name STIG -ProxyCredential 'PowerShell Proxy'
 
         Creates an Agent Proxy on sql2016 with the name STIG with the 'PowerShell Proxy' credential.
         The proxy is automatically added to the CmdExec subsystem.
 
     .EXAMPLE
-        PS C:\> New-DbaAgentProxy -SqlInstance localhost\sql2016 -Name STIG -Credential 'PowerShell Proxy' -Description "Used for auditing purposes" -Login ad\sqlstig -SubSystem CmdExec, PowerShell -ServerRole securtyadmin -MsdbRole ServerGroupAdministratorRole
+        PS C:\> New-DbaAgentProxy -SqlInstance localhost\sql2016 -Name STIG -ProxyCredential 'PowerShell Proxy' -Description "Used for auditing purposes" -Login ad\sqlstig -SubSystem CmdExec, PowerShell -ServerRole securtyadmin -MsdbRole ServerGroupAdministratorRole
 
         Creates an Agent Proxy on sql2016 with the name STIG with the 'PowerShell Proxy' credential and the following principals:
 
@@ -103,7 +103,7 @@ function New-DbaAgentProxy {
         [parameter(Mandatory)]
         [string[]]$Name,
         [parameter(Mandatory)]
-        [string[]]$Credential,
+        [string[]]$ProxyCredential,
         [ValidateSet("ActiveScripting", "AnalysisCommand", "AnalysisQuery", "CmdExec", "Distribution", "LogReader", "Merge", "PowerShell", "QueueReader", "Snapshot", "Ssis", "TransactSql")]
         [string[]]$SubSystem = "CmdExec",
         [string]$Description,
@@ -144,19 +144,19 @@ function New-DbaAgentProxy {
                     }
                 }
 
-                if (-not $server.Credentials[$Credential]) {
-                    Write-Message -Level Warning -Message "Credential '$Credential' does not exist on $instance"
+                if (-not $server.Credentials[$ProxyCredential]) {
+                    Write-Message -Level Warning -Message "Credential '$ProxyCredential' does not exist on $instance"
                     continue
                 }
 
-                if ($Pscmdlet.ShouldProcess($instance, "Adding $proxyname with the $Credential credential")) {
+                if ($Pscmdlet.ShouldProcess($instance, "Adding $proxyname with the $ProxyCredential credential")) {
                     # the new-object is stubborn and $true/$false has to be forced in
                     switch (Test-Bound $disabled) {
                         $false {
-                            $proxy = New-Object Microsoft.SqlServer.Management.Smo.Agent.ProxyAccount -ArgumentList $jobServer, $ProxyName, $Credential, $true, $Description
+                            $proxy = New-Object Microsoft.SqlServer.Management.Smo.Agent.ProxyAccount -ArgumentList $jobServer, $ProxyName, $ProxyCredential, $true, $Description
                         }
                         $true {
-                            $proxy = New-Object Microsoft.SqlServer.Management.Smo.Agent.ProxyAccount -ArgumentList $jobServer, $ProxyName, $Credential, $false, $Description
+                            $proxy = New-Object Microsoft.SqlServer.Management.Smo.Agent.ProxyAccount -ArgumentList $jobServer, $ProxyName, $ProxyCredential, $false, $Description
                         }
                     }
 

--- a/tests/Get-DbaWindowsLog.Tests.ps1
+++ b/tests/Get-DbaWindowsLog.Tests.ps1
@@ -16,9 +16,13 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
 
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command returns proper info" {
+        $results = Get-DbaWindowsLog -SqlInstance $script:instance2
+
+        It "returns results" {
+            $results.Count -gt 0 | Should Be $true
+        }
+    }
+}

--- a/tests/New-DbaAgentProxy.Tests.ps1
+++ b/tests/New-DbaAgentProxy.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         $paramCount = 12
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\New-DbaAgentProxy).Parameters.Keys
-        $knownParameters = 'SqlInstance','SqlCredential','Name','Credential','SubSystem','Description','Login','ServerRole','MsdbRole','Disabled','Force','EnableException'
+        $knownParameters = 'SqlInstance','SqlCredential','Name','ProxyCredential','SubSystem','Description','Login','ServerRole','MsdbRole','Disabled','Force','EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }
@@ -20,7 +20,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 # This is quite light of a test but setting up a proxy requires a lot of setup and I don't have time today
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "does not try to add without" {
-        $results = New-DbaAgentProxy -SqlInstance $script:instance2 -Name STIG -Credential 'dbatoolsci_proxytest' -WarningAction SilentlyContinue -WarningVariable warn
+        $results = New-DbaAgentProxy -SqlInstance $script:instance2 -Name STIG -ProxyCredential 'dbatoolsci_proxytest' -WarningAction SilentlyContinue -WarningVariable warn
         It "does not try to add the proxy without a valid credential" {
             $warn -match 'does not exist' | Should Be $true
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4410)
 - [ ] New feature (non-breaking change, adds functionality)
 - [x] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Replace `[object]` for `[PSCredential]` in a few cmdlets
Change the name of the parameter in `New-DbaAgentProxy` to `-ProxyCredential`
Add a Integration Test for `Get-DbaWindowsLog`

### Approach
<!-- How does this change solve that purpose -->
Placed the parameter type `[PSCredential]` where it seemed to fit. 
On `New-DbaAgentProxy` it seemed that a more descriptive parameter was needed. I did not put a alias for this parameter, but it could be added. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
` Invoke-ScriptAnalyzer .\functions\ -IncludeRule PSUsePSCredentialType`
`.\manual.pester.ps1 -Path .\New-DbaAgentProxy.Tests.ps1 -TestIntegration -ScriptAnalyzer`
`.\manual.pester.ps1 -Path .\Get-DbaWindowsLog.Tests.ps1 -TestIntegration -ScriptAnalyzer`
`.\manual.pester.ps1 -Path .\Find-DbaInstance.Tests.ps1 -TestIntegration -ScriptAnalyzer`
