### PR TITLE
Get-DbaProductKey - breaking changes, fixes #3737

### DIFF
--- a/functions/Get-DbaProductKey.ps1
+++ b/functions/Get-DbaProductKey.ps1
@@ -8,17 +8,16 @@ function Get-DbaProductKey {
 
         Uses key decoder by Jakob Bindslet (http://goo.gl/1jiwcB)
 
-    .PARAMETER SqlInstance
+    .PARAMETER ComputerName
         The target SQL Server instance or instances.
 
+    .PARAMETER Credential
+        Login to the target Windows instance using alternative credentials. Windows Authentication supported. Accepts credential objects (Get-Credential)
+    
     .PARAMETER SqlCredential
-        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
-
-    .PARAMETER SqlCms
-        Deprecated, pipe in from Get-DbaCmsRegServer
-
-    .PARAMETER ServersFromFile
-        Deprecated, pipe in from Get-Content
+        This command logs into the SQL instance to gather additional information. 
+    
+        Use this parameter to connect to the discovered SQL instances using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -37,7 +36,7 @@ function Get-DbaProductKey {
         https://dbatools.io/Get-DbaProductKey
 
     .EXAMPLE
-        PS C:\> Get-DbaProductKey -SqlInstance winxp, sqlservera, sqlserver2014a, win2k8
+        PS C:\> Get-DbaProductKey -ComputerName winxp, sqlservera, sqlserver2014a, win2k8
 
         Gets SQL Server versions, editions and product keys for all instances within each server or workstation.
 
@@ -45,88 +44,139 @@ function Get-DbaProductKey {
     [CmdletBinding()]
     param (
         [parameter(ValueFromPipeline, Mandatory)]
-        [Alias("ServerInstance", "SqlServer", "SqlInstances")]
-        [DbaInstanceParameter[]]$SqlInstance,
+        [Alias("SqlInstance")]
+        [DbaInstanceParameter[]]$ComputerName,
         [PSCredential]$SqlCredential,
-        [string]$SqlCms,
-        [string]$ServersFromFile,
+        [PSCredential]$Credential,
         [switch]$EnableException
     )
 
     begin {
-        Function Unlock-SqlInstanceKey {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory)]
-                [byte[]]$data,
-                [int]$version
-            )
-            try {
-                if ($version -ge 11) { $binArray = ($data)[0 .. 66] }
-                else { $binArray = ($data)[52 .. 66] }
-                $charsArray = "B", "C", "D", "F", "G", "H", "J", "K", "M", "P", "Q", "R", "T", "V", "W", "X", "Y", "2", "3", "4", "6", "7", "8", "9"
-                for ($i = 24; $i -ge 0; $i--) {
-                    $k = 0
-                    for ($j = 14; $j -ge 0; $j--) {
-                        $k = $k * 256 -bxor $binArray[$j]
-                        $binArray[$j] = [math]::truncate($k / 24)
-                        $k = $k % 24
+        $scriptblock = {
+            $versionMajor = $args[0]
+            $instanceReg = $args[1]
+            $edition = $args[2]
+
+            Function Unlock-SqlInstanceKey {
+                [CmdletBinding()]
+                param (
+                    [Parameter(Mandatory)]
+                    [byte[]]$data,
+                    [int]$version
+                )
+                try {
+                    if ($version -ge 11) {
+                        $binArray = ($data)[0 .. 66]
+                    } else {
+                        $binArray = ($data)[52 .. 66]
                     }
-                    $productKey = $charsArray[$k] + $productKey
-                    if (($i % 5 -eq 0) -and ($i -ne 0)) {
-                        $productKey = "-" + $productKey
+                    $charsArray = "B", "C", "D", "F", "G", "H", "J", "K", "M", "P", "Q", "R", "T", "V", "W", "X", "Y", "2", "3", "4", "6", "7", "8", "9"
+                    for ($i = 24; $i -ge 0; $i--) {
+                        $k = 0
+                        for ($j = 14; $j -ge 0; $j--) {
+                            $k = $k * 256 -bxor $binArray[$j]
+                            $binArray[$j] = [math]::truncate($k / 24)
+                            $k = $k % 24
+                        }
+                        $productKey = $charsArray[$k] + $productKey
+                        if (($i % 5 -eq 0) -and ($i -ne 0)) {
+                            $productKey = "-" + $productKey
+                        }
+                    }
+                } catch {
+                    $productkey = "Cannot decode product key."
+                }
+                return $productKey
+            }
+            $localmachine = [Microsoft.Win32.RegistryHive]::LocalMachine
+            $defaultview = [Microsoft.Win32.RegistryView]::Default
+            $reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey($localmachine, $defaultview)
+
+            switch ($versionMajor) {
+                9 {
+                    $sqlversion = "SQL Server 2005 $servicePack"
+                    $findkeys = $reg.OpenSubKey("$($instanceReg.Path)\ProductID", $false)
+                    foreach ($findkey in $findkeys.GetValueNames()) {
+                        if ($findkey -like "DigitalProductID*") {
+                            $key = @("$($instanceReg.Path)\ProductID\$findkey")
+                        }
                     }
                 }
-            } catch {
-                $productkey = "Cannot decode product key."
+                10 {
+                    $sqlversion = "SQL Server 2008 $servicePack"
+                    if ($server.VersionMinor -eq 50) {
+                        $sqlversion = "SQL Server 2008 R2 $servicePack"
+                    }
+                    $key = @("$($instanceReg.Path)\Setup\DigitalProductID")
+                }
+                11 {
+                    $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
+                    $sqlversion = "SQL Server 2012 $servicePack"
+                }
+                12 {
+                    $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
+                    $sqlversion = "SQL Server 2014 $servicePack"
+                }
+                13 {
+                    $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
+                    $sqlversion = "SQL Server 2016 $servicePack"
+                }
+                14 {
+                    $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
+                    $sqlversion = "SQL Server 2017 $servicePack"
+                }
+                default {
+                    Stop-Function -Message "SQL version not currently supported." -Continue
+                }
             }
-            return $productKey
+            if ($edition -notlike "*Express*") {
+                $sqlkey = ''
+                foreach ($k in $key) {
+                    $subkey = Split-Path $k
+                    $binaryvalue = Split-Path $k -Leaf
+                    try {
+                        $binarykey = $($reg.OpenSubKey($subkey)).GetValue($binaryvalue)
+                        break
+                    } catch {
+                        $binarykey = $null
+                    }
+                }
+
+                if ($null -eq $binarykey) {
+                    $sqlkey = "Could not read Product Key from registry on $env:COMPUTERNAME"
+                } else {
+                    try {
+                        $sqlkey = Unlock-SqlInstanceKey $binarykey $versionMajor
+                    } catch {
+                        $sqlkey = "Unable to unlock key"
+                    }
+                }
+            } else {
+                $sqlkey = "SQL Server Express Edition"
+            }
+
+            [pscustomobject]@{
+                Version = $sqlversion
+                Key     = $sqlkey
+            }
+            $reg.Close()
         }
     }
 
     process {
-        if ($SqlCms) {
-            Stop-Function -Message "Please pipe in servers using Get-DbaCmsRegServer instead"
-            return
-        }
-
-        If ($ServersFromFile) {
-            Stop-Function -Message "Please pipe in servers using Get-Content instead"
-            return
-        }
-
-        foreach ($instance in $SqlInstance) {
-            $computerName = $instance.ComputerName
+        foreach ($computer in $ComputerName) {
             try {
-                $regRoots = Get-DbaRegistryRoot -ComputerName $computerName -EnableException
+                $registryroot = Get-DbaRegistryRoot -ComputerName $computer.ComputerName -EnableException
             } catch {
-                Stop-Function -Message "Can't access registry for $computerName. Is the Remote Registry service started?" -Continue
-            }
-            if ($instance.IsLocalhost) {
-                $localmachine = [Microsoft.Win32.RegistryHive]::LocalMachine
-                $defaultview = [Microsoft.Win32.RegistryView]::Default
-                $reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey($localmachine, $defaultview)
-            } else {
-                # Get IP for remote registry access. It's the most reliable.
-                try { $ipaddr = ([System.Net.Dns]::GetHostAddresses($computerName)).IPAddressToString }
-                catch {
-                    Stop-Function -Message "Can't resolve $computerName. Skipping." -Continue
-                }
-
-                try {
-                    $reg = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey("LocalMachine", $ipaddr)
-                } catch {
-                    Stop-Function -Message "Can't access registry for $computerName. Is the Remote Registry service started?" -Continue
-                }
+                Stop-Function -Message "Can't access registry for $($computer.ComputerName). Is the Remote Registry service started?" -Continue
             }
 
-            if (-not($regRoots)) {
-                Stop-Function -Message "No instances found on $computerName. Skipping." -Continue
+            if (-not $registryroot) {
+                Stop-Function -Message "No instances found on $($computer.ComputerName)" -Continue
             }
 
             # Get Product Keys for all instances on the server.
-            foreach ($instanceReg in $regRoots) {
-
+            foreach ($instanceReg in $registryroot) {
                 try {
                     $server = Connect-SqlInstance -SqlInstance $instanceReg.SqlInstance -SqlCredential $SqlCredential -MinimumVersion 10
                 } catch {
@@ -134,86 +184,28 @@ function Get-DbaProductKey {
                 }
 
                 $servicePack = $server.ProductLevel
+                $versionMajor = $server.VersionMajor
                 Write-Message -Level Debug -Message "$instance $instanceName version is $($server.VersionMajor)"
 
-                switch ($server.VersionMajor) {
-                    9 {
-                        $sqlversion = "SQL Server 2005 $servicePack"
-                        $findkeys = $reg.OpenSubKey("$($instanceReg.Path)\ProductID", $false)
-                        foreach ($findkey in $findkeys.GetValueNames()) {
-                            if ($findkey -like "DigitalProductID*") {
-                                $key = @("$($instanceReg.Path)\ProductID\$findkey")
-                            }
-                        }
-                    }
-                    10 {
-                        $sqlversion = "SQL Server 2008 $servicePack"
-                        if ($server.VersionMinor -eq 50) {
-                            $sqlversion = "SQL Server 2008 R2 $servicePack"
-                        }
-                        $key = @("$($instanceReg.Path)\Setup\DigitalProductID")
-                    }
-                    11 {
-                        $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
-                        $sqlversion = "SQL Server 2012 $servicePack"
-                    }
-                    12 {
-                        $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
-                        $sqlversion = "SQL Server 2014 $servicePack"
-                    }
-                    13 {
-                        $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
-                        $sqlversion = "SQL Server 2016 $servicePack"
-                    }
-                    14 {
-                        $key = @("$($instanceReg.Path)\Setup\DigitalProductID", "$($instanceReg.Path)\ClientSetup\DigitalProductID")
-                        $sqlversion = "SQL Server 2017 $servicePack"
-                    }
-                    default {
-                        Stop-Function -Message "SQL version not currently supported." -Continue
-                    }
-                }
-                if ($server.Edition -notlike "*Express*") {
-                    $sqlkey = ''
-                    foreach ($k in $key) {
-                        $subkey = Split-Path $k
-                        $binaryvalue = Split-Path $k -Leaf
-                        try {
-                            $binarykey = $($reg.OpenSubKey($subkey)).GetValue($binaryvalue)
-                            break
-                        } catch {
-                            $binarykey = $null
-                        }
-                    }
-
-                    if ($null -eq $binarykey) {
-                        $sqlkey = "Could not read Product Key from registry on $computername"
-                    } else {
-                        try {
-                            $sqlkey = Unlock-SqlInstanceKey $binarykey $server.VersionMajor
-                        } catch {
-                            $sqlkey = "Unable to unlock key"
-                        }
-                    }
-                } else {
-                    $sqlkey = "SQL Server Express Edition"
+                try {
+                    $results = Invoke-Command2 -ComputerName $computer.ComputerName -Credential $Credential -ScriptBlock $scriptblock -ArgumentList $server.VersionMajor, $instanceReg, $server.Edition
+                } catch {
+                    Stop-Function -Message "Failure" -ErrorRecord $_
                 }
 
                 [pscustomobject]@{
-                    "SQL Instance" = $server.DomainInstanceName
-                    "SQL Version"  = $sqlversion
-                    "SQL Edition"  = $server.Edition
-                    "Product Key"  = $sqlkey
+                    ComputerName = $server.ComputerName
+                    InstanceName = $server.ServiceName
+                    SqlInstance  = $server.DomainInstanceName
+                    Version      = $results.Version
+                    Edition      = $server.Edition
+                    Key          = $results.Key
                 }
             }
-            $reg.Close()
         }
     }
     end {
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Get-SqlServerKey
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Alias Get-DbaSqlProductKey
-
-        Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Parameter CMSStore
-        Test-DbaDeprecation -DeprecatedOn "1.0.0" -EnableException:$false -Parameter ServersFromFile
     }
 }

--- a/functions/Get-DbaProductKey.ps1
+++ b/functions/Get-DbaProductKey.ps1
@@ -14,10 +14,10 @@ function Get-DbaProductKey {
 
     .PARAMETER Credential
         Login to the target Windows instance using alternative credentials. Windows Authentication supported. Accepts credential objects (Get-Credential)
-    
+
     .PARAMETER SqlCredential
-        This command logs into the SQL instance to gather additional information. 
-    
+        This command logs into the SQL instance to gather additional information.
+
         Use this parameter to connect to the discovered SQL instances using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
     .PARAMETER EnableException

--- a/functions/Get-DbaProductKey.ps1
+++ b/functions/Get-DbaProductKey.ps1
@@ -1,10 +1,11 @@
+#ValidationTags#CodeStyle,Messaging,FlowControl,Pipeline#
 function Get-DbaProductKey {
     <#
     .SYNOPSIS
-        Gets SQL Server Product Keys from local or destination SQL Servers. Works with SQL Server 2005-2016
+        Gets SQL Server Product Keys from local or destination SQL Servers. Works with SQL Server 2005-2017
 
     .DESCRIPTION
-        Using a string of servers, a text file, or Central Management Server to provide a list of servers, this script will go to each server and get the product key for all installed instances. Clustered instances are supported as well. Requires regular user access to the SQL instances, SMO installed locally, Remote Registry enabled and accessible by the account running the script.
+        This command find the product key for all installed instances. Clustered instances are supported as well.
 
         Uses key decoder by Jakob Bindslet (http://goo.gl/1jiwcB)
 

--- a/tests/Get-DbaProductKey.Tests.ps1
+++ b/tests/Get-DbaProductKey.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 5
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Get-DbaProductKey).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'SqlCms', 'ServersFromFile', 'EnableException'
+        $knownParameters = 'ComputerName', 'SqlCredential', 'Credential', 'EnableException'
+        $paramCount = $knownParameters.Count
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }


### PR DESCRIPTION
style changes, alias removal, moves everything to invoke-command2 as well, so no remote registry requirement, just WSMAN/PowerShell

the remote registry requirement always bothered me because this is like, the only command that required it.
