### PR TITLE
Add PSSA override with justification

### DIFF
--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -69,6 +69,7 @@ function Get-DbaCmObject {
 
 #>
     [CmdletBinding(DefaultParameterSetName = "Class")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWMICmdlet", "", Justification = "Using Get-WmiObject is used as a fallback for gathering information")]
     param (
         [Parameter(Mandatory, Position = 0, ParameterSetName = "Class")]
         [Alias('Class')]

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -86,6 +86,7 @@ function Reset-DbaAdmin {
 
 #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWMICmdlet", "", Justification = "Using Get-WmiObject for client backwards compatibilty")]
     param (
         [Parameter(Mandatory)]
         [Alias("ServerInstance", "SqlServer")]

--- a/functions/Test-DbaCmConnection.ps1
+++ b/functions/Test-DbaCmConnection.ps1
@@ -64,6 +64,7 @@ function Test-DbaCmConnection {
 
 #>
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWMICmdlet", "", Justification = "Using Get-WmiObject is used as a fallback for testing connections")]
     param (
         [Parameter(ValueFromPipeline)]
         [Sqlcollaborative.Dbatools.Parameter.DbaCmConnectionParameter[]]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4461 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Write a PSSA override with justification for cmdlets that use `Get-WmiObject` as a failback

### Approach
<!-- How does this change solve that purpose -->
Insert:
`    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWMICmdlet", "", Justification = "Using Get-WmiObject for client backwards compatibilty")]`
or something similar for the justification

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-ScriptAnalyzer .\functions\ -IncludeRule PSAvoidUsingWMICmdlet`
