### PR TITLE
Fix logshipping monitor

### DIFF
--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -1709,7 +1709,10 @@ function Invoke-DbaDbLogShipping {
                                 -DisconnectUsers:$DisconnectUsers `
                                 -RestoreThreshold $RestoreThreshold `
                                 -ThresholdAlertEnabled:$SecondaryThresholdAlertEnabled `
-                                -HistoryRetention $HistoryRetention
+                                -HistoryRetention $HistoryRetention `
+                                -MonitorServer $PrimaryMonitorServer `
+                                -MonitorServerSecurityMode $PrimaryMonitorServerSecurityMode `
+                                -MonitorCredential $PrimaryMonitorCredential
 
                             # Check if the copy job needs to be enabled or disabled
                             if ($CopyScheduleDisabled) {

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -248,13 +248,13 @@ function New-DbaLogShippingPrimaryDatabase {
             if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_primary WHERE primary_database = '$Database'"
-                $lsDetails = Invoke-DbaQuery -SqlInstance STADPC -Database $msdb -Query $query
+                $lsDetails = $server.Query($query)
 
                 # Setup the procedure script for adding the monitor for the primary
-                $query = "EXEC msdb.dbo.sp_processlogshippingmonitorprimary @mode = $mode
+                $query = "EXEC msdb.dbo.sp_processlogshippingmonitorprimary @mode = $MonitorServerSecurityMode
                     ,@primary_id = '$($lsDetails.primary_id)'
                     ,@primary_server = '$($lsDetails.primary_server)'
-                    ,@monitor_server = '$monitorserver' "
+                    ,@monitor_server = '$MonitorServer' "
 
                 # Check the MonitorServerSecurityMode if it's SQL Server authentication
                 if ($MonitorServer -and $MonitorServerSecurityMode -eq 0 ) {

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -234,7 +234,7 @@ function New-DbaLogShippingPrimaryDatabase {
             }
         } else {
             $Query += "
-            ,@ignoreremotemonitor = 1"
+                ,@ignoreremotemonitor = 1"
         }
     }
 
@@ -245,7 +245,6 @@ function New-DbaLogShippingPrimaryDatabase {
         $Query += ";"
     }
 
-    $Query
     # Execute the query to add the log shipping primary
     if ($PSCmdlet.ShouldProcess($SqlServer, ("Configuring logshipping for primary database $Database on $SqlInstance"))) {
         try {

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -229,6 +229,9 @@ function New-DbaLogShippingPrimaryDatabase {
             ,@threshold_alert = $ThresholdAlert
             ,@threshold_alert_enabled = $ThresholdAlertEnabled"
     }
+    else{
+        $Query += ",@ignoreremotemonitor = 1"
+    }
 
     if ($Force -or ($server.Version.Major -gt 9)) {
         $Query += ",@overwrite = 1;"

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -207,31 +207,30 @@ function New-DbaLogShippingPrimaryDatabase {
             ,@backup_directory = N'$BackupDirectory'
             ,@backup_share = N'$BackupShare'
             ,@backup_job_name = N'$BackupJob'
-            ,@backup_retention_period = $BackupRetention"
+            ,@backup_retention_period = $BackupRetention
+            ,@backup_threshold = $BackupThreshold
+            ,@history_retention_period = $HistoryRetention
+            ,@backup_job_id = @LS_BackupJobId OUTPUT
+            ,@primary_id = @LS_PrimaryId OUTPUT "
 
     if ($SqlInstance.Version.Major -gt 9) {
         $Query += ",@backup_compression = $BackupCompression"
     }
 
-    if ($MonitorServer) {
+    if ($MonitorServer -and ($SqlInstance.Version.Major -ge 12)) {
+        # Check the MonitorServerSecurityMode if it's SQL Server authentication
+        if ($MonitorServer -and $MonitorServerSecurityMode -eq 0 ) {
+            $Query += ",@monitor_server_login = N'$MonitorLogin'
+                ,@monitor_server_password = N'$MonitorPassword' "
+        }
+
         $Query += ",@monitor_server = N'$MonitorServer'
             ,@monitor_server_security_mode = $MonitorServerSecurityMode
             ,@threshold_alert = $ThresholdAlert
             ,@threshold_alert_enabled = $ThresholdAlertEnabled"
     }
 
-    $Query += ",@backup_threshold = $BackupThreshold
-            ,@history_retention_period = $HistoryRetention
-            ,@backup_job_id = @LS_BackupJobId OUTPUT
-            ,@primary_id = @LS_PrimaryId OUTPUT "
-
-    # Check the MonitorServerSecurityMode if it's SQL Server authentication
-    if ($MonitorServer -and $MonitorServerSecurityMode -eq 0 ) {
-        $Query += ",@monitor_server_login = N'$MonitorLogin'
-            ,@monitor_server_password = N'$MonitorPassword' "
-    }
-
-    if ($server.Version.Major -gt 9) {
+    if ($Force -or ($server.Version.Major -gt 9)) {
         $Query += ",@overwrite = 1;"
     } else {
         $Query += ";"
@@ -243,6 +242,38 @@ function New-DbaLogShippingPrimaryDatabase {
             Write-Message -Message "Configuring logshipping for primary database $Database." -Level Verbose
             Write-Message -Message "Executing query:`n$Query" -Level Verbose
             $server.Query($Query)
+
+            # For versions prior to SQL Server 2014, adding a monitor works in a different way.
+            # The next section makes sure the settings are being synchronized with earlier versions
+            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
+                # Get the details of the primary database
+                $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_primary WHERE primary_database = '$Database'"
+                $lsDetails = Invoke-DbaQuery -SqlInstance STADPC -Database $msdb -Query $query
+
+                # Setup the procedure script for adding the monitor for the primary
+                $query = "EXEC msdb.dbo.sp_processlogshippingmonitorprimary @mode = $mode
+                    ,@primary_id = '$($lsDetails.primary_id)'
+                    ,@primary_server = '$($lsDetails.primary_server)'
+                    ,@monitor_server = '$monitorserver' "
+
+                # Check the MonitorServerSecurityMode if it's SQL Server authentication
+                if ($MonitorServer -and $MonitorServerSecurityMode -eq 0 ) {
+                    $query += ",@monitor_server_login = N'$MonitorLogin'
+                        ,@monitor_server_password = N'$MonitorPassword' "
+                }
+
+                $query += ",@monitor_server_security_mode = 1
+                    ,@primary_database = '$($lsDetails.primary_database)'
+                    ,@backup_threshold = $($lsDetails.backup_threshold)
+                    ,@threshold_alert = $($lsDetails.threshold_alert)
+                    ,@threshold_alert_enabled = $([int]$lsDetails.threshold_alert_enabled)
+                    ,@history_retention_period = $($lsDetails.history_retention_period)
+                "
+
+                Write-Message -Message "Configuring monitor server for primary database $Database." -Level Verbose
+                Write-Message -Message "Executing query:`n$query" -Level Verbose
+                $server.Query($query)
+            }
         } catch {
             Write-Message -Message "$($_.Exception.InnerException.InnerException.InnerException.InnerException.Message)" -Level Warning
             Stop-Function -Message "Error executing the query.`n$($_.Exception.Message)`n$($Query)" -ErrorRecord $_ -Target $SqlInstance -Continue

--- a/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingPrimaryDatabase.ps1
@@ -255,7 +255,6 @@ function New-DbaLogShippingPrimaryDatabase {
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
             if ($MonitorServer -and ($server.Version.Major -lt 12)) {
-                #if ($MonitorServer -and ($SqlInstance.Version.Major -lt 16)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_primary WHERE primary_database = '$Database'"
                 $lsDetails = $server.Query($query)
@@ -284,7 +283,7 @@ function New-DbaLogShippingPrimaryDatabase {
 
                 Write-Message -Message "Configuring monitor server for primary database $Database." -Level Verbose
                 Write-Message -Message "Executing query:`n$query" -Level Verbose
-                $server.Query($query)
+                Invoke-DbaQuery -SqlInstance $MonitorServer -SqlCredential $MonitorCredential -Database msdb -Query $query
 
                 $query = "
                     UPDATE msdb.dbo.log_shipping_primary_databases

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -217,7 +217,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
     if ($ServerSecondary.Version.Major -le 12) {
         $Query += "
-            ,@ignoreremotemonitor = 1"
+        ,@ignoreremotemonitor = 1"
     }
 
     # Add inf extra options to the query when needed

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -214,7 +214,13 @@ function New-DbaLogShippingSecondaryDatabase {
         ,@threshold_alert_enabled = $ThresholdAlertEnabled
         ,@history_retention_period = $HistoryRetention "
 
-    # Addinf extra options to the query when needed
+
+    if ($ServerSecondary.Version.Major -le 12) {
+        $Query += "
+            ,@ignoreremotemonitor = 1"
+    }
+
+    # Add inf extra options to the query when needed
     if ($BlockSize -ne -1) {
         $Query += ",@block_size = $BlockSize"
     }
@@ -227,7 +233,7 @@ function New-DbaLogShippingSecondaryDatabase {
         $Query += ",@max_transfer_size = $MaxTransferSize"
     }
 
-    if ($ServerSecondary.Version.Major -gt 9) {
+    if ($Force -and ($ServerSecondary.Version.Major -gt 9)) {
         $Query += ",@overwrite = 1;"
     } else {
         $Query += ";"
@@ -242,8 +248,8 @@ function New-DbaLogShippingSecondaryDatabase {
 
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
-            #if ($MonitorServer -and ($SqlInstance.Version.Major -lt 16)) {
-            if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 16)) {
+                #if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -248,8 +248,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
-            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 16)) {
-                #if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)
@@ -276,7 +275,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
                 Write-Message -Message "Configuring monitor server for secondary database $SecondaryDatabase." -Level Verbose
                 Write-Message -Message "Executing query:`n$query" -Level Verbose
-                $ServerSecondary.Query($query)
+                Invoke-DbaQuery -SqlInstance $MonitorServer -SqlCredential $MonitorCredential -Database msdb -Query $query
 
                 $query = "
                 UPDATE msdb.dbo.log_shipping_secondary
@@ -287,6 +286,7 @@ function New-DbaLogShippingSecondaryDatabase {
                 Write-Message -Message "Updating monitor information for the secondary database $Database." -Level Verbose
                 Write-Message -Message "Executing query:`n$query" -Level Verbose
                 $ServerSecondary.Query($query)
+
             }
         } catch {
             Write-Message -Message "$($_.Exception.InnerException.InnerException.InnerException.InnerException.Message)" -Level Warning

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -243,7 +243,7 @@ function New-DbaLogShippingSecondaryDatabase {
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
             #if ($MonitorServer -and ($SqlInstance.Version.Major -lt 16)) {
-            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -64,6 +64,19 @@ function New-DbaLogShippingSecondaryDatabase {
         .PARAMETER ThresholdAlertEnabled
             Specifies whether an alert is raised when backup_threshold is exceeded.
 
+        .PARAMETER MonitorServer
+            Is the name of the monitor server.
+            The default is the name of the primary server.
+
+        .PARAMETER MonitorCredential
+            Allows you to login to enter a secure credential.
+            This is only needed in combination with MonitorServerSecurityMode having either a 0 or 'sqlserver' value.
+            To use: $scred = Get-Credential, then pass $scred object to the -MonitorCredential parameter.
+
+        .PARAMETER MonitorServerSecurityMode
+            The security mode used to connect to the monitor server. Allowed values are 0, "sqlserver", 1, "windows"
+            The default is 1 or Windows.
+
         .PARAMETER WhatIf
             Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -120,6 +133,10 @@ function New-DbaLogShippingSecondaryDatabase {
         [object]$SecondaryDatabase,
         [int]$ThresholdAlert = 14420,
         [switch]$ThresholdAlertEnabled,
+        [string]$MonitorServer,
+        [ValidateSet(0, "sqlserver", 1, "windows")]
+        [object]$MonitorServerSecurityMode = 1,
+        [System.Management.Automation.PSCredential]$MonitorCredential,
         [Alias('Silent')]
         [switch]$EnableException,
         [switch]$Force


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For versions prior to SQL Server 2014 the log shipping works a little different. To add the monitoring server a couple of workarounds need to be put in place to make sure SQL Server is able to create them.

### Approach
The changes in the commands check if the version of SQL Server is SQL Server 2012 or lower and with that execute some additional code.

### Commands to test
Invoke-DbaDbLogShipping

