### PR TITLE
Write-DbaDataTable Give different example

### DIFF
--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -112,7 +112,7 @@ function Write-DbaDataTable {
         PS C:\> $dataset = Invoke-DbaQuery -SqlInstance 'localhost,1417' -SqlCredential $containerCred -Database master -Query $query
         PS C:\> $dataset | Select-Object name, create_date, @{L="owner_sid";E={$_."owner_sid"}} | Write-DbaDataTable -SqlInstance 'localhost,1417' -SqlCredential $containerCred -Database tempdb -Table myTestData -Schema dbo -AutoCreateTable
 
-        Pulls data from a SQL Server instance and then performs a bulk insert of the dataset to the table tempdb.dbo.MyTestData.
+        Pulls data from a SQL Server instance and then performs a bulk insert of the dataset to a new, auto-generated table tempdb.dbo.MyTestData.
 
     .EXAMPLE
         PS C:\> $DataTable = Import-Csv C:\temp\customers.csv

--- a/functions/Write-DbaDataTable.ps1
+++ b/functions/Write-DbaDataTable.ps1
@@ -107,11 +107,12 @@ function Write-DbaDataTable {
         Performs a bulk insert of all the data in customers.csv into database mydb, schema dbo, table customers. A progress bar will be shown as rows are inserted. If the destination table does not exist, the import will be halted.
 
     .EXAMPLE
-        PS C:\> $DataTable = Import-Csv C:\temp\customers.csv
-        PS C:\> $DataTable | Write-DbaDataTable -SqlInstance sql2014 -Table mydb.dbo.customers
+        PS C:\> $tableName = "MyTestData"
+        PS C:\> $query = "SELECT name, create_date, owner_sid FROM sys.databases"
+        PS C:\> $dataset = Invoke-DbaQuery -SqlInstance 'localhost,1417' -SqlCredential $containerCred -Database master -Query $query
+        PS C:\> $dataset | Select-Object name, create_date, @{L="owner_sid";E={$_."owner_sid"}} | Write-DbaDataTable -SqlInstance 'localhost,1417' -SqlCredential $containerCred -Database tempdb -Table myTestData -Schema dbo -AutoCreateTable
 
-        Performs a row by row insert of the data in customers.csv. This is significantly slower than a bulk insert and will not show a progress bar.
-        This method is not recommended. Use -InputObject instead.
+        Pulls data from a SQL Server instance and then performs a bulk insert of the dataset to the table tempdb.dbo.MyTestData.
 
     .EXAMPLE
         PS C:\> $DataTable = Import-Csv C:\temp\customers.csv


### PR DESCRIPTION
No reason to include a "not recommended" example.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Noticed all the examples in this command are using the import command for CSV files. To add a bit of color I'm replacing an example that refers to a method we don't actually recommend using. I see no reason to have that example.

The example provided utilizes `Invoke-DbaQuery` and simply shows pulling a dataset from a given source and writing it to a new table (auto generated).