### PR TITLE
Add progress bar to Update-DbaInstance

### DIFF
--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -220,7 +220,7 @@ function Update-DbaInstance {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        
+
         #Resolve all the provided names
         $resolvedComputers = @()
         foreach ($computer in $ComputerName) {


### PR DESCRIPTION
I added some progress bars 😁

![image](https://user-images.githubusercontent.com/8278033/49284702-a9bf6f80-f495-11e8-9595-530a352bedec.png)

Can you update this branch, @nvarscar, and modify the warnings, perhaps make them verbose? It feels like a command that succeeds should not have 4 warnings.

For instance, it ends with "Please restart sql2017.base.local to complete the installation of SQL2017RTMCU12. No further updates will be installed on this computer"

![image](https://user-images.githubusercontent.com/8278033/49284832-0753bc00-f496-11e8-9d2b-5f2252aa1444.png)

But Microsoft doesn't emphasize it this hard in their own installer. It's just all check marks ✔

Can the last one be shown only if more than one relevant exe is found? Or perhaps don't even show it and let the command fail by itself if it lops and detects a reboot needed?

With the Cred access denied failure, can you keep that error in your backpocket and only show it if subsequent related actions fail?

The first one, I'm not sure why I needed to know that. I pointed it to a path that had a relevant patch and all succeeded.