### PR TITLE
install, fixes #4497

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -104,7 +104,8 @@ try {
 catch {
     #try with default proxy and usersettings
     Write-LocalMessage -Message "Probably using a proxy for internet access, trying default proxy settings"
-    $wc = (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+    $wc = (New-Object System.Net.WebClient)
+    $wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
     $wc.DownloadFile($url, $zipfile)
 }
 


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fix a typo that makes the installer crash when behind a proxy as described in #4497
