### PR TITLE
fix: Find-DbaDbGrowthEvent looping

### DIFF
--- a/functions/Find-DbaDbGrowthEvent.ps1
+++ b/functions/Find-DbaDbGrowthEvent.ps1
@@ -138,7 +138,7 @@ function Find-DbaDbGrowthEvent {
 
         $eventClassFilter = $eventClass -join ","
 
-        $sql = "
+        $sqlTemplate = "
             BEGIN TRY
                 IF (SELECT CONVERT(INT,[value_in_use]) FROM sys.configurations WHERE [name] = 'default trace enabled' ) = 1
                     BEGIN
@@ -243,11 +243,11 @@ function Find-DbaDbGrowthEvent {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
 
-            #Create dblist name in 'bd1', 'db2' format
+            #Create dblist name in 'db1', 'db2' format
             $dbsList = "'$($($dbs | ForEach-Object {$_.Name}) -join "','")'"
             Write-Message -Level Verbose -Message "Executing query against $dbsList on $instance"
 
-            $sql = $sql -replace '_DatabaseList_', $dbsList
+            $sql = $sqlTemplate -replace '_DatabaseList_', $dbsList
             Write-Message -Level Debug -Message "Executing SQL Statement:`n $sql"
 
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'EventClass', 'DatabaseName', 'Filename', 'Duration', 'StartTime', 'EndTime', 'ChangeInSize', 'ApplicationName', 'HostName'


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3931)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fix issues when passed multiple servers.

### Approach
Proper reinitialization of the sql statement, via variable rename

### Commands to test
`Find-DbaDbGrowthEvent -SqlInstance 'server1','server2'`, making sure that BOTH 
`Find-DbaDbGrowthEvent -SqlInstance 'server1'` and `Find-DbaDbGrowthEvent -SqlInstance 'server2'` return actual results.
 