### PR TITLE
Update Test-DbaLastBackup parameter help

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -61,7 +61,7 @@ function Test-DbaLastBackup {
         The name of the SQL Server credential on the destination instance that holds the key to the azure storage account.
 
     .PARAMETER IncludeCopyOnly
-        If this switch is enabled, copy only backups will not be counted as a last backup.
+        If this switch is enabled, copy only backups will be counted as a last backup.
 
     .PARAMETER IgnoreLogBackup
         If this switch is enabled, transaction log backups will be ignored. The restore will stop at the latest full or differential backup point.


### PR DESCRIPTION
Changed -IncludeCopyOnly help from "will not" to "will"

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Current documentation says that if you do not want to include copy-only backups then you should use the switch `-IncludeCopyOnly`.

But the parameter has Include in its name, and a quick check of the code confirms that if you include this switch then it does include copy-only backups.

This change should hopefully make the documentation technically correct which is the best kind of correct ;)

### Approach
<!-- How does this change solve that purpose -->
Makes the documentation clearer to remove the confusion.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Get-Help -Name Test-DbaLastBackup -Parameter IncludeCopyOnly`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
