### PR TITLE
Update Install-DbaMaintenanceSolution.ps1 #4950

### DIFF
--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -234,7 +234,7 @@ function Install-DbaMaintenanceSolution {
                 }
 
                 # OutputFileDirectory
-                if (-not $OutputFileDirectory) {
+                if ($OutputFileDirectory) {
                     $findOutputFileDirectory = 'SET @OutputFileDirectory = NULL'
                     $replaceOutputFileDirectory = 'SET @OutputFileDirectory = N''' + $OutputFileDirectory + ''''
                     $fileContents[$file] = $fileContents[$file].Replace($findOutputFileDirectory, $replaceOutputFileDirectory)


### PR DESCRIPTION
Fixed path for output directory in Install-DbaMaintenanceSolution #4950

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #4950)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Bug fix
### Approach
Fixed error in if statement for outputfiledirectory. Removed -not in if statement.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

$ServerInstance = 'MyServer'
[SWITCH]$InstallJobs = $true
$BackupPath = 'C:\Data\Backup'

Install-DbaMaintenanceSolution -SqlInstance $ServerInstance -Database maintenance -ReplaceExisting -InstallJobs:$InstallJobs -LogToTable -BackupLocation $BackupPath -CleanupTime 65 -Verbose

Expects maintenance jobs to be created with a path in the outputfile.