### PR TITLE
Get-DbaBackupInformation Spelling and format of var names

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -192,12 +192,12 @@ function Get-DbaBackupInformation {
         if ((Test-Bound -Parameter Import) -and ($true -eq $Import)) {
             foreach ($f in $Path) {
                 if (Test-Path -Path $f) {
-                    $GroupResults += Import-CliXml -Path $f
-                    foreach ($group in  $GroupResults) {
-                        $Group.FirstLsn = [BigInt]$group.FirstLSN.ToString()
-                        $Group.CheckpointLSN = [BigInt]$group.CheckpointLSN.ToString()
-                        $Group.DatabaseBackupLsn = [BigInt]$group.DatabaseBackupLsn.ToString()
-                        $Group.LastLsn = [BigInt]$group.LastLsn.ToString()
+                    $groupResults += Import-CliXml -Path $f
+                    foreach ($group in  $groupResults) {
+                        $group.FirstLsn = [BigInt]$group.FirstLSN.ToString()
+                        $group.CheckpointLSN = [BigInt]$group.CheckpointLSN.ToString()
+                        $group.DatabaseBackupLsn = [BigInt]$group.DatabaseBackupLsn.ToString()
+                        $group.LastLsn = [BigInt]$group.LastLsn.ToString()
                     }
                 } else {
                     Write-Message -Message "$f does not exist or is unreadable" -Level Warning
@@ -210,11 +210,11 @@ function Get-DbaBackupInformation {
             if ($NoXpDirTree -ne $true) {
                 foreach ($f in $path) {
                     if ([System.IO.Path]::GetExtension($f).Length -gt 1) {
-                        if ("Fullname" -notin $f.PSobject.Properties.name) {
+                        if ("FullName" -notin $f.PSObject.Properties.name) {
                             $f = $f | Select-Object *, @{ Name = "FullName"; Expression = { $f } }
                         }
                         Write-Message -Message "Testing a single file $f " -Level Verbose
-                        if ((Test-DbaPath -Path $f.fullname -SqlInstance $server)) {
+                        if ((Test-DbaPath -Path $f.FullName -SqlInstance $server)) {
                             $files += $f
                         } else {
                             Write-Message -Level Verbose -Message "$server cannot 'see' file $($f.FullName)"
@@ -239,19 +239,19 @@ function Get-DbaBackupInformation {
                     Write-Message -Level VeryVerbose -Message "Not using sql for $f"
                     if ($f -is [System.IO.FileSystemInfo]) {
                         if ($f.PsIsContainer -eq $true -and $true -ne $MaintenanceSolution) {
-                            Write-Message -Level VeryVerbose -Message "folder $($f.fullname)"
-                            $Files += Get-ChildItem -Path $f.fullname -File -Recurse:$DirectoryRecurse
+                            Write-Message -Level VeryVerbose -Message "folder $($f.FullName)"
+                            $Files += Get-ChildItem -Path $f.FullName -File -Recurse:$DirectoryRecurse
                         } elseif ($f.PsIsContainer -eq $true -and $true -eq $MaintenanceSolution) {
                             if ($IgnoreLogBackup -and $f -notlike '*LOG' ) {
                                 Write-Message -Level Verbose -Message "Skipping Log backups for Maintenance backups"
                             } else {
-                                $Files += Get-ChildItem -Path $f.fullname -File -Recurse:$DirectoryRecurse
+                                $Files += Get-ChildItem -Path $f.FullName -File -Recurse:$DirectoryRecurse
                             }
                         } elseif ($true -eq $MaintenanceSolution) {
-                            $Files += Get-ChildItem -Path $f.fullname -Recurse:$DirectoryRecurse
+                            $Files += Get-ChildItem -Path $f.FullName -Recurse:$DirectoryRecurse
                         } else {
                             Write-Message -Level VeryVerbose -Message "File"
-                            $Files += $f.fullname
+                            $Files += $f.FullName
                         }
                     } else {
                         if ($true -eq $MaintenanceSolution) {
@@ -276,12 +276,12 @@ function Get-DbaBackupInformation {
                 $FileDetails = Read-DbaBackupHeader -SqlInstance $server -Path $Files -AzureCredential $AzureCredential
             }
 
-            $groupdetails = $FileDetails | Group-Object -Property BackupSetGUID
+            $groupDetails = $FileDetails | Group-Object -Property BackupSetGUID
 
-            foreach ($Group in $GroupDetails) {
-                $dblsn = $group.Group[0].DatabaseBackupLSN
-                if (-not $dblsn) {
-                    $dblsn = 0
+            foreach ($group in $groupDetails) {
+                $dbLsn = $group.Group[0].DatabaseBackupLSN
+                if (-not $dbLsn) {
+                    $dbLsn = 0
                 }
                 $description = $group.Group[0].BackupTypeDescription
                 if (-not $description) {
@@ -293,25 +293,25 @@ function Get-DbaBackupInformation {
                     }
                 }
                 $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
-                $historyObject.ComputerName = $group.group[0].MachineName
-                $historyObject.InstanceName = $group.group[0].ServiceName
-                $historyObject.SqlInstance = $group.group[0].ServerName
+                $historyObject.ComputerName = $group.Group[0].MachineName
+                $historyObject.InstanceName = $group.Group[0].ServiceName
+                $historyObject.SqlInstance = $group.Group[0].ServerName
                 $historyObject.Database = $group.Group[0].DatabaseName
                 $historyObject.UserName = $group.Group[0].UserName
                 $historyObject.Start = [DateTime]$group.Group[0].BackupStartDate
                 $historyObject.End = [DateTime]$group.Group[0].BackupFinishDate
                 $historyObject.Duration = ([DateTime]$group.Group[0].BackupFinishDate - [DateTime]$group.Group[0].BackupStartDate)
-                $historyObject.Path = [string[]]$Group.Group.BackupPath
+                $historyObject.Path = [string[]]$group.Group.BackupPath
                 $historyObject.FileList = ($group.Group.FileList | Select-Object Type, LogicalName, PhysicalName -Unique)
-                $historyObject.TotalSize = ($Group.Group.BackupSize.Byte | Measure-Object -Sum).Sum
-                $HistoryObject.CompressedBackupSize = ($Group.Group.CompressedBackupSize.Byte | Measure-Object -Sum).Sum
+                $historyObject.TotalSize = ($group.Group.BackupSize.Byte | Measure-Object -Sum).Sum
+                $HistoryObject.CompressedBackupSize = ($group.Group.CompressedBackupSize.Byte | Measure-Object -Sum).Sum
                 $historyObject.Type = $description
                 $historyObject.BackupSetId = $group.group[0].BackupSetGUID
                 $historyObject.DeviceType = 'Disk'
-                $historyObject.FullName = $Group.Group.BackupPath
+                $historyObject.FullName = $group.Group.BackupPath
                 $historyObject.Position = $group.Group[0].Position
                 $historyObject.FirstLsn = $group.Group[0].FirstLSN
-                $historyObject.DatabaseBackupLsn = $dblsn
+                $historyObject.DatabaseBackupLsn = $dbLsn
                 $historyObject.CheckpointLSN = $group.Group[0].CheckpointLSN
                 $historyObject.LastLsn = $group.Group[0].LastLsn
                 $historyObject.SoftwareVersionMajor = $group.Group[0].SoftwareVersionMajor
@@ -327,20 +327,20 @@ function Get-DbaBackupInformation {
             $groupResults = $groupResults | Where-Object {$_.Database -in $DatabaseName}
         }
         if ($true -eq $Anonymise) {
-            foreach ($group in $GroupResults) {
+            foreach ($group in $groupResults) {
                 $group.ComputerName = Get-HashString -InString $group.ComputerName
                 $group.InstanceName = Get-HashString -InString $group.InstanceName
                 $group.SqlInstance = Get-HashString -InString $group.SqlInstance
                 $group.Database = Get-HashString -InString $group.Database
                 $group.UserName = Get-HashString -InString $group.UserName
-                $group.Path = Get-HashString -InString  $Group.Path
-                $group.FullName = Get-HashString -InString $Group.Fullname
+                $group.Path = Get-HashString -InString  $group.Path
+                $group.FullName = Get-HashString -InString $group.FullName
                 $group.FileList = ($group.FileList | Select-Object Type,
                     @{Name = "LogicalName"; Expression = {Get-HashString -InString $_."LogicalName"}},
                     @{Name = "PhysicalName"; Expression = {Get-HashString -InString $_."PhysicalName"}})
             }
         }
-        if ((Test-Bound -parameterName exportpath) -and $null -ne $ExportPath) {
+        if ((Test-Bound -parameterName ExportPath) -and $null -ne $ExportPath) {
             $groupResults | Export-CliXml -Path $ExportPath -Depth 5 -NoClobber:$NoClobber
             if ($true -ne $PassThru) {
                 return


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3618 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Simply fixing spelling and variable formatting.

Majority of standard was addressed in previous PRs by Stuart.