### PR TITLE
Move recommendation for C# extension to C# solution folder

### DIFF
--- a/bin/projects/dbatools/.vscode/extensions.json
+++ b/bin/projects/dbatools/.vscode/extensions.json
@@ -2,6 +2,6 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.PowerShell"
+        "ms-vscode.csharp"
     ]
 }

--- a/bin/projects/dbatools/.vscode/settings.json
+++ b/bin/projects/dbatools/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.trimTrailingWhitespace": true
+}


### PR DESCRIPTION
Related #4669

Do not recommend the C# extension when VS-Code gets opened in the root folder, only recommend the C# extension when someone opens VS-Code in the C# project solution folder. Again, this applies only when using VS-Code AND opening in the C# project, it does not apply to Visual Studio. This way we also keep people trimming trailing whitespace.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
