### PR TITLE
Corrected typo in DefaultDB parameter alias

### DIFF
--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -142,7 +142,7 @@ function New-DbaLogin {
         [string]$MapToAsymmetricKey,
         [string]$MapToCredential,
         [object]$Sid,
-        [Alias("DefaulDB")]
+        [Alias("DefaultDB")]
         [parameter(ParameterSetName = "Password")]
         [parameter(ParameterSetName = "PasswordHash")]
         [string]$DefaultDatabase,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Corrected typo in DefaultDB parameter alias.