### PR TITLE
Add extra helps to Invoke-DbatoolsRenameHelper

### DIFF
--- a/functions/Invoke-DbatoolsRenameHelper.ps1
+++ b/functions/Invoke-DbatoolsRenameHelper.ps1
@@ -56,7 +56,7 @@ function Invoke-DbatoolsRenameHelper {
         Shows what would happen if the command would run. If the command would run and there were matches,
         the resulting changes would be written to disk as Ascii encoded.
 
-          #>
+    #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [parameter(Mandatory, ValueFromPipeline)]

--- a/functions/Invoke-DbatoolsRenameHelper.ps1
+++ b/functions/Invoke-DbatoolsRenameHelper.ps1
@@ -76,10 +76,6 @@ function Invoke-DbatoolsRenameHelper {
                 "Definition" = "UseLastBackup"
             },
             @{
-                "AliasName"  = "ExcludeSystemLogin"
-                "Definition" = "ExcludeSystemLogins"
-            },
-            @{
                 "AliasName"  = "NoSystemLogins"
                 "Definition" = "ExcludeSystemLogins"
             },
@@ -138,7 +134,8 @@ function Invoke-DbatoolsRenameHelper {
             foreach ($name in $allrenames) {
                 if ((Select-String -Pattern $name.AliasName -Path $file)) {
                     if ($Pscmdlet.ShouldProcess($file, "Replacing $($name.AliasName) with $($name.Definition)")) {
-                        (Get-Content -Path $file -Raw).Replace($name.AliasName, $name.Definition) | Set-Content -Path $file -Encoding $Encoding
+                        $content = (Get-Content -Path $file -Raw).Replace($name.AliasName, $name.Definition).Trim()
+                        Set-Content -Path $file -Encoding $Encoding -Value $content
                         [pscustomobject]@{
                             Path         = $file
                             Pattern      = $name.AliasName

--- a/functions/Invoke-DbatoolsRenameHelper.ps1
+++ b/functions/Invoke-DbatoolsRenameHelper.ps1
@@ -76,6 +76,10 @@ function Invoke-DbatoolsRenameHelper {
                 "Definition" = "UseLastBackup"
             },
             @{
+                "AliasName"  = "NetworkShare"
+                "Definition" = "SharedPath"
+            },
+            @{
                 "AliasName"  = "NoSystemLogins"
                 "Definition" = "ExcludeSystemLogins"
             },

--- a/functions/Invoke-DbatoolsRenameHelper.ps1
+++ b/functions/Invoke-DbatoolsRenameHelper.ps1
@@ -74,11 +74,58 @@ function Invoke-DbatoolsRenameHelper {
             @{
                 "AliasName"  = "UseLastBackups"
                 "Definition" = "UseLastBackup"
-            }
-            ,
+            },
             @{
-                "AliasName"  = "NetworkShare"
-                "Definition" = "SharedPath"
+                "AliasName"  = "ExcludeSystemLogin"
+                "Definition" = "ExcludeSystemLogins"
+            },
+            @{
+                "AliasName"  = "NoSystemLogins"
+                "Definition" = "ExcludeSystemLogins"
+            },
+            @{
+                "AliasName"  = "NoJobSteps"
+                "Definition" = "ExcludeJobSteps"
+            },
+            @{
+                "AliasName"  = "NoSystemObjects"
+                "Definition" = "ExcludeSystemObjects"
+            },
+            @{
+                "AliasName"  = "NoJobs"
+                "Definition" = "ExcludeJobs"
+            },
+            @{
+                "AliasName"  = "NoDatabases"
+                "Definition" = "ExcludeDatabases"
+            },
+            @{
+                "AliasName"  = "NoDisabledJobs"
+                "Definition" = "ExcludeDisabledJobs"
+            },
+            @{
+                "AliasName"  = "NoJobSteps"
+                "Definition" = "ExcludeJobSteps"
+            },
+            @{
+                "AliasName"  = "NoSystem"
+                "Definition" = "ExcludeSystemLogins"
+            },
+            @{
+                "AliasName"  = "NoSystemDb"
+                "Definition" = "ExcludeSystemDatabases"
+            },
+            @{
+                "AliasName"  = "NoSystemObjects"
+                "Definition" = "ExcludeSystemObjects"
+            },
+            @{
+                "AliasName"  = "NoSystemSpid"
+                "Definition" = "ExcludeSystemSpids"
+            },
+            @{
+                "AliasName"  = "NoQueryTextColumn"
+                "Definition" = "ExcludeQueryTextColumn"
             }
         )
 

--- a/tests/Invoke-DbatoolsRenameHelper.Tests.ps1
+++ b/tests/Invoke-DbatoolsRenameHelper.Tests.ps1
@@ -21,3 +21,71 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
     for more guidence.
 #>
+
+
+Describe "$CommandName IntegrationTests" -Tag "IntegrationTests" {
+    $content = @'
+function Get-DbaStub {
+    <#
+        .SYNOPSIS
+            is a stub
+
+        .DESCRIPTION
+            Using
+    #>
+    process {
+        do this UseLastBackups
+        then Find-SqlDuplicateIndex
+        or Export-SqlUser -NoSystemLogins
+        Write-Message -Level Verbose "stub"
+    }
+}
+'@
+    
+    $wantedContent = @'
+function Get-DbaStub {
+    <#
+        .SYNOPSIS
+            is a stub
+
+        .DESCRIPTION
+            Using
+    #>
+    process {
+        do this UseLastBackup
+        then Find-DbaDuplicateIndex
+        or Export-DbaUser -ExcludeSystemLogins
+        Write-Message -Level Verbose "stub"
+    }
+}
+
+'@
+    
+    Context "replacement actually works" {
+        $temppath = Join-Path $TestDrive 'somefile2.ps1'
+        [System.IO.File]::WriteAllText($temppath, $content)
+        $results = $temppath | Invoke-DbatoolsRenameHelper
+        $newcontent = [System.IO.File]::ReadAllText($temppath)
+        
+        It "returns 4 results" {
+            $results.Count | Should -Be 4
+        }
+
+        foreach ($result in $results) {
+            It "returns the expected results" {
+                $result.Path | Should -Be $temppath
+                $result.Pattern -in "Export-SqlUser", "Find-SqlDuplicateIndex", "UseLastBackups", "NoSystemLogins" | Should -Be $true
+                $result.ReplacedWith -in "Export-DbaUser", "Find-DbaDuplicateIndex", "UseLastBackup", "ExcludeSystemLogins" | Should -Be $true
+            }
+        }
+
+        It "returns expected specific results" {
+            $result = $results | Where-Object Pattern -eq "Export-SqlUser"
+            $result.ReplacedWith | Should -Be "Export-DbaUser"
+        }
+        
+        It "should return exactly the format we want" {
+            $newcontent | Should -Be $wantedContent
+        }
+    }
+}


### PR DESCRIPTION
NoNoun -> ExcludeNoun aliasing

need to do this for the replaced vars in Start-DbaMigration, brb