### PR TITLE
Added example to copy only SSRS subscription jobs

### DIFF
--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -71,7 +71,11 @@ function Copy-DbaAgentJob {
         PS C:\> Copy-DbaAgentJob -Source sqlserver2014a -Destination sqlcluster -WhatIf -Force
 
         Shows what would happen if the command were executed using force.
-
+        
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a | Where-Object {$_.Category -eq "Report Server"} | ForEach-Object {Copy-DbaAgentJob -Source $_.ComputerName -Job $_.Name -Destination sqlserver2014b}
+        
+        Copies all SSRS jobs (subscriptions) from AlwaysOn Primary SQL instance sqlserver2014a to AlwaysOn Secondary SQL instance sqlserver2014b
     #>
     [cmdletbinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]
     param (

--- a/functions/Copy-DbaAgentJob.ps1
+++ b/functions/Copy-DbaAgentJob.ps1
@@ -73,7 +73,7 @@ function Copy-DbaAgentJob {
         Shows what would happen if the command were executed using force.
         
     .EXAMPLE
-        PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a | Where-Object {$_.Category -eq "Report Server"} | ForEach-Object {Copy-DbaAgentJob -Source $_.ComputerName -Job $_.Name -Destination sqlserver2014b}
+        PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a | Where-Object Category -eq "Report Server" | ForEach-Object {Copy-DbaAgentJob -Source $_.SqlInstance -Job $_.Name -Destination sqlserver2014b}
         
         Copies all SSRS jobs (subscriptions) from AlwaysOn Primary SQL instance sqlserver2014a to AlwaysOn Secondary SQL instance sqlserver2014b
     #>


### PR DESCRIPTION
Added example to get all SSRS jobs (category Report Server) from an instance and copy across the jobs to another instance (AlwaysOn secondary instance)

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Taking first step to contributing to dbatools following Patrick Flynn's post on hacktoberfest. Little late though :)

### Approach
<!-- How does this change solve that purpose -->
Added example to help with documentation. 
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Tested locally. Just change the server names in example

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/45583144/49418976-d8f91800-f7d8-11e8-98fd-45b5ee4ac642.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
