### PR TITLE
add dbatools search recommendation for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.PowerShell"
+        "ms-vscode.PowerShell",
+        "dbatools.search"
     ]
 }


### PR DESCRIPTION
Provides a useful, SQL PowerShell/Microsoft centric search context for repo users to search right from their code.

![dbatools search](https://github.com/potatoqualitee/vscode-dbatools-search/raw/master/resources/search.gif)

At first, I was just gonna add this to the marketplace for fun but it turned out to be something I'll use often myself, so I decided to add it to the recommendations as well. 

Currently, we have two recommendations: dbatools simple search and PowerShell. I don't plan on adding any more at this time, though I'd like to consider a good markdown extension in the future unless one is built into vs code and I'm not aware.

I'll write a blog post about it this week.