### PR TITLE
Adding schema renaming and three-part name support to Copy-DbaDbTableData

### DIFF
--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -31,7 +31,7 @@ function Copy-DbaDbTableData {
         The database to copy the table to. If not specified, it is assumed to be the same of Database
 
     .PARAMETER Table
-        Define a specific table you would like to use as source. You can specify a two-part name like sch.tbl.
+        Define a specific table you would like to use as source. You can specify a three-part name like db.sch.tbl.
         If the object has special characters please wrap them in square brackets [ ].
         This dbo.First.Table will try to find table named 'Table' on schema 'First' and database 'dbo'.
         The correct way to find table named 'First.Table' on schema 'dbo' is passing dbo.[First.Table]
@@ -264,12 +264,16 @@ function Copy-DbaDbTableData {
             $Database = $sqltable.Parent.Name
             $server = $sqltable.Parent.Parent
 
-            if ((Test-Bound -Not -ParameterName DestinationDatabase)) {
-                $DestinationDatabase = $Database
-            }
-
             if ((Test-Bound -Not -ParameterName DestinationTable)) {
                 $DestinationTable = '[' + $sqltable.Schema + '].[' + $sqltable.Name + ']'
+            }
+
+            $newTableParts = Get-TableNameParts $DestinationTable
+            #using FQTN to determine database name
+            if ($newTableParts.Database) {
+                $DestinationDatabase = $newTableParts.Database
+            } elseif ((Test-Bound -Not -ParameterName DestinationDatabase)) {
+                $DestinationDatabase = $Database
             }
 
             if (-not $Destination) {
@@ -290,28 +294,50 @@ function Copy-DbaDbTableData {
                 }
 
                 $desttable = Get-DbaDbTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false | Select-Object -First 1
-                if (-not $desttable) {
-                    if ($AutoCreateTable) {
-                        try {
-                            $tablescript = $sqltable | Export-DbaScript -Passthru | Out-String
-                            $tablescript = $tablescript.Replace($sqltable.Name, $DestinationTable)
-                            $tablescript
-                            return
-                            Invoke-DbaQuery -SqlInstance $destServer -Database $DestinationDatabase -Query "$tablescript" -EnableException # add some string assurance there
-                            $desttable = Get-DbaDbTable -SqlInstance $destinationserver -SqlCredential $DestinationSqlCredential -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false | Select-Object -First 1
-                        } catch {
-                            Stop-Function -Message "Unable to determine destination table: $DestinationTable" -ErrorRecord $_
-                            return
+                if (-not $desttable -and $AutoCreateTable) {
+                    try {
+                        $tablescript = $sqltable | Export-DbaScript -Passthru | Out-String
+                        #replacing table name
+                        if ($newTableParts.Table) {
+                            $rX = "(CREATE TABLE \[$([regex]::Escape($sqltable.Schema))\]\.\[)$([regex]::Escape($sqltable.Name))(\]\()"
+                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Table)`$2"
                         }
-                    } else {
-                        Stop-Function -Message "Table $tbl cannot be found in $database. Use -AutoCreateTable to automatically create the table on the destination." -Continue
+                        #replacing table schema
+                        if ($newTableParts.Schema) {
+                            $rX = "(CREATE TABLE \[)$([regex]::Escape($sqltable.Schema))(\]\.\[$([regex]::Escape($newTableParts.Schema))\]\()"
+                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Schema)`$2"
+                        }
+
+                        if ($PSCmdlet.ShouldProcess($destServer, "Creating new table: $DestinationTable")) {
+                            Write-Message -Message "New table script: $tablescript" -Level VeryVerbose
+                            Invoke-DbaQuery -SqlInstance $destServer -Database $DestinationDatabase -Query "$tablescript" -EnableException # add some string assurance there
+                            #table list was updated, let's grab a fresh one
+                            $destServer.Databases[$DestinationDatabase].Tables.Refresh()
+                            $desttable = Get-DbaDbTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false
+                            Write-Message -Message "New table created: $desttable" -Level Verbose
+                        }
+                    } catch {
+                        Stop-Function -Message "Unable to determine destination table: $DestinationTable" -ErrorRecord $_
+                        return
                     }
+                }
+                if (-not $desttable) {
+                    Stop-Function -Message "Table $DestinationTable cannot be found in $DestinationDatabase. Use -AutoCreateTable to automatically create the table on the destination." -Continue
                 }
 
                 $connstring = $destServer.ConnectionContext.ConnectionString
 
-                $fqtnfrom = "$($server.Databases[$Database]).$sqltable"
-                $fqtndest = "$($destServer.Databases[$DestinationDatabase]).$desttable"
+                if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
+                    $fqtnfrom = "$sqltable"
+                } else {
+                    $fqtnfrom = "$($server.Databases[$Database]).$sqltable"
+                }
+
+                if ($destServer.DatabaseEngineType -eq "SqlAzureDatabase") {
+                    $fqtndest = "$desttable"
+                } else {
+                    $fqtndest = "$($destServer.Databases[$DestinationDatabase]).$desttable"
+                }
 
                 if ($fqtndest -eq $fqtnfrom -and $server.Name -eq $destServer.Name) {
                     Stop-Function -Message "Cannot copy $fqtnfrom on $($server.Name) into $fqtndest on ($destServer.Name). Source and Destination must be different " -Target $Table


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4134)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding support for -DestinationTable database.schema.tablename
Fixing some bugs along the way (schema name replacement)

### Approach
Get-TableNameParts and regex magic

### Commands to test
Copy-DbaDbTableData -SqlInstance sql1 -Database DB1 -AutoCreateTable -Table T1 -DestinationTable DB2.dbo.[T2.1] -Verbose

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
