### PR TITLE
Kill psd1 bypass for PS v2

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -6,7 +6,11 @@ if (($PSVersionTable.PSVersion.Major -lt 6) -or ($PSVersionTable.Keys -contains 
     $script:isWindows = $false
 }
 
-   
+if ($PSVersionTable.PSVersion.Major -lt 3) {
+    # requires doesnt work on modules
+    throw "This module only supports PowerShell v3 and above"
+}
+
 #region Import helper functions
 function Import-ModuleFile {
     <#


### PR DESCRIPTION
psd1 does not allow imports from PowerShell v2. If a user bypasses the psd1 by importing the psm1 directly, they'll mistakenly believe we support v2. This will kill the import.