### PR TITLE
Connect-*Instance, fix errors with Windows logins

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -320,7 +320,7 @@ function Connect-DbaInstance {
                         $server.ConnectionContext.Connect()
                     } elseif ($authtype -eq "Windows Authentication with Credential") {
                         # Make it connect in a natural way, hard to explain.
-                        $null = $server.IsMemberOfWsfcCluster
+                        $null = $server.Information.Version
                         if ($server.ConnectionContext.IsOpen -eq $false) {
                             $server.ConnectionContext.Connect()
                         }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -117,7 +117,7 @@ function Connect-SqlInstance {
                 $server.ConnectionContext.Connect()
             } elseif ($authtypeSMO -eq "Windows Authentication with Credential") {
                 # Make it connect in a natural way, hard to explain.
-                $null = $server.IsMemberOfWsfcCluster
+                $null = $server.Information.Version
                 if ($server.ConnectionContext.IsOpen -eq $false) {
                     $server.ConnectionContext.Connect()
                 }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -186,7 +186,7 @@ function Connect-SqlInstance {
             $server.ConnectionContext.Connect()
         } elseif ($authtype -eq "Windows Authentication with Credential") {
             # Make it connect in a natural way, hard to explain.
-            $null = $server.IsMemberOfWsfcCluster
+            $null = $server.Information.Version
             if ($server.ConnectionContext.IsOpen -eq $false) {
                 $server.ConnectionContext.Connect()
             }

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -111,12 +111,16 @@ function Connect-SqlInstance {
     #region Input Object was a server object
     if ($ConvertedSqlInstance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
         $server = $ConvertedSqlInstance.InputObject
+        $authtypeSMO = $SqlCredential.UserName -like '*\*'
         if ($server.ConnectionContext.IsOpen -eq $false) {
             if ($NonPooled) {
                 $server.ConnectionContext.Connect()
-            } elseif ($authtype -eq "Windows Authentication with Credential") {
+            } elseif ($authtypeSMO -eq "Windows Authentication with Credential") {
                 # Make it connect in a natural way, hard to explain.
                 $null = $server.IsMemberOfWsfcCluster
+                if ($server.ConnectionContext.IsOpen -eq $false) {
+                    $server.ConnectionContext.Connect()
+                }
             } else {
                 $server.ConnectionContext.SqlConnectionObject.Open()
             }
@@ -158,8 +162,8 @@ function Connect-SqlInstance {
     try {
         $server.ConnectionContext.ConnectTimeout = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout
 
-        if ($null -ne $SqlCredential.Username) {
-            $username = ($SqlCredential.Username).TrimStart("\")
+        if ($null -ne $SqlCredential.UserName) {
+            $username = ($SqlCredential.UserName).TrimStart("\")
 
             if ($username -like "*\*") {
                 $username = $username.Split("\")[1]
@@ -183,6 +187,9 @@ function Connect-SqlInstance {
         } elseif ($authtype -eq "Windows Authentication with Credential") {
             # Make it connect in a natural way, hard to explain.
             $null = $server.IsMemberOfWsfcCluster
+            if ($server.ConnectionContext.IsOpen -eq $false) {
+                $server.ConnectionContext.Connect()
+            }
         } else {
             $server.ConnectionContext.SqlConnectionObject.Open()
         }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Discussed at lenght in dbatools-dev . 
All starts when a patient dbatools user reports some weird errors when running backup-dbadatabase in a powershell session started with an unprivileged user but passing the correct credentials.
Turns out that Connect-DbaInstance and Connect-SqlInstance behaved differently. While Connect-DbaInstance at least bombed out when trying to setinitfields, Connect-SqlInstance was quiet.
That, in conjunction with dbatools general - and good - reuse of the $server variable, make the weird error pop up: lower-level functions (such as Test-DbaPath or Get-DbaBackupInformation, used within backup-dbadatabase) were reporting a different user than the one specified via -SqlCredential.

Long story short, this fixes it, but I really don't know why `$null = $server.IsMemberOfWsfcCluster` was there in the first place. What I'm afraid of (and I need the review for, mostly) is that this new piece of code will affect how the connectionpool is handled. 

Sorry I can't be more precise, but the issue is reallly subtle. To replicate, start a powershell session with an unprivileged user (such as a windows user that can't connect to the target instance) and try to issue a Backup-DbaDatabase -SqlInstance foo  ..... -SqlCredential $validcredentials , where $validcredentials are for a WINDOWS user.

Before this PR, windows users and sql users differed in behaviour. Now they match but.... did I screw something else in the process ?
