### PR TITLE
check against ConfiguredValue and not RunningValue

### DIFF
--- a/functions/Set-DbaSpConfigure.ps1
+++ b/functions/Set-DbaSpConfigure.ps1
@@ -89,13 +89,14 @@ function Set-DbaSpConfigure {
         foreach ($configobject in $InputObject) {
             $server = $InputObject.Parent
             $currentRunValue = $configobject.RunningValue
+            $currentConfigValue = $configobject.ConfiguredValue
             $minValue = $configobject.MinValue
             $maxValue = $configobject.MaxValue
             $isDynamic = $configobject.IsDynamic
             $configuration = $configobject.Name
 
             #Let us not waste energy setting the value to itself
-            if ($currentRunValue -eq $value) {
+            if ($currentConfigValue -eq $value) {
                 Stop-Function -Message "Value to set is the same as the existing value. No work being performed." -Continue -Target $server -Category InvalidData
             }
 
@@ -104,7 +105,7 @@ function Set-DbaSpConfigure {
                 Stop-Function -Message "Value out of range for $configuration ($minValue <-> $maxValue)" -Continue -Category InvalidArgument
             }
 
-            If ($Pscmdlet.ShouldProcess($SqlInstance, "Adjusting server configuration $configuration from $currentRunValue to $value.")) {
+            If ($Pscmdlet.ShouldProcess($SqlInstance, "Adjusting server configuration $configuration from $currentConfigValue to $value.")) {
                 try {
                     $server.Configuration.$configuration.ConfigValue = $value
                     $server.Configuration.Alter()
@@ -114,7 +115,7 @@ function Set-DbaSpConfigure {
                         InstanceName  = $server.ServiceName
                         SqlInstance   = $server.DomainInstanceName
                         ConfigName    = $configuration
-                        PreviousValue = $currentRunValue
+                        PreviousValue = $currentConfigValue
                         NewValue      = $value
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
If we change a config that needs an instance restart the `RunningValue` will keep the same until the restart happens. 
If we need to change the value again for the old one the command will return `Value to set is the same as the existing value. No work being performed.`.

This is misleading. We need to confirm the `ConfiguredValue` and not the `RunningValue`.

Scenario:
 - I set C2Audit from 0 to 1.
 - My instance will restart on the next maintenance window.
 - But, I decided after all this instance should keep this setting OFF (0)
 - I try to run the command to set it to 0 but because the current RunningValue stills 0 it will not change my `ConfiguredValue`. Which means if my instance restarts the `RunningValue` will change to 1.

### Approach
Used the `ConfiguredValue` property instead of `RunningValue`
