### PR TITLE
Fixes Pester Tests for SqlWatch

### DIFF
--- a/tests/Install-DbaSqlWatch.Tests.ps1
+++ b/tests/Install-DbaSqlWatch.Tests.ps1
@@ -20,10 +20,13 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Testing SqlWatch installer" {
         BeforeAll {
-            $database = "dbatoolsci_sqlwatch"
+            $database = "dbatoolsci_sqlwatch_$(Get-Random)"
+            $server = Connect-DbaInstance -SqlInstance $script:instance2
+            $server.Query("CREATE DATABASE $database")
         }
         AfterAll {
             Uninstall-DbaSqlWatch -SqlInstance $script:instance2 -Database $database
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $database -Confirm:$false
         }
 
         $results = Install-DbaSqlWatch -SqlInstance $script:instance2 -Database $database

--- a/tests/Uninstall-DbaSqlWatch.Tests.ps1
+++ b/tests/Uninstall-DbaSqlWatch.Tests.ps1
@@ -20,9 +20,14 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Testing SqlWatch uninstaller" {
         BeforeAll {
-            $database = "dbatoolsci_usqlwatch"
+            $database = "dbatoolsci_sqlwatch_$(Get-Random)"
+            $server = Connect-DbaInstance -SqlInstance $script:instance2
+            $server.Query("CREATE DATABASE $database")
             Install-DbaSqlWatch -SqlInstance $script:instance2 -Database $database
             Uninstall-DbaSqlWatch -SqlInstance $script:instance2 -Database $database
+        }
+        AfterAll {
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $database -Confirm:$false
         }
 
         It "Removed all tables" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
It was rightly pointed out by @niphlod in #4407 that all Pester tests should clean up after themselves. Previously, the Pester tests for `Install-DbaSqlWatch` and `Uninstall-DbaSqlWatch` used the master database. 

### Approach
This PR modifies the Pester tests for these two functions to first create their own database, run the tests, and then remove the database when the tests are complete.