### PR TITLE
adding tests for Get-DbaMemoryCondition. Issue #4558

### DIFF
--- a/tests/Get-DbaMemoryCondition.Tests.ps1
+++ b/tests/Get-DbaMemoryCondition.Tests.ps1
@@ -1,0 +1,38 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        $defaultParamCount = 11
+        [object[]]$params = (Get-ChildItem function:\Get-DbaMemoryCondition).Parameters.Keys
+        $knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
+        $paramCount = $knownParameters.Count
+        It "Should contain our specific parameters" {
+            ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
+        }
+        It "Should only contain $paramCount parameters" {
+            $params.Count - $defaultParamCount | Should Be $paramCount
+        }
+    }
+}
+
+<#
+    Integration test should appear below and are custom to the command you are writing.
+    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
+    for more guidence.
+#>
+Describe "Get-DbaMemoryCondition Integration Test" -Tag "IntegrationTests" {
+    Context "Command actually works" {
+        $results = Get-DbaMemoryCondition -SqlInstance $script:instance1
+
+        It "returns results" {
+            $($results | Measure-Object).Count -gt 0 | Should Be $true
+        }
+        It "has the correct properties" {
+            $result = $results[0]
+            $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,Runtime,NotificationTime,NotificationType,MemoryUtilizationPercent,TotalPhysicalMemory,AvailablePhysicalMemory,TotalPageFile,AvailablePageFile,TotalVirtualAddressSpace,AvailableVirtualAddressSpace,NodeId,SQLReservedMemory,SQLCommittedMemory,RecordId,Type,Indicators,RecordTime,CurrentTime'.Split(',')
+            ($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Adding coverage for 1.0! Issue #4558 add coverage for get*
### Approach
<!-- How does this change solve that purpose -->
- standard unit tests
- integration tests check results are returned and expected properties, hard to simulate a memory condition to test the SQL works.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/50356708-0952ed00-0521-11e9-81be-b677cec2c924.png)
