### PR TITLE
Fix BackupDate output, some cleanup

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -7,7 +7,7 @@ function Test-DbaLastBackup {
         Restores all or some of the latest backups and performs a DBCC CHECKDB.
 
         1. Gathers information about the last full backups
-        2. Restores the backups to the Destination with a new name. If no Destination is specified, the originating SqlServer wil be used.
+        2. Restores the backups to the Destination with a new name. If no Destination is specified, the originating SQL Server instance wil be used.
         3. The database is restored as "dbatools-testrestore-$databaseName" by default, but you can change dbatools-testrestore to whatever you would like using -Prefix
         4. The internal file names are also renamed to prevent conflicts with original database
         5. A DBCC CHECKDB is then performed
@@ -105,12 +105,12 @@ function Test-DbaLastBackup {
         Determines the last full backup for SharePoint_Config, attempts to restore it, then performs a DBCC CHECKDB.
 
     .EXAMPLE
-        PS C:\> Get-DbaDatabase -SqlInstance sql2016, sql2017 |Test-DbaLastBackup
+        PS C:\> Get-DbaDatabase -SqlInstance sql2016, sql2017 | Test-DbaLastBackup
 
         Tests every database backup on sql2016 and sql2017
 
     .EXAMPLE
-        PS C:\> Get-DbaDatabase -SqlInstance sql2016, sql2017 -Database SharePoint_Config |Test-DbaLastBackup
+        PS C:\> Get-DbaDatabase -SqlInstance sql2016, sql2017 -Database SharePoint_Config | Test-DbaLastBackup
 
         Tests the database backup for the SharePoint_Config database on sql2016 and sql2017
 
@@ -139,9 +139,9 @@ function Test-DbaLastBackup {
 
         Copies the backup files for sql2014 databases to sql2016 default backup locations and then attempts restore from there.
 
-       #>
+    #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "", Justification = "For Paramters DestinationCredential and AzureCredential")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "", Justification = "For Parameters DestinationCredential and AzureCredential")]
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
@@ -461,7 +461,7 @@ function Test-DbaLastBackup {
                     DbccStart      = [dbadatetime]$startDbcc
                     DbccEnd        = [dbadatetime]$endDbcc
                     DbccElapsed    = $dbccElapsed
-                    BackupDate     = $lastbackup.Start
+                    BackupDates    = [String[]]($lastbackup.Start)
                     BackupFiles    = $lastbackup.FullName
                 }
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #2701 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix #2701

### Approach
ConvertTo-DbaDataTable cannot handle DateTime[], it returns  System.DateTime[]

BackupFiles is plural, s is also added to BackupDate
