### PR TITLE
Remove IsActiveDirectoryUniversalAuth from Connect-DbaInstance

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -67,9 +67,6 @@ function Connect-DbaInstance {
 
         If you specify a failover partner and the primary server is not configured for database mirroring, the connection to the primary server (specified with the Server keyword) will succeed if the primary server is available.
 
-    .PARAMETER IsActiveDirectoryUniversalAuth
-        If this switch is enabled, the connection will be configured to use Azure Active Directory authentication.
-
     .PARAMETER LockTimeout
         Sets the time in seconds required for the connection to time out when the current transaction is locked.
 
@@ -192,7 +189,6 @@ function Connect-DbaInstance {
         [int]$ConnectTimeout = ([Sqlcollaborative.Dbatools.Connection.ConnectionHost]::SqlConnectionTimeout),
         [switch]$EncryptConnection,
         [string]$FailoverPartner,
-        [switch]$IsActiveDirectoryUniversalAuth,
         [int]$LockTimeout,
         [int]$MaxPoolSize,
         [int]$MinPoolSize,
@@ -286,7 +282,6 @@ function Connect-DbaInstance {
                 if (Test-Bound -ParameterName 'ConnectTimeout') { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
                 if (Test-Bound -ParameterName 'Database') { $server.ConnectionContext.DatabaseName = $Database }
                 if (Test-Bound -ParameterName 'EncryptConnection') { $server.ConnectionContext.EncryptConnection = $true }
-                if (Test-Bound -ParameterName 'IsActiveDirectoryUniversalAuth') { $server.ConnectionContext.IsActiveDirectoryUniversalAuth = $true }
                 if (Test-Bound -ParameterName 'LockTimeout') { $server.ConnectionContext.LockTimeout = $LockTimeout }
                 if (Test-Bound -ParameterName 'MaxPoolSize') { $server.ConnectionContext.MaxPoolSize = $MaxPoolSize }
                 if (Test-Bound -ParameterName 'MinPoolSize') { $server.ConnectionContext.MinPoolSize = $MinPoolSize }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 27
         $defaultParamCount = 11
         [object[]]$params = (Get-ChildItem function:\Connect-DbaInstance).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'AccessToken', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'EncryptConnection', 'FailoverPartner', 'IsActiveDirectoryUniversalAuth', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString', 'SqlConnectionOnly', 'DisableException'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'AccessToken', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'EncryptConnection', 'FailoverPartner', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString', 'SqlConnectionOnly', 'DisableException'
+        $paramCount = $knownParameters.Count
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }


### PR DESCRIPTION
per #4611 

```
This property indeed does not exist in our version of SMO
https://dba.stackexchange.com/a/168566/75630

We will be moving to the version of SMO that the `sqlserver` module uses and that does not support IsActiveDirectoryUniversalAuth either. Unfortunately, my PR to fix this will be to remove the property. Azure Auth is on my agenda, but not until dbatools 1.1 unless someone else wants to take a stab at it.
```