### PR TITLE
now copes with AutoClose dbs

### DIFF
--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -77,7 +77,7 @@ function Read-DbaTransactionLog {
         return
     }
 
-    if ($server.databases[$Database].Status -ne 'Normal') {
+    if ('Normal' -notin ($server.databases[$Database].Status -split ',')) {
         Stop-Function -Message "$Database is not in a normal State, command will not run."
         return
     }
@@ -85,6 +85,7 @@ function Read-DbaTransactionLog {
     if ($RowLimit -gt 0) {
         Write-Message -Message "Limiting reults to $RowLimit rows" -Level Verbose
         $RowLimitSql = " TOP $RowLimit "
+        $IgnoreLimit = $true
     } else {
         $RowLimitSql = ""
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4529)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Read-DbaTransactionLog wasn't handling AutoClose dbs properly. It now does

So no LSN was being passed into Convert-DbaLsn

Also forced `IgnoreLimit` with `$RowLimit` as the size of the t-log doesn't matter