### PR TITLE
Remove or hide MB in Backup/Restore commands

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -325,14 +325,14 @@ function Invoke-DbaAdvancedRestore {
                                 RestoredFile           = $((Split-Path $backup.FileList.PhysicalName -Leaf) | Sort-Object -Unique) -Join ','
                                 RestoredFileFull       = ($backup.Filelist.PhysicalName -Join ',')
                                 RestoreDirectory       = $RestoreDirectory
-                                BackupSize             = if ([bool]($backup.psobject.Properties.Name -contains 'TotalSize')) { ($backup | Measure-Object -Property TotalSize -Sum).Sum } else { $null }
-                                CompressedBackupSize   = if ([bool]($backup.psobject.Properties.Name -contains 'CompressedBackupSize')) { ($backup | Measure-Object -Property CompressedBackupSize -Sum).Sum } else { $null }
+                                BackupSize             = if ([bool]($backup.psobject.Properties.Name -contains 'TotalSize')) { [dbasize](($backup | Measure-Object -Property TotalSize -Sum).Sum) } else { $null }
+                                CompressedBackupSize   = if ([bool]($backup.psobject.Properties.Name -contains 'CompressedBackupSize')) { [dbasize](($backup | Measure-Object -Property CompressedBackupSize -Sum).Sum) } else { $null }
                                 Script                 = $script
                                 BackupFileRaw          = ($backups.Fullname)
                                 FileRestoreTime        = New-TimeSpan -Seconds ((Get-Date) - $FileRestoreStartTime).TotalSeconds
                                 DatabaseRestoreTime    = New-TimeSpan -Seconds ((Get-Date) - $DatabaseRestoreStartTime).TotalSeconds
                                 ExitError              = $ExitError
-                            } | Select-DefaultView -ExcludeProperty BackupSize, CompressedBackupSize, ExitError, BackupFileRaw, RestoredFileFull
+                            } | Select-DefaultView -ExcludeProperty BackupSizeMB, CompressedBackupSizeMB, ExitError, BackupFileRaw, RestoredFileFull
                         } else {
                             $script
                         }

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -80,7 +80,7 @@ function Invoke-DbaAdvancedRestore {
 
     .NOTES
         Tags: Restore, Backup
-        Author: Chrissy LeMaire (@cl), netnerds.net
+        Author: Stuart Moore (@napalmgram - http://stuart-moore.com)
 
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -101,7 +101,7 @@ function Invoke-DbaAdvancedRestore {
         First generates just the T-SQL restore scripts so they can be sanity checked, and then if they are good perform the full restore.
         By reusing the BackupHistory object there is no need to rescan all the backup files again
 
-       #>
+    #>
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "AzureCredential", Justification = "For Parameter AzureCredential")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "", Justification = "PSSA Rule Ignored by BOH")]

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -69,9 +69,9 @@ function Read-DbaBackupHeader {
         Also returns detailed information about each of the datafiles contained in the backupset.
 
     .EXAMPLE
-        PS C:\> "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak" | Read-DbaBackupHeader -SqlInstance sql2016
+        PS C:\> "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak" | Read-DbaBackupHeader -SqlInstance sql2016  | Where-Object { $_.BackupSize.Megabyte -gt 100 }
 
-        Similar to running Read-DbaBackupHeader -SqlInstance sql2016 -Path "C:\temp\myfile.bak", "\backupserver\backups\myotherfile.bak"
+        Reads the two files and returns only backups larger than 100 MB
 
     .EXAMPLE
         PS C:\> Get-ChildItem \\nas\sql\*.bak | Read-DbaBackupHeader -SqlInstance sql2016

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -83,7 +83,7 @@ function Read-DbaBackupHeader {
 
         Gets the backup header information from the SQL Server backup file stored at https://dbatoolsaz.blob.core.windows.net/azbackups/restoretime/restoretime_201705131850.bak on Azure
 
-       #>
+    #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", 'AzureCredential', Justification = "For Parameter AzureCredential")]
     [CmdletBinding()]
     param (
@@ -135,13 +135,20 @@ function Read-DbaBackupHeader {
             $null = $dataTable.Columns.Add("FileList", [object])
             $null = $dataTable.Columns.Add("SqlVersion")
             $null = $dataTable.Columns.Add("BackupPath")
-            
+
             foreach ($row in $dataTable) {
                 $row.BackupPath = $Path
+
                 $backupsize = $row.BackupSize
                 $null = $dataTable.Columns.Remove("BackupSize")
                 $null = $dataTable.Columns.Add("BackupSize", [dbasize])
                 $row.BackupSize = [dbasize]$backupsize
+
+                $cbackupsize = $row.CompressedBackupSize
+                $null = $dataTable.Columns.Remove("CompressedBackupSize")
+                $null = $dataTable.Columns.Add("CompressedBackupSize", [dbasize])
+                $row.CompressedBackupSize = [dbasize]$cbackupsize
+
                 $restore.FileNumber = $row.Position
                 <# Select-Object does a quick and dirty conversion from datatable to PS object #>
                 $row.FileList = $restore.ReadFileList($server) | Select-Object *

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -132,31 +132,16 @@ function Read-DbaBackupHeader {
             $device = New-Object Microsoft.SqlServer.Management.Smo.BackupDeviceItem $Path, $DeviceType
             $restore.Devices.Add($device)
             $dataTable = $restore.ReadBackupHeader($server)
-
             $null = $dataTable.Columns.Add("FileList", [object])
-
-            $mb = $dataTable.Columns.Add("BackupSizeMB", [int])
-            $mb.Expression = "BackupSize / 1024 / 1024"
-            $gb = $dataTable.Columns.Add("BackupSizeGB")
-            $gb.Expression = "BackupSizeMB / 1024"
-
-            if ($null -eq $dataTable.Columns['CompressedBackupSize']) {
-                $formula = "0"
-            } else {
-                $formula = "CompressedBackupSize / 1024 / 1024"
-            }
-
-            $cmb = $dataTable.Columns.Add("CompressedBackupSizeMB", [int])
-            $cmb.Expression = $formula
-            $cgb = $dataTable.Columns.Add("CompressedBackupSizeGB")
-            $cgb.Expression = "CompressedBackupSizeMB / 1024"
-
             $null = $dataTable.Columns.Add("SqlVersion")
-
             $null = $dataTable.Columns.Add("BackupPath")
-
+            
             foreach ($row in $dataTable) {
                 $row.BackupPath = $Path
+                $backupsize = $row.BackupSize
+                $null = $dataTable.Columns.Remove("BackupSize")
+                $null = $dataTable.Columns.Add("BackupSize", [dbasize])
+                $row.BackupSize = [dbasize]$backupsize
                 $restore.FileNumber = $row.Position
                 <# Select-Object does a quick and dirty conversion from datatable to PS object #>
                 $row.FileList = $restore.ReadFileList($server) | Select-Object *
@@ -262,7 +247,7 @@ function Read-DbaBackupHeader {
                         }
                     }
                     if ($Simple) {
-                        $dataTable | Select-Object DatabaseName, BackupFinishDate, RecoveryModel, BackupSizeMB, CompressedBackupSizeMB, DatabaseCreationDate, UserName, ServerName, SqlVersion, BackupPath
+                        $dataTable | Select-Object DatabaseName, BackupFinishDate, RecoveryModel, BackupSize, CompressedBackupSize, DatabaseCreationDate, UserName, ServerName, SqlVersion, BackupPath
                     } elseif ($FileList) {
                         $dataTable.filelist
                     } else {


### PR DESCRIPTION
Didn't want to touch these too much, so I 

1. Changed the column hide from `Select-DefaultView` to show without MB by default
2. Left MB in for minimal impact
3. Made BackupSize and CompressedBackupSize `[dbasize]`
4. Made Read-DbaBackupHeader's Size into a `[dbasize]`