### PR TITLE
Fixing "Failure | You cannot call a method on a null-valued expression."

### DIFF
--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -1,4 +1,4 @@
-function Get-DbaPrivilege {
+﻿function Get-DbaPrivilege {
     <#
     .SYNOPSIS
         Gets the users with local privileges on one or more computers.
@@ -85,8 +85,12 @@ function Get-DbaPrivilege {
                         param ($ResolveSID)
                         . ([ScriptBlock]::Create($ResolveSID))
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
-                        (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -match "SeBatchLogonRight" }).substring(20).split(",").replace("`*", "") |
-                            ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        $blEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like "SeBatchLogonRight*" })
+                        
+                        if($null -ne $blEntries) {
+                            $blEntries.substring(20).split(",").replace("`*", "") | ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        }
+                        
                     } -ErrorAction SilentlyContinue
                     if ($BL.count -eq 0) {
                         Write-Message -Level Verbose -Message "No users with Batch Logon Rights on $computer"
@@ -97,8 +101,12 @@ function Get-DbaPrivilege {
                         param ($ResolveSID)
                         . ([ScriptBlock]::Create($ResolveSID))
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
-                        (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeManageVolumePrivilege*' }).substring(26).split(",").replace("`*", "") |
-                            ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        $ifiEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeManageVolumePrivilege*' })
+                        
+                        if($null -ne $ifiEntries) {
+                            $ifiEntries.substring(26).split(",").replace("`*", "") | ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        }
+                        
                     } -ErrorAction SilentlyContinue
                     if ($ifi.count -eq 0) {
                         Write-Message -Level Verbose -Message "No users with Instant File Initialization Rights on $computer"
@@ -109,8 +117,11 @@ function Get-DbaPrivilege {
                         param ($ResolveSID)
                         . ([ScriptBlock]::Create($ResolveSID))
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
-                        (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeLockMemoryPrivilege*' }).substring(24).split(",").replace("`*", "") |
-                            ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        $lpimEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeLockMemoryPrivilege*' })
+
+                        if($null -ne $lpimEntries) {
+                            $lpimEntries.substring(24).split(",").replace("`*", "") |ForEach-Object { Convert-SIDToUserName -SID $_ }
+                        }
                     } -ErrorAction SilentlyContinue
 
                     if ($lpim.count -eq 0) {
@@ -137,4 +148,3 @@ function Get-DbaPrivilege {
         }
     }
 }
-

--- a/functions/Get-DbaPrivilege.ps1
+++ b/functions/Get-DbaPrivilege.ps1
@@ -1,4 +1,4 @@
-﻿function Get-DbaPrivilege {
+function Get-DbaPrivilege {
     <#
     .SYNOPSIS
         Gets the users with local privileges on one or more computers.
@@ -45,7 +45,7 @@
 
         Gets the local privileges on computers sql1 and sql2, and shows them in a grid view.
 
-#>
+    #>
     [CmdletBinding()]
     param (
         [parameter(ValueFromPipeline)]
@@ -86,11 +86,11 @@
                         . ([ScriptBlock]::Create($ResolveSID))
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
                         $blEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like "SeBatchLogonRight*" })
-                        
-                        if($null -ne $blEntries) {
+
+                        if ($null -ne $blEntries) {
                             $blEntries.substring(20).split(",").replace("`*", "") | ForEach-Object { Convert-SIDToUserName -SID $_ }
                         }
-                        
+
                     } -ErrorAction SilentlyContinue
                     if ($BL.count -eq 0) {
                         Write-Message -Level Verbose -Message "No users with Batch Logon Rights on $computer"
@@ -102,11 +102,11 @@
                         . ([ScriptBlock]::Create($ResolveSID))
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
                         $ifiEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeManageVolumePrivilege*' })
-                        
-                        if($null -ne $ifiEntries) {
+
+                        if ($null -ne $ifiEntries) {
                             $ifiEntries.substring(26).split(",").replace("`*", "") | ForEach-Object { Convert-SIDToUserName -SID $_ }
                         }
-                        
+
                     } -ErrorAction SilentlyContinue
                     if ($ifi.count -eq 0) {
                         Write-Message -Level Verbose -Message "No users with Instant File Initialization Rights on $computer"
@@ -119,7 +119,7 @@
                         $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
                         $lpimEntries = (Get-Content $temp\secpolByDbatools.cfg | Where-Object { $_ -like 'SeLockMemoryPrivilege*' })
 
-                        if($null -ne $lpimEntries) {
+                        if ($null -ne $lpimEntries) {
                             $lpimEntries.substring(24).split(",").replace("`*", "") |ForEach-Object { Convert-SIDToUserName -SID $_ }
                         }
                     } -ErrorAction SilentlyContinue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixing missing output when one of the three checks is empty.

PS C:\Users\administrator.LAB> Get-DbaPrivilege -Verbose
VERBOSE: [22:35:03][Test-PSRemoting] Testing GJ-AX2012CU13
VERBOSE: [22:35:03][Get-DbaPrivilege] Getting Privileges on GJ-AX2012CU13
VERBOSE: [22:35:03][Get-DbaPrivilege] Getting Batch Logon Privileges on GJ-AX2012CU13
VERBOSE: [22:35:03][Get-DbaPrivilege] Getting Instant File Initialization Privileges on GJ-AX2012CU13
VERBOSE: [22:35:03][Get-DbaPrivilege] Getting Lock Pages in Memory Privileges on GJ-AX2012CU13
WARNING: [22:35:03][Get-DbaPrivilege] Failure | You cannot call a method on a null-valued expression.

In my case it was that there was no entries at all in the Lock Pages in Memory.

It seems that you expect at least one entry in either and you cannot be entirely sure on that.

### Approach
<!-- How does this change solve that purpose -->
Fetching the output from each check into a local variable and testing if it is $null or not.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
