### PR TITLE
Get-DbaBackupHistory, fixes #4796

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -540,14 +540,14 @@ function Get-DbaBackupHistory {
                 $from = " FROM msdb..backupmediafamily mediafamily
                              INNER JOIN msdb..backupmediaset mediaset ON mediafamily.media_set_id = mediaset.media_set_id
                              INNER JOIN msdb..backupset backupset ON backupset.media_set_id = mediaset.media_set_id"
-                if ($Database -or $Since -or $Last -or $LastFull -or $LastLog -or $LastDiff -or $deviceTypeFilter -or $LastLsn -or $backupTypeFilter) {
+                if ($Database -or $ExcludeDatabase -or $Since -or $Last -or $LastFull -or $LastLog -or $LastDiff -or $deviceTypeFilter -or $LastLsn -or $backupTypeFilter) {
                     $where = " WHERE "
                 }
 
                 $whereArray = @()
 
-                if ($Database.length -gt 0) {
-                    $dbList = $Database -join "','"
+                if ($Database.length -gt 0 -or $ExcludeDatabase.length -gt 0) {
+                    $dbList = $databases.Name -join "','"
                     $whereArray += "database_name IN ('$dbList')"
                 }
 

--- a/tests/Get-DbaBackupHistory.Tests.ps1
+++ b/tests/Get-DbaBackupHistory.Tests.ps1
@@ -63,6 +63,21 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
     }
 
+    Context "ExcludeDatabase is honored" {
+        $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master'
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+        $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master' -Type Full
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+        $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master' -LastFull
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+    }
+
     Context "LastFull should work with multiple databases" {
         $results = Get-DbaBackupHistory -SqlInstance $script:instance1 -Database $dbname, master -lastfull
         It "Should return 2 records" {


### PR DESCRIPTION

## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4796)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Honoring -ExcludeDatabase in all codepaths

### Approach
Checking once for both Database and ExcludeDatabase, and forge the correct query in any case.

### Commands to test
`Get-DbaBackupHistory -SqlInstance foo -ExcludeDatabase master,model,msdb -Type Full -Since '2018-11-10'`

-----

Slapped a regression test to avoid resurfacing in the future
