### PR TITLE
Baby steps for Non-Windows Core

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -171,12 +171,16 @@ Write-ImportTime -Text "Loading dbatools library"
 
 # Load configuration system
 # Should always go after library and path setting
-if (-not ([Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleImported)) {
-    . Import-ModuleFile "$script:PSModuleRoot\internal\configurations\configuration.ps1"
-    Write-ImportTime -Text "Configuration System"
-}
-if (-not ([Sqlcollaborative.Dbatools.Message.LogHost]::LoggingPath)) {
-    [Sqlcollaborative.Dbatools.Message.LogHost]::LoggingPath = "$($env:AppData)\PowerShell\dbatools"
+if (($PSVersionTable.Keys -contains "Platform") -and $PSVersionTable.Platform -ne "Win32NT") {
+    Write-Verbose -Message "Skipping configuration. Not Core compatible yet."
+} else {
+    if (-not ([Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleImported)) {
+        . Import-ModuleFile "$script:PSModuleRoot\internal\configurations\configuration.ps1"
+        Write-ImportTime -Text "Configuration System"
+    }
+    if (-not ([Sqlcollaborative.Dbatools.Message.LogHost]::LoggingPath)) {
+        [Sqlcollaborative.Dbatools.Message.LogHost]::LoggingPath = "$($env:AppData)\PowerShell\dbatools"
+    }
 }
 
 if ($script:multiFileImport) {

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -217,9 +217,13 @@ foreach ($function in (Get-ChildItem -Path (Resolve-Path -Path "$script:PSModule
 }
 Write-ImportTime -Text "Loading Optional Commands"
 
-# Process TEPP parameters
-. Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\insertTepp.ps1")
-Write-ImportTime -Text "Loading TEPP"
+if (($PSVersionTable.Keys -contains "Platform") -and $PSVersionTable.Platform -ne "Win32NT") {
+    Write-Verbose -Message "Skipping tepp configuration. Not Core compatible yet."
+} else {
+    # Process TEPP parameters
+    . Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\insertTepp.ps1")
+    Write-ImportTime -Text "Loading TEPP"
+}
 
 # Process transforms
 . Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\message-transforms.ps1")
@@ -232,9 +236,13 @@ Write-ImportTime -Text "Loading Message Transforms"
 . Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\logfilescript.ps1")
 Write-ImportTime -Text "Script: Logging"
 
-# Start the tepp asynchronous update system (requires the configuration system up and running)
-. Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\updateTeppAsync.ps1")
-Write-ImportTime -Text "Script: Asynchronous TEPP Cache"
+if (($PSVersionTable.Keys -contains "Platform") -and $PSVersionTable.Platform -ne "Win32NT") {
+    Write-Verbose -Message "Skipping tepp configuration. Not Core compatible yet."
+} else {
+    # Start the tepp asynchronous update system (requires the configuration system up and running)
+    . Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\updateTeppAsync.ps1")
+    Write-ImportTime -Text "Script: Asynchronous TEPP Cache"
+}
 
 # Start the maintenance system (requires pretty much everything else already up and running)
 . Import-ModuleFile -Path (Resolve-Path -Path "$script:PSModuleRoot\internal\scripts\dbatools-maintenance.ps1")

--- a/functions/Add-DbaPfDataCollectorCounter.ps1
+++ b/functions/Add-DbaPfDataCollectorCounter.ps1
@@ -85,6 +85,8 @@ function Add-DbaPfDataCollectorCounter {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -164,7 +164,7 @@ function Export-DbaInstance {
             if (-not (Test-Bound -ParameterName Path)) {
                 $timenow = (Get-Date -uformat "%m%d%Y%H%M%S")
                 $mydocs = [Environment]::GetFolderPath('MyDocuments')
-                $path = Resolve-Path -Path "$mydocs\$($server.name.replace('\', '$'))-$timenow"
+                $path = "$mydocs\$($server.name.replace('\', '$'))-$timenow"
             }
 
             if (-not (Test-Path $Path)) {

--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -164,7 +164,7 @@ function Export-DbaInstance {
             if (-not (Test-Bound -ParameterName Path)) {
                 $timenow = (Get-Date -uformat "%m%d%Y%H%M%S")
                 $mydocs = [Environment]::GetFolderPath('MyDocuments')
-                $path = "$mydocs\$($server.name.replace('\', '$'))-$timenow"
+                $path = Resolve-Path -Path "$mydocs\$($server.name.replace('\', '$'))-$timenow"
             }
 
             if (-not (Test-Path $Path)) {

--- a/functions/Export-DbaPfDataCollectorSetTemplate.ps1
+++ b/functions/Export-DbaPfDataCollectorSetTemplate.ps1
@@ -63,6 +63,8 @@ function Export-DbaPfDataCollectorSetTemplate {
         [switch]$EnableException
     )
     process {
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Get-DbaComputerCertificate.ps1
+++ b/functions/Get-DbaComputerCertificate.ps1
@@ -109,8 +109,9 @@ function Get-DbaComputerCertificate {
         }
         #endregion Scriptblock for remoting
     }
-
+    
     process {
+        if (Test-NotWindows) { return }
         foreach ($computer in $computername) {
             try {
                 Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock $scriptblock -ArgumentList $thumbprint, $Store, $Folder, $Path -ErrorAction Stop | Select-DefaultView -Property FriendlyName, DnsNameList, Thumbprint, NotBefore, NotAfter, Subject, Issuer

--- a/functions/Get-DbaPfAvailableCounter.ps1
+++ b/functions/Get-DbaPfAvailableCounter.ps1
@@ -88,6 +88,8 @@ function Get-DbaPfAvailableCounter {
         $Pattern = $Pattern.Replace("*", ".*").Replace("..*", ".*")
     }
     process {
+        if (Test-NotWindows) { return }
+        
         foreach ($computer in $ComputerName) {
 
             try {

--- a/functions/Get-DbaPfDataCollector.ps1
+++ b/functions/Get-DbaPfDataCollector.ps1
@@ -77,6 +77,8 @@ function Get-DbaPfDataCollector {
         $columns = 'ComputerName', 'DataCollectorSet', 'Name', 'DataCollectorType', 'DataSourceName', 'FileName', 'FileNameFormat', 'FileNameFormatPattern', 'LatestOutputLocation', 'LogAppend', 'LogCircular', 'LogFileFormat', 'LogOverwrite', 'SampleInterval', 'SegmentMaxRecords', 'Counters'
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Get-DbaPfDataCollectorCounter.ps1
+++ b/functions/Get-DbaPfDataCollectorCounter.ps1
@@ -87,6 +87,8 @@ function Get-DbaPfDataCollectorCounter {
         #$columns = 'ComputerName', 'Name', 'DataCollectorSet', 'Counters', 'DataCollectorType', 'DataSourceName', 'FileName', 'FileNameFormat', 'FileNameFormatPattern', 'LatestOutputLocation', 'LogAppend', 'LogCircular', 'LogFileFormat', 'LogOverwrite', 'SampleInterval', 'SegmentMaxRecords'
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Get-DbaPfDataCollectorCounterSample.ps1
+++ b/functions/Get-DbaPfDataCollectorCounterSample.ps1
@@ -106,7 +106,8 @@ function Get-DbaPfDataCollectorCounterSample {
         [switch]$EnableException
     )
     process {
-
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Get-DbaPfDataCollectorSet.ps1
+++ b/functions/Get-DbaPfDataCollectorSet.ps1
@@ -177,6 +177,8 @@ function Get-DbaPfDataCollectorSet {
         'SubdirectoryFormatPattern', 'Task', 'TaskArguments', 'TaskRunAsSelf', 'TaskUserTextArguments', 'UserAccount'
     }
     process {
+        if (Test-NotWindows) { return }
+        
         foreach ($computer in $ComputerName.ComputerName) {
             try {
                 Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock $setscript -ArgumentList $CollectorSet, $Credential -ErrorAction Stop | Select-DefaultView -Property $columns

--- a/functions/Get-DbaPfDataCollectorSetTemplate.ps1
+++ b/functions/Get-DbaPfDataCollectorSetTemplate.ps1
@@ -61,6 +61,8 @@ function Get-DbaPfDataCollectorSetTemplate {
         $Pattern = $Pattern.Replace("*", ".*").Replace("..*", ".*")
     }
     process {
+        if (Test-NotWindows) { return }
+        
         foreach ($directory in $Path) {
             $files = Get-ChildItem "$directory\*.xml"
 

--- a/functions/Import-DbaPfDataCollectorSetTemplate.ps1
+++ b/functions/Import-DbaPfDataCollectorSetTemplate.ps1
@@ -169,6 +169,8 @@ function Import-DbaPfDataCollectorSetTemplate {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if ((Test-Bound -ParameterName Path -Not) -and (Test-Bound -ParameterName Template -Not)) {
             Stop-Function -Message "You must specify Path or Template"
         }

--- a/functions/Invoke-DbaPfRelog.ps1
+++ b/functions/Invoke-DbaPfRelog.ps1
@@ -169,6 +169,8 @@ function Invoke-DbaPfRelog {
         [switch]$EnableException
     )
     begin {
+        if (Test-NotWindows) { return }
+        
         if (Test-Bound -ParameterName BeginTime) {
             $script:beginstring = ($BeginTime -f 'M/d/yyyy hh:mm:ss' | Out-String).Trim()
         }

--- a/functions/New-DbaComputerCertificate.ps1
+++ b/functions/New-DbaComputerCertificate.ps1
@@ -229,7 +229,8 @@ function New-DbaComputerCertificate {
 
     process {
         if (Test-FunctionInterrupt) { return }
-
+        if (Test-NotWindows) { return }
+        
         foreach ($computer in $ComputerName) {
 
             if (!$secondaryNode) {

--- a/functions/Remove-DbaComputerCertificate.ps1
+++ b/functions/Remove-DbaComputerCertificate.ps1
@@ -102,8 +102,10 @@ function Remove-DbaComputerCertificate {
         }
         #endregion Scriptblock for remoting
     }
-
+    
     process {
+        if (Test-NotWindows) { return }
+        
         foreach ($computer in $computername) {
             foreach ($thumb in $Thumbprint) {
                 if ($PScmdlet.ShouldProcess("local", "Connecting to $computer to remove cert from Cert:\$Store\$Folder")) {

--- a/functions/Remove-DbaPfDataCollectorCounter.ps1
+++ b/functions/Remove-DbaPfDataCollectorCounter.ps1
@@ -85,6 +85,8 @@ function Remove-DbaPfDataCollectorCounter {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if ($InputObject.Credential -and (Test-Bound -ParameterName Credential -Not)) {
             $Credential = $InputObject.Credential
         }

--- a/functions/Remove-DbaPfDataCollectorSet.ps1
+++ b/functions/Remove-DbaPfDataCollectorSet.ps1
@@ -93,6 +93,8 @@ function Remove-DbaPfDataCollectorSet {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if (-not $InputObject -or ($InputObject -and (Test-Bound -ParameterName ComputerName))) {
             foreach ($computer in $ComputerName) {
                 $InputObject += Get-DbaPfDataCollectorSet -ComputerName $computer -Credential $Credential -CollectorSet $CollectorSet

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -94,8 +94,13 @@ function Resolve-DbaNetworkName {
         [Alias('Silent')]
         [switch]$EnableException
     )
-
+    
     process {
+        if (Test-NotWindows) {
+            Write-Message -Level Verbose -Message "Non-Windows client detected. Turbo (DNS resolution only) set to $true"
+            $Turbo = $true
+        }
+        
         foreach ($Computer in $ComputerName) {
             $conn = $ipaddress = $null
 

--- a/functions/Start-DbaPfDataCollectorSet.ps1
+++ b/functions/Start-DbaPfDataCollectorSet.ps1
@@ -89,6 +89,8 @@ function Start-DbaPfDataCollectorSet {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if (-not $InputObject -or ($InputObject -and (Test-Bound -ParameterName ComputerName))) {
             foreach ($computer in $ComputerName) {
                 $InputObject += Get-DbaPfDataCollectorSet -ComputerName $computer -Credential $Credential -CollectorSet $CollectorSet

--- a/functions/Stop-DbaPfDataCollectorSet.ps1
+++ b/functions/Stop-DbaPfDataCollectorSet.ps1
@@ -91,6 +91,8 @@ function Stop-DbaPfDataCollectorSet {
         }
     }
     process {
+        if (Test-NotWindows) { return }
+        
         if (-not $InputObject -or ($InputObject -and (Test-Bound -ParameterName ComputerName))) {
             foreach ($computer in $ComputerName) {
                 $InputObject += Get-DbaPfDataCollectorSet -ComputerName $computer -Credential $Credential -CollectorSet $CollectorSet

--- a/internal/functions/Test-NotWindows.ps1
+++ b/internal/functions/Test-NotWindows.ps1
@@ -1,0 +1,26 @@
+﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+function Test-NotWindows {
+    <#
+        .SYNOPSIS
+            Internal tool, used to detect non-Windows platforms
+
+        .DESCRIPTION
+            Some things don't work with Windows, this is an easy way to detect
+
+        .EXAMPLE
+            if (Test-NotWindows) { return }
+
+            The calling function will stop if this function returns true.
+       #>
+    [CmdletBinding()]
+    param (
+        
+    )
+    
+    if (($PSVersionTable.Keys -contains "Platform") -and $psversiontable.Platform -ne "Win32NT1") {
+        Write-Message -Level Warning -Message "This command is not supported on non-Windows platforms :("
+        return $true
+    }
+    
+    return $false
+}

--- a/internal/functions/Test-NotWindows.ps1
+++ b/internal/functions/Test-NotWindows.ps1
@@ -1,4 +1,4 @@
-﻿#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
+#ValidationTags#Messaging,FlowControl,Pipeline,CodeStyle#
 function Test-NotWindows {
     <#
         .SYNOPSIS
@@ -11,18 +11,18 @@ function Test-NotWindows {
             if (Test-NotWindows) { return }
 
             The calling function will stop if this function returns true.
-       #>
+    #>
     [CmdletBinding()]
     param (
         [switch]$NoWarn
     )
-    
+
     if (($PSVersionTable.Keys -contains "Platform") -and $psversiontable.Platform -ne "Win32NT") {
         if (-not $NoWarn) {
             Write-Message -Level Warning -Message "This command is not supported on non-Windows platforms :("
         }
         return $true
     }
-    
+
     return $false
 }

--- a/internal/functions/Test-NotWindows.ps1
+++ b/internal/functions/Test-NotWindows.ps1
@@ -14,11 +14,13 @@ function Test-NotWindows {
        #>
     [CmdletBinding()]
     param (
-        
+        [switch]$NoWarn
     )
     
-    if (($PSVersionTable.Keys -contains "Platform") -and $psversiontable.Platform -ne "Win32NT1") {
-        Write-Message -Level Warning -Message "This command is not supported on non-Windows platforms :("
+    if (($PSVersionTable.Keys -contains "Platform") -and $psversiontable.Platform -ne "Win32NT") {
+        if (-not $NoWarn) {
+            Write-Message -Level Warning -Message "This command is not supported on non-Windows platforms :("
+        }
         return $true
     }
     


### PR DESCRIPTION
Removed support for a couple Windows-only commands like the perfmon commands. Bypassed config loading on non-Windows Core. Updated test for notWindows to enable not warning.