### PR TITLE
Get-DecryptedObject.: open after cmd, not before

### DIFF
--- a/internal/functions/Get-DecryptedObject.ps1
+++ b/internal/functions/Get-DecryptedObject.ps1
@@ -133,9 +133,9 @@ function Get-DecryptedObject {
         $results = Invoke-Command2 -ErrorAction Stop -Raw -Credential $Credential -ComputerName $sourceNetBios -ArgumentList $connString, $sql {
             $connString = $args[0]; $sql = $args[1]
             $conn = New-Object System.Data.SqlClient.SQLConnection($connString)
-            $conn.open()
-            $cmd = New-Object System.Data.SqlClient.SqlCommand($sql, $conn);
+            $cmd = New-Object System.Data.SqlClient.SqlCommand($sql, $conn)
             $dt = New-Object System.Data.DataTable
+            $conn.open()
             $dt.Load($cmd.ExecuteReader())
             $conn.Close()
             $conn.Dispose()


### PR DESCRIPTION
should reduce duplicate dac usage. fixes #3522

followed https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.connection?view=netframework-4.7.2

not 100% confident on this resolution but shoudl fix