### PR TITLE
Update Copy-DbaDbQueryStoreOption.ps1

### DIFF
--- a/functions/Copy-DbaDbQueryStoreOption.ps1
+++ b/functions/Copy-DbaDbQueryStoreOption.ps1
@@ -148,15 +148,22 @@ function Copy-DbaDbQueryStoreOption {
                     # Set the Query Store configuration through the Set-DbaQueryStoreConfig function
                     if ($PSCmdlet.ShouldProcess("$db", "Copying QueryStoreConfig")) {
                         try {
-                            $null = Set-DbaDbQueryStoreOption -SqlInstance $destinationServer -SqlCredential $DestinationSqlCredential `
-                                -Database $db.name `
-                                -State $SourceQSConfig.ActualState `
-                                -FlushInterval $SourceQSConfig.FlushInterval `
-                                -CollectionInterval $SourceQSConfig.CollectionInterval `
-                                -MaxSize $SourceQSConfig.MaxSize `
-                                -CaptureMode $SourceQSConfig.CaptureMode `
-                                -CleanupMode $SourceQSConfig.CleanupMode `
-                                -StaleQueryThreshold $SourceQSConfig.StaleQueryThreshold
+
+                            $setDbaDbQueryStoreOptionParameters = @{
+
+                                SqlInstance = $destinationServer;
+                                SqlCredential = $DestinationSqlCredential;
+                                Database = $db.name;
+                                State = $SourceQSConfig.ActualState;
+                                FlushInterval = $SourceQSConfig.DataFlushIntervalInSeconds;
+                                CollectionInterval = $SourceQSConfig.StatisticsCollectionIntervalInMinutes;
+                                MaxSize = $SourceQSConfig.MaxStorageSizeInMB;
+                                CaptureMode = $SourceQSConfig.QueryCaptureMode;
+                                CleanupMode = $SourceQSConfig.SizeBasedCleanupMode;
+                                StaleQueryThreshold = $SourceQSConfig.StaleQueryThresholdInDays;
+                            }
+
+                            $null = Set-DbaDbQueryStoreOption @setDbaDbQueryStoreOptionParameters;
                             $copyQueryStoreStatus.Status = "Successful"
                         } catch {
                             $copyQueryStoreStatus.Status = "Failed"

--- a/functions/Copy-DbaDbQueryStoreOption.ps1
+++ b/functions/Copy-DbaDbQueryStoreOption.ps1
@@ -151,15 +151,15 @@ function Copy-DbaDbQueryStoreOption {
 
                             $setDbaDbQueryStoreOptionParameters = @{
 
-                                SqlInstance = $destinationServer;
-                                SqlCredential = $DestinationSqlCredential;
-                                Database = $db.name;
-                                State = $SourceQSConfig.ActualState;
-                                FlushInterval = $SourceQSConfig.DataFlushIntervalInSeconds;
-                                CollectionInterval = $SourceQSConfig.StatisticsCollectionIntervalInMinutes;
-                                MaxSize = $SourceQSConfig.MaxStorageSizeInMB;
-                                CaptureMode = $SourceQSConfig.QueryCaptureMode;
-                                CleanupMode = $SourceQSConfig.SizeBasedCleanupMode;
+                                SqlInstance         = $destinationServer;
+                                SqlCredential       = $DestinationSqlCredential;
+                                Database            = $db.name;
+                                State               = $SourceQSConfig.ActualState;
+                                FlushInterval       = $SourceQSConfig.DataFlushIntervalInSeconds;
+                                CollectionInterval  = $SourceQSConfig.StatisticsCollectionIntervalInMinutes;
+                                MaxSize             = $SourceQSConfig.MaxStorageSizeInMB;
+                                CaptureMode         = $SourceQSConfig.QueryCaptureMode;
+                                CleanupMode         = $SourceQSConfig.SizeBasedCleanupMode;
                                 StaleQueryThreshold = $SourceQSConfig.StaleQueryThresholdInDays;
                             }
 


### PR DESCRIPTION
Fixing parameter names to match what they are in $SourceQSConfig which came from Get-DbaDbQueryStoreOption, and splatting the parameters to get rid of the back-tick/grave accent syntax.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #4733 )
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixing Copy-DbaDbQueryStoreOption bug 4733 so that it works; previously it had invalid parameter names

### Approach
<!-- How does this change solve that purpose -->
I updated the Copy-DbaDbQueryStoreOption function to use the parameter names output by the call to Get-DbaDbQueryStoreOption

### Commands to test
<!-- if these are the examples in the help just note it as such -->
You just need two databases with different QueryStore settings, then copy one over to the second database.
This was an edited version I used to get deviation:
```Set-DbaDbQueryStoreOption -SqlInstance $devInstance -Database Datamart -FlushInterval 500 -CollectionInterval 30 -CaptureMode Auto -CleanupMode Off -StaleQueryThreshold 20 -State ReadOnly -MaxSize 400```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Screenshot of error is in bug #4733 
Fix is below:
![image](https://user-images.githubusercontent.com/34583836/49324468-356be700-f4fc-11e8-8981-5817adef9426.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
