### PR TITLE
Start-DbaMigration xplat fixes

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -1044,7 +1044,6 @@ $script:xplat = @(
     'Copy-DbaServerRole',
     'Copy-DbaResourceGovernor',
     'Copy-DbaXESession',
-    'Copy-DbaBackupDevice',
     'Copy-DbaServerTrigger',
     'Copy-DbaCmsRegServer',
     'Copy-DbaSysDbUserObject',
@@ -1425,6 +1424,7 @@ $script:noncoresmo = @(
 )
 $script:windowsonly = @(
     # solvable filesystem issues or other workarounds
+    'Copy-DbaBackupDevice',
     'Install-DbaSqlWatch',
     'Uninstall-DbaSqlWatch',
     'Get-DbaRegistryRoot',

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -82,6 +82,7 @@ function Copy-DbaBackupDevice {
     begin {
         if (-not $script:isWindows) {
             Stop-Function -Message "Copy-DbaBackupDevice does not support Linux yet though it looks doable"
+            return
         }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential

--- a/functions/Copy-DbaBackupDevice.ps1
+++ b/functions/Copy-DbaBackupDevice.ps1
@@ -80,6 +80,9 @@ function Copy-DbaBackupDevice {
         [switch]$EnableException
     )
     begin {
+        if (-not $script:isWindows) {
+            Stop-Function -Message "Copy-DbaBackupDevice does not support Linux yet though it looks doable"
+        }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
         } catch {
@@ -163,7 +166,7 @@ function Copy-DbaBackupDevice {
 
                 Write-Message -Level Verbose -Message "Checking if directory $destPath exists"
 
-                if ($(Test-DbaPath -SqlInstance $destinstance -Path $path) -eq $false) {
+                if ($(Test-DbaPath -SqlInstance $destServer -Path $path) -eq $false) {
                     $backupDirectory = $destServer.BackupDirectory
                     $destPath = Join-AdminUnc $destNetBios $backupDirectory
 

--- a/functions/Copy-DbaCmsRegServer.ps1
+++ b/functions/Copy-DbaCmsRegServer.ps1
@@ -90,6 +90,7 @@ function Copy-DbaCmsRegServer {
     begin {
         if (-not $script:isWindows) {
             Stop-Function -Message "Copy-DbaCmsRegServer does not support Linux - we're still waiting for the Core SMOs from Microsoft"
+            return
         }
         
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-DbaCentralManagementServer

--- a/functions/Copy-DbaCmsRegServer.ps1
+++ b/functions/Copy-DbaCmsRegServer.ps1
@@ -88,6 +88,10 @@ function Copy-DbaCmsRegServer {
         [switch]$EnableException
     )
     begin {
+        if (-not $script:isWindows) {
+            Stop-Function -Message "Copy-DbaCmsRegServer does not support Linux - we're still waiting for the Core SMOs from Microsoft"
+        }
+        
         Test-DbaDeprecation -DeprecatedOn "1.0.0" -Alias Copy-DbaCentralManagementServer
         function Invoke-ParseServerGroup {
             [cmdletbinding()]

--- a/functions/Copy-DbaDataCollector.ps1
+++ b/functions/Copy-DbaDataCollector.ps1
@@ -97,6 +97,7 @@ function Copy-DbaDataCollector {
     begin {
         if (-not $script:isWindows) {
             Stop-Function -Message "Copy-DbaDataCollector does not support Linux - we're still waiting for the Core SMOs from Microsoft"
+            return
         }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 10

--- a/functions/Copy-DbaDataCollector.ps1
+++ b/functions/Copy-DbaDataCollector.ps1
@@ -95,6 +95,9 @@ function Copy-DbaDataCollector {
         [switch]$EnableException
     )
     begin {
+        if (-not $script:isWindows) {
+            Stop-Function -Message "Copy-DbaDataCollector does not support Linux - we're still waiting for the Core SMOs from Microsoft"
+        }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 10
         } catch {

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -800,23 +800,6 @@ function Copy-DbaDatabase {
                 Stop-Function -Message "Source and Destination SQL Servers instances are the same. Quitting." -Continue
             }
 
-            if ($SharedPath) {
-                Write-Message -Level Verbose -Message "Checking to ensure network path is valid."
-                if (-not ($SharedPath.StartsWith("\\")) -and -not $script:sameserver) {
-                    Stop-Function -Message "Network share must be a valid UNC path (\\server\share)." -Continue
-                }
-
-                if (-not $script:sameserver) {
-                    try {
-                        if ((Test-Path $SharedPath -ErrorAction Stop)) {
-                            Write-Message -Level Verbose -Message "$SharedPath share can be accessed."
-                        }
-                    } catch {
-                        Write-Message -Level Verbose -Message "$SharedPath share cannot be accessed. Still trying anyway, in case the SQL Server service accounts have access."
-                    }
-                }
-            }
-
             Write-Message -Level Verbose -Message "Checking to ensure server is not SQL Server 7 or below."
             if ($sourceServer.VersionMajor -lt 8 -and $destServer.VersionMajor -lt 8) {
                 Stop-Function -Message "This script can only be run on SQL Server 2000 and above. Quitting." -Continue

--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -278,7 +278,7 @@ function Copy-DbaDatabase {
 
             )
 
-            if ($script:sameserver) {
+            if ($script:sameserver -or (-not $script:isWindows)) {
                 return $filepath
             }
             if (-not $filepath) {

--- a/functions/Copy-DbaPolicyManagement.ps1
+++ b/functions/Copy-DbaPolicyManagement.ps1
@@ -101,7 +101,8 @@ function Copy-DbaPolicyManagement {
     
     begin {
         if (-not $script:isWindows) {
-            Stop-Function -Message "Copy-DbaPolicyManagement does not support Linux - we're still waiting for the Core SMOs from Microsoft"    
+            Stop-Function -Message "Copy-DbaPolicyManagement does not support Linux - we're still waiting for the Core SMOs from Microsoft"
+            return
         }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 10

--- a/functions/Copy-DbaPolicyManagement.ps1
+++ b/functions/Copy-DbaPolicyManagement.ps1
@@ -98,8 +98,11 @@ function Copy-DbaPolicyManagement {
         [Alias('Silent')]
         [switch]$EnableException
     )
-
+    
     begin {
+        if (-not $script:isWindows) {
+            Stop-Function -Message "Copy-DbaPolicyManagement does not support Linux - we're still waiting for the Core SMOs from Microsoft"    
+        }
         try {
             $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -MinimumVersion 10
         } catch {

--- a/internal/functions/Update-SqlDbOwner.ps1
+++ b/internal/functions/Update-SqlDbOwner.ps1
@@ -19,7 +19,7 @@ function Update-SqlDbOwner {
     )
 
     $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
-    $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $SqlCredential
+    $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
 
     $source = $sourceServer.DomainInstanceName
     $destination = $destServer.DomainInstanceName


### PR DESCRIPTION
````
# Get images. First image has a bunch of sample objects, including databases (Northwind, pubs) and some db certs
docker pull dbatools/sqlinstance
# Second one is mostly empty but has an exposed endpoint and a matching certificate for auth with other image
docker pull dbatools/sqlinstance2

# Create network for nodes to talk to each other
docker network create localnet
# Expose engine and endpoint and a shared path in case you want to do a migration too
docker run -p 1433:1433 -p 5022:5022 --volume /tmp:/sharedpath --network localnet --hostname dockersql1 --name dockersql1 -d dbatools/sqlinstance
# Expose second engine and endpoint on different port
docker run -p 14333:1433 -p 5023:5023 --volume /tmp:/sharedpath --network localnet --hostname dockersql2 --name dockersql2 -d dbatools/sqlinstance2
````

Then

````
# password is dbatools.IO
$cert = Get-Credential sqladmin
# Exclude unsupported features
Start-DbaMigration -Source localhost:1433 -Destination localhost:14333 -SourceSqlCredential $cert -DestinationSqlCredential $cert -BackupRestore -SharedPath /sharedpath -Exclude LinkedServers, Credentials, CentralManagementServer, BackupDevices
````


then

![image](https://user-images.githubusercontent.com/8278033/49542156-1347df80-f8d5-11e8-8a01-343b8ff5d594.png)


