### PR TITLE
Allowing system databases in Export-DbaDacPackage

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -194,8 +194,12 @@ function Export-DbaDacPackage {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $cleaninstance = $instance.ToString().Replace('\', '-')
-
-            $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -ExcludeSystem -Database $Database -ExcludeDatabase $ExcludeDatabase
+            if ($Database) {
+                $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -Database $Database -ExcludeDatabase $ExcludeDatabase
+            } else {
+                # all user databases by default
+                $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -ExcludeSystem -ExcludeDatabase $ExcludeDatabase
+            }
             if (-not $dbs) {
                 Stop-Function -Message "Databases not found on $instance" -Target $instance -Continue
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4749)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow system databases in exports

### Approach
Were filtered out by --ExcludeSystem initially, now it's only used when -Database is not specified

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
![image](https://user-images.githubusercontent.com/30303784/49609635-b47c7780-f961-11e8-963f-0ca422729203.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
