### PR TITLE
Invoke-DbatoolsFormatter, aesthetic fixes

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -83,7 +83,7 @@ function Invoke-DbatoolsFormatter {
             foreach ($line in $content.Split("`n")) {
                 $realContent += $line.TrimEnd()
             }
-            [System.IO.File]::WriteAllLines($realPath, $realContent, $Utf8NoBomEncoding)
+            [System.IO.File]::WriteAllText($realPath, ($realContent -Join "`r`n"), $Utf8NoBomEncoding)
         }
     }
 }

--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -42,6 +42,9 @@ function Invoke-DbatoolsFormatter {
         if (!($HasInvokeFormatter)) {
             Stop-Function -Message "You need a recent version of PSScriptAnalyzer installed"
         }
+        $CBHRex = [regex]'(?smi)\s+<#[^#]*#>'
+        $CBHStartRex = [regex]'(?<spaces>[ ]+)<#'
+        $CBHEndRex = [regex]'(?<spaces>[ ]?)#>'
     }
     process {
         if (Test-FunctionInterrupt) { return }
@@ -51,7 +54,7 @@ function Invoke-DbatoolsFormatter {
             } catch {
                 Stop-Function -Message "Cannot find or resolve $p" -Continue
             }
-            
+
             $content = Get-Content -Path $realPath -Raw -Encoding UTF8
             #strip ending empty lines
             $content = $content -replace "(?s)`r`n\s*$"
@@ -60,10 +63,24 @@ function Invoke-DbatoolsFormatter {
             } catch {
                 Write-Message -Level Warning "Unable to format $p"
             }
+            #match the ending indentation of CBH with the starting one, see #4373
+            $CBH = $CBHRex.Match($content).Value
+            if ($CBH) {
+                #get starting spaces
+                $startSpaces = $CBHStartRex.Match($CBH).Groups['spaces']
+                if ($startSpaces) {
+                    #get end
+                    $newCBH = $CBHEndRex.Replace($CBH, "$startSpaces#>")
+                    if ($newCBH) {
+                        #replace the CBH
+                        $content = $CBHRex.Replace($content, $newCBH, 1)
+                    }
+                }
+            }
             $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
             $realContent = @()
             #trim whitespace lines
-            foreach ($line in $content) {
+            foreach ($line in $content.Split("`n")) {
                 $realContent += $line.TrimEnd()
             }
             [System.IO.File]::WriteAllLines($realPath, $realContent, $Utf8NoBomEncoding)

--- a/tests/Invoke-DbatoolsFormatter.Tests.ps1
+++ b/tests/Invoke-DbatoolsFormatter.Tests.ps1
@@ -43,7 +43,7 @@ function Get-DbaStub {
 
         .DESCRIPTION
             Using
-#>
+    #>
     process {
         Write-Message -Level Verbose "stub"
     }

--- a/tests/Invoke-DbatoolsFormatter.Tests.ps1
+++ b/tests/Invoke-DbatoolsFormatter.Tests.ps1
@@ -48,14 +48,15 @@ function Get-DbaStub {
         Write-Message -Level Verbose "stub"
     }
 }
-
 '@
 
     Context "formatting actually works" {
         $temppath = Join-Path $TestDrive 'somefile.ps1'
-        Set-Content -Value $content -Path $temppath
+        ## Set-Content adds a newline...WriteAllText() doesn't
+        #Set-Content -Value $content -Path $temppath
+        [System.IO.File]::WriteAllText($temppath, $content)
         Invoke-DbatoolsFormatter -Path $temppath
-        $newcontent = Get-Content -Path $temppath | Out-String
+        $newcontent = [System.IO.File]::ReadAllText($temppath)
         <#
         write-host -fore cyan "w $($wantedContent | convertto-json)"
         write-host -fore cyan "n $($newcontent | convertto-json)"


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4409 and fixes #4373)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fix the reported bugs

### Approach
Another bit of regexes involved

@potatoqualitee : before doing a mass rewrite please check that the output is consistent with what you want. In any case these aesthetics won't - obviously - checked in CI. One thing is consistency, the other is fixation ^_^