### PR TITLE
Added the ability to set the default database to Set-DbaLogin

### DIFF
--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -18,6 +18,9 @@ function Set-DbaLogin {
     .PARAMETER SecurePassword
         The new password for the login This can be either a credential or a secure string.
 
+    .PARAMETER DefaultDatabase
+        Default database for the login
+
     .PARAMETER Unlock
         Switch to unlock an account. This will only be used in conjunction with the -SecurePassword parameter.
         The default is false.
@@ -141,6 +144,11 @@ function Set-DbaLogin {
 
         Disable the login from the pipeline
 
+    .EXAMPLE
+        PS C:\> Set-DbaLogin -SqlInstance sql1 -Login login1 -DefaultDatabase master
+
+        Set the default database to master on a login
+
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
@@ -152,6 +160,8 @@ function Set-DbaLogin {
         [string[]]$Login,
         [Alias("Password")]
         [object]$SecurePassword, #object so that it can accept credential or securestring
+        [Alias("DefaulDB")]
+        [string]$DefaultDatabase,
         [switch]$Unlock,
         [switch]$MustChange,
         [string]$NewName,
@@ -328,6 +338,16 @@ function Set-DbaLogin {
                             $notes += "Couldn't remove role $role"
                             Stop-Function -Message "Something went wrong removing role $role to $l" -Target $l -ErrorRecord $_ -Continue
                         }
+                    }
+                }
+                
+                # Set the default database
+                if (Test-Bound -ParameterName 'DefaultDatabase') {
+                    if ($l.DefaultDatabase -eq $DefaultDatabase) {
+                        Write-Message -Message "Login $l default database is already set to $($l.DefaultDatabase)" -Level Verbose
+                    }
+                    else {
+                        $l.DefaultDatabase = $DefaultDatabase
                     }
                 }
 

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -160,7 +160,7 @@ function Set-DbaLogin {
         [string[]]$Login,
         [Alias("Password")]
         [object]$SecurePassword, #object so that it can accept credential or securestring
-        [Alias("DefaulDB")]
+        [Alias("DefaultDB")]
         [string]$DefaultDatabase,
         [switch]$Unlock,
         [switch]$MustChange,
@@ -345,8 +345,7 @@ function Set-DbaLogin {
                 if (Test-Bound -ParameterName 'DefaultDatabase') {
                     if ($l.DefaultDatabase -eq $DefaultDatabase) {
                         Write-Message -Message "Login $l default database is already set to $($l.DefaultDatabase)" -Level Verbose
-                    }
-                    else {
+                    } else {
                         $l.DefaultDatabase = $DefaultDatabase
                     }
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->

Adds the ability to set the default database with the Set-DbaLogin command.

Adds a DefaultDatabase parameter and help based off of the DefaultDatabase parameter from New-DbaLogin.

See the help for how to use this new parameter.

![image](https://user-images.githubusercontent.com/6719572/50985397-d372aa00-14c9-11e9-97f2-3ba1ad2bcdfa.png)

The databases variable contains a list of databases on the specified SQL Server. The command shown in the image sets the default database to master for all users who are set to a database that does not exist.
