### PR TITLE
Import-DbaPfDataCollectorSetTemplate - avoid bleeding

### DIFF
--- a/functions/Import-DbaPfDataCollectorSetTemplate.ps1
+++ b/functions/Import-DbaPfDataCollectorSetTemplate.ps1
@@ -216,7 +216,7 @@ function Import-DbaPfDataCollectorSetTemplate {
 
                     foreach ($replacement in $replacements) {
                         $phrase = "<$replacement></$replacement>"
-                        $value = (Get-Variable -Name $replacement).Value
+                        $value = (Get-Variable -Name $replacement -ErrorAction SilentlyContinue).Value
                         if ($value -eq $false) {
                             $value = "0"
                         }


### PR DESCRIPTION
fixes tests in appveyor too, perhaps having to do with older versions of windows