### PR TITLE
Add $null = 1

### DIFF
--- a/functions/Copy-DbaAgentProxyAccount.ps1
+++ b/functions/Copy-DbaAgentProxyAccount.ps1
@@ -130,7 +130,8 @@ function Copy-DbaAgentProxyAccount {
                 try {
                     $credentialtest = $destServer.Credentials[$CredentialName]
                 } catch {
-                    # don't care
+                    #here to avoid an empty catch
+                    $null = 1
                 }
 
                 if ($null -eq $credentialtest) {

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -355,6 +355,8 @@ function Copy-DbaDatabase {
                         $allrows = $fttable.Tables[0].rows
                     } catch {
                         # Nothing, it's just not enabled
+                        # here to avoid an empty catch
+                        $null = 1
                     }
 
                     foreach ($ftc in $allrows) {

--- a/functions/Copy-DbaDbAssembly.ps1
+++ b/functions/Copy-DbaDbAssembly.ps1
@@ -104,7 +104,10 @@ function Copy-DbaDbAssembly {
                 foreach ($assembly in $userAssemblies) {
                     $sourceAssemblies += $assembly
                 }
-            } catch { }
+            } catch {
+                #here to avoid an empty catch
+                $null = 1
+            }
         }
     }
     process {
@@ -125,7 +128,10 @@ function Copy-DbaDbAssembly {
                     foreach ($assembly in $userAssemblies) {
                         $destAssemblies += $assembly
                     }
-                } catch { }
+                } catch {
+                    #here to avoid an empty catch
+                    $null = 1
+                }
             }
             foreach ($currentAssembly in $sourceAssemblies) {
                 $assemblyName = $currentAssembly.Name

--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -109,7 +109,10 @@ function Copy-DbaLinkedServer {
                 try {
                     $destServer.LinkedServers.Refresh()
                     $destServer.LinkedServers.LinkedServerLogins.Refresh()
-                } catch { }
+                } catch {
+                    #here to avoid an empty catch
+                    $null = 1
+                }
 
                 $linkedServerName = $currentLinkedServer.Name
 

--- a/functions/Copy-DbaSsisCatalog.ps1
+++ b/functions/Copy-DbaSsisCatalog.ps1
@@ -412,6 +412,8 @@ function Copy-DbaSsisCatalog {
                     $destinationFolders.Alter()
                 } catch {
                     # Sometimes it says Alter() doesn't exist
+                    # here to avoid an empty catch
+                    $null = 1
                 }
                 $destinationFolders.Refresh()
             }

--- a/functions/Copy-DbaSysDbUserObject.ps1
+++ b/functions/Copy-DbaSysDbUserObject.ps1
@@ -370,11 +370,15 @@ function Copy-DbaSysDbUserObject {
                                     $destServer.Query($sql, $systemDb)
                                 } catch {
                                     # Don't care - long story having to do with duplicate stuff
+                                    # here to avoid an empty catch
+                                    $null = 1
                                 }
                             }
                         }
                     } catch {
                         # Don't care - long story having to do with duplicate stuff
+                        # here to avoid an empty catch
+                        $null = 1
                     }
                 }
             }

