### PR TITLE
Get-DBABackupInformation / logical and physical names hashed

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -338,8 +338,8 @@ function Get-DbaBackupInformation {
                 $group.Path = Get-HashString -InString  $Group.Path
                 $group.FullName = Get-HashString -InString $Group.Fullname
                 $group.FileList = ($group.FileList | Select-Object Type,
-                  @{Name="LogicalName";Expression={Get-HashString -InString $_."LogicalName"}},
-                  @{Name="PhysicalName";Expression={Get-HashString -InString $_."PhysicalName"}})
+                    @{Name = "LogicalName"; Expression = {Get-HashString -InString $_."LogicalName"}},
+                    @{Name = "PhysicalName"; Expression = {Get-HashString -InString $_."PhysicalName"}})
             }
         }
         if ((Test-Bound -parameterName exportpath) -and $null -ne $ExportPath) {

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -337,6 +337,9 @@ function Get-DbaBackupInformation {
                 $group.UserName = Get-HashString -InString $group.UserName
                 $group.Path = Get-HashString -InString  $Group.Path
                 $group.FullName = Get-HashString -InString $Group.Fullname
+                $group.FileList = ($group.FileList | Select-Object Type,
+                  @{Name="LogicalName";Expression={Get-HashString -InString $_."LogicalName"}},
+                  @{Name="PhysicalName";Expression={Get-HashString -InString $_."PhysicalName"}})
             }
         }
         if ((Test-Bound -parameterName exportpath) -and $null -ne $ExportPath) {

--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -42,7 +42,7 @@ function Get-DbaBackupInformation {
         If specified the provided path/directory will be traversed (only applies if not using XpDirTree)
 
     .PARAMETER Anonymise
-        If specified we will output the results with ComputerName, InstanceName, Database, UserName, and Paths hashed out
+        If specified we will output the results with ComputerName, InstanceName, Database, UserName, Paths, and Logical and Physical Names hashed out
         This options is mainly for use if we need you to submit details for fault finding to the dbatools team
 
     .PARAMETER ExportPath


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->

<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality in #3601)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Make the Get-DBABackupInformation function more anonymous when -Anonymize switch is used

### Approach
The logical and physical filenames were hashed when -Anonymize is true

### Commands to test
Get-DBABackupInformation -SQLInstance sql01 -Anonymize