### PR TITLE
Changed names of jobs and schedules. Fixes #4972

### DIFF
--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -1357,7 +1357,7 @@ function Invoke-DbaDbLogShipping {
                 if ($CopyJob) {
                     $DatabaseCopyJob = "$($CopyJob)$($db.Name))"
                 } else {
-                    $DatabaseCopyJob = "LSCopy_$($db.Name)"
+                    $DatabaseCopyJob = "LSCopy_$($SourceServerName)_$($db.Name)"
                 }
                 Write-Message -Message "Copy job name set to $DatabaseCopyJob" -Level Verbose
 
@@ -1365,7 +1365,7 @@ function Invoke-DbaDbLogShipping {
                 if ($CopySchedule) {
                     $DatabaseCopySchedule = "$($CopySchedule)$($db.Name)"
                 } else {
-                    $DatabaseCopySchedule = "LSCopySchedule_$($db.Name)"
+                    $DatabaseCopySchedule = "LSCopySchedule_$($SourceServerName)_$($db.Name)"
                     Write-Message -Message "Copy job schedule name set to $DatabaseCopySchedule" -Level Verbose
                 }
 
@@ -1392,7 +1392,7 @@ function Invoke-DbaDbLogShipping {
                 if ($RestoreJob) {
                     $DatabaseRestoreJob = "$($RestoreJob)$($db.Name)"
                 } else {
-                    $DatabaseRestoreJob = "LSRestore_$($db.Name)"
+                    $DatabaseRestoreJob = "LSRestore_$($SourceServerName)_$($db.Name)"
                 }
                 Write-Message -Message "Restore job name set to $DatabaseRestoreJob" -Level Verbose
 
@@ -1400,7 +1400,7 @@ function Invoke-DbaDbLogShipping {
                 if ($RestoreSchedule) {
                     $DatabaseRestoreSchedule = "$($RestoreSchedule)$($db.Name)"
                 } else {
-                    $DatabaseRestoreSchedule = "LSRestoreSchedule_$($db.Name)"
+                    $DatabaseRestoreSchedule = "LSRestoreSchedule_$($SourceServerName)_$($db.Name)"
                 }
                 Write-Message -Message "Restore job schedule name set to $DatabaseRestoreSchedule" -Level Verbose
 

--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -1165,7 +1165,7 @@ function Invoke-DbaDbLogShipping {
 
                 # Check if the backup job name is set
                 if ($BackupJob) {
-                    $DatabaseBackupJob = "$BackupJob_$($db.Name)"
+                    $DatabaseBackupJob = "$($BackupJob)$($db.Name)"
                 } else {
                     $DatabaseBackupJob = "LSBackup_$($db.Name)"
                 }
@@ -1173,7 +1173,7 @@ function Invoke-DbaDbLogShipping {
 
                 # Check if the backup job schedule name is set
                 if ($BackupSchedule) {
-                    $DatabaseBackupSchedule = "$BackupSchedule_$($db.Name)"
+                    $DatabaseBackupSchedule = "$($BackupSchedule)$($db.Name)"
                 } else {
                     $DatabaseBackupSchedule = "LSBackupSchedule_$($db.Name)"
                 }
@@ -1355,15 +1355,15 @@ function Invoke-DbaDbLogShipping {
 
                 # Check if the copy job name is set
                 if ($CopyJob) {
-                    $DatabaseCopyJob = "$CopyJob_$SourceServerName_$($db.Name)"
+                    $DatabaseCopyJob = "$($CopyJob)$($db.Name))"
                 } else {
-                    $DatabaseCopyJob = "LSCopy_$SourceServerName_$($db.Name)"
+                    $DatabaseCopyJob = "LSCopy_$($db.Name)"
                 }
                 Write-Message -Message "Copy job name set to $DatabaseCopyJob" -Level Verbose
 
                 # Check if the copy job schedule name is set
                 if ($CopySchedule) {
-                    $DatabaseCopySchedule = "$CopySchedule_$($db.Name)"
+                    $DatabaseCopySchedule = "$($CopySchedule)$($db.Name)"
                 } else {
                     $DatabaseCopySchedule = "LSCopySchedule_$($db.Name)"
                     Write-Message -Message "Copy job schedule name set to $DatabaseCopySchedule" -Level Verbose
@@ -1390,15 +1390,15 @@ function Invoke-DbaDbLogShipping {
 
                 # Check if the restore job name is set
                 if ($RestoreJob) {
-                    $DatabaseRestoreJob = "$RestoreJob_$SourceServerName_$($db.Name)"
+                    $DatabaseRestoreJob = "$($RestoreJob)$($db.Name)"
                 } else {
-                    $DatabaseRestoreJob = "LSRestore_$DestinationServerName_$($db.Name)"
+                    $DatabaseRestoreJob = "LSRestore_$($db.Name)"
                 }
                 Write-Message -Message "Restore job name set to $DatabaseRestoreJob" -Level Verbose
 
                 # Check if the restore job schedule name is set
                 if ($RestoreSchedule) {
-                    $DatabaseRestoreSchedule = "$RestoreSchedule_$($db.Name)"
+                    $DatabaseRestoreSchedule = "$($RestoreSchedule)$($db.Name)"
                 } else {
                     $DatabaseRestoreSchedule = "LSRestoreSchedule_$($db.Name)"
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4972)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The names of the jobs were not formatted correctly when setting the name. The schedules names are also fixed now having the same naming convention as the job names.

### Approach
Removed the server name from the job names. The user can now include the name of the server if they like by using the -BackupJob, -CopyJob and -RestoreJob parameters.

### Commands to test
Invoke-DbaDbLogShipping