--- a/functions/Disable-DbaForceNetworkEncryption.ps1
+++ b/functions/Disable-DbaForceNetworkEncryption.ps1
@@ -85,7 +85,9 @@ function Disable-DbaForceNetworkEncryption {
             try {
                 $instancename = $sqlwmi.DisplayName.Replace('SQL Server (', '').Replace(')', '') # Don't clown, I don't know regex :(
             } catch {
-                # Probably because the instance name has been aliased or does not exist or samthin
+                # Probably because the instance name has been aliased or does not exist or something
+                # here to avoid an empty catch
+                $null = 1
             }
             $serviceaccount = $sqlwmi.ServiceAccount
 

--- a/functions/Enable-DbaForceNetworkEncryption.ps1
+++ b/functions/Enable-DbaForceNetworkEncryption.ps1
@@ -85,7 +85,9 @@ function Enable-DbaForceNetworkEncryption {
             try {
                 $instancename = $sqlwmi.DisplayName.Replace('SQL Server (', '').Replace(')', '') # Don't clown, I don't know regex :(
             } catch {
-                # Probably because the instance name has been aliased or does not exist or samthin
+                # Probably because the instance name has been aliased or does not exist or something
+                # here to avoid an empty catch
+                $null = 1
             }
             $serviceaccount = $sqlwmi.ServiceAccount
 

--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -280,13 +280,19 @@ function Find-DbaInstance {
                     #region Gather data
                     if ($ScanType -band [Sqlcollaborative.Dbatools.Discovery.DbaInstanceScanType]::DNSResolve) {
                         try { $resolution = [System.Net.Dns]::GetHostEntry($computer.ComputerName) }
-                        catch { }
+                        catch {
+                            # here to avoid an empty catch
+                            $null = 1
+                        }
                     }
 
                     if ($ScanType -band [Sqlcollaborative.Dbatools.Discovery.DbaInstanceScanType]::Ping) {
                         $ping = New-Object System.Net.NetworkInformation.Ping
                         try { $pingReply = $ping.Send($computer.ComputerName) }
-                        catch { }
+                        catch {
+                            # here to avoid an empty catch
+                            $null = 1
+                        }
                     }
 
                     if ($ScanType -band [Sqlcollaborative.Dbatools.Discovery.DbaInstanceScanType]::SPN) {
@@ -294,7 +300,10 @@ function Find-DbaInstance {
                         if ($resolution.HostName) { $computerByName = $resolution.HostName }
                         if ($computerByName -notmatch "$([dbargx]::IPv4)|$([dbargx]::IPv6)") {
                             try { $sPNs = Get-DomainSPN -DomainController $DomainController -Credential $Credential -ComputerName $computerByName -GetSPN }
-                            catch { }
+                            catch {
+                                # here to avoid an empty catch
+                                $null = 1
+                            }
                         }
                     }
 
@@ -306,8 +315,8 @@ function Find-DbaInstance {
                         try {
                             $browseResult = Get-SQLInstanceBrowserUDP -ComputerName $computer -EnableException
                         } catch {
-                            #Variable marked as unused by PSScriptAnalyzer
-                            #$browseFailed = $true
+                            # here to avoid an empty catch
+                            $null = 1
                         }
                     }
 
@@ -476,7 +485,10 @@ function Find-DbaInstance {
 
                                     try {
                                         $dataSet.MachineName = $server.ComputerNamePhysicalNetBIOS
-                                    } catch { }
+                                    } catch {
+                                        # here to avoid an empty catch
+                                        $null = 1
+                                    }
                                 }
                             } catch {
                                 # Error class definitions
@@ -652,6 +664,8 @@ function Find-DbaInstance {
                         try {
                             $UDPClient.Close()
                         } catch {
+                            # here to avoid an empty catch
+                            $null = 1
                         }
 
                         if ($EnableException) { throw }

--- a/functions/Get-DbaCmsRegServer.ps1
+++ b/functions/Get-DbaCmsRegServer.ps1
@@ -175,7 +175,10 @@ function Get-DbaCmsRegServer {
                         $server.ComputerName = $lookup.ComputerName
                         $server.FQDN = $lookup.FQDN
                         $server.IPAddress = $lookup.IPAddress
-                    } catch { }
+                    } catch {
+                        # here to avoid an empty catch
+                        $null = 1
+                    }
                 }
             }
             Add-Member -Force -InputObject $server -MemberType ScriptMethod -Name ToString -Value { $this.ServerName }

--- a/functions/Get-DbaCmsRegServerGroup.ps1
+++ b/functions/Get-DbaCmsRegServerGroup.ps1
@@ -114,7 +114,10 @@ function Get-DbaCmsRegServerGroup {
                                 Write-Message -Level Verbose -Message "Added $($thisgroup.Name)"
                                 $groups += $thisgroup
                             }
-                        } catch { }
+                        } catch {
+                            # here to avoid an empty catch
+                            $null = 1
+                        }
                     }
                 }
             } else {

--- a/functions/Get-DbaComputerCertificate.ps1
+++ b/functions/Get-DbaComputerCertificate.ps1
@@ -92,6 +92,8 @@ function Get-DbaComputerCertificate {
                     Get-ChildItem "Cert:\$Store\$Folder" -Recurse | Where-Object Thumbprint -in $Thumbprint
                 } catch {
                     # don't care - there's a weird issue with remoting where an exception gets thrown for no apparent reason
+                    # here to avoid an empty catch
+                    $null = 1
                 }
             } else {
                 try {
@@ -100,6 +102,8 @@ function Get-DbaComputerCertificate {
                     Get-ChildItem "Cert:\$Store\$Folder" -Recurse | Where-Object { "$($_.EnhancedKeyUsageList)" -match '1\.3\.6\.1\.5\.5\.7\.3\.1' }
                 } catch {
                     # still don't care
+                    # here to avoid an empty catch
+                    $null = 1
                 }
             }
         }

