### PR TITLE
Fix support for AG in Docker

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -23,6 +23,12 @@ function Add-DbaAgDatabase {
     .PARAMETER AvailabilityGroup
         The availability group where the databases will be added.
 
+    .PARAMETER Secondary
+        Not required - the command will figure this out. But if you'd like to be explicit about replicas, this will help.
+    
+    .PARAMETER SecondarySqlCredential
+        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
+
     .PARAMETER InputObject
         Enables piping from Get-DbaDatabase, Get-DbaDbSharePoint and more.
 
@@ -93,6 +99,8 @@ function Add-DbaAgDatabase {
         [parameter(Mandatory)]
         [string]$AvailabilityGroup,
         [string[]]$Database,
+        [DbaInstanceParameter[]]$Secondary,
+        [PSCredential]$SecondarySqlCredential,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [ValidateSet('Automatic', 'Manual')]
@@ -124,9 +132,13 @@ function Add-DbaAgDatabase {
             if ($ag.AvailabilityDatabases.Name -contains $db.Name) {
                 Stop-Function -Message "$($db.Name) is already joined to $($ag.Name)" -Continue
             }
-
-            $secondaryReplicas = $ag.AvailabilityReplicas | Where-Object Role -eq Secondary | Select-Object -Unique -ExpandProperty Name
-
+            
+            if (-not $Secondary) {
+                $secondaryReplicas = $ag.AvailabilityReplicas | Where-Object Role -eq Secondary
+            } else {
+                $secondaryReplicas = Get-DbaAgReplica -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential -AvailabilityGroup $ag.Name | Where-Object Role -eq Secondary
+            }
+            
             if ($SeedingMode -eq "Automatic") {
                 # first check
                 if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {
@@ -147,7 +159,7 @@ function Add-DbaAgDatabase {
 
             foreach ($replica in $secondaryReplicas) {
 
-                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -AvailabilityGroup $ag.name -Replica $replica
+                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $replica.Name
 
                 if ($SeedingMode) {
                     $agreplica.SeedingMode = $SeedingMode
@@ -172,21 +184,21 @@ function Add-DbaAgDatabase {
                         }
                         if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $Primary")) {
                             # keep going to ensure output is shown even if dbs aren't added well.
-                            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $replica -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
+                            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $replica.Parent.Parent -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
                         }
                     } catch {
                         Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
                     }
                 }
 
-                $replicadb = Get-DbaAgDatabase -SqlInstance $replica -SqlCredential $SqlCredential -Database $db.Name -AvailabilityGroup $ag.Name   #credential of secondary !!
+                $replicadb = Get-DbaAgDatabase -SqlInstance $replica.Parent.Parent -Database $db.Name -AvailabilityGroup $ag.Name   #credential of secondary !!
 
                 if ($replicadb -and -not ($SeedingModeReplica -eq 'Automatic')) {
                     if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Joining availability group $db to $($db.Parent.Name)")) {
                         $timeout = 1
                         do {
                             try {
-                                Write-Message -Level Verbose -Message "Trying to add $($replicadb.Name) to $replica"
+                                Write-Message -Level Verbose -Message "Trying to add $($replicadb.Name) to $($replica.Name)"
                                 $timeout++
                                 $replicadb.JoinAvailablityGroup()
                                 $replicadb.Refresh()
@@ -199,7 +211,7 @@ function Add-DbaAgDatabase {
                         if ($replicadb.IsJoined) {
                             $replicadb
                         } else {
-                            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $replica"
+                            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $($replica.Name)"
                         }
                     }
                 } else {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -25,7 +25,7 @@ function Add-DbaAgDatabase {
 
     .PARAMETER Secondary
         Not required - the command will figure this out. But if you'd like to be explicit about replicas, this will help.
-    
+
     .PARAMETER SecondarySqlCredential
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
@@ -132,13 +132,13 @@ function Add-DbaAgDatabase {
             if ($ag.AvailabilityDatabases.Name -contains $db.Name) {
                 Stop-Function -Message "$($db.Name) is already joined to $($ag.Name)" -Continue
             }
-            
+
             if (-not $Secondary) {
                 $secondaryReplicas = $ag.AvailabilityReplicas | Where-Object Role -eq Secondary
             } else {
                 $secondaryReplicas = Get-DbaAgReplica -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential -AvailabilityGroup $ag.Name | Where-Object Role -eq Secondary
             }
-            
+
             if ($SeedingMode -eq "Automatic") {
                 # first check
                 if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -579,7 +579,7 @@ function New-DbaAvailabilityGroup {
 
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Adding databases"
 
-        Add-DbaAgDatabase -SqlInstance $Primary -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath
+        Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath
 
         foreach ($second in $secondaries) {
             if ($server.HostPlatform -ne "Linux" -and $second.HostPlatform -ne "Linux") {

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -578,7 +578,7 @@ function New-DbaAvailabilityGroup {
         # Add databases
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Adding databases"
 
-        $null = Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath
+        $null = Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath -Secondary $Secondary -SecondarySqlCredential $SecondarySqlCredential
 
         foreach ($second in $secondaries) {
             if ($server.HostPlatform -ne "Linux" -and $second.HostPlatform -ne "Linux") {

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -479,14 +479,14 @@ function New-DbaAvailabilityGroup {
             return
         }
 
-         # Add listener
+        # Add listener
         if ($IPAddress -or $Dhcp) {
-            $progressmsg ="Adding listener"
+            $progressmsg = "Adding listener"
         } else {
-            $progressmsg ="Joining availability group"
+            $progressmsg = "Joining availability group"
         }
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message $progressmsg
-        
+
         if ($IPAddress) {
             if ($Pscmdlet.ShouldProcess($Primary, "Adding static IP listener for $Name to the Primary replica")) {
                 $null = Add-DbaAgListener -InputObject $ag -IPAddress $IPAddress[0] -SubnetMask $SubnetMask -Port $Port -Dhcp:$Dhcp

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -479,9 +479,14 @@ function New-DbaAvailabilityGroup {
             return
         }
 
-        # Add listener
-        Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Adding listener"
-
+         # Add listener
+        if ($IPAddress -or $Dhcp) {
+            $progressmsg ="Adding listener"
+        } else {
+            $progressmsg ="Joining availability group"
+        }
+        Write-ProgressHelper -StepNumber ($stepCounter++) -Message $progressmsg
+        
         if ($IPAddress) {
             if ($Pscmdlet.ShouldProcess($Primary, "Adding static IP listener for $Name to the Primary replica")) {
                 $null = Add-DbaAgListener -InputObject $ag -IPAddress $IPAddress[0] -SubnetMask $SubnetMask -Port $Port -Dhcp:$Dhcp

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -576,10 +576,9 @@ function New-DbaAvailabilityGroup {
         }
 
         # Add databases
-
         Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Adding databases"
 
-        Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath
+        $null = Add-DbaAgDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -AvailabilityGroup $Name -Database $Database -SeedingMode $SeedingMode -SharedPath $SharedPath
 
         foreach ($second in $secondaries) {
             if ($server.HostPlatform -ne "Linux" -and $second.HostPlatform -ne "Linux") {

--- a/tests/Add-DbaAgDatabase.Tests.ps1
+++ b/tests/Add-DbaAgDatabase.Tests.ps1
@@ -7,7 +7,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         <#
             Get commands, Default count = 11
             Commands with SupportShouldProcess = 13
-               #>
+        #>
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Add-DbaAgDatabase).Parameters.Keys
         $knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Database', 'InputObject', 'EnableException', 'SeedingMode', 'SharedPath', 'UseLastBackup'

--- a/tests/Add-DbaAgDatabase.Tests.ps1
+++ b/tests/Add-DbaAgDatabase.Tests.ps1
@@ -10,7 +10,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         #>
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Add-DbaAgDatabase).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Database', 'InputObject', 'EnableException', 'SeedingMode', 'SharedPath', 'UseLastBackup'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Database', 'InputObject', 'EnableException', 'SeedingMode', 'SharedPath', 'UseLastBackup', 'Secondary', 'SecondarySqlCredential'
         $paramCount = $knownParameters.Count
         It "Should contain our specific parameters" {
             ((Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count) | Should Be $paramCount

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -8,7 +8,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
         <#
             Get commands, Default count = 11
             Commands with SupportShouldProcess = 13
-               #>
+        #>
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\New-DbaAvailabilityGroup).Parameters.Keys
         $knownParameters = 'Primary', 'PrimarySqlCredential', 'Secondary', 'SecondarySqlCredential', 'Name', 'DtcSupport', 'ClusterType', 'AutomatedBackupPreference', 'FailureConditionLevel', 'HealthCheckTimeout', 'Basic', 'DatabaseHealthTrigger', 'Passthru', 'Database', 'SharedPath', 'UseLastBackup', 'Force', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'IPAddress', 'SubnetMask', 'Port', 'Dhcp', 'EnableException'


### PR DESCRIPTION
Also add the ability to add explicit secondaries to add-dbaagdb. this helps with name resolution in docker.

![image](https://user-images.githubusercontent.com/8278033/49395718-903d5280-f737-11e8-896f-1c3dafd8d9dd.png)

If you'd like to replicate this whole thing

````
# Get images. First image has a bunch of sample objects, including databases (Northwind, pubs) and some db certs
docker pull dbatools/sqlinstance
# Second one is mostly empty but has an exposed endpoint and a matching certificate for auth with otehr image
docker pull dbatools/sqlinstance2

# Create network for nodes to talk to eachother
docker network create localnet
# Expose engine and endpoint
docker run -p 1433:1433 -p 5022:5022 --network localnet --hostname dockersql1 --name dockersql1 -d dbatools/sqlinstance
# Expose second engine and endpoint on different port
docker run -p 14333:1433 -p 5023:5023  --network localnet --hostname dockersql2 --name dockersql2 -d dbatools/sqlinstance2

# password is dbatools.IO
$cred = Get-Credential sqladmin

$params = @{
    Primary = "localhost"
    PrimarySqlCredential = $cred
    Secondary = "localhost:14333"
    SecondarySqlCredential = $cred
    Name = "test-ag"
    Database = "pubs"
    ClusterType = "None"
    SeedingMode = "Automatic"
    FailoverMode = "Manual"
    Confirm = $false
 }

 Start-Sleep 15
 
 New-DbaAvailabilityGroup @params
````