### PR TITLE
fixing most recent fork as default and making sure it fires when gbh …

### DIFF
--- a/functions/Get-DbaBackupHistory.ps1
+++ b/functions/Get-DbaBackupHistory.ps1
@@ -260,7 +260,7 @@ function Get-DbaBackupHistory {
                     if ($RecoveryFork) {
                         $recoveryForkSqlFilter = "AND backupset.last_recovery_fork_guid ='$RecoveryFork'"
                     }
-                    if ($null -eq (Get-PsCallStack)[1].Command) {
+                    if ($null -eq (Get-PsCallStack)[1].Command -or '{ScriptBlock}' -eq (Get-PsCallStack)[1].Command) {
                         $forkCheckSql = "
                                 SELECT
                                     database_name,
@@ -275,6 +275,7 @@ function Get-DbaBackupHistory {
                                 $sinceSqlFilter
                                 $recoveryForkSqlFilter
                                 GROUP by database_name, last_recovery_fork_guid
+                                ORDER by MaxDate Asc
                                 "
 
                         $results = $server.ConnectionContext.ExecuteWithResults($forkCheckSql).Tables.Rows
@@ -283,7 +284,10 @@ function Get-DbaBackupHistory {
                             foreach ($result in $results) {
                                 Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
                             }
-
+                            if ($null -eq $RecoveryFork) {
+                                $RecoveryFork = $results[-1].RecFork
+                                Write-Message -Message "Defaulting to last Recovery Fork, ID - $RecoveryFork"
+                            }
                         }
                     }
                     #Get the full and build upwards


### PR DESCRIPTION
…is called on its own

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4841 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Ensures that the recovery fork check is called every time GBH is called on it's own (ie not by another command)

Sets default recoveryfork to the latest as that seems to be what people are expecting

### Approach
Added a check for being called in a scriptblock which is the the other outcome from Get-PsCallstack 

Set $RecoveryForkID to the latest recoveryforkid


