### PR TITLE
Fixed server issue in command New-DbaAgentJobStep

### DIFF
--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -27,6 +27,9 @@ function New-DbaAgentJobStep {
         Allowed values 'ActiveScripting','AnalysisCommand','AnalysisQuery','CmdExec','Distribution','LogReader','Merge','PowerShell','QueueReader','Snapshot','Ssis','TransactSql'
         The default is 'TransactSql'
 
+    .PARAMETER SubSystemServer
+        The subsystems AnalysisScripting, AnalysisCommand, AnalysisQuery ned the server property to be able to apply
+
     .PARAMETER Command
         The commands to be executed by SQLServerAgent service through subsystem.
 
@@ -147,6 +150,7 @@ function New-DbaAgentJobStep {
         [string]$StepName,
         [ValidateSet('ActiveScripting', 'AnalysisCommand', 'AnalysisQuery', 'CmdExec', 'Distribution', 'LogReader', 'Merge', 'PowerShell', 'QueueReader', 'Snapshot', 'Ssis', 'TransactSql')]
         [string]$Subsystem = 'TransactSql',
+        [string]$SubsystemServer,
         [string]$Command,
         [int]$CmdExecSuccessCode,
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
@@ -179,6 +183,13 @@ function New-DbaAgentJobStep {
         if (($OnFailAction -ne 'GoToStep') -and ($OnFailStepId -ge 1)) {
             Stop-Function -Message "Parameter OnFailStepId can only be used with OnFailAction 'GoToStep'." -Target $SqlInstance
             return
+        }
+
+        if($Subsystem -in 'AnalysisScripting','AnalysisCommand','AnalysisQuery'){
+            if(-not $SubsystemServer){
+                Stop-Function -Message "Please enter the server value using -SubSystemServer for subsystem $Subsystem." -Target $Subsystem
+                return
+            }
         }
     }
 
@@ -259,6 +270,11 @@ function New-DbaAgentJobStep {
                     if ($Subsystem) {
                         Write-Message -Message "Setting job step subsystem to $Subsystem" -Level Verbose
                         $JobStep.Subsystem = $Subsystem
+                    }
+
+                    if($SubsystemServer){
+                        Write-Message -Message "Setting job step subsystem server to $SubsystemServer" -Level Verbose
+                        $JobStep.Server = $SubsystemServer
                     }
 
                     if ($Command) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The server property was missing which was needed for several subsystems. 

### Approach
A new parameter is added called "SubsystemServer" which needs to be used when a particular subsytem is chosen.

### Commands to test
New-DbaAgentJobStep -SqlInstance . -Database [db] -Job [jobname]-StepName [stepname] -OnSuccessAction 'GoToNextStep' -OnFailAction  'QuitWithFailure' -Subsystem AnalysisCommand -SubsystemServer [server] -Command "Test"

### Screenshots
![image](https://user-images.githubusercontent.com/6154981/49236618-c3f93f00-f3fc-11e8-86c5-21cca48bf93c.png)

