### PR TITLE
Update Copy-DbaDbTableData output & bugfix

### DIFF
--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -200,7 +200,7 @@ function Copy-DbaDbTableData {
                 }
             }
         }'
-        
+
         Add-Type -ReferencedAssemblies System.Data.dll -TypeDefinition $sourcecode -ErrorAction Stop
         if (-not $script:core) {
             try {
@@ -209,7 +209,7 @@ function Copy-DbaDbTableData {
                 $null = 1
             }
         }
-        
+
         $bulkCopyOptions = 0
         $options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default"
 
@@ -312,7 +312,7 @@ function Copy-DbaDbTableData {
                         }
                         #replacing table schema
                         if ($newTableParts.Schema) {
-                            $rX = "(CREATE TABLE \[)$([regex]::Escape($sqltable.Schema))(\]\.\[$([regex]::Escape($newTableParts.Schema))\]\()"
+                            $rX = "(CREATE TABLE \[)$([regex]::Escape($sqltable.Schema))(\]\.\[$([regex]::Escape($newTableParts.Table))\]\()"
                             $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Schema)`$2"
                         }
 
@@ -404,9 +404,11 @@ function Copy-DbaDbTableData {
                         [pscustomobject]@{
                             SourceInstance      = $server.Name
                             SourceDatabase      = $Database
+                            SourceSchema        = $sqltable.Schema
                             SourceTable         = $sqltable.Name
                             DestinationInstance = $destServer.name
                             DestinationDatabase = $DestinationDatabase
+                            DestinationSchema   = $desttable.Schema
                             DestinationTable    = $desttable.Name
                             RowsCopied          = $rowstotal
                             Elapsed             = [prettytimespan]$elapsed.Elapsed


### PR DESCRIPTION
Adding (Source and Destination) Schema to the output; helpful in cases where you have >1 schema with the same named table.
Also fixed -AutoCreateTable -> It was not properly replacing the schema name for the new table if it differed from the source schema.  It was retaining the original source schema due to bug in regex

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes <didn't log bug, found during feature 4786>)
 - [X ] New feature (non-breaking change, adds functionality #4786 )
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Fixes AutoCreateTable when the Source schema differs from the desired destination schema.  the current code just used the source due to typo in the regex.

Second change is to add SourceSchema and DestinationSchema to the pscustomobject output of the function so that you can clearly see what schema the tables are in

### Approach
<!-- How does this change solve that purpose -->
Added the values to the output.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
$copyArgs = @{

   SqlInstance = $devInstance;
   Database = "Sandbox";
   Table = 'ref.YourTable';
   Destination = $devInstance;
   DestinationDatabase = "Sandbox";
   DestinationTable = 'new.NewName';
   AutoCreateTable = $true;
   KeepIdentity = $true;
   KeepNulls = $true;
   Truncate = $true;
   Verbose = $true;
}

Copy-DbaDbTableData @copyArgs;
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/34583836/49673062-2e346400-fa3b-11e8-9656-5d020a51522e.png)


