### PR TITLE
Restore-DbaDatabase - added dbaools default outputs

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -311,9 +311,13 @@ function Invoke-DbaAdvancedRestore {
                             $pathSep = Get-DbaPathSep -Server $server
                             $RestoreDirectory = ((Split-Path $backup.FileList.PhysicalName -Parent) | Sort-Object -Unique).Replace('\', $pathSep) -Join ','
                             [PSCustomObject]@{
-                                SqlInstance            = $SqlInstance
+                                ComputerName           = $server.ComputerName
+                                InstanceName           = $server.ServiceName
+                                SqlInstance            = $server.DomainInstanceName
+                                Database               = $backup.Database
                                 DatabaseName           = $backup.Database
                                 DatabaseOwner          = $server.ConnectionContext.TrueLogin
+                                Owner                  = $server.ConnectionContext.TrueLogin
                                 NoRecovery             = $Restore.NoRecovery
                                 WithReplace            = $WithReplace
                                 RestoreComplete        = $RestoreComplete
@@ -332,7 +336,7 @@ function Invoke-DbaAdvancedRestore {
                                 FileRestoreTime        = New-TimeSpan -Seconds ((Get-Date) - $FileRestoreStartTime).TotalSeconds
                                 DatabaseRestoreTime    = New-TimeSpan -Seconds ((Get-Date) - $DatabaseRestoreStartTime).TotalSeconds
                                 ExitError              = $ExitError
-                            } | Select-DefaultView -ExcludeProperty BackupSizeMB, CompressedBackupSizeMB, ExitError, BackupFileRaw, RestoredFileFull
+                            } | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, BackupFile, BackupFilesCount, BackupSize, CompressedBackupSize, Database, Owner, DatabaseRestoreTime, FileRestoreTime, NoRecovery, RestoreComplete, RestoredFile, RestoredFilesCount, Script, RestoreDirectory, WithReplace
                         } else {
                             $script
                         }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -326,39 +326,75 @@ function Restore-DbaDatabase {
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Restore")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "AzureCredential", Justification = "For Parameter AzureCredential")]
     param (
-        [parameter(Mandatory)][Alias("ServerInstance", "SqlServer")][DbaInstanceParameter]$SqlInstance,
+        [parameter(Mandatory)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")][parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")][object[]]$Path,
-        [parameter(ValueFromPipeline)][Alias("Name")][object[]]$DatabaseName,
-        [parameter(ParameterSetName = "Restore")][String]$DestinationDataDirectory,
-        [parameter(ParameterSetName = "Restore")][String]$DestinationLogDirectory,
-        [parameter(ParameterSetName = "Restore")][String]$DestinationFileStreamDirectory,
-        [parameter(ParameterSetName = "Restore")][DateTime]$RestoreTime = (Get-Date).AddYears(1),
-        [parameter(ParameterSetName = "Restore")][switch]$NoRecovery,
-        [parameter(ParameterSetName = "Restore")][switch]$WithReplace,
-        [parameter(ParameterSetName = "Restore")][Switch]$XpDirTree,
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
+        [object[]]$Path,
+        [parameter(ValueFromPipeline)]
+        [Alias("Name")]
+        [object[]]$DatabaseName,
+        [parameter(ParameterSetName = "Restore")]
+        [String]$DestinationDataDirectory,
+        [parameter(ParameterSetName = "Restore")]
+        [String]$DestinationLogDirectory,
+        [parameter(ParameterSetName = "Restore")]
+        [String]$DestinationFileStreamDirectory,
+        [parameter(ParameterSetName = "Restore")]
+        [DateTime]$RestoreTime = (Get-Date).AddYears(1),
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$NoRecovery,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$WithReplace,
+        [parameter(ParameterSetName = "Restore")]
+        [Switch]$XpDirTree,
         [switch]$OutputScriptOnly,
-        [parameter(ParameterSetName = "Restore")][switch]$VerifyOnly,
-        [parameter(ParameterSetName = "Restore")][switch]$MaintenanceSolutionBackup,
-        [parameter(ParameterSetName = "Restore")][hashtable]$FileMapping,
-        [parameter(ParameterSetName = "Restore")][switch]$IgnoreLogBackup,
-        [parameter(ParameterSetName = "Restore")][switch]$UseDestinationDefaultDirectories,
-        [parameter(ParameterSetName = "Restore")][switch]$ReuseSourceFolderStructure,
-        [parameter(ParameterSetName = "Restore")][string]$DestinationFilePrefix = '',
-        [parameter(ParameterSetName = "Restore")][string]$RestoredDatabaseNamePrefix,
-        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][switch]$TrustDbBackupHistory,
-        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$MaxTransferSize,
-        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$BlockSize,
-        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$BufferCount,
-        [parameter(ParameterSetName = "Restore")][switch]$DirectoryRecurse,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$VerifyOnly,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$MaintenanceSolutionBackup,
+        [parameter(ParameterSetName = "Restore")]
+        [hashtable]$FileMapping,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$IgnoreLogBackup,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$UseDestinationDefaultDirectories,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$ReuseSourceFolderStructure,
+        [parameter(ParameterSetName = "Restore")]
+        [string]$DestinationFilePrefix = '',
+        [parameter(ParameterSetName = "Restore")]
+        [string]$RestoredDatabaseNamePrefix,
+        [parameter(ParameterSetName = "Restore")]
+        [parameter(ParameterSetName = "RestorePage")]
+        [switch]$TrustDbBackupHistory,
+        [parameter(ParameterSetName = "Restore")]
+        [parameter(ParameterSetName = "RestorePage")]
+        [int]$MaxTransferSize,
+        [parameter(ParameterSetName = "Restore")]
+        [parameter(ParameterSetName = "RestorePage")]
+        [int]$BlockSize,
+        [parameter(ParameterSetName = "Restore")]
+        [parameter(ParameterSetName = "RestorePage")]
+        [int]$BufferCount,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$DirectoryRecurse,
         [switch]$EnableException,
-        [parameter(ParameterSetName = "Restore")][string]$StandbyDirectory,
-        [parameter(ParameterSetName = "Restore")][switch]$Continue,
+        [parameter(ParameterSetName = "Restore")]
+        [string]$StandbyDirectory,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$Continue,
         [string]$AzureCredential,
-        [parameter(ParameterSetName = "Restore")][switch]$ReplaceDbNameInFile,
-        [parameter(ParameterSetName = "Restore")][string]$DestinationFileSuffix,
-        [parameter(ParameterSetName = "Recovery")][switch]$Recover,
-        [parameter(ParameterSetName = "Restore")][switch]$KeepCDC,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$ReplaceDbNameInFile,
+        [parameter(ParameterSetName = "Restore")]
+        [string]$DestinationFileSuffix,
+        [parameter(ParameterSetName = "Recovery")]
+        [switch]$Recover,
+        [parameter(ParameterSetName = "Restore")]
+        [switch]$KeepCDC,
         [switch]$AllowContinue,
         [string]$GetBackupInformation,
         [switch]$StopAfterGetBackupInformation,
@@ -368,347 +404,449 @@ function Restore-DbaDatabase {
         [switch]$StopAfterFormatBackupInformation,
         [string]$TestBackupInformation,
         [switch]$StopAfterTestBackupInformation,
-        [parameter(Mandatory, ParameterSetName = "RestorePage")][object]$PageRestore,
-        [parameter(Mandatory, ParameterSetName = "RestorePage")][string]$PageRestoreTailFolder,
+        [parameter(Mandatory, ParameterSetName = "RestorePage")]
+        [object]$PageRestore,
+        [parameter(Mandatory, ParameterSetName = "RestorePage")]
+        [string]$PageRestoreTailFolder,
         [int]$StatementTimeout = 0
     )
     begin {
-        Write-Message -Level InternalComment -Message "Starting"
-        Write-Message -Level Debug -Message "Parameters bound: $($PSBoundParameters.Keys -join ", ")"
+        function Restore-Internal {
+            [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Restore")]
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "AzureCredential", Justification = "For Parameter AzureCredential")]
+            param (
+                [parameter(Mandatory)]
+                [Alias("ServerInstance", "SqlServer")]
+                [DbaInstanceParameter]$SqlInstance,
+                [PSCredential]$SqlCredential,
+                [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
+                [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
+                [object[]]$Path,
+                [parameter(ValueFromPipeline)]
+                [Alias("Name")]
+                [object[]]$DatabaseName,
+                [parameter(ParameterSetName = "Restore")]
+                [String]$DestinationDataDirectory,
+                [parameter(ParameterSetName = "Restore")]
+                [String]$DestinationLogDirectory,
+                [parameter(ParameterSetName = "Restore")]
+                [String]$DestinationFileStreamDirectory,
+                [parameter(ParameterSetName = "Restore")]
+                [DateTime]$RestoreTime = (Get-Date).AddYears(1),
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$NoRecovery,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$WithReplace,
+                [parameter(ParameterSetName = "Restore")]
+                [Switch]$XpDirTree,
+                [switch]$OutputScriptOnly,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$VerifyOnly,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$MaintenanceSolutionBackup,
+                [parameter(ParameterSetName = "Restore")]
+                [hashtable]$FileMapping,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$IgnoreLogBackup,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$UseDestinationDefaultDirectories,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$ReuseSourceFolderStructure,
+                [parameter(ParameterSetName = "Restore")]
+                [string]$DestinationFilePrefix = '',
+                [parameter(ParameterSetName = "Restore")]
+                [string]$RestoredDatabaseNamePrefix,
+                [parameter(ParameterSetName = "Restore")]
+                [parameter(ParameterSetName = "RestorePage")]
+                [switch]$TrustDbBackupHistory,
+                [parameter(ParameterSetName = "Restore")]
+                [parameter(ParameterSetName = "RestorePage")]
+                [int]$MaxTransferSize,
+                [parameter(ParameterSetName = "Restore")]
+                [parameter(ParameterSetName = "RestorePage")]
+                [int]$BlockSize,
+                [parameter(ParameterSetName = "Restore")]
+                [parameter(ParameterSetName = "RestorePage")]
+                [int]$BufferCount,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$DirectoryRecurse,
+                [switch]$EnableException,
+                [parameter(ParameterSetName = "Restore")]
+                [string]$StandbyDirectory,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$Continue,
+                [string]$AzureCredential,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$ReplaceDbNameInFile,
+                [parameter(ParameterSetName = "Restore")]
+                [string]$DestinationFileSuffix,
+                [parameter(ParameterSetName = "Recovery")]
+                [switch]$Recover,
+                [parameter(ParameterSetName = "Restore")]
+                [switch]$KeepCDC,
+                [switch]$AllowContinue,
+                [string]$GetBackupInformation,
+                [switch]$StopAfterGetBackupInformation,
+                [string]$SelectBackupInformation,
+                [switch]$StopAfterSelectBackupInformation,
+                [string]$FormatBackupInformation,
+                [switch]$StopAfterFormatBackupInformation,
+                [string]$TestBackupInformation,
+                [switch]$StopAfterTestBackupInformation,
+                [parameter(Mandatory, ParameterSetName = "RestorePage")]
+                [object]$PageRestore,
+                [parameter(Mandatory, ParameterSetName = "RestorePage")]
+                [string]$PageRestoreTailFolder,
+                [int]$StatementTimeout = 0
+            )
+            begin {
+                Write-Message -Level InternalComment -Message "Starting"
+                Write-Message -Level Debug -Message "Parameters bound: $($PSBoundParameters.Keys -join ", ")"
 
-        #region Validation
-        try {
-            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        } catch {
-            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            return
-        }
-        if ($PSCmdlet.ParameterSetName -eq "Restore") {
-            $UseDestinationDefaultDirectories = $true
-            $paramCount = 0
-
-            if (!(Test-Bound "AllowContinue") -and $true -ne $AllowContinue) {
-                $AllowContinue = $false
-            }
-            if (Test-Bound "FileMapping") {
-                $paramCount += 1
-            }
-            if (Test-Bound "ReuseSourceFolderStructure") {
-                $paramCount += 1
-            }
-            if (Test-Bound "DestinationDataDirectory") {
-                $paramCount += 1
-            }
-            if ($paramCount -gt 1) {
-                Stop-Function -Category InvalidArgument -Message "You've specified incompatible Location parameters. Please only specify one of FileMapping, ReuseSourceFolderStructure or DestinationDataDirectory"
-                return
-            }
-            if (($ReplaceDbNameInFile) -and !(Test-Bound "DatabaseName")) {
-                Stop-Function -Category InvalidArgument -Message "To use ReplaceDbNameInFile you must specify DatabaseName"
-                return
-            }
-
-            if ((Test-Bound "DestinationLogDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
-                Stop-Function -Category InvalidArgument -Message "The parameters DestinationLogDirectory and UseDestinationDefaultDirectories are mutually exclusive"
-                return
-            }
-            if ((Test-Bound "DestinationLogDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
-                Stop-Function -Category InvalidArgument -Message "The parameter DestinationLogDirectory can only be specified together with DestinationDataDirectory"
-                return
-            }
-            if ((Test-Bound "DestinationFileStreamDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
-                Stop-Function -Category InvalidArgument -Message "The parameters DestinationFileStreamDirectory and UseDestinationDefaultDirectories are mutually exclusive"
-                return
-            }
-            if ((Test-Bound "DestinationFileStreamDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
-                Stop-Function -Category InvalidArgument -Message "The parameter DestinationFileStreamDirectory can only be specified together with DestinationDataDirectory"
-                return
-            }
-            if (($null -ne $FileMapping) -or $ReuseSourceFolderStructure -or ($DestinationDataDirectory -ne '')) {
-                $UseDestinationDefaultDirectories = $false
-            }
-            if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
-                Stop-Function -Category InvalidArgument -Message "MaxTransferSize value must be a multiple of 64kb and no greater than 4MB"
-                return
-            }
-            if ($BlockSize) {
-                if ($BlockSize -notin (0.5kb, 1kb, 2kb, 4kb, 8kb, 16kb, 32kb, 64kb)) {
-                    Stop-Function -Category InvalidArgument -Message "Block size must be one of 0.5kb,1kb,2kb,4kb,8kb,16kb,32kb,64kb"
+                #region Validation
+                try {
+                    $restoreserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+                } catch {
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                     return
                 }
+                if ($PSCmdlet.ParameterSetName -eq "Restore") {
+                    $UseDestinationDefaultDirectories = $true
+                    $paramCount = 0
+
+                    if (!(Test-Bound "AllowContinue") -and $true -ne $AllowContinue) {
+                        $AllowContinue = $false
+                    }
+                    if (Test-Bound "FileMapping") {
+                        $paramCount += 1
+                    }
+                    if (Test-Bound "ReuseSourceFolderStructure") {
+                        $paramCount += 1
+                    }
+                    if (Test-Bound "DestinationDataDirectory") {
+                        $paramCount += 1
+                    }
+                    if ($paramCount -gt 1) {
+                        Stop-Function -Category InvalidArgument -Message "You've specified incompatible Location parameters. Please only specify one of FileMapping, ReuseSourceFolderStructure or DestinationDataDirectory"
+                        return
+                    }
+                    if (($ReplaceDbNameInFile) -and !(Test-Bound "DatabaseName")) {
+                        Stop-Function -Category InvalidArgument -Message "To use ReplaceDbNameInFile you must specify DatabaseName"
+                        return
+                    }
+
+                    if ((Test-Bound "DestinationLogDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
+                        Stop-Function -Category InvalidArgument -Message "The parameters DestinationLogDirectory and UseDestinationDefaultDirectories are mutually exclusive"
+                        return
+                    }
+                    if ((Test-Bound "DestinationLogDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
+                        Stop-Function -Category InvalidArgument -Message "The parameter DestinationLogDirectory can only be specified together with DestinationDataDirectory"
+                        return
+                    }
+                    if ((Test-Bound "DestinationFileStreamDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
+                        Stop-Function -Category InvalidArgument -Message "The parameters DestinationFileStreamDirectory and UseDestinationDefaultDirectories are mutually exclusive"
+                        return
+                    }
+                    if ((Test-Bound "DestinationFileStreamDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
+                        Stop-Function -Category InvalidArgument -Message "The parameter DestinationFileStreamDirectory can only be specified together with DestinationDataDirectory"
+                        return
+                    }
+                    if (($null -ne $FileMapping) -or $ReuseSourceFolderStructure -or ($DestinationDataDirectory -ne '')) {
+                        $UseDestinationDefaultDirectories = $false
+                    }
+                    if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
+                        Stop-Function -Category InvalidArgument -Message "MaxTransferSize value must be a multiple of 64kb and no greater than 4MB"
+                        return
+                    }
+                    if ($BlockSize) {
+                        if ($BlockSize -notin (0.5kb, 1kb, 2kb, 4kb, 8kb, 16kb, 32kb, 64kb)) {
+                            Stop-Function -Category InvalidArgument -Message "Block size must be one of 0.5kb,1kb,2kb,4kb,8kb,16kb,32kb,64kb"
+                            return
+                        }
+                    }
+                    if ('' -ne $StandbyDirectory) {
+                        if (!(Test-DbaPath -Path $StandbyDirectory -SqlInstance $restoreserver)) {
+                            Stop-Function -Message "$SqlServer cannot see the specified Standby Directory $StandbyDirectory" -Target $SqlInstance
+                            return
+                        }
+                    }
+                    if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))) {
+                        Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
+                        return
+                    }
+                    if ($Continue) {
+                        Write-Message -Message "Called with continue, so assume we have an existing db in norecovery"
+                        $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $restoreserver
+                        $LastRestoreType = Get-DbaDbRestoreHistory -SqlInstance $restoreserver -Last
+                    }
+                    if (!($PSBoundParameters.ContainsKey("DataBasename"))) {
+                        $PipeDatabaseName = $true
+                    }
+                }
+
+                if ($StatementTimeout -eq 0) {
+                    Write-Message -Level Verbose -Message "Changing statement timeout to infinity"
+                } else {
+                    Write-Message -Level Verbose -Message "Changing statement timeout to ($StatementTimeout) minutes"
+                }
+                $restoreserver.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
+                #endregion Validation
+
+                if ($UseDestinationDefaultDirectories) {
+                    $DefaultPath = (Get-DbaDefaultPath -SqlInstance $restoreserver)
+                    $DestinationDataDirectory = $DefaultPath.Data
+                    $DestinationLogDirectory = $DefaultPath.Log
+                }
+
+                $BackupHistory = @()
             }
-            if ('' -ne $StandbyDirectory) {
-                if (!(Test-DbaPath -Path $StandbyDirectory -SqlInstance $RestoreInstance)) {
-                    Stop-Function -Message "$SqlServer cannot see the specified Standby Directory $StandbyDirectory" -Target $SqlInstance
+            process {
+                if (Test-FunctionInterrupt) {
                     return
                 }
+                if ($restoreserver.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
+                    foreach ($file in $Path) {
+                        $bh = Get-DbaBackupInformation -SqlInstance $restoreserver -Path $file
+                        $bound = $PSBoundParameters
+                        $bound['TrustDbBackupHistory'] = $true
+                        $bound['Path'] = $bh
+                        Restore-Dbadatabase @bound
+                    }
+                    break
+                }
+                if ($PSCmdlet.ParameterSetName -like "Restore*") {
+                    if ($PipeDatabaseName -eq $true) {
+                        $DatabaseName = ''
+                    }
+                    Write-Message -message "ParameterSet  = Restore" -Level Verbose
+                    if ($TrustDbBackupHistory -or $path[0].GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
+                        foreach ($f in $path) {
+                            Write-Message -Level Verbose -Message "Trust Database Backup History Set"
+                            if ("BackupPath" -notin $f.PSobject.Properties.name) {
+                                Write-Message -Level Verbose -Message "adding BackupPath - $($_.FullName)"
+                                $f = $f | Select-Object *, @{
+                                    Name = "BackupPath"; Expression = {
+                                        $_.FullName
+                                    }
+                                }
+                            }
+                            if ("DatabaseName" -notin $f.PSobject.Properties.Name) {
+                                $f = $f | Select-Object *, @{
+                                    Name = "DatabaseName"; Expression = {
+                                        $_.Database
+                                    }
+                                }
+                            }
+                            if ("Database" -notin $f.PSobject.Properties.Name) {
+                                $f = $f | Select-Object *, @{
+                                    Name = "Database"; Expression = {
+                                        $_.DatabaseName
+                                    }
+                                }
+                            }
+                            if ("BackupSetGUID" -notin $f.PSobject.Properties.Name) {
+                                $f = $f | Select-Object *, @{
+                                    Name = "BackupSetGUID"; Expression = {
+                                        $_.BackupSetID
+                                    }
+                                }
+                            }
+
+                            if ($f.BackupPath -like 'http*') {
+                                if ('' -ne $AzureCredential) {
+                                    Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
+                                    Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
+                                } else {
+                                    $f.BackupPath -match 'https://.*/.*/'
+                                    if (Get-DbaCredential -SqlInstance $restoreserver -name $matches[0].trim('/')) {
+                                        Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
+                                    } else {
+                                        Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
+                                        return
+                                    }
+                                }
+                            }
+                            $BackupHistory += $F | Select-Object *, @{
+                                Name = "ServerName"; Expression = {
+                                    $_.SqlInstance
+                                }
+                            }, @{
+                                Name = "BackupStartDate"; Expression = {
+                                    $_.Start -as [DateTime]
+                                }
+                            }
+                        }
+                    } else {
+                        $files = @()
+                        foreach ($f in $Path) {
+                            if ($f -is [System.IO.FileSystemInfo]) {
+                                $files += $f.FullName
+                            } else {
+                                $files += $f
+                            }
+                        }
+                        Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
+                        if ($BackupHistory.GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
+                            $BackupHistory = @($BackupHistory)
+                        }
+                        $BackupHistory += Get-DbaBackupInformation -SqlInstance $restoreserver -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
+                    }
+                    if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                        if (-not (Test-DbaPath -SqlInstance $restoreserver -Path $PageRestoreTailFolder)) {
+                            Stop-Function -Message "Instance $restoreserver cannot read $PageRestoreTailFolder, cannot proceed" -Target $PageRestoreTailFolder
+                            return
+                        }
+                        $WithReplace = $true
+                    }
+                } elseif ($PSCmdlet.ParameterSetName -eq "Recovery") {
+                    Write-Message -Message "$($Database.Count) databases to recover" -level Verbose
+                    foreach ($Database in $DatabaseName) {
+                        if ($Database -is [object]) {
+                            #We've got an object, try the normal options Database, DatabaseName, Name
+                            if ("Database" -in $Database.PSobject.Properties.Name) {
+                                [string]$DataBase = $Database.Database
+                            } elseif ("DatabaseName" -in $Database.PSobject.Properties.Name) {
+                                [string]$DataBase = $Database.DatabaseName
+                            } elseif ("Name" -in $Database.PSobject.Properties.Name) {
+                                [string]$Database = $Database.name
+                            }
+                        }
+                        Write-Message -Level Verbose -Message "existence - $($restoreserver.Databases[$DataBase].State)"
+                        if ($restoreserver.Databases[$DataBase].State -ne 'Existing') {
+                            Write-Message -Message "$Database does not exist on $restoreserver" -level Warning
+                            continue
+                        }
+                        if ($restoreserver.Databases[$Database].Status -ne "Restoring") {
+                            Write-Message -Message "$Database on $restoreserver is not in a Restoring State" -Level Warning
+                            continue
+                        }
+                        $RestoreComplete = $true
+                        $RecoverSql = "RESTORE DATABASE $Database WITH RECOVERY"
+                        Write-Message -Message "Recovery Sql Query - $RecoverSql" -level verbose
+                        try {
+                            $restoreserver.query($RecoverSql)
+                        } catch {
+                            $RestoreComplete = $False
+                            $ExitError = $_.Exception.InnerException
+                            Write-Message -Level Warning -Message "Failed to recover $Database on $restoreserver, `n $ExitError"
+                        } finally {
+                            [PSCustomObject]@{
+                                ComputerName    = $restoreserver.ComputerName
+                                InstanceName    = $restoreserver.ServiceName
+                                SqlInstance     = $restoreserver.DomainInstanceName
+                                DatabaseName    = $Database
+                                RestoreComplete = $RestoreComplete
+                                Scripts         = $RecoverSql
+                            }
+                        }
+                    }
+                }
             }
-            if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))) {
-                Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
-                return
-            }
-            if ($Continue) {
-                Write-Message -Message "Called with continue, so assume we have an existing db in norecovery"
-                $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $RestoreInstance
-                $LastRestoreType = Get-DbaDbRestoreHistory -SqlInstance $RestoreInstance -Last
-            }
-            if (!($PSBoundParameters.ContainsKey("DataBasename"))) {
-                $PipeDatabaseName = $true
+            end {
+                if (Test-FunctionInterrupt) {
+                    return
+                }
+                if ($PSCmdlet.ParameterSetName -like "Restore*") {
+                    if ($BackupHistory.Count -eq 0) {
+                        Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
+                        return
+                    }
+                    Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
+                    $FilteredBackupHistory = @()
+                    if (Test-Bound -ParameterName GetBackupInformation) {
+                        Write-Message -Message "Setting $GetBackupInformation to BackupHistory" -Level Verbose
+                        Set-Variable -Name $GetBackupInformation -Value $BackupHistory -Scope Global
+                    }
+                    if ($StopAfterGetBackupInformation) {
+                        return
+                    }
+                    $pathSep = Get-DbaPathSep -Server $restoreserver
+                    $null = $BackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatabaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping -PathSep $pathSep
+
+                    if (Test-Bound -ParameterName FormatBackupInformation) {
+                        Set-Variable -Name $FormatBackupInformation -Value $BackupHistory -Scope Global
+                    }
+                    if ($StopAfterFormatBackupInformation) {
+                        return
+                    }
+
+                    $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -IgnoreLogs:$IgnoreLogBackups -ContinuePoints $ContinuePoints -LastRestoreType $LastRestoreType -DatabaseName $DatabaseName
+
+                    if (Test-Bound -ParameterName SelectBackupInformation) {
+                        Write-Message -Message "Setting $SelectBackupInformation to FilteredBackupHistory" -Level Verbose
+                        Set-Variable -Name $SelectBackupInformation -Value $FilteredBackupHistory -Scope Global
+
+                    }
+                    if ($StopAfterSelectBackupInformation) {
+                        return
+                    }
+                    try {
+                        Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
+                        $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $restoreserver -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
+                    } catch {
+                        Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
+                    }
+                    if (Test-Bound -ParameterName TestBackupInformation) {
+                        Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
+                    }
+                    if ($StopAfterTestBackupInformation) {
+                        return
+                    }
+                    $DbVerfied = ($FilteredBackupHistory | Where-Object {
+                            $_.IsVerified -eq $True
+                        } | Select-Object -Property Database -Unique).Database -join ','
+                    Write-Message -Message "$DbVerfied passed testing" -Level Verbose
+                    if (($FilteredBackupHistory | Where-Object {
+                                $_.IsVerified -eq $True
+                            }).count -lt $FilteredBackupHistory.count) {
+                        $DbUnVerified = ($FilteredBackupHistory | Where-Object {
+                                $_.IsVerified -eq $False
+                            } | Select-Object -Property Database -Unique).Database -join ','
+                        if ($AllowContinue) {
+                            Write-Message -Message "$DbUnverified failed testing, AllowContinue set" -Level Verbose
+                        } else {
+                            Stop-Function -Message "Database $DbUnverified failed testing, AllowContinue not set, exiting"
+                            return
+                        }
+                    }
+                    If ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                        if (($FilteredBackupHistory.Database | select-Object -unique | Measure-Object).count -ne 1) {
+                            Stop-Function -Message "Must only 1 database passed in for Page Restore. Sorry"
+                            return
+                        } else {
+                            $WithReplace = $false
+                        }
+                    }
+                    Write-Message -Message "Passing in to restore" -Level Verbose
+                    if ($PSCmdlet.ParameterSetName -eq "RestorePage" -and $restoreserver.Edition -notlike '*Enterprise*') {
+                        Write-Message -Message "Taking Tail log backup for page restore for non-Enterprise" -Level Verbose
+                        $TailBackup = Backup-DbaDatabase -SqlInstance $restoreserver -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
+                    }
+                    try {
+                        $FilteredBackupHistory | Where-Object {
+                            $_.IsVerified -eq $true
+                        } | Invoke-DbaAdvancedRestore -SqlInstance $restoreserver -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC -VerifyOnly:$VerifyOnly -PageRestore $PageRestore -EnableException -AzureCredential $AzureCredential
+                    } catch {
+                        Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $restoreserver
+                    }
+                    if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                        if ($restoreserver.Edition -like '*Enterprise*') {
+                            Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose
+                            $TailBackup = Backup-DbaDatabase -SqlInstance $restoreserver -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
+                        }
+                        Write-Message -Message "Restoring Tail log backup for page restore" -Level Verbose
+                        $TailBackup | Restore-DbaDatabase -SqlInstance $restoreserver -TrustDbBackupHistory -NoRecovery -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -Continue
+                        Restore-DbaDatabase -SqlInstance $restoreserver -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
+                    }
+                }
             }
         }
-
-        if ($StatementTimeout -eq 0) {
-            Write-Message -Level Verbose -Message "Changing statement timeout to infinity"
-        } else {
-            Write-Message -Level Verbose -Message "Changing statement timeout to ($StatementTimeout) minutes"
-        }
-        $RestoreInstance.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
-        #endregion Validation
-
-        if ($UseDestinationDefaultDirectories) {
-            $DefaultPath = (Get-DbaDefaultPath -SqlInstance $RestoreInstance)
-            $DestinationDataDirectory = $DefaultPath.Data
-            $DestinationLogDirectory = $DefaultPath.Log
-        }
-
-        $BackupHistory = @()
+        $boundparams = $PSBoundParameters
+        $null = $boundparams.Remove("SqlInstance")
     }
     process {
-        if (Test-FunctionInterrupt) {
-            return
-        }
-        if ($RestoreInstance.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
-            foreach ($file in $Path) {
-                $bh = Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $file
-                $bound = $PSBoundParameters
-                $bound['TrustDbBackupHistory'] = $true
-                $bound['Path'] = $bh
-                Restore-Dbadatabase @bound
-            }
-            break
-        }
-        if ($PSCmdlet.ParameterSetName -like "Restore*") {
-            if ($PipeDatabaseName -eq $true) {
-                $DatabaseName = ''
-            }
-            Write-Message -message "ParameterSet  = Restore" -Level Verbose
-            if ($TrustDbBackupHistory -or $path[0].GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
-                foreach ($f in $path) {
-                    Write-Message -Level Verbose -Message "Trust Database Backup History Set"
-                    if ("BackupPath" -notin $f.PSobject.Properties.name) {
-                        Write-Message -Level Verbose -Message "adding BackupPath - $($_.FullName)"
-                        $f = $f | Select-Object *, @{
-                            Name = "BackupPath"; Expression = {
-                                $_.FullName
-                            }
-                        }
-                    }
-                    if ("DatabaseName" -notin $f.PSobject.Properties.Name) {
-                        $f = $f | Select-Object *, @{
-                            Name = "DatabaseName"; Expression = {
-                                $_.Database
-                            }
-                        }
-                    }
-                    if ("Database" -notin $f.PSobject.Properties.Name) {
-                        $f = $f | Select-Object *, @{
-                            Name = "Database"; Expression = {
-                                $_.DatabaseName
-                            }
-                        }
-                    }
-                    if ("BackupSetGUID" -notin $f.PSobject.Properties.Name) {
-                        $f = $f | Select-Object *, @{
-                            Name = "BackupSetGUID"; Expression = {
-                                $_.BackupSetID
-                            }
-                        }
-                    }
-
-                    if ($f.BackupPath -like 'http*') {
-                        if ('' -ne $AzureCredential) {
-                            Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
-                            Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
-                        } else {
-                            $f.BackupPath -match 'https://.*/.*/'
-                            if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ) {
-                                Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
-                            } else {
-                                Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
-                                return
-                            }
-                        }
-                    }
-                    $BackupHistory += $F | Select-Object *, @{
-                        Name = "ServerName"; Expression = {
-                            $_.SqlInstance
-                        }
-                    }, @{
-                        Name = "BackupStartDate"; Expression = {
-                            $_.Start -as [DateTime]
-                        }
-                    }
-                }
-            } else {
-                $files = @()
-                foreach ($f in $Path) {
-                    if ($f -is [System.IO.FileSystemInfo]) {
-                        $files += $f.FullName
-                    } else {
-                        $files += $f
-                    }
-                }
-                Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
-                if ($BackupHistory.GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
-                    $BackupHistory = @($BackupHistory)
-                }
-                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
-            }
-            if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                if (-not (Test-DbaPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {
-                    Stop-Function -Message "Instance $RestoreInstance cannot read $PageRestoreTailFolder, cannot proceed" -Target $PageRestoreTailFolder
-                    return
-                }
-                $WithReplace = $true
-            }
-        } elseif ($PSCmdlet.ParameterSetName -eq "Recovery") {
-            Write-Message -Message "$($Database.Count) databases to recover" -level Verbose
-            foreach ($Database in $DatabaseName) {
-                if ($Database -is [object]) {
-                    #We've got an object, try the normal options Database, DatabaseName, Name
-                    if ("Database" -in $Database.PSobject.Properties.Name) {
-                        [string]$DataBase = $Database.Database
-                    } elseif ("DatabaseName" -in $Database.PSobject.Properties.Name) {
-                        [string]$DataBase = $Database.DatabaseName
-                    } elseif ("Name" -in $Database.PSobject.Properties.Name) {
-                        [string]$Database = $Database.name
-                    }
-                }
-                Write-Message -Level Verbose -Message "existence - $($RestoreInstance.Databases[$DataBase].State)"
-                if ($RestoreInstance.Databases[$DataBase].State -ne 'Existing') {
-                    Write-Message -Message "$Database does not exist on $RestoreInstance" -level Warning
-                    continue
-                }
-                if ($RestoreInstance.Databases[$Database].Status -ne "Restoring") {
-                    Write-Message -Message "$Database on $RestoreInstance is not in a Restoring State" -Level Warning
-                    continue
-                }
-                $RestoreComplete = $true
-                $RecoverSql = "RESTORE DATABASE $Database WITH RECOVERY"
-                Write-Message -Message "Recovery Sql Query - $RecoverSql" -level verbose
-                try {
-                    $RestoreInstance.query($RecoverSql)
-                } catch {
-                    $RestoreComplete = $False
-                    $ExitError = $_.Exception.InnerException
-                    Write-Message -Level Warning -Message "Failed to recover $Database on $RestoreInstance, `n $ExitError"
-                } finally {
-                    [PSCustomObject]@{
-                        SqlInstance     = $SqlInstance
-                        DatabaseName    = $Database
-                        RestoreComplete = $RestoreComplete
-                        Scripts         = $RecoverSql
-                    }
-                }
-            }
-        }
-    }
-    end {
-        if (Test-FunctionInterrupt) {
-            return
-        }
-        if ($PSCmdlet.ParameterSetName -like "Restore*") {
-            if ($BackupHistory.Count -eq 0) {
-                Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
-                return
-            }
-            Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
-            $FilteredBackupHistory = @()
-            if (Test-Bound -ParameterName GetBackupInformation) {
-                Write-Message -Message "Setting $GetBackupInformation to BackupHistory" -Level Verbose
-                Set-Variable -Name $GetBackupInformation -Value $BackupHistory -Scope Global
-            }
-            if ($StopAfterGetBackupInformation) {
-                return
-            }
-            $pathSep = Get-DbaPathSep -Server $RestoreInstance
-            $null = $BackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatabaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping -PathSep $pathSep
-
-            if (Test-Bound -ParameterName FormatBackupInformation) {
-                Set-Variable -Name $FormatBackupInformation -Value $BackupHistory -Scope Global
-            }
-            if ($StopAfterFormatBackupInformation) {
-                return
-            }
-
-            $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -IgnoreLogs:$IgnoreLogBackups -ContinuePoints $ContinuePoints -LastRestoreType $LastRestoreType -DatabaseName $DatabaseName
-
-            if (Test-Bound -ParameterName SelectBackupInformation) {
-                Write-Message -Message "Setting $SelectBackupInformation to FilteredBackupHistory" -Level Verbose
-                Set-Variable -Name $SelectBackupInformation -Value $FilteredBackupHistory -Scope Global
-
-            }
-            if ($StopAfterSelectBackupInformation) {
-                return
-            }
-            try {
-                Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
-                $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
-            } catch {
-                Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
-            }
-            if (Test-Bound -ParameterName TestBackupInformation) {
-                Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
-            }
-            if ($StopAfterTestBackupInformation) {
-                return
-            }
-            $DbVerfied = ($FilteredBackupHistory | Where-Object {
-                    $_.IsVerified -eq $True
-                } | Select-Object -Property Database -Unique).Database -join ','
-            Write-Message -Message "$DbVerfied passed testing" -Level Verbose
-            if (($FilteredBackupHistory | Where-Object {
-                        $_.IsVerified -eq $True
-                    }).count -lt $FilteredBackupHistory.count) {
-                $DbUnVerified = ($FilteredBackupHistory | Where-Object {
-                        $_.IsVerified -eq $False
-                    } | Select-Object -Property Database -Unique).Database -join ','
-                if ($AllowContinue) {
-                    Write-Message -Message "$DbUnverified failed testing, AllowContinue set" -Level Verbose
-                } else {
-                    Stop-Function -Message "Database $DbUnverified failed testing, AllowContinue not set, exiting"
-                    return
-                }
-            }
-            If ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                if (($FilteredBackupHistory.Database | select-Object -unique | Measure-Object).count -ne 1) {
-                    Stop-Function -Message "Must only 1 database passed in for Page Restore. Sorry"
-                    return
-                } else {
-                    $WithReplace = $false
-                }
-            }
-            Write-Message -Message "Passing in to restore" -Level Verbose
-            if ($PSCmdlet.ParameterSetName -eq "RestorePage" -and $RestoreInstance.Edition -notlike '*Enterprise*') {
-                Write-Message -Message "Taking Tail log backup for page restore for non-Enterprise" -Level Verbose
-                $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
-            }
-            try {
-                $FilteredBackupHistory | Where-Object {
-                    $_.IsVerified -eq $true
-                } | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC -VerifyOnly:$VerifyOnly -PageRestore $PageRestore -EnableException -AzureCredential $AzureCredential
-            } catch {
-                Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $RestoreInstance
-            }
-            if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                if ($RestoreInstance.Edition -like '*Enterprise*') {
-                    Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose
-                    $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
-                }
-                Write-Message -Message "Restoring Tail log backup for page restore" -Level Verbose
-                $TailBackup | Restore-DbaDatabase -SqlInstance $RestoreInstance -TrustDbBackupHistory -NoRecovery -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -Continue
-                Restore-DbaDatabase -SqlInstance $RestoreInstance -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
-            }
+        foreach ($instance in $SqlInstance) {
+            Restore-Internal -SqlInstance $instance @boundparams
         }
     }
 }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -326,75 +326,39 @@ function Restore-DbaDatabase {
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Restore")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "AzureCredential", Justification = "For Parameter AzureCredential")]
     param (
-        [parameter(Mandatory)]
-        [Alias("ServerInstance", "SqlServer")]
-        [DbaInstanceParameter[]]$SqlInstance,
+        [parameter(Mandatory)][Alias("ServerInstance", "SqlServer")][DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
-        [object[]]$Path,
-        [parameter(ValueFromPipeline)]
-        [Alias("Name")]
-        [object[]]$DatabaseName,
-        [parameter(ParameterSetName = "Restore")]
-        [String]$DestinationDataDirectory,
-        [parameter(ParameterSetName = "Restore")]
-        [String]$DestinationLogDirectory,
-        [parameter(ParameterSetName = "Restore")]
-        [String]$DestinationFileStreamDirectory,
-        [parameter(ParameterSetName = "Restore")]
-        [DateTime]$RestoreTime = (Get-Date).AddYears(1),
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$NoRecovery,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$WithReplace,
-        [parameter(ParameterSetName = "Restore")]
-        [Switch]$XpDirTree,
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")][parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")][object[]]$Path,
+        [parameter(ValueFromPipeline)][Alias("Name")][object[]]$DatabaseName,
+        [parameter(ParameterSetName = "Restore")][String]$DestinationDataDirectory,
+        [parameter(ParameterSetName = "Restore")][String]$DestinationLogDirectory,
+        [parameter(ParameterSetName = "Restore")][String]$DestinationFileStreamDirectory,
+        [parameter(ParameterSetName = "Restore")][DateTime]$RestoreTime = (Get-Date).AddYears(1),
+        [parameter(ParameterSetName = "Restore")][switch]$NoRecovery,
+        [parameter(ParameterSetName = "Restore")][switch]$WithReplace,
+        [parameter(ParameterSetName = "Restore")][Switch]$XpDirTree,
         [switch]$OutputScriptOnly,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$VerifyOnly,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$MaintenanceSolutionBackup,
-        [parameter(ParameterSetName = "Restore")]
-        [hashtable]$FileMapping,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$IgnoreLogBackup,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$UseDestinationDefaultDirectories,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$ReuseSourceFolderStructure,
-        [parameter(ParameterSetName = "Restore")]
-        [string]$DestinationFilePrefix = '',
-        [parameter(ParameterSetName = "Restore")]
-        [string]$RestoredDatabaseNamePrefix,
-        [parameter(ParameterSetName = "Restore")]
-        [parameter(ParameterSetName = "RestorePage")]
-        [switch]$TrustDbBackupHistory,
-        [parameter(ParameterSetName = "Restore")]
-        [parameter(ParameterSetName = "RestorePage")]
-        [int]$MaxTransferSize,
-        [parameter(ParameterSetName = "Restore")]
-        [parameter(ParameterSetName = "RestorePage")]
-        [int]$BlockSize,
-        [parameter(ParameterSetName = "Restore")]
-        [parameter(ParameterSetName = "RestorePage")]
-        [int]$BufferCount,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$DirectoryRecurse,
+        [parameter(ParameterSetName = "Restore")][switch]$VerifyOnly,
+        [parameter(ParameterSetName = "Restore")][switch]$MaintenanceSolutionBackup,
+        [parameter(ParameterSetName = "Restore")][hashtable]$FileMapping,
+        [parameter(ParameterSetName = "Restore")][switch]$IgnoreLogBackup,
+        [parameter(ParameterSetName = "Restore")][switch]$UseDestinationDefaultDirectories,
+        [parameter(ParameterSetName = "Restore")][switch]$ReuseSourceFolderStructure,
+        [parameter(ParameterSetName = "Restore")][string]$DestinationFilePrefix = '',
+        [parameter(ParameterSetName = "Restore")][string]$RestoredDatabaseNamePrefix,
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][switch]$TrustDbBackupHistory,
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$MaxTransferSize,
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$BlockSize,
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][int]$BufferCount,
+        [parameter(ParameterSetName = "Restore")][switch]$DirectoryRecurse,
         [switch]$EnableException,
-        [parameter(ParameterSetName = "Restore")]
-        [string]$StandbyDirectory,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$Continue,
+        [parameter(ParameterSetName = "Restore")][string]$StandbyDirectory,
+        [parameter(ParameterSetName = "Restore")][switch]$Continue,
         [string]$AzureCredential,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$ReplaceDbNameInFile,
-        [parameter(ParameterSetName = "Restore")]
-        [string]$DestinationFileSuffix,
-        [parameter(ParameterSetName = "Recovery")]
-        [switch]$Recover,
-        [parameter(ParameterSetName = "Restore")]
-        [switch]$KeepCDC,
+        [parameter(ParameterSetName = "Restore")][switch]$ReplaceDbNameInFile,
+        [parameter(ParameterSetName = "Restore")][string]$DestinationFileSuffix,
+        [parameter(ParameterSetName = "Recovery")][switch]$Recover,
+        [parameter(ParameterSetName = "Restore")][switch]$KeepCDC,
         [switch]$AllowContinue,
         [string]$GetBackupInformation,
         [switch]$StopAfterGetBackupInformation,
@@ -404,449 +368,347 @@ function Restore-DbaDatabase {
         [switch]$StopAfterFormatBackupInformation,
         [string]$TestBackupInformation,
         [switch]$StopAfterTestBackupInformation,
-        [parameter(Mandatory, ParameterSetName = "RestorePage")]
-        [object]$PageRestore,
-        [parameter(Mandatory, ParameterSetName = "RestorePage")]
-        [string]$PageRestoreTailFolder,
+        [parameter(Mandatory, ParameterSetName = "RestorePage")][object]$PageRestore,
+        [parameter(Mandatory, ParameterSetName = "RestorePage")][string]$PageRestoreTailFolder,
         [int]$StatementTimeout = 0
     )
     begin {
-        function Restore-Internal {
-            [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "Restore")]
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "AzureCredential", Justification = "For Parameter AzureCredential")]
-            param (
-                [parameter(Mandatory)]
-                [Alias("ServerInstance", "SqlServer")]
-                [DbaInstanceParameter]$SqlInstance,
-                [PSCredential]$SqlCredential,
-                [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
-                [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
-                [object[]]$Path,
-                [parameter(ValueFromPipeline)]
-                [Alias("Name")]
-                [object[]]$DatabaseName,
-                [parameter(ParameterSetName = "Restore")]
-                [String]$DestinationDataDirectory,
-                [parameter(ParameterSetName = "Restore")]
-                [String]$DestinationLogDirectory,
-                [parameter(ParameterSetName = "Restore")]
-                [String]$DestinationFileStreamDirectory,
-                [parameter(ParameterSetName = "Restore")]
-                [DateTime]$RestoreTime = (Get-Date).AddYears(1),
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$NoRecovery,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$WithReplace,
-                [parameter(ParameterSetName = "Restore")]
-                [Switch]$XpDirTree,
-                [switch]$OutputScriptOnly,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$VerifyOnly,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$MaintenanceSolutionBackup,
-                [parameter(ParameterSetName = "Restore")]
-                [hashtable]$FileMapping,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$IgnoreLogBackup,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$UseDestinationDefaultDirectories,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$ReuseSourceFolderStructure,
-                [parameter(ParameterSetName = "Restore")]
-                [string]$DestinationFilePrefix = '',
-                [parameter(ParameterSetName = "Restore")]
-                [string]$RestoredDatabaseNamePrefix,
-                [parameter(ParameterSetName = "Restore")]
-                [parameter(ParameterSetName = "RestorePage")]
-                [switch]$TrustDbBackupHistory,
-                [parameter(ParameterSetName = "Restore")]
-                [parameter(ParameterSetName = "RestorePage")]
-                [int]$MaxTransferSize,
-                [parameter(ParameterSetName = "Restore")]
-                [parameter(ParameterSetName = "RestorePage")]
-                [int]$BlockSize,
-                [parameter(ParameterSetName = "Restore")]
-                [parameter(ParameterSetName = "RestorePage")]
-                [int]$BufferCount,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$DirectoryRecurse,
-                [switch]$EnableException,
-                [parameter(ParameterSetName = "Restore")]
-                [string]$StandbyDirectory,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$Continue,
-                [string]$AzureCredential,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$ReplaceDbNameInFile,
-                [parameter(ParameterSetName = "Restore")]
-                [string]$DestinationFileSuffix,
-                [parameter(ParameterSetName = "Recovery")]
-                [switch]$Recover,
-                [parameter(ParameterSetName = "Restore")]
-                [switch]$KeepCDC,
-                [switch]$AllowContinue,
-                [string]$GetBackupInformation,
-                [switch]$StopAfterGetBackupInformation,
-                [string]$SelectBackupInformation,
-                [switch]$StopAfterSelectBackupInformation,
-                [string]$FormatBackupInformation,
-                [switch]$StopAfterFormatBackupInformation,
-                [string]$TestBackupInformation,
-                [switch]$StopAfterTestBackupInformation,
-                [parameter(Mandatory, ParameterSetName = "RestorePage")]
-                [object]$PageRestore,
-                [parameter(Mandatory, ParameterSetName = "RestorePage")]
-                [string]$PageRestoreTailFolder,
-                [int]$StatementTimeout = 0
-            )
-            begin {
-                Write-Message -Level InternalComment -Message "Starting"
-                Write-Message -Level Debug -Message "Parameters bound: $($PSBoundParameters.Keys -join ", ")"
+        Write-Message -Level InternalComment -Message "Starting"
+        Write-Message -Level Debug -Message "Parameters bound: $($PSBoundParameters.Keys -join ", ")"
 
-                #region Validation
-                try {
-                    $restoreserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-                } catch {
-                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-                    return
-                }
-                if ($PSCmdlet.ParameterSetName -eq "Restore") {
-                    $UseDestinationDefaultDirectories = $true
-                    $paramCount = 0
+        #region Validation
+        try {
+            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            return
+        }
+        if ($PSCmdlet.ParameterSetName -eq "Restore") {
+            $UseDestinationDefaultDirectories = $true
+            $paramCount = 0
 
-                    if (!(Test-Bound "AllowContinue") -and $true -ne $AllowContinue) {
-                        $AllowContinue = $false
-                    }
-                    if (Test-Bound "FileMapping") {
-                        $paramCount += 1
-                    }
-                    if (Test-Bound "ReuseSourceFolderStructure") {
-                        $paramCount += 1
-                    }
-                    if (Test-Bound "DestinationDataDirectory") {
-                        $paramCount += 1
-                    }
-                    if ($paramCount -gt 1) {
-                        Stop-Function -Category InvalidArgument -Message "You've specified incompatible Location parameters. Please only specify one of FileMapping, ReuseSourceFolderStructure or DestinationDataDirectory"
-                        return
-                    }
-                    if (($ReplaceDbNameInFile) -and !(Test-Bound "DatabaseName")) {
-                        Stop-Function -Category InvalidArgument -Message "To use ReplaceDbNameInFile you must specify DatabaseName"
-                        return
-                    }
-
-                    if ((Test-Bound "DestinationLogDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
-                        Stop-Function -Category InvalidArgument -Message "The parameters DestinationLogDirectory and UseDestinationDefaultDirectories are mutually exclusive"
-                        return
-                    }
-                    if ((Test-Bound "DestinationLogDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
-                        Stop-Function -Category InvalidArgument -Message "The parameter DestinationLogDirectory can only be specified together with DestinationDataDirectory"
-                        return
-                    }
-                    if ((Test-Bound "DestinationFileStreamDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
-                        Stop-Function -Category InvalidArgument -Message "The parameters DestinationFileStreamDirectory and UseDestinationDefaultDirectories are mutually exclusive"
-                        return
-                    }
-                    if ((Test-Bound "DestinationFileStreamDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
-                        Stop-Function -Category InvalidArgument -Message "The parameter DestinationFileStreamDirectory can only be specified together with DestinationDataDirectory"
-                        return
-                    }
-                    if (($null -ne $FileMapping) -or $ReuseSourceFolderStructure -or ($DestinationDataDirectory -ne '')) {
-                        $UseDestinationDefaultDirectories = $false
-                    }
-                    if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
-                        Stop-Function -Category InvalidArgument -Message "MaxTransferSize value must be a multiple of 64kb and no greater than 4MB"
-                        return
-                    }
-                    if ($BlockSize) {
-                        if ($BlockSize -notin (0.5kb, 1kb, 2kb, 4kb, 8kb, 16kb, 32kb, 64kb)) {
-                            Stop-Function -Category InvalidArgument -Message "Block size must be one of 0.5kb,1kb,2kb,4kb,8kb,16kb,32kb,64kb"
-                            return
-                        }
-                    }
-                    if ('' -ne $StandbyDirectory) {
-                        if (!(Test-DbaPath -Path $StandbyDirectory -SqlInstance $restoreserver)) {
-                            Stop-Function -Message "$SqlServer cannot see the specified Standby Directory $StandbyDirectory" -Target $SqlInstance
-                            return
-                        }
-                    }
-                    if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))) {
-                        Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
-                        return
-                    }
-                    if ($Continue) {
-                        Write-Message -Message "Called with continue, so assume we have an existing db in norecovery"
-                        $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $restoreserver
-                        $LastRestoreType = Get-DbaDbRestoreHistory -SqlInstance $restoreserver -Last
-                    }
-                    if (!($PSBoundParameters.ContainsKey("DataBasename"))) {
-                        $PipeDatabaseName = $true
-                    }
-                }
-
-                if ($StatementTimeout -eq 0) {
-                    Write-Message -Level Verbose -Message "Changing statement timeout to infinity"
-                } else {
-                    Write-Message -Level Verbose -Message "Changing statement timeout to ($StatementTimeout) minutes"
-                }
-                $restoreserver.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
-                #endregion Validation
-
-                if ($UseDestinationDefaultDirectories) {
-                    $DefaultPath = (Get-DbaDefaultPath -SqlInstance $restoreserver)
-                    $DestinationDataDirectory = $DefaultPath.Data
-                    $DestinationLogDirectory = $DefaultPath.Log
-                }
-
-                $BackupHistory = @()
+            if (!(Test-Bound "AllowContinue") -and $true -ne $AllowContinue) {
+                $AllowContinue = $false
             }
-            process {
-                if (Test-FunctionInterrupt) {
+            if (Test-Bound "FileMapping") {
+                $paramCount += 1
+            }
+            if (Test-Bound "ReuseSourceFolderStructure") {
+                $paramCount += 1
+            }
+            if (Test-Bound "DestinationDataDirectory") {
+                $paramCount += 1
+            }
+            if ($paramCount -gt 1) {
+                Stop-Function -Category InvalidArgument -Message "You've specified incompatible Location parameters. Please only specify one of FileMapping, ReuseSourceFolderStructure or DestinationDataDirectory"
+                return
+            }
+            if (($ReplaceDbNameInFile) -and !(Test-Bound "DatabaseName")) {
+                Stop-Function -Category InvalidArgument -Message "To use ReplaceDbNameInFile you must specify DatabaseName"
+                return
+            }
+
+            if ((Test-Bound "DestinationLogDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
+                Stop-Function -Category InvalidArgument -Message "The parameters DestinationLogDirectory and UseDestinationDefaultDirectories are mutually exclusive"
+                return
+            }
+            if ((Test-Bound "DestinationLogDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
+                Stop-Function -Category InvalidArgument -Message "The parameter DestinationLogDirectory can only be specified together with DestinationDataDirectory"
+                return
+            }
+            if ((Test-Bound "DestinationFileStreamDirectory") -and (Test-Bound "ReuseSourceFolderStructure")) {
+                Stop-Function -Category InvalidArgument -Message "The parameters DestinationFileStreamDirectory and UseDestinationDefaultDirectories are mutually exclusive"
+                return
+            }
+            if ((Test-Bound "DestinationFileStreamDirectory") -and -not (Test-Bound "DestinationDataDirectory")) {
+                Stop-Function -Category InvalidArgument -Message "The parameter DestinationFileStreamDirectory can only be specified together with DestinationDataDirectory"
+                return
+            }
+            if (($null -ne $FileMapping) -or $ReuseSourceFolderStructure -or ($DestinationDataDirectory -ne '')) {
+                $UseDestinationDefaultDirectories = $false
+            }
+            if (($MaxTransferSize % 64kb) -ne 0 -or $MaxTransferSize -gt 4mb) {
+                Stop-Function -Category InvalidArgument -Message "MaxTransferSize value must be a multiple of 64kb and no greater than 4MB"
+                return
+            }
+            if ($BlockSize) {
+                if ($BlockSize -notin (0.5kb, 1kb, 2kb, 4kb, 8kb, 16kb, 32kb, 64kb)) {
+                    Stop-Function -Category InvalidArgument -Message "Block size must be one of 0.5kb,1kb,2kb,4kb,8kb,16kb,32kb,64kb"
                     return
                 }
-                if ($restoreserver.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
-                    foreach ($file in $Path) {
-                        $bh = Get-DbaBackupInformation -SqlInstance $restoreserver -Path $file
-                        $bound = $PSBoundParameters
-                        $bound['TrustDbBackupHistory'] = $true
-                        $bound['Path'] = $bh
-                        Restore-Dbadatabase @bound
-                    }
-                    break
+            }
+            if ('' -ne $StandbyDirectory) {
+                if (!(Test-DbaPath -Path $StandbyDirectory -SqlInstance $RestoreInstance)) {
+                    Stop-Function -Message "$SqlServer cannot see the specified Standby Directory $StandbyDirectory" -Target $SqlInstance
+                    return
                 }
-                if ($PSCmdlet.ParameterSetName -like "Restore*") {
-                    if ($PipeDatabaseName -eq $true) {
-                        $DatabaseName = ''
-                    }
-                    Write-Message -message "ParameterSet  = Restore" -Level Verbose
-                    if ($TrustDbBackupHistory -or $path[0].GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
-                        foreach ($f in $path) {
-                            Write-Message -Level Verbose -Message "Trust Database Backup History Set"
-                            if ("BackupPath" -notin $f.PSobject.Properties.name) {
-                                Write-Message -Level Verbose -Message "adding BackupPath - $($_.FullName)"
-                                $f = $f | Select-Object *, @{
-                                    Name = "BackupPath"; Expression = {
-                                        $_.FullName
-                                    }
-                                }
-                            }
-                            if ("DatabaseName" -notin $f.PSobject.Properties.Name) {
-                                $f = $f | Select-Object *, @{
-                                    Name = "DatabaseName"; Expression = {
-                                        $_.Database
-                                    }
-                                }
-                            }
-                            if ("Database" -notin $f.PSobject.Properties.Name) {
-                                $f = $f | Select-Object *, @{
-                                    Name = "Database"; Expression = {
-                                        $_.DatabaseName
-                                    }
-                                }
-                            }
-                            if ("BackupSetGUID" -notin $f.PSobject.Properties.Name) {
-                                $f = $f | Select-Object *, @{
-                                    Name = "BackupSetGUID"; Expression = {
-                                        $_.BackupSetID
-                                    }
-                                }
-                            }
+            }
+            if ($KeepCDC -and ($NoRecovery -or ('' -ne $StandbyDirectory))) {
+                Stop-Function -Category InvalidArgument -Message "KeepCDC cannot be specified with Norecovery or Standby as it needs recovery to work"
+                return
+            }
+            if ($Continue) {
+                Write-Message -Message "Called with continue, so assume we have an existing db in norecovery"
+                $ContinuePoints = Get-RestoreContinuableDatabase -SqlInstance $RestoreInstance
+                $LastRestoreType = Get-DbaDbRestoreHistory -SqlInstance $RestoreInstance -Last
+            }
+            if (!($PSBoundParameters.ContainsKey("DataBasename"))) {
+                $PipeDatabaseName = $true
+            }
+        }
 
-                            if ($f.BackupPath -like 'http*') {
-                                if ('' -ne $AzureCredential) {
-                                    Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
-                                    Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
-                                } else {
-                                    $f.BackupPath -match 'https://.*/.*/'
-                                    if (Get-DbaCredential -SqlInstance $restoreserver -name $matches[0].trim('/')) {
-                                        Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
-                                    } else {
-                                        Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
-                                        return
-                                    }
-                                }
-                            }
-                            $BackupHistory += $F | Select-Object *, @{
-                                Name = "ServerName"; Expression = {
-                                    $_.SqlInstance
-                                }
-                            }, @{
-                                Name = "BackupStartDate"; Expression = {
-                                    $_.Start -as [DateTime]
-                                }
+        if ($StatementTimeout -eq 0) {
+            Write-Message -Level Verbose -Message "Changing statement timeout to infinity"
+        } else {
+            Write-Message -Level Verbose -Message "Changing statement timeout to ($StatementTimeout) minutes"
+        }
+        $RestoreInstance.ConnectionContext.StatementTimeout = ($StatementTimeout * 60)
+        #endregion Validation
+
+        if ($UseDestinationDefaultDirectories) {
+            $DefaultPath = (Get-DbaDefaultPath -SqlInstance $RestoreInstance)
+            $DestinationDataDirectory = $DefaultPath.Data
+            $DestinationLogDirectory = $DefaultPath.Log
+        }
+
+        $BackupHistory = @()
+    }
+    process {
+        if (Test-FunctionInterrupt) {
+            return
+        }
+        if ($RestoreInstance.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
+            foreach ($file in $Path) {
+                $bh = Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $file
+                $bound = $PSBoundParameters
+                $bound['TrustDbBackupHistory'] = $true
+                $bound['Path'] = $bh
+                Restore-Dbadatabase @bound
+            }
+            break
+        }
+        if ($PSCmdlet.ParameterSetName -like "Restore*") {
+            if ($PipeDatabaseName -eq $true) {
+                $DatabaseName = ''
+            }
+            Write-Message -message "ParameterSet  = Restore" -Level Verbose
+            if ($TrustDbBackupHistory -or $path[0].GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
+                foreach ($f in $path) {
+                    Write-Message -Level Verbose -Message "Trust Database Backup History Set"
+                    if ("BackupPath" -notin $f.PSobject.Properties.name) {
+                        Write-Message -Level Verbose -Message "adding BackupPath - $($_.FullName)"
+                        $f = $f | Select-Object *, @{
+                            Name = "BackupPath"; Expression = {
+                                $_.FullName
                             }
                         }
-                    } else {
-                        $files = @()
-                        foreach ($f in $Path) {
-                            if ($f -is [System.IO.FileSystemInfo]) {
-                                $files += $f.FullName
+                    }
+                    if ("DatabaseName" -notin $f.PSobject.Properties.Name) {
+                        $f = $f | Select-Object *, @{
+                            Name = "DatabaseName"; Expression = {
+                                $_.Database
+                            }
+                        }
+                    }
+                    if ("Database" -notin $f.PSobject.Properties.Name) {
+                        $f = $f | Select-Object *, @{
+                            Name = "Database"; Expression = {
+                                $_.DatabaseName
+                            }
+                        }
+                    }
+                    if ("BackupSetGUID" -notin $f.PSobject.Properties.Name) {
+                        $f = $f | Select-Object *, @{
+                            Name = "BackupSetGUID"; Expression = {
+                                $_.BackupSetID
+                            }
+                        }
+                    }
+
+                    if ($f.BackupPath -like 'http*') {
+                        if ('' -ne $AzureCredential) {
+                            Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
+                            Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
+                        } else {
+                            $f.BackupPath -match 'https://.*/.*/'
+                            if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ) {
+                                Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
                             } else {
-                                $files += $f
+                                Stop-Function -Message "A URL to a backup has been passed in, but no credential can be found to access it"
+                                return
                             }
                         }
-                        Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
-                        if ($BackupHistory.GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
-                            $BackupHistory = @($BackupHistory)
-                        }
-                        $BackupHistory += Get-DbaBackupInformation -SqlInstance $restoreserver -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
                     }
-                    if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                        if (-not (Test-DbaPath -SqlInstance $restoreserver -Path $PageRestoreTailFolder)) {
-                            Stop-Function -Message "Instance $restoreserver cannot read $PageRestoreTailFolder, cannot proceed" -Target $PageRestoreTailFolder
-                            return
+                    $BackupHistory += $F | Select-Object *, @{
+                        Name = "ServerName"; Expression = {
+                            $_.SqlInstance
                         }
-                        $WithReplace = $true
-                    }
-                } elseif ($PSCmdlet.ParameterSetName -eq "Recovery") {
-                    Write-Message -Message "$($Database.Count) databases to recover" -level Verbose
-                    foreach ($Database in $DatabaseName) {
-                        if ($Database -is [object]) {
-                            #We've got an object, try the normal options Database, DatabaseName, Name
-                            if ("Database" -in $Database.PSobject.Properties.Name) {
-                                [string]$DataBase = $Database.Database
-                            } elseif ("DatabaseName" -in $Database.PSobject.Properties.Name) {
-                                [string]$DataBase = $Database.DatabaseName
-                            } elseif ("Name" -in $Database.PSobject.Properties.Name) {
-                                [string]$Database = $Database.name
-                            }
-                        }
-                        Write-Message -Level Verbose -Message "existence - $($restoreserver.Databases[$DataBase].State)"
-                        if ($restoreserver.Databases[$DataBase].State -ne 'Existing') {
-                            Write-Message -Message "$Database does not exist on $restoreserver" -level Warning
-                            continue
-                        }
-                        if ($restoreserver.Databases[$Database].Status -ne "Restoring") {
-                            Write-Message -Message "$Database on $restoreserver is not in a Restoring State" -Level Warning
-                            continue
-                        }
-                        $RestoreComplete = $true
-                        $RecoverSql = "RESTORE DATABASE $Database WITH RECOVERY"
-                        Write-Message -Message "Recovery Sql Query - $RecoverSql" -level verbose
-                        try {
-                            $restoreserver.query($RecoverSql)
-                        } catch {
-                            $RestoreComplete = $False
-                            $ExitError = $_.Exception.InnerException
-                            Write-Message -Level Warning -Message "Failed to recover $Database on $restoreserver, `n $ExitError"
-                        } finally {
-                            [PSCustomObject]@{
-                                ComputerName    = $restoreserver.ComputerName
-                                InstanceName    = $restoreserver.ServiceName
-                                SqlInstance     = $restoreserver.DomainInstanceName
-                                DatabaseName    = $Database
-                                RestoreComplete = $RestoreComplete
-                                Scripts         = $RecoverSql
-                            }
+                    }, @{
+                        Name = "BackupStartDate"; Expression = {
+                            $_.Start -as [DateTime]
                         }
                     }
                 }
+            } else {
+                $files = @()
+                foreach ($f in $Path) {
+                    if ($f -is [System.IO.FileSystemInfo]) {
+                        $files += $f.FullName
+                    } else {
+                        $files += $f
+                    }
+                }
+                Write-Message -Level Verbose -Message "Unverified input, full scans - $($files -join ';')"
+                if ($BackupHistory.GetType().ToString() -eq 'Sqlcollaborative.Dbatools.Database.BackupHistory') {
+                    $BackupHistory = @($BackupHistory)
+                }
+                $BackupHistory += Get-DbaBackupInformation -SqlInstance $RestoreInstance -SqlCredential $SqlCredential -Path $files -DirectoryRecurse:$DirectoryRecurse -MaintenanceSolution:$MaintenanceSolutionBackup -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential
             }
-            end {
-                if (Test-FunctionInterrupt) {
+            if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                if (-not (Test-DbaPath -SqlInstance $RestoreInstance -Path $PageRestoreTailFolder)) {
+                    Stop-Function -Message "Instance $RestoreInstance cannot read $PageRestoreTailFolder, cannot proceed" -Target $PageRestoreTailFolder
                     return
                 }
-                if ($PSCmdlet.ParameterSetName -like "Restore*") {
-                    if ($BackupHistory.Count -eq 0) {
-                        Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
-                        return
+                $WithReplace = $true
+            }
+        } elseif ($PSCmdlet.ParameterSetName -eq "Recovery") {
+            Write-Message -Message "$($Database.Count) databases to recover" -level Verbose
+            foreach ($Database in $DatabaseName) {
+                if ($Database -is [object]) {
+                    #We've got an object, try the normal options Database, DatabaseName, Name
+                    if ("Database" -in $Database.PSobject.Properties.Name) {
+                        [string]$DataBase = $Database.Database
+                    } elseif ("DatabaseName" -in $Database.PSobject.Properties.Name) {
+                        [string]$DataBase = $Database.DatabaseName
+                    } elseif ("Name" -in $Database.PSobject.Properties.Name) {
+                        [string]$Database = $Database.name
                     }
-                    Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
-                    $FilteredBackupHistory = @()
-                    if (Test-Bound -ParameterName GetBackupInformation) {
-                        Write-Message -Message "Setting $GetBackupInformation to BackupHistory" -Level Verbose
-                        Set-Variable -Name $GetBackupInformation -Value $BackupHistory -Scope Global
-                    }
-                    if ($StopAfterGetBackupInformation) {
-                        return
-                    }
-                    $pathSep = Get-DbaPathSep -Server $restoreserver
-                    $null = $BackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatabaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping -PathSep $pathSep
-
-                    if (Test-Bound -ParameterName FormatBackupInformation) {
-                        Set-Variable -Name $FormatBackupInformation -Value $BackupHistory -Scope Global
-                    }
-                    if ($StopAfterFormatBackupInformation) {
-                        return
-                    }
-
-                    $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -IgnoreLogs:$IgnoreLogBackups -ContinuePoints $ContinuePoints -LastRestoreType $LastRestoreType -DatabaseName $DatabaseName
-
-                    if (Test-Bound -ParameterName SelectBackupInformation) {
-                        Write-Message -Message "Setting $SelectBackupInformation to FilteredBackupHistory" -Level Verbose
-                        Set-Variable -Name $SelectBackupInformation -Value $FilteredBackupHistory -Scope Global
-
-                    }
-                    if ($StopAfterSelectBackupInformation) {
-                        return
-                    }
-                    try {
-                        Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
-                        $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $restoreserver -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
-                    } catch {
-                        Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
-                    }
-                    if (Test-Bound -ParameterName TestBackupInformation) {
-                        Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
-                    }
-                    if ($StopAfterTestBackupInformation) {
-                        return
-                    }
-                    $DbVerfied = ($FilteredBackupHistory | Where-Object {
-                            $_.IsVerified -eq $True
-                        } | Select-Object -Property Database -Unique).Database -join ','
-                    Write-Message -Message "$DbVerfied passed testing" -Level Verbose
-                    if (($FilteredBackupHistory | Where-Object {
-                                $_.IsVerified -eq $True
-                            }).count -lt $FilteredBackupHistory.count) {
-                        $DbUnVerified = ($FilteredBackupHistory | Where-Object {
-                                $_.IsVerified -eq $False
-                            } | Select-Object -Property Database -Unique).Database -join ','
-                        if ($AllowContinue) {
-                            Write-Message -Message "$DbUnverified failed testing, AllowContinue set" -Level Verbose
-                        } else {
-                            Stop-Function -Message "Database $DbUnverified failed testing, AllowContinue not set, exiting"
-                            return
-                        }
-                    }
-                    If ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                        if (($FilteredBackupHistory.Database | select-Object -unique | Measure-Object).count -ne 1) {
-                            Stop-Function -Message "Must only 1 database passed in for Page Restore. Sorry"
-                            return
-                        } else {
-                            $WithReplace = $false
-                        }
-                    }
-                    Write-Message -Message "Passing in to restore" -Level Verbose
-                    if ($PSCmdlet.ParameterSetName -eq "RestorePage" -and $restoreserver.Edition -notlike '*Enterprise*') {
-                        Write-Message -Message "Taking Tail log backup for page restore for non-Enterprise" -Level Verbose
-                        $TailBackup = Backup-DbaDatabase -SqlInstance $restoreserver -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
-                    }
-                    try {
-                        $FilteredBackupHistory | Where-Object {
-                            $_.IsVerified -eq $true
-                        } | Invoke-DbaAdvancedRestore -SqlInstance $restoreserver -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC -VerifyOnly:$VerifyOnly -PageRestore $PageRestore -EnableException -AzureCredential $AzureCredential
-                    } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $restoreserver
-                    }
-                    if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
-                        if ($restoreserver.Edition -like '*Enterprise*') {
-                            Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose
-                            $TailBackup = Backup-DbaDatabase -SqlInstance $restoreserver -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
-                        }
-                        Write-Message -Message "Restoring Tail log backup for page restore" -Level Verbose
-                        $TailBackup | Restore-DbaDatabase -SqlInstance $restoreserver -TrustDbBackupHistory -NoRecovery -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -Continue
-                        Restore-DbaDatabase -SqlInstance $restoreserver -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
+                }
+                Write-Message -Level Verbose -Message "existence - $($RestoreInstance.Databases[$DataBase].State)"
+                if ($RestoreInstance.Databases[$DataBase].State -ne 'Existing') {
+                    Write-Message -Message "$Database does not exist on $RestoreInstance" -level Warning
+                    continue
+                }
+                if ($RestoreInstance.Databases[$Database].Status -ne "Restoring") {
+                    Write-Message -Message "$Database on $RestoreInstance is not in a Restoring State" -Level Warning
+                    continue
+                }
+                $RestoreComplete = $true
+                $RecoverSql = "RESTORE DATABASE $Database WITH RECOVERY"
+                Write-Message -Message "Recovery Sql Query - $RecoverSql" -level verbose
+                try {
+                    $RestoreInstance.query($RecoverSql)
+                } catch {
+                    $RestoreComplete = $False
+                    $ExitError = $_.Exception.InnerException
+                    Write-Message -Level Warning -Message "Failed to recover $Database on $RestoreInstance, `n $ExitError"
+                } finally {
+                    [PSCustomObject]@{
+                        SqlInstance     = $SqlInstance
+                        DatabaseName    = $Database
+                        RestoreComplete = $RestoreComplete
+                        Scripts         = $RecoverSql
                     }
                 }
             }
         }
-        $boundparams = $PSBoundParameters
-        $null = $boundparams.Remove("SqlInstance")
     }
-    process {
-        foreach ($instance in $SqlInstance) {
-            Restore-Internal -SqlInstance $instance @boundparams
+    end {
+        if (Test-FunctionInterrupt) {
+            return
+        }
+        if ($PSCmdlet.ParameterSetName -like "Restore*") {
+            if ($BackupHistory.Count -eq 0) {
+                Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
+                return
+            }
+            Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose
+            $FilteredBackupHistory = @()
+            if (Test-Bound -ParameterName GetBackupInformation) {
+                Write-Message -Message "Setting $GetBackupInformation to BackupHistory" -Level Verbose
+                Set-Variable -Name $GetBackupInformation -Value $BackupHistory -Scope Global
+            }
+            if ($StopAfterGetBackupInformation) {
+                return
+            }
+            $pathSep = Get-DbaPathSep -Server $RestoreInstance
+            $null = $BackupHistory | Format-DbaBackupInformation -DataFileDirectory $DestinationDataDirectory -LogFileDirectory $DestinationLogDirectory -DestinationFileStreamDirectory $DestinationFileStreamDirectory -DatabaseFileSuffix $DestinationFileSuffix -DatabaseFilePrefix $DestinationFilePrefix -DatabaseNamePrefix $RestoredDatabaseNamePrefix -ReplaceDatabaseName $DatabaseName -Continue:$Continue -ReplaceDbNameInFile:$ReplaceDbNameInFile -FileMapping $FileMapping -PathSep $pathSep
+
+            if (Test-Bound -ParameterName FormatBackupInformation) {
+                Set-Variable -Name $FormatBackupInformation -Value $BackupHistory -Scope Global
+            }
+            if ($StopAfterFormatBackupInformation) {
+                return
+            }
+
+            $FilteredBackupHistory = $BackupHistory | Select-DbaBackupInformation -RestoreTime $RestoreTime -IgnoreLogs:$IgnoreLogBackups -ContinuePoints $ContinuePoints -LastRestoreType $LastRestoreType -DatabaseName $DatabaseName
+
+            if (Test-Bound -ParameterName SelectBackupInformation) {
+                Write-Message -Message "Setting $SelectBackupInformation to FilteredBackupHistory" -Level Verbose
+                Set-Variable -Name $SelectBackupInformation -Value $FilteredBackupHistory -Scope Global
+
+            }
+            if ($StopAfterSelectBackupInformation) {
+                return
+            }
+            try {
+                Write-Message -Level Verbose -Message "VerifyOnly = $VerifyOnly"
+                $null = $FilteredBackupHistory | Test-DbaBackupInformation -SqlInstance $RestoreInstance -WithReplace:$WithReplace -Continue:$Continue -VerifyOnly:$VerifyOnly -EnableException:$true -OutputScriptOnly:$OutputScriptOnly
+            } catch {
+                Stop-Function -ErrorRecord $_ -Message "Failure" -Continue
+            }
+            if (Test-Bound -ParameterName TestBackupInformation) {
+                Set-Variable -Name $TestBackupInformation -Value $FilteredBackupHistory -Scope Global
+            }
+            if ($StopAfterTestBackupInformation) {
+                return
+            }
+            $DbVerfied = ($FilteredBackupHistory | Where-Object {
+                    $_.IsVerified -eq $True
+                } | Select-Object -Property Database -Unique).Database -join ','
+            Write-Message -Message "$DbVerfied passed testing" -Level Verbose
+            if (($FilteredBackupHistory | Where-Object {
+                        $_.IsVerified -eq $True
+                    }).count -lt $FilteredBackupHistory.count) {
+                $DbUnVerified = ($FilteredBackupHistory | Where-Object {
+                        $_.IsVerified -eq $False
+                    } | Select-Object -Property Database -Unique).Database -join ','
+                if ($AllowContinue) {
+                    Write-Message -Message "$DbUnverified failed testing, AllowContinue set" -Level Verbose
+                } else {
+                    Stop-Function -Message "Database $DbUnverified failed testing, AllowContinue not set, exiting"
+                    return
+                }
+            }
+            If ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                if (($FilteredBackupHistory.Database | select-Object -unique | Measure-Object).count -ne 1) {
+                    Stop-Function -Message "Must only 1 database passed in for Page Restore. Sorry"
+                    return
+                } else {
+                    $WithReplace = $false
+                }
+            }
+            Write-Message -Message "Passing in to restore" -Level Verbose
+            if ($PSCmdlet.ParameterSetName -eq "RestorePage" -and $RestoreInstance.Edition -notlike '*Enterprise*') {
+                Write-Message -Message "Taking Tail log backup for page restore for non-Enterprise" -Level Verbose
+                $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
+            }
+            try {
+                $FilteredBackupHistory | Where-Object {
+                    $_.IsVerified -eq $true
+                } | Invoke-DbaAdvancedRestore -SqlInstance $RestoreInstance -WithReplace:$WithReplace -RestoreTime $RestoreTime -StandbyDirectory $StandbyDirectory -NoRecovery:$NoRecovery -Continue:$Continue -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -KeepCDC:$KeepCDC -VerifyOnly:$VerifyOnly -PageRestore $PageRestore -EnableException -AzureCredential $AzureCredential
+            } catch {
+                Stop-Function -Message "Failure" -ErrorRecord $_ -Continue -Target $RestoreInstance
+            }
+            if ($PSCmdlet.ParameterSetName -eq "RestorePage") {
+                if ($RestoreInstance.Edition -like '*Enterprise*') {
+                    Write-Message -Message "Taking Tail log backup for page restore for Enterprise" -Level Verbose
+                    $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly
+                }
+                Write-Message -Message "Restoring Tail log backup for page restore" -Level Verbose
+                $TailBackup | Restore-DbaDatabase -SqlInstance $RestoreInstance -TrustDbBackupHistory -NoRecovery -OutputScriptOnly:$OutputScriptOnly -BlockSize $BlockSize -MaxTransferSize $MaxTransferSize -Buffercount $Buffercount -Continue
+                Restore-DbaDatabase -SqlInstance $RestoreInstance -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
+            }
         }
     }
 }


### PR DESCRIPTION
Stuart, I moved the routine to an internal routine in `begin` to easily enable multi instance restore as requested by 👞  and I thought we supported it anyway.

i also added `ComputerName, InstanceName` to the output and ordered it properly. While I was at it, i changed `restoreinstance` to `restoreserver` to be closer to our `server` standard. Tho i recall `server` caused scoping issues in the past.

![image](https://user-images.githubusercontent.com/8278033/49317717-dacf8c80-f4f5-11e8-82a0-849422a3eb55.png)
