### PR TITLE
Fixed random creation of values based on faker

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -152,7 +152,7 @@ function Invoke-DbaDbDataMasking {
                 return
             }
         }
-        
+
         foreach ($tabletest in $tables.Tables) {
             if ($Table -and $tabletest.Name -notin $Table) {
                 continue
@@ -174,13 +174,13 @@ function Invoke-DbaDbDataMasking {
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            
+
             if ($Database) {
                 $dbs = Get-DbaDatabase -SqlInstance $server -Database $Database
             } else {
                 $dbs = Get-DbaDatabase -SqlInstance $server -Database $tables.Name
             }
-            
+
             foreach ($db in $dbs) {
                 $stepcounter = 0
                 foreach ($tableobject in $tables.Tables) {
@@ -227,6 +227,7 @@ function Invoke-DbaDbDataMasking {
                             $updates = $wheres = @()
 
                             foreach ($columnobject in $tablecolumns) {
+
                                 # make sure max is good
                                 if ($MaxValue) {
                                     if ($columnobject.MaxValue -le $MaxValue) {
@@ -321,7 +322,7 @@ function Invoke-DbaDbDataMasking {
                                     }
 
                                     if (-not $newValue) {
-                                        $newValue = switch ($columnobject.Subtype.ToLower()) {
+                                        $newValue = switch ($columnobject.SubType.ToLower()) {
                                             'number' {
                                                 $faker.$($columnobject.MaskingType).$($columnobject.SubType)($columnobject.MaxValue)
                                             }
@@ -329,11 +330,6 @@ function Invoke-DbaDbDataMasking {
                                                 $psitem -in 'bit', 'bool'
                                             } {
                                                 $faker.System.Random.Bool()
-                                            }
-                                            {
-                                                $psitem -in 'name', 'address', 'finance'
-                                            } {
-                                                $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
                                             }
                                             {
                                                 $psitem -in 'date', 'datetime', 'datetime2', 'smalldatetime'
@@ -363,6 +359,19 @@ function Invoke-DbaDbDataMasking {
                                                 } else {
                                                     $faker.$($columnobject.MaskingType).String2($max, $charstring)
                                                 }
+                                            }
+                                            default {
+                                                $null
+                                            }
+                                        }
+                                    }
+
+                                    if (-not $newValue) {
+                                        $newValue = switch ($columnobject.MaskingType.ToLower()) {
+                                            {
+                                                $psitem -in 'name', 'address', 'finance'
+                                            } {
+                                                $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
                                             }
                                             default {
                                                 if ($max -eq -1) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When using the specific faker assigned types like Name it would create a random string instead of a name. 

### Approach
Added another section that creates the values

### Commands to test
Invoke-DbaDbDataMasking

### Screenshots
With the firstname changed as random string
![image](https://user-images.githubusercontent.com/6154981/50223424-79376b00-039b-11e9-9540-68010b789e0d.png)

With the firstname changed as type firstname from bogus
![image](https://user-images.githubusercontent.com/6154981/50223454-89e7e100-039b-11e9-97e3-c583f0be45f2.png)

