### PR TITLE
Agent server new commands

### DIFF
--- a/functions/Get-DbaAgentServer.ps1
+++ b/functions/Get-DbaAgentServer.ps1
@@ -45,7 +45,6 @@ function Get-DbaAgentServer {
         [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [Alias('Silent')]
         [switch]$EnableException
     )
 

--- a/functions/Get-DbaAgentServer.ps1
+++ b/functions/Get-DbaAgentServer.ps1
@@ -1,0 +1,73 @@
+function Get-DbaAgentServer {
+    <#
+    .SYNOPSIS
+        Gets SQL Agent Server information for each instance(s) of SQL Server.
+
+    .DESCRIPTION
+        The Get-DbaAgentServer returns connected SMO object for SQL Agent Server information for each instance(s) of SQL Server.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Job, Agent
+        Author: Cláudio Silva (@claudioessilva), https://claudioessilva.eu
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaAgentServer
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentServer -SqlInstance localhost
+
+        Returns SQL Agent Server on the local default SQL Server instance
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentServer -SqlInstance localhost, sql2016
+
+        Returns SQL Agent Servers for the localhost and sql2016 SQL Server instances
+
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [Alias('Silent')]
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            $jobServer = $server.JobServer
+
+            $defaultView = 'ComputerName', 'InstanceName', 'SqlInstance', 'AgentDomainGroup', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'ErrorLogFile', 'IdleCpuDuration', 'IdleCpuPercentage', 'IsCpuPollingEnabled', 'JobServerType', 'LoginTimeout', 'JobHistoryIsEnabled', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'MsxAccountCredentialName', 'MsxAccountName', 'MsxServerName', 'Name', 'NetSendRecipient', 'ServiceAccount', 'ServiceStartMode', 'SqlAgentAutoStart', 'SqlAgentMailProfile', 'SqlAgentRestart', 'SqlServerRestart', 'State', 'SysAdminOnly'
+
+            Add-Member -Force -InputObject $jobServer -MemberType NoteProperty -Name ComputerName -Value $jobServer.Parent.ComputerName
+            Add-Member -Force -InputObject $jobServer -MemberType NoteProperty -Name InstanceName -value $jobServer.Parent.ServiceName
+            Add-Member -Force -InputObject $jobServer -MemberType NoteProperty -Name SqlInstance -Value $jobServer.Parent.DomainInstanceName
+            Add-Member -Force -InputObject $jobServer -MemberType ScriptProperty -Name JobHistoryIsEnabled -Value { switch ( $jobServer.MaximumHistoryRows ) { -1 { $false } default { $true } } }
+
+            Select-DefaultView -InputObject $jobServer -Property $defaultView
+        }
+    }
+}

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -40,8 +40,9 @@ function Set-DbaAgentServer {
     .PARAMETER IdleCpuPercentage
         Idle CPU Percentage value to be used
 
-    .PARAMETER IsCpuPollingEnabled
-        Enable the Polling. If you want to set it to false you should use -IsCpuPollingEnabled:$false
+    .PARAMETER CpuPolling
+        Enable or Disable the Polling.
+        Allowed values Enabled, Disabled
 
     .PARAMETER LocalHostAlias
         The value for Local Host Alias configuration
@@ -58,26 +59,32 @@ function Set-DbaAgentServer {
     .PARAMETER NetSendRecipient
         The Net send recipient value
 
-    .PARAMETER ReplaceAlertTokensEnabled
-        Enable the Token replacement property. If you want to set it to false you should use -ReplaceAlertTokensEnabled:$false
+    .PARAMETER ReplaceAlertTokens
+        Enable or Disable the Token replacement property.
+        Allowed values Enabled, Disabled
 
     .PARAMETER SaveInSentFolder
-        Specify if a Copy of the sent messages is save in the Sent Items folder. If you want to set it to false you should use -SaveInSentFolder:$false
+        Enable or Disable the copy of the sent messages is save in the Sent Items folder.
+        Allowed values Enabled, Disabled
 
     .PARAMETER SqlAgentAutoStart
-        Enable the SQL Agent Auto Start. If you want to set it to false you should use -SqlAgentAutoStart:$false
+        Enable or Disable the SQL Agent Auto Start.
+        Allowed values Enabled, Disabled
 
     .PARAMETER SqlAgentMailProfile
         The SQL Server Agent Mail Profile to be used. Must exists on database mail profiles.
 
     .PARAMETER SqlAgentRestart
-        Enable the SQL Agent Restart. If you want to set it to false you should use -SqlAgentRestart:$false
+        Enable or Disable the SQL Agent Restart.
+        Allowed values Enabled, Disabled
 
     .PARAMETER SqlServerRestart
-        Enable the SQL Server Restart. If you want to set it to false you should use -SqlServerRestart:$false
+        Enable or Disable the SQL Server Restart.
+        Allowed values Enabled, Disabled
 
     .PARAMETER WriteOemErrorLog
-        Enable the Write OEM Error Log. If you want to set it to false you should use -WriteOemErrorLog:$false
+        Enable or Disable the Write OEM Error Log.
+        Allowed values Enabled, Disabled
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
@@ -107,7 +114,7 @@ function Set-DbaAgentServer {
         Changes the job history retention to 10000 rows with an maximum of 100 rows per job.
 
     .EXAMPLE
-        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -IsCpuPollingEnabled
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -CpuPolling Enabled
 
         Enable the CPU Polling configurations.
 
@@ -117,7 +124,7 @@ function Set-DbaAgentServer {
         Set the agent log level to Errors and Warnings on multiple servers.
 
     .EXAMPLE
-        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -IsCpuPollingEnabled:$false
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -CpuPolling Disabled
 
         Disable the CPU Polling configurations.
 
@@ -138,19 +145,26 @@ function Set-DbaAgentServer {
         [string]$ErrorLogFile,
         [int]$IdleCpuDuration,
         [int]$IdleCpuPercentage,
-        [switch]$IsCpuPollingEnabled,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$CpuPolling,
         [string]$LocalHostAlias,
         [int]$LoginTimeout,
         [int]$MaximumHistoryRows,
         [int]$MaximumJobHistoryRows,
         [string]$NetSendRecipient,
-        [switch]$ReplaceAlertTokensEnabled,
-        [switch]$SaveInSentFolder,
-        [switch]$SqlAgentAutoStart,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$ReplaceAlertTokens,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$SaveInSentFolder,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$SqlAgentAutoStart,
         [string]$SqlAgentMailProfile,
-        [switch]$SqlAgentRestart,
-        [switch]$SqlServerRestart,
-        [switch]$WriteOemErrorLog,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$SqlAgentRestart,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$SqlServerRestart,
+        [ValidateSet("Enabled", "Disabled")]
+        [string]$WriteOemErrorLog,
         [switch]$EnableException
     )
 
@@ -230,9 +244,9 @@ function Set-DbaAgentServer {
                 $jobServer.IdleCpuPercentage = $IdleCpuPercentage
             }
 
-            if (-not ($null -eq $IsCpuPollingEnabled)) {
+            if ($CpuPolling) {
                 Write-Message -Message "Setting agent server IsCpuPollingEnabled to $IsCpuPollingEnabled" -Level Verbose
-                $jobServer.IsCpuPollingEnabled = $IsCpuPollingEnabled
+                $jobServer.IsCpuPollingEnabled = if ($CpuPolling -eq "Enabled") {$true} else {$false}
             }
 
             if ($LocalHostAlias) {
@@ -260,39 +274,39 @@ function Set-DbaAgentServer {
                 $jobServer.NetSendRecipient = $NetSendRecipient
             }
 
-            if (-not ($null -eq $ReplaceAlertTokensEnabled)) {
-                Write-Message -Message "Setting agent server ReplaceAlertTokensEnabled to $ReplaceAlertTokensEnabled" -Level Verbose
-                $jobServer.ReplaceAlertTokensEnabled = $ReplaceAlertTokensEnabled
+            if ($ReplaceAlertTokens) {
+                Write-Message -Message "Setting agent server ReplaceAlertTokensEnabled to $ReplaceAlertTokens" -Level Verbose
+                $jobServer.ReplaceAlertTokens = if ($ReplaceAlertTokens -eq "Enabled") {$true} else {$false}
             }
 
-            if (-not ($null -eq $SaveInSentFolder)) {
+            if ($SaveInSentFolder) {
                 Write-Message -Message "Setting agent server SaveInSentFolder to $SaveInSentFolder" -Level Verbose
-                $jobServer.SaveInSentFolder = $SaveInSentFolder
+                $jobServer.SaveInSentFolder = if ($SaveInSentFolder -eq "Enabled") {$true} else {$false}
             }
 
-            if (-not ($null -eq $SqlAgentAutoStart)) {
+            if ($SqlAgentAutoStart) {
                 Write-Message -Message "Setting agent server SqlAgentAutoStart to $SqlAgentAutoStart" -Level Verbose
-                $jobServer.SqlAgentAutoStart = $SqlAgentAutoStart
+                $jobServer.SqlAgentAutoStart = if ($SqlAgentAutoStart -eq "Enabled") {$true} else {$false}
             }
 
-            if (-not ($null -eq $SqlAgentMailProfile)) {
+            if ($SqlAgentMailProfile) {
                 Write-Message -Message "Setting agent server SqlAgentMailProfile to $SqlAgentMailProfile" -Level Verbose
                 $jobServer.SqlAgentMailProfile = $SqlAgentMailProfile
             }
 
-            if (-not ($null -eq $SqlAgentRestart)) {
+            if ($SqlAgentRestart) {
                 Write-Message -Message "Setting agent server SqlAgentRestart to $SqlAgentRestart" -Level Verbose
-                $jobServer.SqlAgentRestart = $SqlAgentRestart
+                $jobServer.SqlAgentRestart = if ($SqlAgentRestart -eq "Enabled") {$true} else {$false}
             }
 
-            if (-not ($null -eq $SqlServerRestart)) {
+            if ($SqlServerRestart) {
                 Write-Message -Message "Setting agent server SqlServerRestart to $SqlServerRestart" -Level Verbose
-                $jobServer.SqlServerRestart = $SqlServerRestart
+                $jobServer.SqlServerRestart = if ($SqlServerRestart -eq "Enabled") {$true} else {$false}
             }
 
-            if (-not ($null -eq $WriteOemErrorLog)) {
+            if ($WriteOemErrorLog) {
                 Write-Message -Message "Setting agent server WriteOemErrorLog to $WriteOemErrorLog" -Level Verbose
-                $jobServer.WriteOemErrorLog = $WriteOemErrorLog
+                $jobServer.WriteOemErrorLog = if ($WriteOemErrorLog -eq "Enabled") {$true} else {$false}
             }
 
             #endregion server agent options

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -15,8 +15,8 @@ function Set-DbaAgentServer {
     .PARAMETER InputObject
         Enables piping agent server objects
 
-    .PARAMETER AgentLogType
-        Specifies the agent log type.
+    .PARAMETER AgentLogLevel
+        Specifies the agent log level.
         Allowed values 1, "Errors", 2, "Warnings", 3, "Errors, Warnings", 4, "Informational", 5, "Errors, Informational", 6, "Warnings, Informational", 7, "All"
         The text value can either be lowercase, uppercase or something in between as long as the text is correct.
 
@@ -152,10 +152,6 @@ function Set-DbaAgentServer {
         [switch]$SqlServerRestart,
         [switch]$WriteOemErrorLog,
         [switch]$EnableException
-
-#$AgentLogLevel             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentLogLevels AgentLogLevel {get;set;}
-#$AgentMailType             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentMailType AgentMailType {get;set;}
-#$UserData                  Property   System.Object UserData {get;set;}
     )
 
     begin {

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -216,82 +216,82 @@ function Set-DbaAgentServer {
             }
 
             if ($ErrorLogFile) {
-                Write-Message -Message "Setting alert to ErrorLogFile" -Level Verbose
+                Write-Message -Message "Setting agent server ErrorLogFile to $ErrorLogFile" -Level Verbose
                 $jobServer.ErrorLogFile = $ErrorLogFile
             }
 
             if ($IdleCpuDuration) {
-                Write-Message -Message "Setting alert to IdleCpuDuration" -Level Verbose
+                Write-Message -Message "Setting agent server IdleCpuDuration to $IdleCpuDuration" -Level Verbose
                 $jobServer.IdleCpuDuration = $IdleCpuDuration
             }
 
             if ($IdleCpuPercentage) {
-                Write-Message -Message "Setting alert to IdleCpuPercentage" -Level Verbose
+                Write-Message -Message "Setting agent server IdleCpuPercentage to $IdleCpuPercentage" -Level Verbose
                 $jobServer.IdleCpuPercentage = $IdleCpuPercentage
             }
 
             if (-not ($null -eq $IsCpuPollingEnabled)) {
-                Write-Message -Message "Setting alert to IsCpuPollingEnabled" -Level Verbose
+                Write-Message -Message "Setting agent server IsCpuPollingEnabled to $IsCpuPollingEnabled" -Level Verbose
                 $jobServer.IsCpuPollingEnabled = $IsCpuPollingEnabled
             }
 
             if ($LocalHostAlias) {
-                Write-Message -Message "Setting alert to LocalHostAlias" -Level Verbose
+                Write-Message -Message "Setting agent server LocalHostAlias to $LocalHostAlias" -Level Verbose
                 $jobServer.LocalHostAlias = $LocalHostAlias
             }
 
             if ($LoginTimeout) {
-                Write-Message -Message "Setting alert to LoginTimeout" -Level Verbose
+                Write-Message -Message "Setting agent server LoginTimeout to $LoginTimeout" -Level Verbose
                 $jobServer.LoginTimeout = $LoginTimeout
             }
 
             if ($MaximumHistoryRows) {
-                Write-Message -Message "Setting alert to MaximumHistoryRows" -Level Verbose
+                Write-Message -Message "Setting agent server MaximumHistoryRows to $MaximumHistoryRows" -Level Verbose
                 $jobServer.MaximumHistoryRows = $MaximumHistoryRows
             }
 
             if ($MaximumJobHistoryRows) {
-                Write-Message -Message "Setting alert to MaximumJobHistoryRows" -Level Verbose
+                Write-Message -Message "Setting agent server MaximumJobHistoryRows to $MaximumJobHistoryRows" -Level Verbose
                 $jobServer.MaximumJobHistoryRows = $MaximumJobHistoryRows
             }
 
             if ($NetSendRecipient) {
-                Write-Message -Message "Setting alert to NetSendRecipient" -Level Verbose
+                Write-Message -Message "Setting agent server NetSendRecipient to $NetSendRecipient" -Level Verbose
                 $jobServer.NetSendRecipient = $NetSendRecipient
             }
 
             if (-not ($null -eq $ReplaceAlertTokensEnabled)) {
-                Write-Message -Message "Setting alert to ReplaceAlertTokensEnabled" -Level Verbose
+                Write-Message -Message "Setting agent server ReplaceAlertTokensEnabled to $ReplaceAlertTokensEnabled" -Level Verbose
                 $jobServer.ReplaceAlertTokensEnabled = $ReplaceAlertTokensEnabled
             }
 
             if (-not ($null -eq $SaveInSentFolder)) {
-                Write-Message -Message "Setting alert to SaveInSentFolder" -Level Verbose
+                Write-Message -Message "Setting agent server SaveInSentFolder to $SaveInSentFolder" -Level Verbose
                 $jobServer.SaveInSentFolder = $SaveInSentFolder
             }
 
             if (-not ($null -eq $SqlAgentAutoStart)) {
-                Write-Message -Message "Setting alert to SqlAgentAutoStart" -Level Verbose
+                Write-Message -Message "Setting agent server SqlAgentAutoStart to $SqlAgentAutoStart" -Level Verbose
                 $jobServer.SqlAgentAutoStart = $SqlAgentAutoStart
             }
 
             if (-not ($null -eq $SqlAgentMailProfile)) {
-                Write-Message -Message "Setting alert to SqlAgentMailProfile" -Level Verbose
+                Write-Message -Message "Setting agent server SqlAgentMailProfile to $SqlAgentMailProfile" -Level Verbose
                 $jobServer.SqlAgentMailProfile = $SqlAgentMailProfile
             }
 
             if (-not ($null -eq $SqlAgentRestart)) {
-                Write-Message -Message "Setting alert to SqlAgentRestart" -Level Verbose
+                Write-Message -Message "Setting agent server SqlAgentRestart to $SqlAgentRestart" -Level Verbose
                 $jobServer.SqlAgentRestart = $SqlAgentRestart
             }
 
             if (-not ($null -eq $SqlServerRestart)) {
-                Write-Message -Message "Setting alert to SqlServerRestart" -Level Verbose
+                Write-Message -Message "Setting agent server SqlServerRestart to $SqlServerRestart" -Level Verbose
                 $jobServer.SqlServerRestart = $SqlServerRestart
             }
 
             if (-not ($null -eq $WriteOemErrorLog)) {
-                Write-Message -Message "Setting alert to WriteOemErrorLog" -Level Verbose
+                Write-Message -Message "Setting agent server WriteOemErrorLog to $WriteOemErrorLog" -Level Verbose
                 $jobServer.WriteOemErrorLog = $WriteOemErrorLog
             }
 

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -151,8 +151,7 @@ function Set-DbaAgentServer {
         [switch]$SqlAgentRestart,
         [switch]$SqlServerRestart,
         [switch]$WriteOemErrorLog,
-        [switch][Alias('Silent')]
-        $EnableException
+        [switch]$EnableException
 
 #$AgentLogLevel             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentLogLevels AgentLogLevel {get;set;}
 #$AgentMailType             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentMailType AgentMailType {get;set;}

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -1,0 +1,323 @@
+function Set-DbaAgentServer {
+    <#
+    .SYNOPSIS
+        Set-DbaAgentServer updates properties of a SQL Agent Server.
+
+    .DESCRIPTION
+        Set-DbaAgentServer updates properties in the SQL Server Server with parameters supplied.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
+
+    .PARAMETER InputObject
+        Enables piping agent server objects
+
+    .PARAMETER AgentLogType
+        Specifies the agent log type.
+        Allowed values 1, "Errors", 2, "Warnings", 3, "Errors, Warnings", 4, "Informational", 5, "Errors, Informational", 6, "Warnings, Informational", 7, "All"
+        The text value can either be lowercase, uppercase or something in between as long as the text is correct.
+
+    .PARAMETER AgentMailType
+        Specifies the agent mail type.
+        Allowed values 0, "SqlAgentMail", 1, "DatabaseMail"
+        The text value can either be lowercase, uppercase or something in between as long as the text is correct.
+
+    .PARAMETER AgentShutdownWaitTime
+        The Agent Shutdown Wait Time value of the server agent.
+
+    .PARAMETER DatabaseMailProfile
+        The Database Mail Profile to be used. Must exists on database mail profiles.
+
+    .PARAMETER ErrorLogFile
+        Error log file location
+
+    .PARAMETER IdleCpuDuration
+        Idle CPU Duration value to be used
+
+    .PARAMETER IdleCpuPercentage
+        Idle CPU Percentage value to be used
+
+    .PARAMETER IsCpuPollingEnabled
+        Enable the Polling. If you want to set it to false you should use -IsCpuPollingEnabled:$false
+
+    .PARAMETER LocalHostAlias
+        The value for Local Host Alias configuration
+
+    .PARAMETER LoginTimeout
+        The value for Login Timeout configuration
+
+    .PARAMETER MaximumHistoryRows
+        Indicates the Maximum job history log size (in rows). If you want to turn it off use the value -1
+
+    .PARAMETER MaximumJobHistoryRows
+        Indicates the Maximum job history rows per job. If you want to turn it off use the value 0
+
+    .PARAMETER NetSendRecipient
+        The Net send recipient value
+
+    .PARAMETER ReplaceAlertTokensEnabled
+        Enable the Token replacement property. If you want to set it to false you should use -ReplaceAlertTokensEnabled:$false
+
+    .PARAMETER SaveInSentFolder
+        Specify if a Copy of the sent messages is save in the Sent Items folder. If you want to set it to false you should use -SaveInSentFolder:$false
+
+    .PARAMETER SqlAgentAutoStart
+        Enable the SQL Agent Auto Start. If you want to set it to false you should use -SqlAgentAutoStart:$false
+
+    .PARAMETER SqlAgentMailProfile
+        The SQL Server Agent Mail Profile to be used. Must exists on database mail profiles.
+
+    .PARAMETER SqlAgentRestart
+        Enable the SQL Agent Restart. If you want to set it to false you should use -SqlAgentRestart:$false
+
+    .PARAMETER SqlServerRestart
+        Enable the SQL Server Restart. If you want to set it to false you should use -SqlServerRestart:$false
+
+    .PARAMETER WriteOemErrorLog
+        Enable the Write OEM Error Log. If you want to set it to false you should use -WriteOemErrorLog:$false
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Agent, Server
+        Author: Cláudio Silva (@claudioessilva), https://claudioessilva.com
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Set-DbaAgentServer
+
+    .EXAMPLE
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -MaximumHistoryRows 10000 -MaximumJobHistoryRows 100
+
+        Changes the job history retention to 10000 rows with an maximum of 100 rows per job.
+
+    .EXAMPLE
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -IsCpuPollingEnabled
+
+        Enable the CPU Polling configurations.
+
+    .EXAMPLE
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1, sql2, sql3 -AgentLogLevel 'Errors, Warnings'
+
+        Set the agent log level to Errors and Warnings on multiple servers.
+
+    .EXAMPLE
+        PS C:\> Set-DbaAgentServer -SqlInstance sql1 -IsCpuPollingEnabled:$false
+
+        Disable the CPU Polling configurations.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Low")]
+    param (
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Agent.JobServer[]]$InputObject,
+        [ValidateSet(1, "Errors", 2, "Warnings", 3, "Errors, Warnings", 4, "Informational", 5, "Errors, Informational", 6, "Warnings, Informational", 7, "All")]
+        [object]$AgentLogLevel,
+        [ValidateSet(0, "SqlAgentMail", 1, "DatabaseMail")]
+        [object]$AgentMailType,
+        [int]$AgentShutdownWaitTime,
+        [string]$DatabaseMailProfile,
+        [string]$ErrorLogFile,
+        [int]$IdleCpuDuration,
+        [int]$IdleCpuPercentage,
+        [switch]$IsCpuPollingEnabled,
+        [string]$LocalHostAlias,
+        [int]$LoginTimeout,
+        [int]$MaximumHistoryRows,
+        [int]$MaximumJobHistoryRows,
+        [string]$NetSendRecipient,
+        [switch]$ReplaceAlertTokensEnabled,
+        [switch]$SaveInSentFolder,
+        [switch]$SqlAgentAutoStart,
+        [string]$SqlAgentMailProfile,
+        [switch]$SqlAgentRestart,
+        [switch]$SqlServerRestart,
+        [switch]$WriteOemErrorLog,
+        [switch][Alias('Silent')]
+        $EnableException
+
+#$AgentLogLevel             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentLogLevels AgentLogLevel {get;set;}
+#$AgentMailType             Property   Microsoft.SqlServer.Management.Smo.Agent.AgentMailType AgentMailType {get;set;}
+#$UserData                  Property   System.Object UserData {get;set;}
+    )
+
+    begin {
+        # Check of the agent mail type is of type string and set the integer value
+        if (($AgentMailType -notin 0, 1) -and ($null -ne $AgentMailType)) {
+            $AgentMailType = switch ($AgentMailType) { "SqlAgentMail" { 0 } "DatabaseMail" { 1 } }
+        }
+
+        # Check of the agent log level is of type string and set the integer value
+        if (($AgentLogLevel -notin 0, 1) -and ($null -ne $AgentLogLevel)) {
+            $AgentLogLevel = switch ($AgentLogLevel) { "Errors" { 1 } "Warnings" { 2 } "Errors, Warnings" { 3 } "Informational" { 4 } "Errors, Informational" { 5 } "Warnings, Informational" { 6 } "All" { 7 } }
+        }
+    }
+    process {
+
+        if (Test-FunctionInterrupt) { return }
+
+        if ((-not $InputObject) -and (-not $SqlInstance)) {
+            Stop-Function -Message "You must specify an Instance or pipe in results from another command" -Target $sqlinstance
+            return
+        }
+
+        foreach ($instance in $sqlinstance) {
+            # Try connecting to the instance
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            $InputObject += $server.JobServer
+            $InputObject.Refresh()
+        }
+
+        foreach ($jobServer in $InputObject) {
+            $server = $jobServer.Parent
+
+            #region job server options
+            # Settings the options for the job server
+            if ($AgentLogLevel) {
+                Write-Message -Message "Setting Agent log level to $AgentLogLevel" -Level Verbose
+                $jobServer.AgentLogLevel = $AgentLogLevel
+            }
+
+            if ($AgentMailType) {
+                Write-Message -Message "Setting Agent Mail Type to $AgentMailType" -Level Verbose
+                $jobServer.AgentMailType = $AgentMailType
+            }
+
+            if ($AgentShutdownWaitTime) {
+                Write-Message -Message "Setting Agent Shutdown Wait Time to $AgentShutdownWaitTime" -Level Verbose
+                $jobServer.AgentShutdownWaitTime = $AgentShutdownWaitTime
+            }
+
+            if ($DatabaseMailProfile) {
+                if ($DatabaseMailProfile -in (Get-DbaDbMail -SqlInstance $server).Profiles.Name) {
+                    Write-Message -Message "Setting Database Mail Profile to $DatabaseMailProfile" -Level Verbose
+                    $jobServer.DatabaseMailProfile = $DatabaseMailProfile
+                } else {
+                    Write-Message -Message "Database mail profile not found on $server" -Level Warning
+                }
+            }
+
+            if ($ErrorLogFile) {
+                Write-Message -Message "Setting alert to ErrorLogFile" -Level Verbose
+                $jobServer.ErrorLogFile = $ErrorLogFile
+            }
+
+            if ($IdleCpuDuration) {
+                Write-Message -Message "Setting alert to IdleCpuDuration" -Level Verbose
+                $jobServer.IdleCpuDuration = $IdleCpuDuration
+            }
+
+            if ($IdleCpuPercentage) {
+                Write-Message -Message "Setting alert to IdleCpuPercentage" -Level Verbose
+                $jobServer.IdleCpuPercentage = $IdleCpuPercentage
+            }
+
+            if (-not ($null -eq $IsCpuPollingEnabled)) {
+                Write-Message -Message "Setting alert to IsCpuPollingEnabled" -Level Verbose
+                $jobServer.IsCpuPollingEnabled = $IsCpuPollingEnabled
+            }
+
+            if ($LocalHostAlias) {
+                Write-Message -Message "Setting alert to LocalHostAlias" -Level Verbose
+                $jobServer.LocalHostAlias = $LocalHostAlias
+            }
+
+            if ($LoginTimeout) {
+                Write-Message -Message "Setting alert to LoginTimeout" -Level Verbose
+                $jobServer.LoginTimeout = $LoginTimeout
+            }
+
+            if ($MaximumHistoryRows) {
+                Write-Message -Message "Setting alert to MaximumHistoryRows" -Level Verbose
+                $jobServer.MaximumHistoryRows = $MaximumHistoryRows
+            }
+
+            if ($MaximumJobHistoryRows) {
+                Write-Message -Message "Setting alert to MaximumJobHistoryRows" -Level Verbose
+                $jobServer.MaximumJobHistoryRows = $MaximumJobHistoryRows
+            }
+
+            if ($NetSendRecipient) {
+                Write-Message -Message "Setting alert to NetSendRecipient" -Level Verbose
+                $jobServer.NetSendRecipient = $NetSendRecipient
+            }
+
+            if (-not ($null -eq $ReplaceAlertTokensEnabled)) {
+                Write-Message -Message "Setting alert to ReplaceAlertTokensEnabled" -Level Verbose
+                $jobServer.ReplaceAlertTokensEnabled = $ReplaceAlertTokensEnabled
+            }
+
+            if (-not ($null -eq $SaveInSentFolder)) {
+                Write-Message -Message "Setting alert to SaveInSentFolder" -Level Verbose
+                $jobServer.SaveInSentFolder = $SaveInSentFolder
+            }
+
+            if (-not ($null -eq $SqlAgentAutoStart)) {
+                Write-Message -Message "Setting alert to SqlAgentAutoStart" -Level Verbose
+                $jobServer.SqlAgentAutoStart = $SqlAgentAutoStart
+            }
+
+            if (-not ($null -eq $SqlAgentMailProfile)) {
+                Write-Message -Message "Setting alert to SqlAgentMailProfile" -Level Verbose
+                $jobServer.SqlAgentMailProfile = $SqlAgentMailProfile
+            }
+
+            if (-not ($null -eq $SqlAgentRestart)) {
+                Write-Message -Message "Setting alert to SqlAgentRestart" -Level Verbose
+                $jobServer.SqlAgentRestart = $SqlAgentRestart
+            }
+
+            if (-not ($null -eq $SqlServerRestart)) {
+                Write-Message -Message "Setting alert to SqlServerRestart" -Level Verbose
+                $jobServer.SqlServerRestart = $SqlServerRestart
+            }
+
+            if (-not ($null -eq $WriteOemErrorLog)) {
+                Write-Message -Message "Setting alert to WriteOemErrorLog" -Level Verbose
+                $jobServer.WriteOemErrorLog = $WriteOemErrorLog
+            }
+
+            #endregion server agent options
+
+            # Execute
+            if ($PSCmdlet.ShouldProcess($SqlInstance, "Changing the agent server")) {
+                try {
+                    Write-Message -Message "Changing the agent server" -Level Verbose
+
+                    # Change the agent server
+                    $jobServer.Alter()
+                } catch {
+                    Stop-Function -Message "Something went wrong changing the agent server" -ErrorRecord $_ -Target $instance -Continue
+                }
+
+                Get-DbaAgentServer -SqlInstance $server | Where-Object Name -eq $jobServer.name
+            }
+        }
+    }
+    end {
+        Write-Message -Message "Finished changing agent server(s)" -Level Verbose
+    }
+}

--- a/tests/Get-DbaAgentServer.Tests.ps1
+++ b/tests/Get-DbaAgentServer.Tests.ps1
@@ -23,11 +23,5 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "Should get 1 agent server" {
             $results.count | Should Be 1
         }
-
-        It "returns the correct properties" {
-            $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,AgentDomainGroup,AgentLogLevel,AgentMailType,AgentShutdownWaitTime,ErrorLogFile,IdleCpuDuration,IdleCpuPercentage,IsCpuPollingEnabled,JobServerType,LoginTimeout,JobHistoryIsEnabled,MaximumHistoryRows,MaximumJobHistoryRows,MsxAccountCredentialName,MsxAccountName,MsxServerName,Name,NetSendRecipient,ServiceAccount,ServiceStartMode,SqlAgentAutoStart,SqlAgentMailProfile,SqlAgentRestart,SqlServerRestart,State,SysAdminOnly'.Split(',')
-            ($results.PsObject.Properties.Name | Sort-Object) | Should -Be ($ExpectedProps | Sort-Object)
-        }
-
     }
 }

--- a/tests/Get-DbaAgentServer.Tests.ps1
+++ b/tests/Get-DbaAgentServer.Tests.ps1
@@ -1,0 +1,33 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = 3
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaAgentServer).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command gets server agent" {
+        $results = Get-DbaAgentServer -SqlInstance $script:instance2
+        It "Should get 1 agent server" {
+            $results.count | Should Be 1
+        }
+
+        It "returns the correct properties" {
+            $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,AgentDomainGroup,AgentLogLevel,AgentMailType,AgentShutdownWaitTime,ErrorLogFile,IdleCpuDuration,IdleCpuPercentage,IsCpuPollingEnabled,JobServerType,LoginTimeout,JobHistoryIsEnabled,MaximumHistoryRows,MaximumJobHistoryRows,MsxAccountCredentialName,MsxAccountName,MsxServerName,Name,NetSendRecipient,ServiceAccount,ServiceStartMode,SqlAgentAutoStart,SqlAgentMailProfile,SqlAgentRestart,SqlServerRestart,State,SysAdminOnly'.Split(',')
+            ($results.PsObject.Properties.Name | Sort-Object) | Should -Be ($ExpectedProps | Sort-Object)
+        }
+
+    }
+}

--- a/tests/Set-DbaAgentServer.Tests.ps1
+++ b/tests/Set-DbaAgentServer.Tests.ps1
@@ -1,0 +1,35 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $paramCount = 24
+        $defaultParamCount = 13
+        [object[]]$params = (Get-ChildItem function:\Set-DbaAgentServer).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'DatabaseMailProfile ', 'ErrorLogFile ', 'IdleCpuDuration', 'IdleCpuPercentage ', 'IsCpuPollingEnabled ', 'LocalHostAlias ', 'LoginTimeout ', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'NetSendRecipient', 'ReplaceAlertTokensEnabled', 'SaveInSentFolder', 'SqlAgentAutoStart ', 'SqlAgentMailProfile ', 'SqlAgentRestart', 'SqlServerRestart', 'WriteOemErrorLog', 'EnableException'
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -MaximumHistoryRows 10000 -MaximumJobHistoryRows 100
+    It "changes agent server job history properties to 10000 / 100" {
+        $results.MaximumHistoryRows | Should Be 10000
+        $results.MaximumJobHistoryRows | Should Be 100
+    }
+
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -IsCpuPollingEnabled
+    It "changes agent server CPU Polling to true" {
+        $results.IsCpuPollingEnabled | Should Be $true
+    }
+
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -IsCpuPollingEnabled:$false
+    It "changes agent server CPU Polling to false" {
+        $results.IsCpuPollingEnabled | Should Be $false
+    }
+}

--- a/tests/Set-DbaAgentServer.Tests.ps1
+++ b/tests/Set-DbaAgentServer.Tests.ps1
@@ -23,12 +23,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $results.MaximumJobHistoryRows | Should Be 100
     }
 
-    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -IsCpuPollingEnabled
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -CpuPolling Enabled
     It "changes agent server CPU Polling to true" {
         $results.IsCpuPollingEnabled | Should Be $true
     }
 
-    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -IsCpuPollingEnabled:$false
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -CpuPolling Disable
     It "changes agent server CPU Polling to false" {
         $results.IsCpuPollingEnabled | Should Be $false
     }

--- a/tests/Set-DbaAgentServer.Tests.ps1
+++ b/tests/Set-DbaAgentServer.Tests.ps1
@@ -6,7 +6,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Set-DbaAgentServer).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'DatabaseMailProfile', 'ErrorLogFile', 'IdleCpuDuration', 'IdleCpuPercentage', 'IsCpuPollingEnabled', 'LocalHostAlias', 'LoginTimeout', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'NetSendRecipient', 'ReplaceAlertTokensEnabled', 'SaveInSentFolder', 'SqlAgentAutoStart', 'SqlAgentMailProfile', 'SqlAgentRestart', 'SqlServerRestart', 'WriteOemErrorLog', 'EnableException'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'DatabaseMailProfile', 'ErrorLogFile', 'IdleCpuDuration', 'IdleCpuPercentage', 'CpuPolling', 'LocalHostAlias', 'LoginTimeout', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'NetSendRecipient', 'ReplaceAlertTokens', 'SaveInSentFolder', 'SqlAgentAutoStart', 'SqlAgentMailProfile', 'SqlAgentRestart', 'SqlServerRestart', 'WriteOemErrorLog', 'EnableException'
         $paramCount = $knownParameters.Count
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
@@ -28,7 +28,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $results.IsCpuPollingEnabled | Should Be $true
     }
 
-    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -CpuPolling Disable
+    $results = Set-DbaAgentServer -SqlInstance $script:instance2 -CpuPolling Disabled
     It "changes agent server CPU Polling to false" {
         $results.IsCpuPollingEnabled | Should Be $false
     }

--- a/tests/Set-DbaAgentServer.Tests.ps1
+++ b/tests/Set-DbaAgentServer.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 24
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Set-DbaAgentServer).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'DatabaseMailProfile ', 'ErrorLogFile ', 'IdleCpuDuration', 'IdleCpuPercentage ', 'IsCpuPollingEnabled ', 'LocalHostAlias ', 'LoginTimeout ', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'NetSendRecipient', 'ReplaceAlertTokensEnabled', 'SaveInSentFolder', 'SqlAgentAutoStart ', 'SqlAgentMailProfile ', 'SqlAgentRestart', 'SqlServerRestart', 'WriteOemErrorLog', 'EnableException'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'AgentLogLevel', 'AgentMailType', 'AgentShutdownWaitTime', 'DatabaseMailProfile', 'ErrorLogFile', 'IdleCpuDuration', 'IdleCpuPercentage', 'IsCpuPollingEnabled', 'LocalHostAlias', 'LoginTimeout', 'MaximumHistoryRows', 'MaximumJobHistoryRows', 'NetSendRecipient', 'ReplaceAlertTokensEnabled', 'SaveInSentFolder', 'SqlAgentAutoStart', 'SqlAgentMailProfile', 'SqlAgentRestart', 'SqlServerRestart', 'WriteOemErrorLog', 'EnableException'
+        $paramCount = $knownParameters.Count
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add two new commands to the module:
`Get-DbaAgentServer`
`Set-DbaAgentServer`

### Approach
We don't have commands to change the Agent Server Job history configurations (for example).
This doesn't touch on the sub level configurations already done by other commands like:
Jobs, Operators, Alerts, Categories

### Commands to test
```powershell
Get-DbaAgentServer
Set-DbaAgentServer
```