### PR TITLE
Cope with recovery forks in backup history 

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -149,7 +149,7 @@ function Get-DbaBackupHistory {
         [Parameter(ParameterSetName = "NoLast")]
         [switch]$Force,
         [DateTime]$Since = (Get-Date '01/01/1970'),
-        [ValidateScript({($_ -match '^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$') -or ('' -eq $_)})]
+        [ValidateScript( {($_ -match '^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$') -or ('' -eq $_)})]
         [string]$RecoveryFork,
         [Parameter(ParameterSetName = "Last")]
         [switch]$Last,
@@ -256,7 +256,7 @@ function Get-DbaBackupHistory {
                         $recoveryForkSqlFilter = "AND backupset.last_recovery_fork_guid ='$RecoveryFork'"
                     }
                     if ((Get-PsCallStack)[1].Command -notlike 'Get-DbaBackupHistory*') {
-                            $forkCheckSql = "
+                        $forkCheckSql = "
                                 SELECT
                                     database_name,
                                     MIN(database_backup_lsn) as 'FirstLsn',
@@ -272,61 +272,61 @@ function Get-DbaBackupHistory {
                                 GROUP by database_name, last_recovery_fork_guid
                                 "
 
-                            $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
-                            if ($results.count -gt 1){
-                                Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
-                                foreach ($result in $results){
-                                    Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
-                                }
+                        $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
+                        if ($results.count -gt 1) {
+                            Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
+                            foreach ($result in $results) {
+                                Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
+                            }
 
-                            }
                         }
-                        #Get the full and build upwards
-                        $allBackups = @()
-                        $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
-                        $diffDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
-                        if ($diffDb.LastLsn -gt $fullDb.LastLsn -and $diffDb.DatabaseBackupLSN -eq $fullDb.CheckPointLSN ) {
-                            Write-Message -Level Verbose -Message "Valid Differential backup "
-                            $allBackups += $diffDb
-                            $tlogStartDsn = ($diffDb.FirstLsn -as [bigint])
-                        } else {
-                            Write-Message -Level Verbose -Message "No Diff found"
-                            try {
-                                [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
-                            } catch {
-                                continue
-                            }
-                        }
-                        $allBackups += Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork | Where-Object {
-                            $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$fullDb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid
-                        }
-                        #This line does the output for -Last!!!
-                        $allBackups |  Sort-Object -Property LastLsn, Type
                     }
-                    continue
+                    #Get the full and build upwards
+                    $allBackups = @()
+                    $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
+                    $diffDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
+                    if ($diffDb.LastLsn -gt $fullDb.LastLsn -and $diffDb.DatabaseBackupLSN -eq $fullDb.CheckPointLSN ) {
+                        Write-Message -Level Verbose -Message "Valid Differential backup "
+                        $allBackups += $diffDb
+                        $tlogStartDsn = ($diffDb.FirstLsn -as [bigint])
+                    } else {
+                        Write-Message -Level Verbose -Message "No Diff found"
+                        try {
+                            [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
+                        } catch {
+                            continue
+                        }
+                    }
+                    $allBackups += Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork | Where-Object {
+                        $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$fullDb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid
+                    }
+                    #This line does the output for -Last!!!
+                    $allBackups |  Sort-Object -Property LastLsn, Type
                 }
+                continue
+            }
 
-                if ($LastFull -or $LastDiff -or $LastLog) {
-                    if ($LastFull) {
-                        $first = 'D'; $second = 'P'
+            if ($LastFull -or $LastDiff -or $LastLog) {
+                if ($LastFull) {
+                    $first = 'D'; $second = 'P'
+                }
+                if ($LastDiff) {
+                    $first = 'I'; $second = 'Q'
+                }
+                if ($LastLog) {
+                    $first = 'L'; $second = 'L'
+                }
+                $databases = $databases | Select-Object -Unique -Property Name
+                $sql = ""
+                foreach ($db in $databases) {
+                    Write-Message -Level Verbose -Message "Processing $($db.name)" -Target $db
+                    if ($since) {
+                        $sinceSqlFilter = "AND backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
                     }
-                    if ($LastDiff) {
-                        $first = 'I'; $second = 'Q'
+                    if ($RecoveryFork) {
+                        $recoveryForkSqlFilter = "AND backupset.last_recovery_fork_guid ='$RecoveryFork'"
                     }
-                    if ($LastLog) {
-                        $first = 'L'; $second = 'L'
-                    }
-                    $databases = $databases | Select-Object -Unique -Property Name
-                    $sql = ""
-                    foreach ($db in $databases) {
-                        Write-Message -Level Verbose -Message "Processing $($db.name)" -Target $db
-                        if ($since) {
-                            $sinceSqlFilter = "AND backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
-                        }
-                        if ($RecoveryFork) {
-                            $recoveryForkSqlFilter = "AND backupset.last_recovery_fork_guid ='$RecoveryFork'"
-                        }
-                        if ((Get-PsCallStack)[1].Command -notlike 'Get-DbaBackupHistory*') {
+                    if ((Get-PsCallStack)[1].Command -notlike 'Get-DbaBackupHistory*') {
                         $forkCheckSql = "
                             SELECT
                                 database_name,
@@ -344,9 +344,9 @@ function Get-DbaBackupHistory {
                         "
 
                         $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
-                        if ($results.count -gt 1){
+                        if ($results.count -gt 1) {
                             Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
-                            foreach ($result in $results){
+                            foreach ($result in $results) {
                                 Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
                             }
 
@@ -662,4 +662,3 @@ function Get-DbaBackupHistory {
         }
     }
 }
-

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -133,6 +133,11 @@ function Get-DbaBackupHistory {
 
         Returns detailed backup history for all databases on SqlInstance2014a and sql2016.
 
+    .EXAMPLE
+        PS C:\> Get-DbaBackupHistory -SqlInstance sql2016 -Database db1 -RecoveryFork 38e5e84a-3557-4643-a5d5-eed607bef9c6 -Last
+
+        If db1 has multiple recovery forks, specifying the RecoveryFork GUID will restrict the search to that fork.
+
 #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -145,8 +145,7 @@ function Get-DbaBackupHistory {
         [switch]$IncludeCopyOnly,
         [Parameter(ParameterSetName = "NoLast")]
         [switch]$Force,
-        [Parameter(ParameterSetName = "NoLast")]
-        [DateTime]$Since,
+        [DateTime]$Since = (Get-Date '01/01/1970'),
         [Parameter(ParameterSetName = "Last")]
         [switch]$Last,
         [Parameter(ParameterSetName = "Last")]
@@ -273,7 +272,7 @@ function Get-DbaBackupHistory {
                     }
                     #Get the full and build upwards
                     $allBackups = @()
-                    $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since $since
+                    $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since
                     $diffDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly
                     if ($diffDb.LastLsn -gt $fullDb.LastLsn -and $diffDb.DatabaseBackupLSN -eq $fullDb.CheckPointLSN ) {
                         Write-Message -Level Verbose -Message "Valid Differential backup "

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -245,6 +245,9 @@ function Get-DbaBackupHistory {
 
             if ($last) {
                 foreach ($db in $databases) {
+                    if ($since) {
+                        $sinceSqlFilter = "AND backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
+                    }
                     $forkCheckSql = "
                         SELECT
                             database_name,
@@ -256,6 +259,7 @@ function Get-DbaBackupHistory {
                             count(1) as 'backupcount'
                         FROM msdb.dbo.backupset
                         WHERE database_name='$($db.name)'
+                        $sinceSqlFilter
                         GROUP by database_name, last_recovery_fork_guid
                         "
 
@@ -269,7 +273,7 @@ function Get-DbaBackupHistory {
                     }
                     #Get the full and build upwards
                     $allBackups = @()
-                    $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly
+                    $allBackups += $fullDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since $since
                     $diffDb = Get-DbaBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly
                     if ($diffDb.LastLsn -gt $fullDb.LastLsn -and $diffDb.DatabaseBackupLSN -eq $fullDb.CheckPointLSN ) {
                         Write-Message -Level Verbose -Message "Valid Differential backup "
@@ -306,34 +310,41 @@ function Get-DbaBackupHistory {
                 $sql = ""
                 foreach ($db in $databases) {
                     Write-Message -Level Verbose -Message "Processing $($db.name)" -Target $db
+                    if ($since) {
+                        $sinceSqlFilter = "AND backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
+                    }
                     $forkCheckSql = "
-                    SELECT
-                        database_name,
-                        MIN(database_backup_lsn) as 'FirstLsn',
-                        MAX(database_backup_lsn) as 'FinalLsn',
-                        MIN(backup_start_date) as 'MinDate',
-                        MAX(backup_finish_date) as 'MaxDate',
-                        last_recovery_fork_guid 'RecFork',
-                        count(1) as 'backupcount'
-                    FROM msdb.dbo.backupset
-                    WHERE database_name='$($db.name)'
-                    GROUP by database_name, last_recovery_fork_guid
+                        SELECT
+                            database_name,
+                            MIN(database_backup_lsn) as 'FirstLsn',
+                            MAX(database_backup_lsn) as 'FinalLsn',
+                            MIN(backup_start_date) as 'MinDate',
+                            MAX(backup_finish_date) as 'MaxDate',
+                            last_recovery_fork_guid 'RecFork',
+                            count(1) as 'backupcount'
+                        FROM msdb.dbo.backupset
+                        WHERE database_name='$($db.name)'
+                        $sinceSqlFilter
+                        GROUP by database_name, last_recovery_fork_guid
                     "
 
-                $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
-                if ($results.count -gt 1){
-                    Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
-                    foreach ($result in $results){
-                        Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
-                    }
+                    $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
+                    if ($results.count -gt 1){
+                        Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
+                        foreach ($result in $results){
+                            Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
+                        }
 
-                }
+                    }
                     $whereCopyOnly = $null
                     if ($true -ne $IncludeCopyOnly) {
                         $whereCopyOnly = " AND is_copy_only='0' "
                     }
                     if ($deviceTypeFilter) {
                         $devTypeFilterWhere = "AND mediafamily.device_type $deviceTypeFilterRight"
+                    }
+                    if ($since) {
+                        $sinceSqlFilter = "AND backupset.backup_finish_date >= '$($Since.ToString("yyyy-MM-ddTHH:mm:ss"))'"
                     }
                     # recap for future editors (as this has been discussed over and over):
                     #   - original editors (from hereon referred as "we") rank over backupset.last_lsn desc, backupset.backup_finish_date desc for a good reason: DST
@@ -443,6 +454,7 @@ function Get-DbaBackupHistory {
                                 WHERE backupset.database_name = '$($db.Name)' $whereCopyOnly
                                 AND (type = '$first' OR type = '$second')
                                 $devTypeFilterWhere
+                                $sinceSqlFilter
                                 ) AS a
                                 WHERE a.BackupSetRank = 1
                                 ORDER BY a.Type;

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -34,7 +34,7 @@ function Get-DbaBackupHistory {
     .PARAMETER Since
         Specifies a DateTime object to use as the starting point for the search for backups.
 
-    .PARAMETER RecoveryForkGUID
+    .PARAMETER RecoveryFork
         Specifies the Recovery Fork you want backup history for
 
     .PARAMETER Last

--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 16
+        $paramCount = 17
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaBackupHistory).Parameters.Keys
-        $knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','IncludeCopyOnly','Force','Since','Last','LastFull','LastDiff','LastLog','DeviceType','Raw','LastLsn','Type','EnableException'
+        $knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','IncludeCopyOnly','Force','Since','Last','LastFull','LastDiff','LastLog','DeviceType','Raw','LastLsn','Type','EnableException','RecoveryFork'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3610)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Finally broke an msdb enough to have a test case :)

Functionality has not changed to 99% of users

If someone runs Get-DbaBackupHistory for a database with multiple last_recovery_fork_guids they get the results, but also a warning that they have multiple forks:
```
C:\github\dbatools [historyforklsn ≡]> $a = Get-DbaBackupHistory -SqlInstance localhost\sql2016 -Database stripetest -last
WARNING: [12:22:18][Get-DbaBackupHistory] Found backups from multiple recovery forks for stripetest on localhost\sql2016, this may affect your results
WARNING: [12:22:18][Get-DbaBackupHistory] Between 11/02/2018 14:58:23/20000000018800043 and 11/02/2018 14:58:23/20000000018800043  was on Recovery Fork GUID
8b44fb49-7160-46e7-a8d2-0d2e006d6c5a (1 backups)
WARNING: [12:22:18][Get-DbaBackupHistory] Between 11/06/2018 11:43:43/20000000018800043 and 11/06/2018 12:06:20/34000000008200037  was on Recovery Fork GUID
fdc22614-704d-4661-8163-4581cc03b10c (2 backups)
WARNING: [12:22:18][Get-DbaBackupHistory] Between 11/06/2018 08:59:44/20000000018800043 and 11/06/2018 09:02:13/34000000010500037  was on Recovery Fork GUID
38e5e84a-3557-4643-a5d5-eed607bef9c6 (2 backups)
```

To help people out who are affected by this I've added 2 options:

Since parameter now works with Last, which it didn't before

RecoveryFork parameter to filter down to a specific recovery fork

