### PR TITLE
Get-DbaHelpIndex - break out Statistics from Index column in output

### DIFF
--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -1028,7 +1028,7 @@ function Get-DbaHelpIndex {
             Write-Message -Level Debug -Message "$indexesQuery"
             try {
                 $IndexDetails = $db.Query($indexesQuery)
-                
+
                 if (!$Raw) {
                     foreach ($detail in $IndexDetails) {
                         $recentlyused = [datetime]$detail.MostRecentlyUsed
@@ -1052,7 +1052,7 @@ function Get-DbaHelpIndex {
                             DataCompression    = $detail.DataCompression
                             IndexReads         = "{0:N0}" -f $detail.IndexReads
                             IndexUpdates       = "{0:N0}" -f $detail.IndexUpdates
-                            SizeKB             = "{0:N0}" -f $detail.SizeKB
+                            Size               = "{0:N0}" -f $detail.SizeKB
                             IndexRows          = "{0:N0}" -f $detail.IndexRows
                             IndexLookups       = "{0:N0}" -f $detail.IndexLookups
                             MostRecentlyUsed   = $recentlyused
@@ -1061,7 +1061,7 @@ function Get-DbaHelpIndex {
                             HistogramSteps     = $detail.HistogramSteps
                             StatsLastUpdated   = $detail.StatsLastUpdated
                             IndexFragInPercent = "{0:F2}" -f $detail.IndexFragInPercent
-                        } #| Select-DefaultView -Property $OutputProperties
+                        }
                     }
                 }
 
@@ -1088,7 +1088,7 @@ function Get-DbaHelpIndex {
                             DataCompression    = $detail.DataCompression
                             IndexReads         = $detail.IndexReads
                             IndexUpdates       = $detail.IndexUpdates
-                            SizeKB             = $detail.SizeKB
+                            Size               = [dbasize]($detail.SizeKB * 1024)
                             IndexRows          = $detail.IndexRows
                             IndexLookups       = $detail.IndexLookups
                             MostRecentlyUsed   = $recentlyused
@@ -1097,7 +1097,7 @@ function Get-DbaHelpIndex {
                             HistogramSteps     = $detail.HistogramSteps
                             StatsLastUpdated   = $detail.StatsLastUpdated
                             IndexFragInPercent = $detail.IndexFragInPercent
-                        } | Select-DefaultView -Property $OutputProperties
+                        }
                     }
                 }
             } catch {

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -490,7 +490,7 @@ function Get-DbaHelpIndex {
                                                             AND si.stats_id = c.Index_Id
                     UNION
                     SELECT   QUOTENAME(sch.name) + '.' + QUOTENAME(tbl.name) AS FullObjectName ,
-                                '' , 
+                                '' ,
                                 '' ,
                                 stats_name ,
                                 StatsColumns ,

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -861,7 +861,7 @@ function Get-DbaHelpIndex {
                                 ci.FullObjectName
                     ), AllResults AS
                         (		 SELECT   c.FullObjectName ,
-                                IndexType ,
+                                ISNULL(IndexType, 'STATISTICS') AS IndexType ,
                                 ISNULL(IndexName, '') AS IndexName ,
                                 ISNULL(KeyColumns, '') AS KeyColumns ,
                                 ISNULL(IncludeColumns, '') AS IncludeColumns ,
@@ -887,7 +887,7 @@ function Get-DbaHelpIndex {
                                                             AND si.stats_id = c.Index_Id
                         UNION
                     SELECT   QUOTENAME(sch.name) + '.' + QUOTENAME(tbl.name) AS FullObjectName ,
-                                '' ,
+                                'STATISTICS' ,
                                 stats_name ,
                                 StatsColumns ,
                                 '' ,
@@ -920,7 +920,7 @@ function Get-DbaHelpIndex {
             INSERT INTO @AllResults
             SELECT  row_number() OVER (ORDER BY FullObjectName) AS RowNum ,
                     FullObjectName ,
-                    IndexType ,
+                    ISNULL(IndexType, 'STATISTICS') AS IndexType ,
                     IndexName ,
                     KeyColumns ,
                     ISNULL(IncludeColumns, '') AS IncludeColumns ,

--- a/functions/Get-DbaHelpIndex.ps1
+++ b/functions/Get-DbaHelpIndex.ps1
@@ -1,4 +1,4 @@
-﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Get-DbaHelpIndex {
     <#
     .SYNOPSIS

--- a/tests/Get-DbaHelpIndex.Tests.ps1
+++ b/tests/Get-DbaHelpIndex.Tests.ps1
@@ -46,12 +46,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
     }
     Context "Command works when including statistics" {
-        $results = Get-DbaHelpIndex -SqlInstance $script:instance2 -Database $dbname -IncludeStats | Where-Object {$_.IndexType -eq 'Statistics'}
+        $results = Get-DbaHelpIndex -SqlInstance $script:instance2 -Database $dbname -IncludeStats | Where-Object {$_.Statistics}
         It 'Results should be returned' {
             $results | Should Not BeNullOrEmpty
         }
         It 'Returns dbatools_stats from test object' {
-            $results.Index | Should Be 'dbatools_stats'
+            $results.Statistics | Should Contain 'dbatools_stats'
         }
     }
     Context "Command output includes data types" {
@@ -68,7 +68,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It 'Formatted as strings' {
             $results.IndexReads | Should BeOfType 'String'
             $results.IndexUpdates | Should BeOfType 'String'
-            $results.SizeKB | Should BeOfType 'String'
+            $results.Size | Should BeOfType 'String'
             $results.IndexRows | Should BeOfType 'String'
             $results.IndexLookups | Should BeOfType 'String'
             $results.StatsSampleRows | Should BeOfType 'String'
@@ -80,7 +80,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It 'Formatted as Long' {
             $results.IndexReads | Should BeOfType 'Long'
             $results.IndexUpdates | Should BeOfType 'Long'
-            $results.SizeKB | Should BeOfType 'Long'
+            $results.Size | Should BeOfType 'dbasize'
             $results.IndexRows | Should BeOfType 'Long'
             $results.IndexLookups | Should BeOfType 'Long'
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [X] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix #2819 to add Statistics column. 

### Approach
<!-- How does this change solve that purpose -->
Adds column to output for Statistics.
I need some help testing the function against 2005 boxes. I'm not sure the code is currently working but I don't have a 2005 instance to test against currently.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/48634649-09952100-e994-11e8-9495-0c3ac7ec20f7.png)