--- a/functions/Get-DbaForceNetworkEncryption.ps1
+++ b/functions/Get-DbaForceNetworkEncryption.ps1
@@ -87,7 +87,9 @@ function Get-DbaForceNetworkEncryption {
             try {
                 $instancename = $sqlwmi.DisplayName.Replace('SQL Server (', '').Replace(')', '') # Don't clown, I don't know regex :(
             } catch {
-                # Probably because the instance name has been aliased or does not exist or samthin
+                # Probably because the instance name has been aliased or does not exist or something
+                # here to avoid an empty catch
+                $null = 1
             }
             $serviceaccount = $sqlwmi.ServiceAccount
 

--- a/functions/Get-DbaNetworkCertificate.ps1
+++ b/functions/Get-DbaNetworkCertificate.ps1
@@ -96,6 +96,8 @@ function Get-DbaNetworkCertificate {
                         $cert = Get-ChildItem Cert:\LocalMachine -Recurse -ErrorAction Stop | Where-Object Thumbprint -eq $Thumbprint
                     } catch {
                         # Don't care - sometimes there's errors that are thrown for apparent good reason
+                        # here to avoid an empty catch
+                        $null = 1
                     }
 
                     if (!$cert) { continue }

--- a/functions/Get-DbaService.ps1
+++ b/functions/Get-DbaService.ps1
@@ -157,7 +157,10 @@ function Get-DbaService {
                 }
                 Write-Message -Level Verbose -Message "Getting SQL Server namespace on $Computer" -Target $Computer
                 try { $namespaces = Get-DbaCmObject -ComputerName $Computer -NameSpace root\Microsoft\SQLServer -Query "Select Name FROM __NAMESPACE WHERE Name Like 'ComputerManagement%'" -EnableException -Credential $credential | Sort-Object Name -Descending }
-                catch { }
+                catch {
+                    # here to avoid an empty catch
+                    $null = 1
+                }
                 if ($namespaces) {
                     $servicesTemp = @()
 

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -63,7 +63,7 @@ function Get-DbaUserPermission {
         Check server and database permissions on server sql2008 for only the TestDB database,
         including public and guest grants, and sys schema objects.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [parameter(Position = 0, Mandatory, ValueFromPipeline)]
@@ -219,7 +219,8 @@ function Get-DbaUserPermission {
 
                 #Create objects in active database
                 Write-Message -Level Verbose -Message "Creating objects"
-                try { $db.ExecuteNonQuery($sql)
+                try {
+                    $db.ExecuteNonQuery($sql)
                 } catch {
                     # here to avoid an empty catch
                     $null = 1
@@ -229,7 +230,8 @@ function Get-DbaUserPermission {
                 if (-not $serverDT) {
                     Write-Message -Level Verbose -Message "Building data table for server objects"
 
-                    try { $serverDT = $db.Query($serverSQL)
+                    try {
+                        $serverDT = $db.Query($serverSQL)
                     } catch {
                         # here to avoid an empty catch
                         $null = 1
@@ -258,7 +260,8 @@ function Get-DbaUserPermission {
                 }
 
                 Write-Message -Level Verbose -Message "Building data table for $db objects"
-                try { $dbDT = $db.Query($dbSQL)
+                try {
+                    $dbDT = $db.Query($dbSQL)
                 } catch {
                     # here to avoid an empty catch
                     $null = 1
@@ -287,7 +290,8 @@ function Get-DbaUserPermission {
 
                 #Delete objects
                 Write-Message -Level Verbose -Message "Deleting objects"
-                try { $db.ExecuteNonQuery($endSQL)
+                try {
+                    $db.ExecuteNonQuery($endSQL)
                 } catch {
                     # here to avoid an empty catch
                     $null = 1
@@ -302,4 +306,3 @@ function Get-DbaUserPermission {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Get-DbaUserLevelPermission
     }
 }
-

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -219,13 +219,21 @@ function Get-DbaUserPermission {
 
                 #Create objects in active database
                 Write-Message -Level Verbose -Message "Creating objects"
-                try { $db.ExecuteNonQuery($sql) } catch {} # sometimes it complains about not being able to drop the stig schema if the person Ctrl-C'd before.
+                try { $db.ExecuteNonQuery($sql)
+                } catch {
+                    # here to avoid an empty catch
+                    $null = 1
+                } # sometimes it complains about not being able to drop the stig schema if the person Ctrl-C'd before.
 
                 #Grab permissions data
                 if (-not $serverDT) {
                     Write-Message -Level Verbose -Message "Building data table for server objects"
 
-                    try { $serverDT = $db.Query($serverSQL) } catch { }
+                    try { $serverDT = $db.Query($serverSQL)
+                    } catch {
+                        # here to avoid an empty catch
+                        $null = 1
+                    }
 
                     foreach ($row in $serverDT) {
                         [PSCustomObject]@{
@@ -250,7 +258,11 @@ function Get-DbaUserPermission {
                 }
 
                 Write-Message -Level Verbose -Message "Building data table for $db objects"
-                try { $dbDT = $db.Query($dbSQL) } catch { }
+                try { $dbDT = $db.Query($dbSQL)
+                } catch {
+                    # here to avoid an empty catch
+                    $null = 1
+                }
 
                 foreach ($row in $dbDT) {
                     [PSCustomObject]@{
@@ -275,7 +287,11 @@ function Get-DbaUserPermission {
 
                 #Delete objects
                 Write-Message -Level Verbose -Message "Deleting objects"
-                try { $db.ExecuteNonQuery($endSQL) } catch { }
+                try { $db.ExecuteNonQuery($endSQL)
+                } catch {
+                    # here to avoid an empty catch
+                    $null = 1
+                }
                 $sql = $sql.Replace($db.Name, "<TARGETDB>")
 
                 #Sashay Away

--- a/functions/Get-DbaWindowsLog.ps1
+++ b/functions/Get-DbaWindowsLog.ps1
@@ -176,7 +176,10 @@ function Get-DbaWindowsLog {
                     while (-not $reader.EndOfStream) {
                         Convert-ErrorRecord -Line $reader.ReadLine()
                     }
-                } catch { }
+                } catch {
+                    # here to avoid an empty catch
+                    $null = 1
+                }
             }
             #endregion Script that processes an individual file
 

--- a/functions/Import-DbaCsvToSql.ps1
+++ b/functions/Import-DbaCsvToSql.ps1
@@ -1270,7 +1270,8 @@ function Import-DbaCsvToSql {
             $null = $bulkCopy.close(); $bulkcopy.dispose();
             $null = $reader.close(); $null = $reader.dispose()
         } catch {
-
+            #here to avoid an empty catch
+            $null = 1
         }
 
         # Delete all the temp files

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -373,6 +373,8 @@ function Install-DbaMaintenanceSolution {
         try {
             $server.ConnectionContext.Disconnect()
         } catch {
+            # here to avoid an empty catch
+            $null = 1
         }
 
         Write-Message -Level Output -Message "Installation complete."

--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -85,7 +85,7 @@ function Install-DbaSqlWatch {
         $stepCounter = 0
         $totalSteps = 3
         $activity = "Installing SQLWatch"
-        
+
         $DbatoolsData = Get-DbatoolsConfigValue -FullName "Path.DbatoolsData"
         $tempFolder = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
         $zipfile = "$tempFolder\SqlWatch.zip"
@@ -93,7 +93,7 @@ function Install-DbaSqlWatch {
         if (-not $LocalFile) {
             if ($PSCmdlet.ShouldProcess($env:computername, "Downloading latest release from GitHub")) {
                 Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Downloading latest release from GitHub"
-                
+
                 # query the releases to find the latest, check and see if its cached
                 $ReleasesUrl = "https://api.github.com/repos/marcingminski/sqlwatch/releases"
                 $DownloadBase = "https://github.com/marcingminski/sqlwatch/releases/download/"
@@ -124,6 +124,8 @@ function Install-DbaSqlWatch {
                         Copy-Item -Path $zipfile -Destination $LocallyCachedZip -Force
                     } catch {
                         # should we stop the function if the file copy fails?
+                        # here to avoid an empty catch
+                        $null = 1
                     }
                 }
             }
@@ -181,7 +183,7 @@ function Install-DbaSqlWatch {
                 } catch {
                     Stop-Function -Message "Failure." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
-                
+
                 Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Starting installing/updating SqlWatch in $database on $instance"
 
                 try {
@@ -190,7 +192,7 @@ function Install-DbaSqlWatch {
                     $PublishOptions = @{
                         RegisterDataTierApplication = $true
                     }
-                    
+
                     Write-ProgressHelper -TotalSteps $totalSteps -Activity $activity -StepNumber ($stepCounter++) -Message "Publishing SqlWatch dacpac to $database on $instance"
                     $DacProfile = New-DbaDacProfile -SqlInstance $server -Database $Database -Path $LocalCacheFolder -PublishOptions $PublishOptions | Select-Object -ExpandProperty FileName
                     $PublishResults = Publish-DbaDacPackage -SqlInstance $server -Database $Database -Path $DacPacPath -PublishXml $DacProfile
@@ -200,7 +202,7 @@ function Install-DbaSqlWatch {
                     if ($parens.matches) {
                         $ExtractedResult = $parens.matches | Select-Object -Last 1
                     }
-                    
+
                     [PSCustomObject]@{
                         ComputerName = $PublishResults.ComputerName
                         InstanceName = $PublishResults.InstanceName

--- a/functions/Install-DbaWatchUpdate.ps1
+++ b/functions/Install-DbaWatchUpdate.ps1
@@ -64,6 +64,8 @@ function Install-DbaWatchUpdate {
                 $null = Register-ScheduledTask -Principal $principal -TaskName 'dbatools version check' -Action $action -Trigger $trigger -Settings $settings -ErrorAction Stop
             } catch {
                 # keep moving
+                # here to avoid an empty catch
+                $null = 1
             }
         }
 

--- a/functions/New-DbatoolsSupportPackage.ps1
+++ b/functions/New-DbatoolsSupportPackage.ps1
@@ -117,7 +117,10 @@ function New-DbatoolsSupportPackage {
 
                 # Cut results to the limit and return them
                 return $lines[$int .. $z]
-            } catch { }
+            } catch {
+                # here to avoid an empty catch
+                $null = 1
+            }
         }
         #endregion Helper functions
     }

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -125,11 +125,9 @@ function Test-DbaConnection {
                     $tcp.Connect($baseaddress, 1433)
                     $tcp.Close()
                     $tcp.Dispose()
-                    #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
-                    #$sqlport = $true
                 } catch {
-                    #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
-                    #$sqlport = $false
+                    # here to avoid an empty catch
+                    $null = 1
                 }
             }
 

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -449,7 +449,8 @@ function Write-DbaDataTable {
             try {
                 $null = $server.Databases
             } catch {
-                #do nothing
+                # here to avoid an empty catch
+                $null = 1
             }
         }
         $databaseObject = $server.Databases[$databaseName]

--- a/tests/Get-DbaUserPermission.Tests.ps1
+++ b/tests/Get-DbaUserPermission.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         $paramCount = 8
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaUserPermission).Parameters.Keys
-        $knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','ExcludeSystemDatabase','IncludePublicGuest','IncludeSystemObjects','EnableException'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemDatabase', 'IncludePublicGuest', 'IncludeSystemObjects', 'EnableException'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4378 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Address the ~35 occurrences of the the PSAvoidUsingEmptyCatchBlock PSSA rule

### Approach
<!-- How does this change solve that purpose -->
Adding `$null =1` as discussed in issue.
This suppresses the PSSA rule while allowing empty catch blocks.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-ScriptAnalyzer .\functions\ -IncludeRule PSAvoidUsingEmptyCatchBlock`
