### PR TITLE
Invoke-DbatoolsFormatter, fix for spaced end comment

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -44,7 +44,7 @@ function Invoke-DbatoolsFormatter {
         }
         $CBHRex = [regex]'(?smi)\s+<#[^#]*#>'
         $CBHStartRex = [regex]'(?<spaces>[ ]+)<#'
-        $CBHEndRex = [regex]'(?<spaces>[ ]?)#>'
+        $CBHEndRex = [regex]'(?<spaces>[ ]*)#>'
     }
     process {
         if (Test-FunctionInterrupt) { return }


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Irregardless on how many spaces the ending CBH mark has, always align to the opening one.
