### PR TITLE
Replace with $Global with directly assigned variable

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -224,8 +224,8 @@ function Export-DbaDacPackage {
                     } else {
                         $opts = $DacOption
                     }
-                    $global:output = @()
-                    Register-ObjectEvent -InputObject $dacSvc -EventName "Message" -SourceIdentifier "msg" -Action { $global:output += $EventArgs.Message.Message } | Out-Null
+
+                    $null = $output = Register-ObjectEvent -InputObject $dacSvc -EventName "Message" -SourceIdentifier "msg" -Action { $EventArgs.Message.Message }
 
                     if ($Type -eq 'Dacpac') {
                         Write-Message -Level Verbose -Message "Initiating Dacpac extract to $currentFileName"
@@ -248,7 +248,7 @@ function Export-DbaDacPackage {
                             Unregister-Event -SourceIdentifier "msg"
                         }
                     }
-                    $finalResult = ($global:output -join "`r`n" | Out-String).Trim()
+                    $finalResult = ($output.output -join "`r`n" | Out-String).Trim()
                 } elseif ($PsCmdlet.ParameterSetName -eq 'CMD') {
                     if ($Type -eq 'Dacpac') { $action = 'Extract' }
                     elseif ($Type -eq 'Bacpac') { $action = 'Export' }

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -281,8 +281,7 @@ function Publish-DbaDacPackage {
                     Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
                 }
                 try {
-                    $global:output = @()
-                    Register-ObjectEvent -InputObject $dacServices -EventName "Message" -SourceIdentifier "msg" -Action { $global:output += $EventArgs.Message.Message } | Out-Null
+                    $null = $output = Register-ObjectEvent -InputObject $dacServices -EventName "Message" -SourceIdentifier "msg" -Action { $EventArgs.Message.Message }
                     #Perform proper action depending on the Type
                     if ($Type -eq 'Dacpac') {
                         if ($ScriptOnly) {
@@ -318,7 +317,7 @@ function Publish-DbaDacPackage {
                             Write-Message -Level Verbose -Message "Master database change script - $($result.MasterDbScript)."
                         }
                     }
-                    $resultoutput = ($global:output -join "`r`n" | Out-String).Trim()
+                    $resultoutput = ($output.output -join "`r`n" | Out-String).Trim()
                     if ($resultoutput -match "Failed" -and ($options.GenerateDeploymentReport -or $options.GenerateDeploymentScript)) {
                         Write-Message -Level Warning -Message "Seems like the attempt to publish/script may have failed. If scripts have not generated load dacpac into Visual Studio to check SQL is valid."
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4412 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Remove use of `$Global:output` variables.

### Approach
<!-- How does this change solve that purpose -->
Output the `Register-ObjectEvent` execution to a variable that can be dot sourced into 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Example 2 of `Export-DbaDacPackage` and Example1 of `Publish-DbaDacPackage`
`Invoke-Pester .\Export-DbaDacPackage.Tests.ps1`
`Invoke-Pester .\Publish-DbaDacPackage.Tests.ps1`
