### PR TITLE
ApplicationIntent fixes

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -352,6 +352,9 @@ function Connect-DbaInstance {
                 if (Test-Bound -ParameterName 'WorkstationId') {
                     $server.ConnectionContext.WorkstationId = $WorkstationId
                 }
+                if (Test-Bound -ParameterName 'ApplicationIntent') {
+                    $server.ConnectionContext.ApplicationIntent = $ApplicationIntent
+                }
 
                 $connstring = $server.ConnectionContext.ConnectionString
                 if (Test-Bound -ParameterName 'MultiSubnetFailover') {
@@ -359,9 +362,6 @@ function Connect-DbaInstance {
                 }
                 if (Test-Bound -ParameterName 'FailoverPartner') {
                     $connstring = "$connstring;Failover Partner=$FailoverPartner"
-                }
-                if (Test-Bound -ParameterName 'ApplicationIntent') {
-                    $connstring = "$connstring;ApplicationIntent=$ApplicationIntent"
                 }
 
                 if ($connstring -ne $server.ConnectionContext.ConnectionString) {

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -297,8 +297,14 @@ function Invoke-DbaQuery {
         }
         foreach ($instance in $SqlInstance) {
             try {
-                $intent = if ($ReadOnly) { "ReadOnly" } else { "ReadWrite" }
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -ApplicationIntent $intent
+                $connDbaInstanceParams = @{
+                    SqlInstance   = $instance
+                    SqlCredential = $SqlCredential
+                }
+                if ($ReadOnly) {
+                    $connDbaInstanceParams.ApplicationIntent = "ReadOnly"
+                }
+                $server = Connect-DbaInstance @connDbaInstanceParams
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4946)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing ApplicationIntent that causes authentication failures 

### Approach
ApplicationIntent is now set as a parameter, not inside the connection string.
With that said, setting one of MultiSubnetFailover and FailoverPartner parameters will cause the same exact issues when used together with SqlCredential.

### Commands to test
Invoke-DbaQuery -ReadOnly:$true/$false
Connect-DbaIntsance -ApplicationIntent Readonly

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
