### PR TITLE
Add deterministic masking

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -168,6 +168,8 @@ function Invoke-DbaDbDataMasking {
             return
         }
 
+        $dictionary = @{}
+
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
@@ -201,6 +203,8 @@ function Invoke-DbaDbDataMasking {
                     } catch {
                         Stop-Function -Message "Failure retrieving the data from table $($tableobject.Name)" -Target $Database -ErrorRecord $_ -Continue
                     }
+
+                    $deterministicColumns = $tables.Tables.Columns | Where-Object Deterministic -eq $true
 
                     $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
                     $tablecolumns = $tableobject.Columns
@@ -272,52 +276,60 @@ function Invoke-DbaDbDataMasking {
                                 }
 
                                 try {
-                                    $newValue = switch ($columnobject.ColumnType) {
-                                        {
-                                            $psitem -in 'bit', 'bool'
-                                        } {
-                                            $faker.System.Random.Bool()
-                                        }
-                                        {
-                                            $psitem -match 'date'
-                                        } {
-                                            if ($columnobject.MinValue -or $columnobject.MaxValue) {
-                                                ($faker.Date.Between($nowmin, $nowmax)).ToString("yyyyMMdd")
-                                            } else {
-                                                ($faker.Date.Past()).ToString("yyyyMMdd")
-                                            }
-                                        }
-                                        {
-                                            $psitem -match 'int'
-                                        } {
-                                            if ($columnobject.MinValue -or $columnobject.MaxValue) {
-                                                $faker.System.Random.Int($columnobject.MinValue, $columnobject.MaxValue)
-                                            } else {
-                                                $faker.System.Random.Int(0, $max)
-                                            }
-                                        }
-                                        'money' {
-                                            if ($columnobject.MinValue -or $columnobject.MaxValue) {
-                                                $faker.Finance.Amount($columnobject.MinValue, $columnobject.MaxValue)
-                                            } else {
-                                                $faker.Finance.Amount(0, $max)
-                                            }
-                                        }
-                                        'time' {
-                                            ($faker.Date.Past()).ToString("h:mm tt zzz")
-                                        }
-                                        'uniqueidentifier' {
-                                            $faker.System.Random.Guid().Guid
-                                        }
-                                        'userdefineddatatype' {
-                                            if ($columnobject.MaxValue -eq 1) {
+                                    $newValue = $null
+
+                                    if($columnobject.Deterministic -and ($row.$($columnobject.Name) -in $dictionary.Keys)){
+                                        $newValue = $dictionary.$($row.$($columnobject.Name))
+                                    }
+
+                                    if (-not $newValue) {
+                                        $newValue = switch ($columnobject.ColumnType) {
+                                            {
+                                                $psitem -in 'bit', 'bool'
+                                            } {
                                                 $faker.System.Random.Bool()
-                                            } else {
+                                            }
+                                            {
+                                                $psitem -match 'date'
+                                            } {
+                                                if ($columnobject.MinValue -or $columnobject.MaxValue) {
+                                                    ($faker.Date.Between($nowmin, $nowmax)).ToString("yyyyMMdd")
+                                                } else {
+                                                    ($faker.Date.Past()).ToString("yyyyMMdd")
+                                                }
+                                            }
+                                            {
+                                                $psitem -match 'int'
+                                            } {
+                                                if ($columnobject.MinValue -or $columnobject.MaxValue) {
+                                                    $faker.System.Random.Int($columnobject.MinValue, $columnobject.MaxValue)
+                                                } else {
+                                                    $faker.System.Random.Int(0, $max)
+                                                }
+                                            }
+                                            'money' {
+                                                if ($columnobject.MinValue -or $columnobject.MaxValue) {
+                                                    $faker.Finance.Amount($columnobject.MinValue, $columnobject.MaxValue)
+                                                } else {
+                                                    $faker.Finance.Amount(0, $max)
+                                                }
+                                            }
+                                            'time' {
+                                                ($faker.Date.Past()).ToString("h:mm tt zzz")
+                                            }
+                                            'uniqueidentifier' {
+                                                $faker.System.Random.Guid().Guid
+                                            }
+                                            'userdefineddatatype' {
+                                                if ($columnobject.MaxValue -eq 1) {
+                                                    $faker.System.Random.Bool()
+                                                } else {
+                                                    $null
+                                                }
+                                            }
+                                            default {
                                                 $null
                                             }
-                                        }
-                                        default {
-                                            $null
                                         }
                                     }
 
@@ -384,6 +396,7 @@ function Invoke-DbaDbDataMasking {
                                             }
                                         }
                                     }
+
                                 } catch {
                                     Stop-Function -Message "Failure" -Target $faker -Continue -ErrorRecord $_
                                 }
@@ -402,6 +415,10 @@ function Invoke-DbaDbDataMasking {
                                 if ($columnobject.ColumnType -notin 'xml', 'geography', 'geometry') {
                                     $oldValue = ($row.$($columnobject.Name)).Tostring().Replace("'", "''")
                                     $wheres += "[$($columnobject.Name)] = '$oldValue'"
+                                }
+
+                                if($columnobject.Deterministic -and ($row.$($columnobject.Name) -notin $dictionary.Keys)){
+                                    $dictionary.Add($row.$($columnobject.Name), $newValue)
                                 }
                             }
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -278,7 +278,7 @@ function Invoke-DbaDbDataMasking {
                                 try {
                                     $newValue = $null
 
-                                    if($columnobject.Deterministic -and ($row.$($columnobject.Name) -in $dictionary.Keys)){
+                                    if ($columnobject.Deterministic -and ($row.$($columnobject.Name) -in $dictionary.Keys)) {
                                         $newValue = $dictionary.$($row.$($columnobject.Name))
                                     }
 
@@ -417,7 +417,7 @@ function Invoke-DbaDbDataMasking {
                                     $wheres += "[$($columnobject.Name)] = '$oldValue'"
                                 }
 
-                                if($columnobject.Deterministic -and ($row.$($columnobject.Name) -notin $dictionary.Keys)){
+                                if ($columnobject.Deterministic -and ($row.$($columnobject.Name) -notin $dictionary.Keys)) {
                                     $dictionary.Add($row.$($columnobject.Name), $newValue)
                                 }
                             }

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -211,6 +211,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Name"
                                     SubType         = "Firstname"
+                                    Deterministic   = $false
                                 }
                             }
                             "lastname" {
@@ -222,6 +223,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Name"
                                     SubType         = "Lastname"
+                                    Deterministic   = $false
                                 }
                             }
                             "creditcard" {
@@ -233,6 +235,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Finance"
                                     SubType         = "CreditcardNumber"
+                                    Deterministic   = $false
                                 }
                             }
                             "address" {
@@ -244,6 +247,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Address"
                                     SubType         = "StreetAddress"
+                                    Deterministic   = $false
                                 }
                             }
                             "city" {
@@ -255,6 +259,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Address"
                                     SubType         = "City"
+                                    Deterministic   = $false
                                 }
                             }
                             "zipcode" {
@@ -266,6 +271,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Address"
                                     SubType         = "Zipcode"
+                                    Deterministic   = $false
                                 }
                             }
                         }
@@ -344,6 +350,7 @@ function New-DbaDbMaskingConfig {
                             MaxValue        = $MaxValue
                             MaskingType     = $type
                             SubType         = $subType
+                            Deterministic   = $false
                         }
                     }
                 }

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -6,7 +6,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\Invoke-DbaDbDataMasking).Parameters.Keys
-        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'Query', 'MaxValue', 'EnableException','ExactLength'
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'Query', 'MaxValue', 'EnableException', 'ExactLength'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $knownParameters.Count
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add functionality to mask data using a dictionary making he masking deterministic.
That way the values across tables will be the same even if they're not referenced.

### Commands to test
Invoke-DbaDbDataMasking
New-DbaDataMaskingConfig

### Screenshots
before
![image](https://user-images.githubusercontent.com/6154981/50233799-7eed7a80-03b4-11e9-8736-458763ea2946.png)

after
![image](https://user-images.githubusercontent.com/6154981/50233813-89a80f80-03b4-11e9-9b43-5bda248dd622.png)

