### PR TITLE
add function Get-ErrorMessage to get inner exception of failed deploy…

### DIFF
--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -302,7 +302,7 @@ function Publish-DbaDacPackage {
                         Write-Message -Level Verbose -Message "Executing Bacpac import."
                         $dacServices.ImportBacpac($bacPackage, $dbname, $options, $null)
                     }
-                } catch {
+                } catch [Microsoft.SqlServer.Dac.DacServicesException] {
                     $message = Get-ErrorMessage -Record $_ 
                     Stop-Function -Message "Deployment failed - $($message)" -ErrorRecord $_ -Continue
                 } finally {

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -302,8 +302,9 @@ function Publish-DbaDacPackage {
                         Write-Message -Level Verbose -Message "Executing Bacpac import."
                         $dacServices.ImportBacpac($bacPackage, $dbname, $options, $null)
                     }
-                } catch [Microsoft.SqlServer.Dac.DacServicesException] {
-                    Stop-Function -Message "Deployment failed" -ErrorRecord $_ -Continue
+                } catch {
+                    $message = Get-ErrorMessage -Record $_ 
+                    Stop-Function -Message "Deployment failed - $($message)" -ErrorRecord $_ -Continue
                 } finally {
                     Unregister-Event -SourceIdentifier "msg"
                     if ($options.GenerateDeploymentReport) {


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Get inner exceptions when dacpac fails to deploy
adding Get-ErrorMessage that @potatoqualitee recommended to use  (see #4396 )
### Commands to test
Publish-DbaDacpackage 

### Learning
Catching exceptions is hard!
I really need to add negative tests for this function.