### PR TITLE
Adding support packages to the end of the CI build for debugging purposes

### DIFF
--- a/functions/New-DbatoolsSupportPackage.ps1
+++ b/functions/New-DbatoolsSupportPackage.ps1
@@ -23,6 +23,9 @@ function New-DbatoolsSupportPackage {
         Name of additional variables to attach.
         This allows you to add the content of variables to the support package, if you believe them to be relevant to the case.
 
+    .PARAMETER PassThru
+        Returns file object that was created during execution.
+
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 
@@ -58,6 +61,9 @@ function New-DbatoolsSupportPackage {
 
         [string[]]
         $Variables,
+
+        [switch]
+        $PassThru,
 
         [switch]
         [Alias('Silent')]$EnableException
@@ -161,8 +167,11 @@ This will make it easier for us to troubleshoot and you won't be sending us the 
             $hash["History"] = Get-History
             Write-Message -Level Output -Message "Collecting list of loaded modules (Get-Module)"
             $hash["Modules"] = Get-Module
-            Write-Message -Level Output -Message "Collecting list of loaded snapins (Get-PSSnapin)"
-            $hash["SnapIns"] = Get-PSSnapin
+            # Snapins not supported in Core: https://github.com/PowerShell/PowerShell/issues/6135
+            if ($PSVersionTable.PSEdition -ne 'Core') {
+                Write-Message -Level Output -Message "Collecting list of loaded snapins (Get-PSSnapin)"
+                $hash["SnapIns"] = Get-PSSnapin
+            }
             Write-Message -Level Output -Message "Collecting list of loaded assemblies (Name, Version, and Location)"
             $hash["Assemblies"] = [appdomain]::CurrentDomain.GetAssemblies() | Select-Object CodeBase, FullName, Location, ImageRuntimeVersion, GlobalAssemblyCache, IsDynamic
 
@@ -186,6 +195,9 @@ This will make it easier for us to troubleshoot and you won't be sending us the 
             }
 
             Remove-Item -Path $filePathXml -ErrorAction Ignore
+            if ($PassThru) {
+                Get-Item $filePathZip
+            }
         }
     }
     end {

--- a/tests/New-DbatoolsSupportPackage.Tests.ps1
+++ b/tests/New-DbatoolsSupportPackage.Tests.ps1
@@ -4,10 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        $paramCount = 3
+        $paramCount = 4
         $defaultParamCount = 13
         [object[]]$params = (Get-ChildItem function:\New-DbatoolsSupportPackage).Parameters.Keys
-        $knownParameters = 'Path', 'Variables', 'EnableException'
+        $knownParameters = 'Path', 'Variables', 'EnableException', 'PassThru'
         It "Should contain our specific parameters" {
             ( (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params -IncludeEqual | Where-Object SideIndicator -eq "==").Count ) | Should Be $paramCount
         }

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -331,6 +331,8 @@ if (-not $Finalize) {
         Add-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Running
         $PesterRun = Invoke-Pester @PesterSplat
         $PesterRun | Export-Clixml -Path "$ModuleBase\PesterResults$PSVersion$Counter.xml"
+        # Gather support package as an artifact
+        New-DbatoolsSupportPackage -Path $ModuleBase
         Update-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Passed -Duration $PesterRun.Time.TotalMilliseconds
     }
 } else {
@@ -351,6 +353,8 @@ if (-not $Finalize) {
     #>
     #What failed? How many tests did we run ?
     $results = @(Get-ChildItem -Path "$ModuleBase\PesterResults*.xml" | Import-Clixml)
+    #Publish the support package regardless of the outcome
+    Get-ChildItem $ModuleBase\dbatools_support_pack*.zip | ForEach-Object { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
     #$totalcount = $results | Select-Object -ExpandProperty TotalCount | Measure-Object -Sum | Select-Object -ExpandProperty Sum
     $failedcount = $results | Select-Object -ExpandProperty FailedCount | Measure-Object -Sum | Select-Object -ExpandProperty Sum
     if ($failedcount -gt 0) {

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -340,7 +340,7 @@ if (-not $Finalize) {
         Write-Host -ForegroundColor DarkGreen "Dumping message log into $msgFile"
         Get-DbatoolsLog | Select-Object FunctionName, Level, TimeStamp, Message | Export-Clixml -Path $msgFile -ErrorAction Stop
         Compress-Archive -Path $msgFile -DestinationPath "$msgFile.zip" -ErrorAction Stop
-        Remote-Item $msgFile
+        Remove-Item $msgFile
     } catch {
         Write-Host -ForegroundColor Red "Message collection failed: $($_.Exception.Message)"
     }

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -331,10 +331,10 @@ if (-not $Finalize) {
         Add-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Running
         $PesterRun = Invoke-Pester @PesterSplat
         $PesterRun | Export-Clixml -Path "$ModuleBase\PesterResults$PSVersion$Counter.xml"
-        # Gather support package as an artifact
-        New-DbatoolsSupportPackage -Path $ModuleBase
         Update-AppveyorTest -Name $f.Name -Framework NUnit -FileName $f.FullName -Outcome Passed -Duration $PesterRun.Time.TotalMilliseconds
     }
+    # Gather support package as an artifact
+    New-DbatoolsSupportPackage -Path $ModuleBase
 } else {
     # Unsure why we're uploading so I removed it for now
     <#


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Sometimes I cannot repro issue on my local machine, but appveyor dies without proper explanation.
I want to have an option to download the execution log and see what went wrong.

### Approach
Using New-DbatoolsSupportPackage to create a zip with every possible bit of information and then publish this zip as an appveyor artifact