### PR TITLE
PS Core adjustments related to Test-Connection

### DIFF
--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -182,11 +182,12 @@ function Reset-DbaAdmin {
                     Stop-Function -Continue -Message "Remote PowerShell access not enabled on on $instance or access denied. Quitting."
                 }
 
-                # Test Connection first using Test-Connection which requires ICMP access then failback to tcp if pings are blocked
+                # Test Connection first using ping class which requires ICMP access then failback to tcp if pings are blocked
                 Write-Message -Level Verbose -Message "Testing connection to $baseaddress"
-                $testconnect = Test-Connection -ComputerName $baseaddress -Count 1 -Quiet
-
-                if ($testconnect -eq $false) {
+                $ping = New-Object System.Net.NetworkInformation.Ping
+                $timeout = 1000 #milliseconds
+                $reply = $ping.Send($baseaddress, $timeout)
+                if ($reply.Status -ne 'Success') {
                     Write-Message -Level Verbose -Message "First attempt using ICMP failed. Trying to connect using sockets. This may take up to 20 seconds."
                     $tcp = New-Object System.Net.Sockets.TcpClient
                     try {

--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -105,7 +105,9 @@ function Resolve-DbaNetworkName {
                 if ($ComputerName -match "\.") {
                     return $ComputerName.Substring($ComputerName.IndexOf(".") + 1)
                 } else {
-                    return $env:USERDNSDOMAIN.ToLower()
+                    if ($env:USERDNSDOMAIN) {
+                        return $env:USERDNSDOMAIN.ToLower()
+                    }
                 }
             } else {
                 return $fqdn.Substring($fqdn.IndexOf(".") + 1)

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -76,8 +76,9 @@ function Test-DbaConnection {
             Write-Message -Level Verbose -Message "Getting local environment information"
             $localInfo = [pscustomobject]@{
                 Windows    = [environment]::OSVersion.Version.ToString()
+                Edition    = $PSVersionTable.PSEdition
                 PowerShell = $PSVersionTable.PSversion.ToString()
-                CLR        = $PSVersionTable.CLRVersion.ToString()
+                CLR        = [string]$PSVersionTable.CLRVersion
                 SMO        = ((([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]).TrimStart("Version=")
                 DomainUser = $env:computername -ne $env:USERDOMAIN
                 RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
@@ -110,32 +111,39 @@ function Test-DbaConnection {
                 $remoting = $_
             }
 
-            # Test Connection first using Test-Connection which requires ICMP access then failback to tcp if pings are blocked
+            # Test Connection first using Ping class which requires ICMP access then failback to tcp if pings are blocked
             Write-Message -Level Verbose -Message "Testing ping to $($instance.ComputerName)"
-            $pingable = Test-Connection -ComputerName $instance.ComputerName -Count 1 -Quiet
+            $ping = New-Object System.Net.NetworkInformation.Ping
+            $timeout = 1000 #milliseconds
+            $reply = $ping.Send($instance.ComputerName, $timeout)
+            $pingable = $reply.Status -eq 'Success'
 
+            # this whole section does nothing and returns errors for default instances with a non-default port - baseaddress not defined
+            # commenting it all out
             # SQL Server connection
-            if ($instance.InstanceName -ne "MSSQLSERVER") {
-                #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
-                #$sqlport = "N/A"
-            } else {
-                Write-Message -Level Verbose -Message "Testing raw socket connection to default SQL port"
-                $tcp = New-Object System.Net.Sockets.TcpClient
-                try {
-                    $tcp.Connect($baseaddress, 1433)
-                    $tcp.Close()
-                    $tcp.Dispose()
-                } catch {
-                    # here to avoid an empty catch
-                    $null = 1
-                }
-            }
+            # if ($instance.InstanceName -ne "MSSQLSERVER") {
+            #     #Variable marked as unused by PSScriptAnalyzer, need to be in PSCustomObject?
+            #     #$sqlport = "N/A"
+            # } else {
+            #     Write-Message -Level Verbose -Message "Testing raw socket connection to default SQL port"
+            #     $tcp = New-Object System.Net.Sockets.TcpClient
+            #     try {
+            #         $tcp.Connect($baseaddress, 1433)
+            #         $tcp.Close()
+            #         $tcp.Dispose()
+            #     } catch {
+            #         # here to avoid an empty catch
+            #         $null = 1
+            #     }
+            # }
 
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance.FullSmoName -SqlCredential $SqlCredential
                 $connectSuccess = $true
+                $instanceName = $server.InstanceName
             } catch {
                 $connectSuccess = $false
+                $instanceName = $instance.InstanceName
                 Stop-Function -Message "Issue connection to SQL Server on $instance" -Category ConnectionError -Target $instance -ErrorRecord $_ -Continue
             }
 
@@ -166,7 +174,7 @@ function Test-DbaConnection {
 
             [pscustomobject]@{
                 ComputerName         = $resolved.ComputerName
-                InstanceName         = $instance.InstanceName
+                InstanceName         = $instanceName
                 SqlInstance          = $instance.FullSmoName
                 SqlVersion           = $server.Version
                 ConnectingAsUser     = $username
@@ -185,6 +193,7 @@ function Test-DbaConnection {
                 LocalSMOVersion      = $localInfo.SMO
                 LocalDomainUser      = $localInfo.DomainUser
                 LocalRunAsAdmin      = $localInfo.RunAsAdmin
+                LocalEdition         = $localInfo.Edition
             }
         }
     }

--- a/internal/functions/Resolve-IpAddress.ps1
+++ b/internal/functions/Resolve-IpAddress.ps1
@@ -6,10 +6,11 @@ function Resolve-IpAddress {
         [Alias("ServerInstance", "SqlInstance", "ComputerName", "SqlServer")]
         [object]$Server
     )
-
+    $ping = New-Object System.Net.NetworkInformation.Ping
+    $timeout = 1000 #milliseconds
     if ($Server.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
-        return $ipaddress = ((Test-Connection $Server.ComputerName -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+        return $ping.Send($Server.ComputerName, $timeout).Address.IPAddressToString
     } else {
-        return $ipaddress = ((Test-Connection $server.Split('\')[0] -Count 1 -ErrorAction SilentlyContinue).Ipv4Address).IPAddressToString
+        return $ping.Send($server.Split('\')[0], $timeout).Address.IPAddressToString
     }
 }

--- a/internal/functions/Resolve-SqlIpAddress.ps1
+++ b/internal/functions/Resolve-SqlIpAddress.ps1
@@ -9,6 +9,6 @@ function Resolve-SqlIpAddress {
 
     $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     $servernetbios = $server.ComputerNamePhysicalNetBIOS
-    $ipaddr = (Test-Connection $servernetbios -count 1).Ipv4Address
+    $ipaddr = (Resolve-DbaNetworkName -ComputerName $servernetbios -Turbo).IPAddress
     return $ipaddr
 }

--- a/tests/Resolve-DbaNetworkName.Tests.ps1
+++ b/tests/Resolve-DbaNetworkName.Tests.ps1
@@ -46,6 +46,20 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 $result.FullComputerName | Should -Be ($result.ComputerName + "." + $result.DNSDomain)
             }
         }
+        foreach ($turbo in $true, $false) {
+            It "should test 8.8.8.8 with Turbo = $turbo" {
+                $result = Resolve-DbaNetworkName 8.8.8.8 -EnableException -Turbo:$turbo
+                $result.InputName | Should -Be 8.8.8.8
+                $result.ComputerName | Should -Be google-public-dns-a
+                $result.IPAddress | Should -Be 8.8.8.8
+                $result.DNSHostName | Should -Be google-public-dns-a
+                $result.DNSDomain | Should -Be google.com
+                $result.Domain | Should -Be google.com
+                $result.DNSHostEntry | Should -Be google-public-dns-a.google.com
+                $result.FQDN | Should -Be google-public-dns-a.google.com
+                $result.FullComputerName | Should -Be google-public-dns-a.google.com
+            }
+        }
     }
 }
 <#

--- a/tests/Resolve-DbaNetworkName.Tests.ps1
+++ b/tests/Resolve-DbaNetworkName.Tests.ps1
@@ -15,6 +15,38 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             $params.Count - $defaultParamCount | Should Be $paramCount
         }
     }
+    Context "Testing basic name resolution" {
+        It "should test env:computername" {
+            $result = Resolve-DbaNetworkName $env:computername -EnableException
+            $result.InputName | Should -Be $env:computername
+            $result.ComputerName | Should -Be $env:computername
+            $result.IPAddress | Should -Not -BeNullOrEmpty
+            $result.DNSHostName | Should -Be $env:computername
+            if ($result.DNSDomain) {
+                $result.FullComputerName | Should -Be ($result.ComputerName + "." + $result.DNSDomain)
+            }
+        }
+        It "should test localhost" {
+            $result = Resolve-DbaNetworkName localhost -EnableException
+            $result.InputName | Should -Be localhost
+            $result.ComputerName | Should -Be $env:computername
+            $result.IPAddress | Should -Not -BeNullOrEmpty
+            $result.DNSHostName | Should -Be $env:computername
+            if ($result.DNSDomain) {
+                $result.FullComputerName | Should -Be ($result.ComputerName + "." + $result.DNSDomain)
+            }
+        }
+        It "should test 127.0.0.1" {
+            $result = Resolve-DbaNetworkName 127.0.0.1 -EnableException
+            $result.InputName | Should -Be 127.0.0.1
+            $result.ComputerName | Should -Be $env:computername
+            $result.IPAddress | Should -Not -BeNullOrEmpty
+            $result.DNSHostName | Should -Be $env:computername
+            if ($result.DNSDomain) {
+                $result.FullComputerName | Should -Be ($result.ComputerName + "." + $result.DNSDomain)
+            }
+        }
+    }
 }
 <#
     Integration test should appear below and are custom to the command you are writing.


### PR DESCRIPTION
Let's see how many commands will blow after this one
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4840)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolving issues in the commands relying on Test-Connection function in PS6 and a few other issues I discovered while testing them on PS Core

### Approach
Resolve-DbaNetworkName was rewritten, reducing the number of calls to DNS.
Test-Connection was replaced by 
```powershell
$ping = New-Object System.Net.NetworkInformation.Ping
$timeout = 1000 #milliseconds
$reply = $ping.Send($computer, $timeout)
```
### Commands to test
Resolve-DbaNetworkName

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
Test-Connection is a different beast in PS6.0 and has different set of properties
$PSVersionTable.CLRVersion is null in Core.

