### PR TITLE
Remove mandatory = $false

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -122,9 +122,7 @@ function Backup-DbaDbCertificate {
         [object[]]$Database,
         [parameter(ParameterSetName = "instance")]
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $false)]
         [Security.SecureString]$EncryptionPassword,
-        [parameter(Mandatory = $false)]
         [Security.SecureString]$DecryptionPassword,
         [System.IO.FileInfo]$Path,
         [string]$Suffix = "$(Get-Date -format 'yyyyMMddHHmmssms')",

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -166,7 +166,6 @@ function Copy-DbaDatabase {
     [CmdletBinding(DefaultParameterSetName = "DbBackup", SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "", Justification = "PSSA Rule Ignored by BOH")]
     param (
-        [parameter(Mandatory = $false)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
         [parameter(Mandatory)]

--- a/functions/Find-DbaBackup.ps1
+++ b/functions/Find-DbaBackup.ps1
@@ -71,7 +71,6 @@ function Find-DbaBackup {
         [string]$BackupFileExtension ,
         [parameter(Mandatory, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
         [string]$RetentionPeriod ,
-        [parameter(Mandatory = $false)]
         [switch]$CheckArchiveBit = $false ,
         [Alias('Silent')]
         [switch]$EnableException
@@ -97,7 +96,7 @@ function Find-DbaBackup {
                 '7d' = 7 days
                 '4w' = 4 weeks
                 '1m' = 1 month
-                       #>
+            #>
 
             [int]$Length = ($UserFriendlyRetention).Length
             $Value = ($UserFriendlyRetention).Substring(0, $Length - 1)

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -85,9 +85,7 @@ function Find-DbaOrphanedFile {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [parameter(Mandatory = $false)]
         [pscredential]$SqlCredential,
-        [parameter(Mandatory = $false)]
         [string[]]$Path,
         [string[]]$FileType,
         [switch]$LocalOnly,

--- a/functions/Get-DbaAgentJobOutputFile.ps1
+++ b/functions/Get-DbaAgentJobOutputFile.ps1
@@ -90,7 +90,7 @@ function Get-DbaAgentJobOutputFile {
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false, HelpMessage = 'SQL Credential',
+        [Parameter(HelpMessage = 'SQL Credential',
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false,
             Position = 1)]

--- a/functions/Get-DbaBuildReference.ps1
+++ b/functions/Get-DbaBuildReference.ps1
@@ -63,7 +63,7 @@ function Get-DbaBuildReference {
         [version[]]
         $Build,
 
-        [parameter(Mandatory = $false, ValueFromPipeline)]
+        [parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]
         $SqlInstance,

--- a/functions/Get-DbaQueryExecutionTime.ps1
+++ b/functions/Get-DbaQueryExecutionTime.ps1
@@ -74,13 +74,13 @@ function Get-DbaQueryExecutionTime {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Position = 1, Mandatory = $false)]
+        [parameter(Position = 1)]
         [int]$MaxResultsPerDb = 100,
-        [parameter(Position = 2, Mandatory = $false)]
+        [parameter(Position = 2)]
         [int]$MinExecs = 100,
-        [parameter(Position = 3, Mandatory = $false)]
+        [parameter(Position = 3)]
         [int]$MinExecMs = 500,
-        [parameter(Position = 4, Mandatory = $false)]
+        [parameter(Position = 4)]
         [Alias("ExcludeSystemDatabases")]
         [switch]$ExcludeSystem,
         [Alias('Silent')]

--- a/functions/Get-DbaSpn.ps1
+++ b/functions/Get-DbaSpn.ps1
@@ -52,11 +52,9 @@ function Get-DbaSpn {
     [cmdletbinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseApprovedVerbs", "", Justification = "Internal functions are ignored")]
     param (
-        [Parameter(Mandatory = $false, ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [string[]]$ComputerName,
-        [Parameter(Mandatory = $false)]
         [string[]]$AccountName,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$Credential,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Get-DbaSsisEnvironmentVariable.ps1
+++ b/functions/Get-DbaSsisEnvironmentVariable.ps1
@@ -110,15 +110,10 @@ function Get-DbaSsisEnvironmentVariable {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias('SqlServer', 'ServerInstance')]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory = $false)]
         [object[]]$Environment,
-        [parameter(Mandatory = $false)]
         [object[]]$EnvironmentExclude,
-        [parameter(Mandatory = $false)]
         [object[]]$Folder,
-        [parameter(Mandatory = $false)]
         [object[]]$FolderExclude,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -63,7 +63,7 @@ function Get-DbaUserPermission {
         Check server and database permissions on server sql2008 for only the TestDB database,
         including public and guest grants, and sys schema objects.
 
-       #>
+    #>
     [CmdletBinding()]
     param (
         [parameter(Position = 0, Mandatory, ValueFromPipeline)]
@@ -73,7 +73,7 @@ function Get-DbaUserPermission {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Position = 1, Mandatory = $false)]
+        [parameter(Position = 1)]
         [switch]$ExcludeSystemDatabase,
         [switch]$IncludePublicGuest,
         [switch]$IncludeSystemObjects,

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -75,7 +75,6 @@ function Install-DbaWhoIsActive {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PsCredential]$SqlCredential,
-        [parameter(Mandatory = $false)]
         [ValidateScript( { Test-Path -Path $_ -PathType Leaf })]
         [string]$LocalFile,
         [object]$Database,

--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -398,19 +398,15 @@ function Invoke-DbaDbLogShipping {
         [Alias("DestinationServerInstance", "DestinationSqlServer", "Destination")]
         [object[]]$DestinationSqlInstance,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $SourceSqlCredential,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $SourceCredential,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $DestinationSqlCredential,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $DestinationCredential,
 
@@ -420,230 +416,159 @@ function Invoke-DbaDbLogShipping {
         [parameter(Mandatory)]
         [string]$BackupNetworkPath,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupLocalPath,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupJob,
 
-        [parameter(Mandatory = $false)]
         [int]$BackupRetention,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupSchedule,
 
-        [parameter(Mandatory = $false)]
         [switch]$BackupScheduleDisabled,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet("Daily", "Weekly", "AgentStart", "IdleComputer")]
         [object]$BackupScheduleFrequencyType,
 
-        [parameter(Mandatory = $false)]
         [object[]]$BackupScheduleFrequencyInterval,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet('Time', 'Seconds', 'Minutes', 'Hours')]
         [object]$BackupScheduleFrequencySubdayType,
 
-        [parameter(Mandatory = $false)]
         [int]$BackupScheduleFrequencySubdayInterval,
 
-        [Parameter(Mandatory = $false)]
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
         [object]$BackupScheduleFrequencyRelativeInterval,
 
-        [Parameter(Mandatory = $false)]
         [int]$BackupScheduleFrequencyRecurrenceFactor,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupScheduleStartDate,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupScheduleEndDate,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupScheduleStartTime,
 
-        [parameter(Mandatory = $false)]
         [string]$BackupScheduleEndTime,
 
-        [parameter(Mandatory = $false)]
         [int]$BackupThreshold,
 
-        [parameter(Mandatory = $false)]
         [switch]$CompressBackup,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyDestinationFolder,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyJob,
 
-        [parameter(Mandatory = $false)]
         [int]$CopyRetention,
 
-        [parameter(Mandatory = $false)]
         [string]$CopySchedule,
 
-        [parameter(Mandatory = $false)]
         [switch]$CopyScheduleDisabled,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet("Daily", "Weekly", "AgentStart", "IdleComputer")]
         [object]$CopyScheduleFrequencyType,
 
-        [parameter(Mandatory = $false)]
         [object[]]$CopyScheduleFrequencyInterval,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet('Time', 'Seconds', 'Minutes', 'Hours')]
         [object]$CopyScheduleFrequencySubdayType,
 
-        [parameter(Mandatory = $false)]
         [int]$CopyScheduleFrequencySubdayInterval,
 
-        [Parameter(Mandatory = $false)]
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
         [object]$CopyScheduleFrequencyRelativeInterval,
 
-        [Parameter(Mandatory = $false)]
         [int]$CopyScheduleFrequencyRecurrenceFactor,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyScheduleStartDate,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyScheduleEndDate,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyScheduleStartTime,
 
-        [parameter(Mandatory = $false)]
         [string]$CopyScheduleEndTime,
 
-        [parameter(Mandatory = $false)]
         [switch]$DisconnectUsers,
 
-        [parameter(Mandatory = $false)]
         [string]$FullBackupPath,
 
-        [parameter(Mandatory = $false)]
         [switch]$GenerateFullBackup,
 
-        [parameter(Mandatory = $false)]
         [int]$HistoryRetention,
 
-        [parameter(Mandatory = $false)]
         [switch]$NoRecovery,
 
-        [parameter(Mandatory = $false)]
         [switch]$NoInitialization,
 
-        [Parameter(Mandatory = $false)]
         [string]$PrimaryMonitorServer,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $PrimaryMonitorCredential,
 
-        [Parameter(Mandatory = $false)]
         [ValidateSet(0, "sqlserver", 1, "windows")]
         [object]$PrimaryMonitorServerSecurityMode,
 
-        [Parameter(Mandatory = $false)]
         [switch]$PrimaryThresholdAlertEnabled,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreDataFolder,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreLogFolder,
 
-        [parameter(Mandatory = $false)]
         [int]$RestoreDelay,
 
-        [parameter(Mandatory = $false)]
         [int]$RestoreAlertThreshold,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreJob,
 
-        [parameter(Mandatory = $false)]
         [int]$RestoreRetention,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreSchedule,
 
-        [parameter(Mandatory = $false)]
         [switch]$RestoreScheduleDisabled,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet("Daily", "Weekly", "AgentStart", "IdleComputer")]
         [object]$RestoreScheduleFrequencyType,
 
-        [parameter(Mandatory = $false)]
         [object[]]$RestoreScheduleFrequencyInterval,
 
-        [parameter(Mandatory = $false)]
         [ValidateSet('Time', 'Seconds', 'Minutes', 'Hours')]
         [object]$RestoreScheduleFrequencySubdayType,
 
-        [parameter(Mandatory = $false)]
         [int]$RestoreScheduleFrequencySubdayInterval,
 
-        [Parameter(Mandatory = $false)]
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
         [object]$RestoreScheduleFrequencyRelativeInterval,
 
-        [Parameter(Mandatory = $false)]
         [int]$RestoreScheduleFrequencyRecurrenceFactor,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreScheduleStartDate,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreScheduleEndDate,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreScheduleStartTime,
 
-        [parameter(Mandatory = $false)]
         [string]$RestoreScheduleEndTime,
 
-        [parameter(Mandatory = $false)]
         [int]$RestoreThreshold,
 
-        [parameter(Mandatory = $false)]
         [string]$SecondaryDatabasePrefix,
 
-        [parameter(Mandatory = $false)]
         [string]$SecondaryDatabaseSuffix,
 
-        [Parameter(Mandatory = $false)]
         [string]$SecondaryMonitorServer,
 
-        [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]
         $SecondaryMonitorCredential,
 
-        [Parameter(Mandatory = $false)]
         [ValidateSet(0, "sqlserver", 1, "windows")]
         [object]$SecondaryMonitorServerSecurityMode,
 
-        [Parameter(Mandatory = $false)]
         [switch]$SecondaryThresholdAlertEnabled,
 
-        [parameter(Mandatory = $false)]
         [switch]$Standby,
 
-        [parameter(Mandatory = $false)]
         [string]$StandbyDirectory,
 
-        [parameter(Mandatory = $false)]
         [switch]$UseExistingFullBackup,
 
-        [parameter(Mandatory = $false)]
         [string]$UseBackupFolder,
 
         [switch]$Force,

--- a/functions/Invoke-SqlCmd2.ps1
+++ b/functions/Invoke-SqlCmd2.ps1
@@ -193,7 +193,6 @@ function Invoke-Sqlcmd2 {
         [ValidateNotNullOrEmpty()]
         [string[]]$ServerInstance,
         [Parameter(Position = 1,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [string]$Database,
@@ -222,67 +221,54 @@ function Invoke-Sqlcmd2 {
         [string]$InputFile,
         [Parameter(ParameterSetName = 'Ins-Que',
             Position = 3,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Ins-Fil',
             Position = 3,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Alias('SqlCredential')]
         [System.Management.Automation.PSCredential]$Credential,
         [Parameter(ParameterSetName = 'Ins-Que',
             Position = 4,
-            Mandatory = $false,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Ins-Fil',
             Position = 4,
-            Mandatory = $false,
             ValueFromRemainingArguments = $false)]
         [switch]$Encrypt,
         [Parameter(Position = 5,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Int32]$QueryTimeout = 600,
         [Parameter(ParameterSetName = 'Ins-Fil',
             Position = 6,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Ins-Que',
             Position = 6,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [Int32]$ConnectionTimeout = 15,
         [Parameter(Position = 7,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "SingleValue")]
         [string]$As = "DataRow",
         [Parameter(Position = 8,
-            Mandatory = $false,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [System.Collections.IDictionary]$SqlParameters,
-        [Parameter(Position = 9,
-            Mandatory = $false)]
+        [Parameter(Position = 9)]
         [switch]$AppendServerInstance,
-        [Parameter(Position = 10,
-            Mandatory = $false)]
+        [Parameter(Position = 10)]
         [switch]$ParseGO,
         [Parameter(ParameterSetName = 'Con-Que',
             Position = 11,
-            Mandatory = $false,
             ValueFromPipeline = $false,
             ValueFromPipelineByPropertyName = $false,
             ValueFromRemainingArguments = $false)]
         [Parameter(ParameterSetName = 'Con-Fil',
             Position = 11,
-            Mandatory = $false,
             ValueFromPipeline = $false,
             ValueFromPipelineByPropertyName = $false,
             ValueFromRemainingArguments = $false)]

--- a/functions/Measure-DbaDiskSpaceRequirement.ps1
+++ b/functions/Measure-DbaDiskSpaceRequirement.ps1
@@ -77,15 +77,15 @@ function Measure-DbaDiskSpaceRequirement {
         [DbaInstanceParameter]$Source,
         [Parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [string]$Database,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [PSCredential]$SourceSqlCredential,
         [Parameter(Mandatory, ValueFromPipelineByPropertyName = $true)]
         [DbaInstanceParameter]$Destination,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [string]$DestinationDatabase,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [PSCredential]$DestinationSqlCredential,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [PSCredential]$Credential,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/New-DbaConnectionStringBuilder.ps1
+++ b/functions/New-DbaConnectionStringBuilder.ps1
@@ -69,29 +69,20 @@ function New-DbaConnectionStringBuilder {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingUserNameAndPassWordParams", "")]
     param (
-        [Parameter(Mandatory = $false, ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [string[]]$ConnectionString = "",
-        [Parameter(Mandatory = $false)]
         [string]$ApplicationName = "dbatools Powershell Module",
-        [Parameter(Mandatory = $false)]
         [string]$DataSource = $null,
-        [Parameter(Mandatory = $false)]
         [string]$InitialCatalog = $null,
-        [Parameter(Mandatory = $false)]
         [Nullable[bool]]$IntegratedSecurity = $null,
-        [Parameter(Mandatory = $false)]
         [string]$UserName = $null,
         # No point in securestring here, the memory is never stored securely in memory.
-        [Parameter(Mandatory = $false)]
         [string]$Password = $null,
         [Alias('MARS')]
-        [Parameter(Mandatory = $false)]
         [switch]$MultipleActiveResultSets,
         [Alias('AlwaysEncrypted')]
-        [Parameter(Mandatory = $false)]
         [Data.SqlClient.SqlConnectionColumnEncryptionSetting]$ColumnEncryptionSetting =
         [Data.SqlClient.SqlConnectionColumnEncryptionSetting]::Enabled,
-        [Parameter(Mandatory = $false)]
         [string]$WorkstationId = $env:COMPUTERNAME
     )
     process {

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -63,7 +63,6 @@ function Remove-DbaAgentJobCategory {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Category,
         [switch]$Force,

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -73,7 +73,6 @@ function Remove-DbaAgentJobStep {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/functions/Remove-DbaBackup.ps1
+++ b/functions/Remove-DbaBackup.ps1
@@ -94,9 +94,7 @@ function Remove-DbaBackup {
         [string]$BackupFileExtension ,
         [parameter(Mandatory, HelpMessage = "Backup retention period. (ex. 24h, 7d, 4w, 6m)")]
         [string]$RetentionPeriod ,
-        [parameter(Mandatory = $false)]
         [switch]$CheckArchiveBit = $false ,
-        [parameter(Mandatory = $false)]
         [switch]$RemoveEmptyBackupFolder = $false,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -73,7 +73,6 @@ function Remove-DbaDatabase {
         [parameter(Mandatory, ParameterSetName = "instance")]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [parameter(Mandatory = $false)]
         [Alias("Credential")]
         [PSCredential]
         $SqlCredential,

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -119,20 +119,15 @@ function Remove-DbaDatabaseSafely {
         $SqlCredential,
         [Alias("Databases")]
         [object[]]$Database,
-        [parameter(Mandatory = $false)]
         [DbaInstanceParameter]$Destination = $sqlinstance,
         [PSCredential]
         $DestinationCredential,
-        [parameter(Mandatory = $false)]
         [Alias("NoCheck")]
         [switch]$NoDbccCheckDb,
         [parameter(Mandatory)]
         [string]$BackupFolder,
-        [parameter(Mandatory = $false)]
         [string]$CategoryName = 'Rationalisation',
-        [parameter(Mandatory = $false)]
         [string]$JobOwner,
-        [parameter(Mandatory = $false)]
         [switch]$AllDatabases,
         [ValidateSet("Default", "On", "Of")]
         [string]$BackupCompression = 'Default',

--- a/functions/Remove-DbaDbBackupRestoreHistory.ps1
+++ b/functions/Remove-DbaDbBackupRestoreHistory.ps1
@@ -67,11 +67,10 @@ function Remove-DbaDbBackupRestoreHistory {
         PS C:\> Get-DbaDatabase -SqlInstance sql2016 | Remove-DbaDbBackupRestoreHistory -WhatIf
 
         Remove complete backup and restore history for all databases on SQL Server sql2016
-          #>
+    #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
         [DbaInstanceParameter[]]$SqlInstance,
-        [parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
         [int]$KeepDays = 30,
         [string[]]$Database,

--- a/functions/Remove-DbaLogin.ps1
+++ b/functions/Remove-DbaLogin.ps1
@@ -69,7 +69,6 @@ function Remove-DbaLogin {
         [parameter(Mandatory, ParameterSetName = "instance")]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [parameter(Mandatory = $false)]
         [Alias("Credential")]
         [PSCredential]$SqlCredential,
         [parameter(Mandatory, ParameterSetName = "instance")]

--- a/functions/Remove-DbaOrphanUser.ps1
+++ b/functions/Remove-DbaOrphanUser.ps1
@@ -97,7 +97,7 @@ function Remove-DbaOrphanUser {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $false, ValueFromPipeline)]
+        [parameter(ValueFromPipeline)]
         [object[]]$User,
         [switch]$Force,
         [Alias('Silent')]

--- a/functions/Remove-DbaSpn.ps1
+++ b/functions/Remove-DbaSpn.ps1
@@ -74,7 +74,7 @@ function Remove-DbaSpn {
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("InstanceServiceAccount", "AccountName")]
         [string]$ServiceAccount,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [PSCredential]$Credential,
         [Alias('Silent')]
         [switch]$EnableException

--- a/functions/Repair-DbaOrphanUser.ps1
+++ b/functions/Repair-DbaOrphanUser.ps1
@@ -98,7 +98,7 @@ function Repair-DbaOrphanUser {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Mandatory = $false, ValueFromPipeline)]
+        [parameter(ValueFromPipeline)]
         [object[]]$Users,
         [switch]$RemoveNotExisting,
         [switch]$Force,

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -61,7 +61,6 @@ function Set-DbaAgentJobCategory {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Category,
         [string[]]$NewName,

--- a/functions/Set-DbaAgentJobOutputFile.ps1
+++ b/functions/Set-DbaAgentJobOutputFile.ps1
@@ -57,13 +57,13 @@ function Set-DbaAgentJobOutputFile {
         [ValidateNotNullOrEmpty()]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false, HelpMessage = 'SQL Credential',
+        [Parameter(HelpMessage = 'SQL Credential',
             ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true,
             ValueFromRemainingArguments = $false)]
         [PSCredential]$SqlCredential,
         [object[]]$Job,
-        [Parameter(Mandatory = $false, HelpMessage = 'The Job Step name',
+        [Parameter(HelpMessage = 'The Job Step name',
             ValueFromPipeline,
             ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNull()]

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -140,7 +140,6 @@ function Set-DbaAgentJobStep {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -148,44 +147,27 @@ function Set-DbaAgentJobStep {
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$StepName,
-        [Parameter(Mandatory = $false)]
         [string]$NewName,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('ActiveScripting', 'AnalysisCommand', 'AnalysisQuery', 'CmdExec', 'Distribution', 'LogReader', 'Merge', 'PowerShell', 'QueueReader', 'Snapshot', 'Ssis', 'TransactSql')]
         [string]$Subsystem,
-        [Parameter(Mandatory = $false)]
         [string]$Command,
-        [Parameter(Mandatory = $false)]
         [int]$CmdExecSuccessCode,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnSuccessAction,
-        [Parameter(Mandatory = $false)]
         [int]$OnSuccessStepId,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnFailAction,
-        [Parameter(Mandatory = $false)]
         [int]$OnFailStepId,
-        [Parameter(Mandatory = $false)]
         [string]$Database,
-        [Parameter(Mandatory = $false)]
         [string]$DatabaseUser,
-        [Parameter(Mandatory = $false)]
         [int]$RetryAttempts,
-        [Parameter(Mandatory = $false)]
         [int]$RetryInterval,
-        [Parameter(Mandatory = $false)]
         [string]$OutputFileName,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('AppendAllCmdExecOutputToJobHistory', 'AppendToJobHistory', 'AppendToLogFile', 'LogToTableWithOverwrite', 'None', 'ProvideStopProcessEvent')]
         [string[]]$Flag,
-        [Parameter(Mandatory = $false)]
         [string]$ProxyName,
-        [Parameter(Mandatory = $false)]
         [Alias('Silent')]
         [switch]$EnableException,
-        [Parameter(Mandatory = $false)]
         [switch]$Force
     )
 

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -129,7 +129,6 @@ function Set-DbaAgentSchedule {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(Mandatory = $false)]
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
@@ -137,38 +136,24 @@ function Set-DbaAgentSchedule {
         [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$ScheduleName,
-        [Parameter(Mandatory = $false)]
         [string]$NewName,
-        [Parameter(Mandatory = $false)]
         [switch]$Enabled,
-        [Parameter(Mandatory = $false)]
         [switch]$Disabled,
         [ValidateSet(1, "Once", 4, "Daily", 8, "Weekly", 16, "Monthly", 32, "MonthlyRelative", 64, "AgentStart", 128, "IdleComputer")]
         [object]$FrequencyType,
-        [Parameter(Mandatory = $false)]
         [object[]]$FrequencyInterval,
-        [Parameter(Mandatory = $false)]
         [ValidateSet(1, "Time", 2, "Seconds", 4, "Minutes", 8, "Hours")]
         [object]$FrequencySubdayType,
-        [Parameter(Mandatory = $false)]
         [int]$FrequencySubdayInterval,
-        [Parameter(Mandatory = $false)]
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
         [object]$FrequencyRelativeInterval,
-        [Parameter(Mandatory = $false)]
         [int]$FrequencyRecurrenceFactor,
-        [Parameter(Mandatory = $false)]
         [string]$StartDate,
-        [Parameter(Mandatory = $false)]
         [string]$EndDate,
-        [Parameter(Mandatory = $false)]
         [string]$StartTime,
-        [Parameter(Mandatory = $false)]
         [string]$EndTime,
-        [Parameter(Mandatory = $false)]
         [Alias('Silent')]
         [switch]$EnableException,
-        [Parameter(Mandatory = $false)]
         [switch]$Force
     )
 

--- a/functions/Set-DbaSpn.ps1
+++ b/functions/Set-DbaSpn.ps1
@@ -79,7 +79,7 @@ function Set-DbaSpn {
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [Alias("InstanceServiceAccount", "AccountName")]
         [string]$ServiceAccount,
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [PSCredential]$Credential,
         [switch]$NoDelegation,
         [Alias('Silent')]

--- a/functions/Test-DbaBuild.ps1
+++ b/functions/Test-DbaBuild.ps1
@@ -105,7 +105,7 @@ function Test-DbaBuild {
         [version]$MinimumBuild,
         [string]$MaxBehind,
         [switch] $Latest,
-        [parameter(Mandatory = $false, ValueFromPipeline)]
+        [parameter(ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("Credential")]

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -65,9 +65,9 @@ function Test-DbaIdentityUsage {
         [Alias("Databases")]
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
-        [parameter(Position = 1, Mandatory = $false)]
+        [parameter(Position = 1)]
         [int]$Threshold = 0,
-        [parameter(Position = 2, Mandatory = $false)]
+        [parameter(Position = 2)]
         [Alias("ExcludeSystemDb")]
         [switch]$ExcludeSystem,
         [Alias('Silent')]

--- a/functions/Update-dbatools.ps1
+++ b/functions/Update-dbatools.ps1
@@ -46,7 +46,6 @@ function Update-Dbatools {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "It is the proper noun of the cmdlet")]
     param(
-        [parameter(Mandatory = $false)]
         [Alias("dev", "devbranch")]
         [switch]$Development,
         [Alias('Silent')]

--- a/internal/dynamicparams/tag.ps1
+++ b/internal/dynamicparams/tag.ps1
@@ -29,7 +29,6 @@ $ScriptBlock = {
             [System.Management.Automation.CompletionResultType]
             $CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue,
 
-            [Parameter(Mandatory = $false)]
             [switch]
             $NoQuotes = $false
         )

--- a/internal/functions/Get-OfflineSqlFileStructure.ps1
+++ b/internal/functions/Get-OfflineSqlFileStructure.ps1
@@ -13,7 +13,7 @@ Internal function. Returns dictionary object that contains file structures for S
         [string]$dbname,
         [Parameter(Mandatory, Position = 2)]
         [object]$filelist,
-        [Parameter(Mandatory = $false, Position = 3)]
+        [Parameter(Position = 3)]
         [bool]$ReuseSourceFolderStructure,
         [PSCredential]$SqlCredential
     )

--- a/internal/functions/Get-SqlFileStructure.ps1
+++ b/internal/functions/Get-SqlFileStructure.ps1
@@ -12,7 +12,7 @@ function Get-SqlFileStructure {
         [Parameter(Mandatory, Position = 1)]
         [ValidateNotNullOrEmpty()]
         [object]$destination,
-        [Parameter(Mandatory = $false, Position = 2)]
+        [Parameter(Position = 2)]
         [bool]$ReuseSourceFolderStructure,
         [PSCredential]$SourceSqlCredential,
         [PSCredential]$DestinationSqlCredential

--- a/internal/functions/Invoke-DbaDatabaseCorruption.ps1
+++ b/internal/functions/Invoke-DbaDatabaseCorruption.ps1
@@ -50,13 +50,12 @@ function Invoke-DbaDbCorruption {
       .EXAMPLE
       Invoke-DbaDbCorruption -SqlInstance sql2016 -Database containeddb -Table Customers -Confirm:$false
       Does not prompt and immediately corrupts table customers in database containeddb on the sql2016 instance (by putting database into single user mode, writing to garbage to its first non-iam page, and returning it to multi-user.)
-     #>
+    #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter]$SqlInstance,
-        [parameter(Mandatory = $false)]
         [Alias("Credential")]
         [PSCredential]
         $SqlCredential,

--- a/internal/functions/Invoke-Parallel.ps1
+++ b/internal/functions/Invoke-Parallel.ps1
@@ -150,10 +150,10 @@ function Invoke-Parallel {
     #>
     [cmdletbinding(DefaultParameterSetName = 'ScriptBlock')]
     param (
-        [Parameter(Mandatory = $false, position = 0, ParameterSetName = 'ScriptBlock')]
+        [Parameter(Position = 0, ParameterSetName = 'ScriptBlock')]
         [System.Management.Automation.ScriptBlock]$ScriptBlock,
 
-        [Parameter(Mandatory = $false, ParameterSetName = 'ScriptFile')]
+        [Parameter(ParameterSetName = 'ScriptFile')]
         [ValidateScript( {Test-Path $_ -pathtype leaf})]
         $ScriptFile,
 

--- a/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryPrimary.ps1
@@ -81,7 +81,7 @@ function New-DbaLogShippingSecondaryPrimary {
 
         .EXAMPLE
             New-DbaLogShippingSecondaryPrimary -SqlInstance sql2 -BackupSourceDirectory "\\sql1\logshipping\DB1" -BackupDestinationDirectory D:\Data\logshippingdestination\DB1_DR -CopyJob LSCopy_sql2_DB1_DR -FileRetentionPeriod 4320 -MonitorServer sql2 -MonitorServerSecurityMode 'Windows' -PrimaryServer sql1 -PrimaryDatabase DB1 -RestoreJob LSRestore_sql2_DB1_DR
-       #>
+    #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory)]
@@ -91,7 +91,6 @@ function New-DbaLogShippingSecondaryPrimary {
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$BackupSourceDirectory,
-        [Parameter(Mandatory = $false)]
         [string]$BackupDestinationDirectory,
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]

--- a/internal/functions/New-DbaTeppCompletionResult.ps1
+++ b/internal/functions/New-DbaTeppCompletionResult.ps1
@@ -26,7 +26,7 @@ function global:New-DbaTeppCompletionResult {
             New-DbaTeppCompletionResult -CompletionText 'master' -ToolTip 'master'
 
             Returns a CompletionResult with the text and tooltip 'master'
-       #>
+    #>
     param (
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = $true, Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
@@ -44,7 +44,6 @@ function global:New-DbaTeppCompletionResult {
         [System.Management.Automation.CompletionResultType]
         $CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue,
 
-        [Parameter(Mandatory = $false)]
         [switch]
         $NoQuotes = $false
     )

--- a/optional/Expand-Archive.ps1
+++ b/optional/Expand-Archive.ps1
@@ -73,7 +73,7 @@ Which ships with PowerShell Version 5 but will run under v3.
             [string]
             $LiteralPath,
 
-            [parameter (mandatory = $false,
+            [parameter (
                 Position = 1,
                 ValueFromPipeline = $false,
                 ValueFromPipelineByPropertyName = $false)]
@@ -81,7 +81,7 @@ Which ships with PowerShell Version 5 but will run under v3.
             [string]
             $DestinationPath,
 
-            [parameter (mandatory = $false,
+            [parameter (
                 ValueFromPipeline = $false,
                 ValueFromPipelineByPropertyName = $false)]
             [switch]

--- a/optional/TabExpansionPlusPlus.ps1
+++ b/optional/TabExpansionPlusPlus.ps1
@@ -63,7 +63,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             [System.Management.Automation.CompletionResultType]
             $CompletionResultType = [System.Management.Automation.CompletionResultType]::ParameterValue,
 
-            [Parameter(Mandatory = $false)]
             [switch]
             $NoQuotes = $false
         )


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality) #4673
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
 #4673
Parameter Attribute Mandatory is used to make a parameter required. It takes a true or false value. The default is false so typically this is only applied if you want to make a parameter required.

### Approach
These are also included:
optional\Expand-Archive.ps1
optional\TabExpansionPlusPlus.ps1

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
