### PR TITLE
Recoveryfork2

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -529,7 +529,7 @@ function Backup-DbaDatabase {
                             if ($server.VersionMajor -eq '8') {
                                 $HeaderInfo = Get-BackupAncientHistory -SqlInstance $server -Database $dbname
                             } else {
-                                $HeaderInfo = Get-DbaBackupHistory -SqlInstance $server -Database $dbname -Last -IncludeCopyOnly -LastLsn $NumericLsn -WarningAction SilentlyContinue | Sort-Object -Property End -Descending | Select-Object -First 1
+                                $HeaderInfo = Get-DbaBackupHistory -SqlInstance $server -Database $dbname -Last -IncludeCopyOnly -LastLsn $NumericLsn  | Sort-Object -Property End -Descending | Select-Object -First 1
                             }
                             $Verified = $false
                             if ($Verify) {

--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -260,7 +260,7 @@ function Get-DbaBackupHistory {
                     if ($RecoveryFork) {
                         $recoveryForkSqlFilter = "AND backupset.last_recovery_fork_guid ='$RecoveryFork'"
                     }
-                    if ((Get-PsCallStack)[1].Command -notlike 'Get-DbaBackupHistory*') {
+                    if ($null -eq (Get-PsCallStack)[1].Command) {
                         $forkCheckSql = "
                                 SELECT
                                     database_name,

--- a/internal/functions/Convert-DbaLsn.ps1
+++ b/internal/functions/Convert-DbaLsn.ps1
@@ -17,7 +17,7 @@ function Convert-DbaLSN {
         Will return object $Output with the following value
         $Output.HexLSN = 0000002f:000044aa:002b
         $Output.NumbericLSN =
-    #>
+       #>
     [CmdletBinding()]
     param(
         [string]$LSN,
@@ -36,9 +36,9 @@ function Convert-DbaLSN {
 
     } elseif ($LSN -match '^[0-9]{15}[0-9]+$') {
         Write-Message -Message 'Numeric LSN passed in, converting to Hexadecimal' -Level Verbose
-        $sect1 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(0, $LSN.length-15), 16).PadLeft(8,'0')
-        $sect2 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length-14, 9), 16).PadLeft(8, '0')
-        $sect3 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length-5, 5), 16).PadLeft(4, '0')
+        $sect1 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(0, $LSN.length - 15), 16).PadLeft(8, '0')
+        $sect2 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length - 14, 9), 16).PadLeft(8, '0')
+        $sect3 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length - 5, 5), 16).PadLeft(4, '0')
         $Numeric = $LSN
         $Hexadecimal = $sect1 + ':' + $sect2 + ':' + $sect3
     } else {

--- a/internal/functions/Convert-DbaLsn.ps1
+++ b/internal/functions/Convert-DbaLsn.ps1
@@ -28,17 +28,17 @@ function Convert-DbaLSN {
     if ($LSN -match '^[a-fA-F0-9]{8}:[a-fA-F0-9]{8}:[a-fA-F0-9]{4}$') {
         Write-Message -Message 'Hexadecimal LSN passed in, converting to numeric' -Level Verbose
         $sections = $LSN.Split(':')
-        $sect1 = [System.Convert]::ToInt64($sections[0], 16).ToString().PadLeft(11, '0')
+        $sect1 = [System.Convert]::ToInt64($sections[0], 16).ToString()
         $sect2 = [System.Convert]::ToInt64($sections[1], 16).ToString().PadLeft(10, '0')
         $sect3 = [System.Convert]::ToInt64($sections[2], 16).ToString().PadLeft(5, '0')
         $Hexadecimal = $LSN
         $Numeric = $sect1 + $sect2 + $sect3
 
-    } elseif ($LSN -match '^[0-9]+$') {
+    } elseif ($LSN -match '^[0-9]{15}[0-9]+$') {
         Write-Message -Message 'Numeric LSN passed in, converting to Hexadecimal' -Level Verbose
-        $sect1 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(0, 11), 16).PadLeft(8, '0')
-        $sect2 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(12, 9), 16).PadLeft(8, '0')
-        $sect3 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(21, 5), 16).PadLeft(4, '0')
+        $sect1 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring(0, $LSN.length-15), 16).PadLeft(8,'0')
+        $sect2 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length-14, 9), 16).PadLeft(8, '0')
+        $sect3 = '{0:x}' -f [System.Convert]::ToString($LSN.Substring($lsn.length-5, 5), 16).PadLeft(4, '0')
         $Numeric = $LSN
         $Hexadecimal = $sect1 + ':' + $sect2 + ':' + $sect3
     } else {

--- a/tests/Convert-DbaLsn.Tests.ps1
+++ b/tests/Convert-DbaLsn.Tests.ps1
@@ -18,15 +18,22 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
     Context "Converts Numeric LSN to Hex"{
         $LSN = '00000000020000000024300001'
-        It "Should convert to " {
+        It "Should convert to 00000014:000000f3:0001" {
+            (Convert-DbaLSN -Lsn $Lsn).Hexadecimal | Should -Be '00000014:000000f3:0001'
+        }
+    }
+
+    Context "Converts Numeric LSN to Hex without leading 0s"{
+        $LSN = '20000000024300001'
+        It "Should convert to 00000014:000000f3:0001" {
             (Convert-DbaLSN -Lsn $Lsn).Hexadecimal | Should -Be '00000014:000000f3:0001'
         }
     }
 
     Context "Converts Hex LSN to Numeric"{
         $LSN = '00000014:000000f3:0001'
-        It "Should convert to " {
-            (Convert-DbaLSN -Lsn $Lsn).Numeric | Should -Be 00000000020000000024300001
+        It "Should convert to 20000000024300001" {
+            (Convert-DbaLSN -Lsn $Lsn).Numeric | Should -Be 20000000024300001
         }
     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change,)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Warnings in Get-DbaBackupHistory for multiple recovery forks now only happen if Get-DbaBackupHistory is the first command called. So won't trigger with Backup-DbaDatabase or Copy-DbaDatabase for example.

Piping will trigger it as PSCallstack doesn't catch that.

Removed leading 0s fom Numeric LSN output and fixed up the regex as well.