### PR TITLE
Fixing Set-DbaAgentJob not being able to set some of the values to 0

### DIFF
--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -379,12 +379,12 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($EventLogLevel) {
+            if ($null -ne $EventLogLevel) {
                 Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
                 $currentjob.EventLogLevel = $EventLogLevel
             }
 
-            if ($EmailLevel) {
+            if ($null -ne $EmailLevel) {
                 # Check if the notifiction needs to be removed
                 if ($EmailLevel -eq 0) {
                     # Remove the operator
@@ -403,7 +403,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($NetsendLevel) {
+            if ($null -ne $NetsendLevel) {
                 # Check if the notifiction needs to be removed
                 if ($NetsendLevel -eq 0) {
                     # Remove the operator
@@ -422,7 +422,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($PageLevel) {
+            if ($null -ne $PageLevel) {
                 # Check if the notifiction needs to be removed
                 if ($PageLevel -eq 0) {
                     # Remove the operator
@@ -472,7 +472,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($DeleteLevel) {
+            if ($null -ne $DeleteLevel) {
                 Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
                 $currentjob.DeleteLevel = $DeleteLevel
             }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -379,12 +379,12 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($null -ne $EventLogLevel) {
+            if (Test-Bound -ParameterName EventLogLevel) {
                 Write-Message -Message "Setting job event log level to $EventlogLevel" -Level Verbose
                 $currentjob.EventLogLevel = $EventLogLevel
             }
 
-            if ($null -ne $EmailLevel) {
+            if (Test-Bound -ParameterName EmailLevel) {
                 # Check if the notifiction needs to be removed
                 if ($EmailLevel -eq 0) {
                     # Remove the operator
@@ -403,7 +403,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($null -ne $NetsendLevel) {
+            if (Test-Bound -ParameterName NetsendLevel) {
                 # Check if the notifiction needs to be removed
                 if ($NetsendLevel -eq 0) {
                     # Remove the operator
@@ -422,7 +422,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($null -ne $PageLevel) {
+            if (Test-Bound -ParameterName PageLevel) {
                 # Check if the notifiction needs to be removed
                 if ($PageLevel -eq 0) {
                     # Remove the operator
@@ -472,7 +472,7 @@ function Set-DbaAgentJob {
                 }
             }
 
-            if ($null -ne $DeleteLevel) {
+            if (Test-Bound -ParameterName DeleteLevel) {
                 Write-Message -Message "Setting job delete level to $DeleteLevel" -Level Verbose
                 $currentjob.DeleteLevel = $DeleteLevel
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4927)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow setting some values to 0

### Approach
`if($null -ne $value)` instead of `if ($value)`

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
