### PR TITLE
Resetting the restoreresult variable at the top of the database loop.

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -184,6 +184,7 @@ function Test-DbaLastBackup {
             $instance = [DbaInstanceParameter]$source
             $copysuccess = $true
             $dbname = $db.Name
+            $restoreresult = $null
 
             if (-not (Test-Bound -ParameterName Destination)) {
                 $destination = $sourceserver.Name


### PR DESCRIPTION
### Purpose
All databases after a skipped restore are also skipped. This fixes that issue.

### Commands to test
Test-DbaLastBackup -SqlInstance SQL2014.example.com -Destination SQL2014-1 -Prefix test_ -Verbose
