### PR TITLE
More enhancements for Update-DbaInstance

### DIFF
--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -357,8 +357,8 @@ function Update-DbaInstance {
                     }
                     # update components to mirror the updated version - will be used for multi-step upgrades
                     foreach ($component in $components) {
-                        if ($component.Version.NameLevel -in $upgradeDetdetailails.TargetVersion.NameLevel) {
-                            $component.Version = $detail.TargetVersion | Where-Object NameLevel -eq $component.Version.NameLevel
+                        if ($component.Version.NameLevel -eq $detail.TargetVersion.NameLevel) {
+                            $component.Version = $detail.TargetVersion
                         }
                     }
                     # finally, add the upgrade details to the upgrade list

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -297,11 +297,10 @@ function Update-DbaInstance {
             }
             $upgrades = @()
             :actions foreach ($currentAction in $actions) {
-                if ($restartNeeded = Test-PendingReboot -ComputerName $resolvedName) {
-                    if (-not $Restart) {
-                        #Exit the actions loop altogether - nothing can be installed here anyways
-                        Stop-Function -Message "$resolvedName is pending a reboot. Reboot the computer before proceeding." -Continue -ContinueLabel computers
-                    }
+                $restartNeeded = Test-PendingReboot -ComputerName $resolvedName
+                if ($restartNeeded -and (-not $Restart -or ([DbaInstanceParameter]$resolvedName).IsLocalHost)) {
+                    #Exit the actions loop altogether - nothing can be installed here anyways
+                    Stop-Function -Message "$resolvedName is pending a reboot. Reboot the computer before proceeding." -Continue -ContinueLabel computers
                 }
                 # Attempt to configure CredSSP for the remote host when credentials are defined
                 if ($Credential -and -not ([DbaInstanceParameter]$resolvedName).IsLocalHost -and $Authentication -eq 'Credssp') {

--- a/internal/configurations/settings/remoting.ps1
+++ b/internal/configurations/settings/remoting.ps1
@@ -3,6 +3,3 @@ Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.ExpirationTimeout' -Value (New
 
 # Disables session caching
 Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.Enable' -Value $true -Initialize -Validation bool -Handler { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionCacheEnabled = $args[0] } -Description 'Globally enables session caching for PowerShell remoting'
-
-# Prefer CredSSP failback in Invoke-Program
-Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.UsePSSessionConfiguration' -Value $false -Initialize -Validation bool -Description 'Skip CredSSP connection attempt and use a PSSessionConfiguration workaround when executing Invoke-Program'

--- a/internal/functions/Find-SqlServerUpdate.ps1
+++ b/internal/functions/Find-SqlServerUpdate.ps1
@@ -52,8 +52,43 @@ function Find-SqlServerUpdate {
                 }
             }
         }
+        $params = @{
+            ComputerName = $ComputerName
+            Credential   = $Credential
+            ScriptBlock  = $getFileScript
+            ArgumentList = @($Path, $filter)
+            ErrorAction  = 'Stop'
+            Raw          = $true
+        }
         try {
-            Invoke-Command2 -ComputerName $ComputerName -Authentication $Authentication -Credential $Credential -ScriptBlock $getFileScript -ArgumentList @($Path, $filter)
+            Invoke-Command2 @params -Authentication $Authentication
+        } catch [System.Management.Automation.Remoting.PSRemotingTransportException] {
+            if ($Credential) {
+                #try fallback
+                $configuration = Register-RemoteSessionConfiguration -Computer $ComputerName -Credential $Credential -Name dbatoolsFindUpdate
+                if ($configuration.Successful) {
+                    Write-Message -Level Debug -Message "RemoteSessionConfiguration ($($configuration.Name)) was successful, using it."
+                    try {
+                        Invoke-Command2 @params -ConfigurationName $configuration.Name
+                    } catch {
+                        Stop-Function -Message "Failed to enumerate files in $Path using PSSession config" -ErrorRecord $_
+                        return
+                    } finally {
+                        # Unregister PSRemote configurations once completed. It's slow, but necessary - otherwise we're gonna have leftover junk with credentials on a remote
+                        Write-Message -Level Verbose -Message "Unregistering leftover PSSession Configuration on $ComputerName"
+                        $unreg = Unregister-RemoteSessionConfiguration -ComputerName $ComputerName -Credential $Credential -Name $configuration.Name
+                        if (!$unreg.Successful) {
+                            Stop-Function -Message "Failed to unregister PSSession Configurations on $ComputerName | $($configuration.Status)" -EnableException $false
+                        }
+                    }
+                } else {
+                    Stop-Function -Message "RemoteSession configuration unsuccessful, no valid connection options found | $($configuration.Status)"
+                    return
+                }
+            } else {
+                Stop-Function -Message "Failed to enumerate files in $Path" -ErrorRecord $_
+                return
+            }
         } catch {
             Stop-Function -Message "Failed to enumerate files in $Path" -ErrorRecord $_
             return

--- a/internal/functions/Get-SqlInstanceComponent.ps1
+++ b/internal/functions/Get-SqlInstanceComponent.ps1
@@ -207,12 +207,7 @@ function Get-SQLInstanceComponent {
                             # attempt to recover a real version of a sqlservr.exe by getting file properties from a remote machine
                             # not sure how to support SSRS/SSAS, as SSDS is the only one that has binary path in the Setup node
                             if ($binRoot = $instanceRegSetup.GetValue("SQLBinRoot")) {
-                                $fileVersion = Invoke-Command2 -ArgumentList $binRoot -Raw -Credential $Credential -ComputerName $computer -ScriptBlock {
-                                    Param (
-                                        $Path
-                                    )
-                                    (Get-Item -Path (Join-Path $Path "sqlservr.exe") -ErrorAction Stop).VersionInfo.ProductVersion
-                                }
+                                $fileVersion = (Get-Item -Path (Join-Path $binRoot "sqlservr.exe") -ErrorAction Stop).VersionInfo.ProductVersion
                                 if ($fileVersion) {
                                     $version = $fileVersion
                                     $log += "New version from the binary file: $version"
@@ -303,7 +298,7 @@ function Get-SQLInstanceComponent {
     process {
         foreach ($computer in $ComputerName) {
             try {
-                $results = Invoke-Command2 -ComputerName $computer -ScriptBlock $regScript -Credential $Credential -ErrorAction Stop -Raw -ArgumentList @($Component)
+                $results = Invoke-Command2 -ComputerName $computer -ScriptBlock $regScript -Credential $Credential -ErrorAction Stop -Raw -ArgumentList @($Component) -RequiredPSVersion 3.0
             } catch {
                 Stop-Function -Message "Failed to get instance components from $computer" -ErrorRecord $_ -Continue
             }

--- a/internal/functions/Get-SqlServerUpdate.ps1
+++ b/internal/functions/Get-SqlServerUpdate.ps1
@@ -87,6 +87,7 @@ function Get-SqlServerUpdate {
 
             # create a parameter set for Find-SqlServerUpdate
             $kbLookupParams = @{
+                ComputerName = $ComputerName
                 Architecture = $arch
                 MajorVersion = $currentGroup.Name
                 Path         = $Path
@@ -175,6 +176,12 @@ function Get-SqlServerUpdate {
             $output.TargetLevel = $targetLevel
             $output.KB = $kbLookupParams.KB
             ## Find the installer to use
+            if ($Credential) {
+                $kbLookupParams += @{
+                    Credential     = $Credential
+                    Authentication = 'CredSSP'
+                }
+            }
 
             $installer = Find-SqlServerUpdate @kbLookupParams
             if (!$installer) {

--- a/internal/functions/Get-SqlServerUpdate.ps1
+++ b/internal/functions/Get-SqlServerUpdate.ps1
@@ -1,7 +1,7 @@
 function Get-SqlServerUpdate {
     <#
     Originally based on https://github.com/adbertram/PSSqlUpdater
-    Internal function. Provides information on the update path for a specific set of SQL Server instances based on current and target SQL Server levels.
+    Internal function. Provides information on the target update version for a specific set of SQL Server instances based on current and target SQL Server levels.
     Component parameter is using the output object of Get-SqlInstanceComponent.
     #>
     [CmdletBinding(DefaultParameterSetName = 'Latest')]
@@ -22,9 +22,7 @@ function Get-SqlServerUpdate {
         [Parameter(Mandatory, ParameterSetName = 'KB')]
         [ValidateNotNullOrEmpty()]
         [string]$KB,
-        [bool]$Restart,
         [string]$InstanceName,
-        [string[]]$Path,
         [bool]$EnableException = $EnableException,
         [bool]$Continue
     )
@@ -72,6 +70,7 @@ function Get-SqlServerUpdate {
                 ComputerName  = $ComputerName
                 MajorVersion  = $currentMajorNumber
                 Build         = $currentVersion.Build
+                Architecture  = $arch
                 TargetVersion = $null
                 TargetLevel   = $null
                 KB            = $null
@@ -80,18 +79,11 @@ function Get-SqlServerUpdate {
                 InstanceName  = $InstanceName
                 Installer     = $null
                 ExtractPath   = $null
-                Notes         = $null
+                Notes         = @()
                 ExitCode      = $null
                 Log           = $null
             }
 
-            # create a parameter set for Find-SqlServerUpdate
-            $kbLookupParams = @{
-                ComputerName = $ComputerName
-                Architecture = $arch
-                MajorVersion = $currentGroup.Name
-                Path         = $Path
-            }
             # Find target KB number based on provided SP/CU levels or KB numbers
             if ($CumulativeUpdate -gt 0) {
                 #Cumulative update is present - installing CU
@@ -147,12 +139,13 @@ function Get-SqlServerUpdate {
                 $output.TargetVersion = $targetKB
                 $targetLevel = "$($targetKB.SPLevel | Where-Object { $_ -ne 'LATEST' })$($targetKB.CULevel)"
                 $targetKBLevel = $targetKB.KBLevel | Select-Object -First 1
-                Write-Message -Level Verbose -Message "Upgrading SQL$($targetKB.NameLevel) to $targetLevel (KB$($targetKBLevel))"
-                $kbLookupParams.KB = $targetKBLevel
+                Write-Message -Level Verbose -Message "Found applicable upgrade for SQL$($targetKB.NameLevel) to $targetLevel (KB$($targetKBLevel))"
+                $output.KB = $targetKBLevel
             } else {
-                $output.Notes = "Could not find a KB$KB reference for $currentMajorVersion SP $ServicePack CU $CumulativeUpdate"
+                $msg = "Could not find a KB$KB reference for $currentMajorVersion SP $ServicePack CU $CumulativeUpdate"
+                $output.Notes += $msg
                 $output
-                Stop-Function -Message $output.Notes -Continue
+                Stop-Function -Message $msg -Continue
             }
 
             # Compare versions - whether to proceed with the installation
@@ -174,22 +167,6 @@ function Get-SqlServerUpdate {
             }
 
             $output.TargetLevel = $targetLevel
-            $output.KB = $kbLookupParams.KB
-            ## Find the installer to use
-            if ($Credential) {
-                $kbLookupParams += @{
-                    Credential     = $Credential
-                    Authentication = 'CredSSP'
-                }
-            }
-
-            $installer = Find-SqlServerUpdate @kbLookupParams
-            if (!$installer) {
-                $output.Notes = "Could not find installer for the $currentMajorVersion update KB$($kbLookupParams.KB)"
-                $output
-                Stop-Function -Message $output.Notes -Continue
-            }
-            $output.Installer = $installer.FullName
             $output.Successful = $true
             #Return the object for further processing
             $output

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -63,12 +63,11 @@ function Initialize-CredSSP {
     # Configure remote machine
     Write-Message -Level Verbose -Message "Configuring remote host to use CredSSP"
     try {
-        Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -Raw -ScriptBlock {
+        Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -Raw -RequiredPSVersion 3.0 -ScriptBlock {
             $sspList = Get-WSManCredSSP -ErrorAction Stop
             if ($sspList[1] -ne 'This computer is configured to receive credentials from a remote client computer.') {
                 $null = Enable-WSManCredSSP -Role Server -Force -ErrorAction Stop
             }
-            # netsh http add iplisten 127.0.0.1 - whaattt?
         }
     } catch {
         Stop-Function -Message "Failed to configure remote CredSSP on $ComputerName as a server" -ErrorRecord $_

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -37,6 +37,9 @@ function Invoke-Command2 {
         .PARAMETER Raw
             Passes through the raw return data, rather than prettifying stuff.
 
+        .PARAMETER RequiredPSVersion
+            Verifies that remote Powershell version is meeting specified requirements.
+
         .EXAMPLE
             PS C:\> Invoke-Command2 -ComputerName sql2014 -Credential $Credential -ScriptBlock { dir }
 
@@ -56,13 +59,12 @@ function Invoke-Command2 {
         [ValidateSet('Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos')]
         [string]$Authentication = 'Default',
         [string]$ConfigurationName,
-        [switch]$Raw
+        [switch]$Raw,
+        [version]$RequiredPSVersion
     )
     <# Note: Credential stays as an object type for legacy reasons. #>
 
-    $InvokeCommandSplat = @{
-        ScriptBlock = $ScriptBlock
-    }
+    $InvokeCommandSplat = @{}
     if ($ArgumentList) {
         $InvokeCommandSplat["ArgumentList"] = $ArgumentList
     }
@@ -111,7 +113,14 @@ function Invoke-Command2 {
             [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionSet($runspaceId, $ComputerName.ComputerName, $currentSession)
         }
     }
+    if ($RequiredPSVersion) {
+        $remoteVersion = Invoke-Command @InvokeCommandSplat -ScriptBlock { $PSVersionTable }
+        if ($remoteVersion.PSVersion -and $remoteVersion.PSVersion -lt $RequiredPSVersion) {
+            throw "Remote PS version $($remoteVersion.PSVersion) is less than defined requirement ($RequiredPSVersion)"
+        }
+    }
 
+    $InvokeCommandSplat.ScriptBlock = $ScriptBlock
     if ($Raw) {
         Invoke-Command @InvokeCommandSplat
     } else {

--- a/internal/functions/Invoke-CommandWithFallback.ps1
+++ b/internal/functions/Invoke-CommandWithFallback.ps1
@@ -1,0 +1,52 @@
+function Invoke-CommandWithFallback {
+    <#
+    When credentials are specified, it is possible that the chosen protocol would fail to connect with them.
+    Fallback will use PSSessionConfiguration to create a session configuration on a remote machine that uses
+    provided set of credentials by default. A new session will be created that uses this custom configuration
+    and performs remote execution under defined set of credentials without relying on delegation or CredSSP.
+    #>
+    param (
+        [DbaInstanceParameter]$ComputerName = $env:COMPUTERNAME,
+        [object]$Credential,
+        [scriptblock]$ScriptBlock,
+        [object[]]$ArgumentList,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [ValidateSet('Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos')]
+        [string]$Authentication = 'Default',
+        [switch]$Raw,
+        [version]$RequiredPSVersion
+    )
+    try {
+        Invoke-Command2 @PSBoundParameters
+    } catch [System.Management.Automation.Remoting.PSRemotingTransportException] {
+        # This implements a fallback scenario, when both credentials and fallback are specified, but the original session has failed
+        # Credentials will be passed on through a default session and used as a default PSSessionConfiguration
+        if ($Credential) {
+            Write-Message -Level Verbose -Message "Initial connection to $($ComputerName.ComputerName) through $Authentication protocol unsuccessful, falling back to PSSession configurations | $($_.Exception.Message)"
+            $configuration = Register-RemoteSessionConfiguration -Computer $ComputerName.ComputerName -Credential $Credential -Name dbatoolsInvokeCommandWithFailback -Confirm:$false
+            if ($configuration.Successful) {
+                $PSBoundParameters.ConfigurationName = $configuration.Name
+                $PSBoundParameters.Authentication = 'Default'
+                try {
+                    Invoke-Command2 @PSBoundParameters
+                } catch {
+                    throw $_
+                } finally {
+                    # Unregister PSRemote configurations once completed. It's slow, but necessary - otherwise we're gonna have leftover junk with credentials on a remote
+                    $unreg = Unregister-RemoteSessionConfiguration -ComputerName $ComputerName.ComputerName -Credential $Credential -Name $configuration.Name -Confirm:$false
+                    if (-not $unreg.Successful) {
+                        Write-Warning -Message "Failed to unregister PSSession Configurations on $($ComputerName.ComputerName) | $($configuration.Status)"
+                    }
+                }
+            } else {
+                Stop-Function -Message "Both $Authentication and failback connections failed | $($configuration.Status)" -ErrorRecord $_ -EnableException $true
+            }
+        } else {
+            #default behavior
+            throw $_
+        }
+    } catch {
+        throw $_
+    }
+}

--- a/internal/functions/Invoke-Program.ps1
+++ b/internal/functions/Invoke-Program.ps1
@@ -38,10 +38,6 @@ function Invoke-Program {
     .PARAMETER Authentication
         Choose authentication mechanism to use
 
-    .PARAMETER UsePSSessionConfiguration
-        Skips the regular connection attempt and proceeds directly to PSSessionConfiguration connections workaround.
-        Mostly used for debugging. See -Fallback for more information.
-
     .PARAMETER Raw
         Return plain stdout without any additional information
 

--- a/internal/functions/Register-RemoteSessionConfiguration.ps1
+++ b/internal/functions/Register-RemoteSessionConfiguration.ps1
@@ -28,10 +28,6 @@ function Register-RemoteSessionConfiguration {
                 $pwd
             )
             $output = [pscustomobject]@{ 'Name' = $Name; 'Status' = $null ; Successful = $false }
-            if ($PSVersionTable.PSVersion -le '2.0') {
-                $output.Status = "Current version of Powershell $($PSVersionTable.PSVersion) does not support SessionConfiguration with custom credentials. Minimum requirement is 3.0"
-                return $output
-            }
             $credential = New-Object System.Management.Automation.PSCredential @($user, (ConvertTo-SecureString -Force -AsPlainText $pwd))
             try {
                 $existing = Get-PSSessionConfiguration -Name $Name -ErrorAction Stop 2>$null
@@ -60,7 +56,7 @@ function Register-RemoteSessionConfiguration {
                 $Name,
                 $RunAsCredential.UserName,
                 $RunAsCredential.GetNetworkCredential().Password
-            ) -Raw
+            ) -Raw -RequiredPSVersion 3.0
         } catch {
             Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
         }

--- a/internal/functions/Register-RemoteSessionConfiguration.ps1
+++ b/internal/functions/Register-RemoteSessionConfiguration.ps1
@@ -7,7 +7,7 @@ function Register-RemoteSessionConfiguration {
         Designed to overcome the double-hop issue and as an alternative to CredSSP protocol.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     Param (
         [Parameter(Mandatory)]
         $ComputerName,
@@ -36,12 +36,12 @@ function Register-RemoteSessionConfiguration {
             }
             try {
                 if ($null -eq $existing) {
-                    $null = Register-PSSessionConfiguration -Name $Name -RunAsCredential $credential -Force -ErrorAction Stop -NoServiceRestart 3>$null
+                    $null = Register-PSSessionConfiguration -Name $Name -RunAsCredential $credential -ErrorAction Stop -NoServiceRestart -Confirm:$false 3>$null
                     $output.Status = 'Created'
                     $output.Successful = $true
                     return $output
                 } else {
-                    Set-PSSessionConfiguration -Name $Name -RunAsCredential $credential -Force -ErrorAction Stop -NoServiceRestart 3>$null
+                    Set-PSSessionConfiguration -Name $Name -RunAsCredential $credential -ErrorAction Stop -NoServiceRestart -Confirm:$false 3>$null
                     $output.Status = 'Updated'
                     $output.Successful = $true
                     return $output
@@ -51,14 +51,17 @@ function Register-RemoteSessionConfiguration {
                 return $output
             }
         }
-        try {
-            $registerIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $createRunasSession -ArgumentList @(
-                $Name,
-                $RunAsCredential.UserName,
-                $RunAsCredential.GetNetworkCredential().Password
-            ) -Raw -RequiredPSVersion 3.0
-        } catch {
-            Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
+        Write-Message -Level Debug -Message "Registering new session configuration $Name on $ComputerName"
+        if ($PSCmdlet.ShouldProcess($ComputerName, "Registering new session configuration $Name")) {
+            try {
+                $registerIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $createRunasSession -ArgumentList @(
+                    $Name,
+                    $RunAsCredential.UserName,
+                    $RunAsCredential.GetNetworkCredential().Password
+                ) -Raw -RequiredPSVersion 3.0 -ErrorAction Stop
+            } catch {
+                Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
+            }
         }
         if ($registerIt) {
             Write-Message -Level Debug -Message "Configuration attempt returned the following status`: $($registerIt.Status)"

--- a/internal/functions/Restart-WinRMService.ps1
+++ b/internal/functions/Restart-WinRMService.ps1
@@ -31,7 +31,8 @@ function Restart-WinRMService {
             Write-Message -Level Debug "Removing existing local sessions to $ComputerName - they are no longer valid"
             $runspaceId = [System.Management.Automation.Runspaces.Runspace]::DefaultRunspace.InstanceId
             # Retrieve a session from the session cache, if available (it's unique per runspace)
-            $currentSessions = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceId, $ComputerName)
+            [array]$currentSessions = [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionGet($runspaceId, $ComputerName)
+            Write-Message -Level Debug -Message "Removing $($currentSessions.Count) sessions from $ComputerName in runspace $runspaceId"
             $currentSessions | Remove-PSSession
             Write-Message -Level Debug "Waiting for the WinRM service to restart on $ComputerName"
             $waitCounter = 0
@@ -46,5 +47,6 @@ function Restart-WinRMService {
                 $waitCounter++
             }
         }
+        Write-Message -Level Debug -Message "WinRM restart comlete on $ComputerName"
     }
 }

--- a/internal/functions/Unregister-RemoteSessionConfiguration.ps1
+++ b/internal/functions/Unregister-RemoteSessionConfiguration.ps1
@@ -37,7 +37,7 @@ function Unregister-RemoteSessionConfiguration {
         }
 
         try {
-            $unregisterIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $removeRunasSession -ArgumentList @($Name) -Raw
+            $unregisterIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $removeRunasSession -ArgumentList @($Name) -Raw -RequiredPSVersion 3.0
         } catch {
             Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
         }

--- a/internal/functions/Unregister-RemoteSessionConfiguration.ps1
+++ b/internal/functions/Unregister-RemoteSessionConfiguration.ps1
@@ -5,7 +5,7 @@ function Unregister-RemoteSessionConfiguration {
     .DESCRIPTION
         Unregisters a session previously created with Register-RemoteSessionConfiguration through WinRM.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     Param (
         [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -28,18 +28,19 @@ function Unregister-RemoteSessionConfiguration {
                 return [pscustomobject]@{ 'Name' = $Name ; 'Status' = 'Not found'; Successful = $true }
             } else {
                 try {
-                    Unregister-PSSessionConfiguration -Name $Name -Force -ErrorAction Stop -NoServiceRestart 3>$null
+                    Unregister-PSSessionConfiguration -Name $Name -ErrorAction Stop -NoServiceRestart -Confirm:$false 3>$null
                     [pscustomobject]@{ 'Name' = $Name; 'Status' = 'Unregistered' ; Successful = $true }
                 } catch {
                     return [pscustomobject]@{ 'Name' = $Name ; 'Status' = $_  ; Successful = $false}
                 }
             }
         }
-
-        try {
-            $unregisterIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $removeRunasSession -ArgumentList @($Name) -Raw -RequiredPSVersion 3.0
-        } catch {
-            Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
+        if ($PSCmdlet.ShouldProcess($ComputerName, "Unregistering session configuration $Name")) {
+            try {
+                $unregisterIt = Invoke-Command2 -ComputerName $ComputerName -Credential $Credential -ScriptBlock $removeRunasSession -ArgumentList @($Name) -Raw -RequiredPSVersion 3.0
+            } catch {
+                Stop-Function -Message "Failure during remote session configuration execution" -ErrorRecord $_ -EnableException $true
+            }
         }
         if ($unregisterIt) {
             Write-Message -Level Debug -Message "Configuration attempt returned the following status`: $($unregisterIt.Status)"

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -7,7 +7,7 @@ $exeDir = "C:\Temp\dbatools_$CommandName"
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     BeforeAll {
         # Prevent the functions from executing dangerous stuff and getting right responses where needed
-        Mock -CommandName Invoke-Program -MockWith { [pscustomobject]@{ Successful = $true } } -ModuleName dbatools
+        Mock -CommandName Invoke-Program -MockWith { [pscustomobject]@{ Successful = $true; ExitCode = [uint32[]]3010 } } -ModuleName dbatools
         Mock -CommandName Test-PendingReboot -MockWith { $false } -ModuleName dbatools
         Mock -CommandName Test-ElevationRequirement -MockWith { $null } -ModuleName dbatools
         Mock -CommandName Restart-Computer -MockWith { $null } -ModuleName dbatools
@@ -128,9 +128,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 1 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             $result | Should -Not -BeNullOrEmpty
             $result.MajorVersion | Should -Be 2008
@@ -149,9 +146,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 4 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 2 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             ($results | Measure-Object).Count | Should -Be 2
 
@@ -235,9 +229,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 1 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             $result | Should -Not -BeNullOrEmpty
             $result.MajorVersion | Should -Be 2008
@@ -254,9 +245,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 1 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             $result | Should -Not -BeNullOrEmpty
             $result.MajorVersion | Should -Be 2016
@@ -273,9 +261,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 6 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 3 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             ($results | Measure-Object).Count | Should -Be 3
 
@@ -345,9 +330,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 1 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Restart-Computer -Exactly 1 -Scope It -ModuleName dbatools
-            #no remote execution in tests
-            #Assert-MockCalled -CommandName Register-RemoteSessionConfiguration -Exactly 0 -Scope It -ModuleName dbatools
-            #Assert-MockCalled -CommandName Unregister-RemoteSessionConfiguration -Exactly 1 -Scope It -ModuleName dbatools
 
             $result | Should -Not -BeNullOrEmpty
             $result.MajorVersion | Should -Be 2012
@@ -650,7 +632,7 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
         It "Should whatif-upgrade to latest SPCU" {
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $instance = $server.ServiceName
-            $result = Update-DbaInstance -ComputerName $script:instance1 -Path $exeDir -Restart -EnableException -WhatIf -InstanceName $instance 3>$null
+            $null = Update-DbaInstance -ComputerName $script:instance1 -Path $exeDir -Restart -EnableException -WhatIf -InstanceName $instance 3>$null
             $testBuild = Test-DbaBuild -SqlInstance $server -MaxBehind 0CU
             Assert-MockCalled -CommandName Test-PendingReboot -Scope It -ModuleName dbatools
             Assert-MockCalled -CommandName Test-ElevationRequirement -Scope It -ModuleName dbatools


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding new features to the existing set of commands:
* Users can now specify which authentication to use; CredSSP is still a default for remote connections with credentials, but is no longer a requirement per se. Will be useful when patch repository is accessible locally or does not require authentication.
* If a target machine (not a localhost) has a restart pending, the function will now restart the machine prior to beginning the installation 
* Passing credentials through the insecure connection now asks for confirmation (but only once)
* Invoke-Program now has a -Fallback option for remote execution with Credentials that enables execution through...
* New internal function Invoke-CommandWithFallback - a wrapper for Invoke-Command2 that does a retry in case an initial connection (CredSSP in particular) has failed due to transport issues.
* Minor fixes and improvements across the board

### Screenshots
Running in a non-elavated session without means to configure CredSSP:

![image](https://user-images.githubusercontent.com/30303784/50313778-16fd6980-0472-11e9-98d1-9d0baf74914e.png)

Only needs one confirmation of using insecure transit:

![image](https://user-images.githubusercontent.com/30303784/50313823-3d230980-0472-11e9-8d57-9e1ca71696f9.png)

Restarting computer prior to starting the installation due to pending restart:

![image](https://user-images.githubusercontent.com/30303784/50313877-70fe2f00-0472-11e9-9e4e-08d985b3c084.png)


