### PR TITLE
Fix the output mismatch with continuing restores

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -175,7 +175,7 @@ function Format-DbaBackupInformation {
                 }
             }
             $History.Database = $DatabaseNamePrefix + $History.Database
-            if ($true -ne $Continue) {
+          #  if ($true -ne $Continue) {
                 $History.FileList | ForEach-Object {
                     if ($null -ne $FileMapping ) {
                         if ($null -ne $FileMapping[$_.LogicalName]) {
@@ -210,7 +210,7 @@ function Format-DbaBackupInformation {
                         Write-Message -Message "PhysicalName = $($_.PhysicalName) " -Level Verbose
                     }
                 }
-            }
+           # }
             if ('' -ne $RebaseBackupFolder -and $History.FullName[0] -notmatch 'http') {
                 Write-Message -Message 'Rebasing backup files' -Level Verbose
 

--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -175,42 +175,41 @@ function Format-DbaBackupInformation {
                 }
             }
             $History.Database = $DatabaseNamePrefix + $History.Database
-          #  if ($true -ne $Continue) {
-                $History.FileList | ForEach-Object {
-                    if ($null -ne $FileMapping ) {
-                        if ($null -ne $FileMapping[$_.LogicalName]) {
-                            $_.PhysicalName = $FileMapping[$_.LogicalName]
-                        }
-                    } else {
-                        if ($ReplaceDbNameInFile -eq $true) {
-                            $_.PhysicalName = $_.PhysicalName -Replace $History.OriginalDatabase, $History.Database
-                        }
-                        Write-Message -Message " 1 PhysicalName = $($_.PhysicalName) " -Level Verbose
-                        $Pname = [System.Io.FileInfo]$_.PhysicalName
-                        $RestoreDir = $Pname.DirectoryName
-                        if ($_.Type -eq 'D' -or $_.FileType -eq 'D') {
-                            if ('' -ne $DataFileDirectory) {
-                                $RestoreDir = $DataFileDirectory
-                            }
-                        } elseif ($_.Type -eq 'L' -or $_.FileType -eq 'L') {
-                            if ('' -ne $LogFileDirectory) {
-                                $RestoreDir = $LogFileDirectory
-                            } elseif ('' -ne $DataFileDirectory) {
-                                $RestoreDir = $DataFileDirectory
-                            }
-                        } elseif ($_.Type -eq 'S' -or $_.FileType -eq 'S') {
-                            if ('' -ne $DestinationFileStreamDirectory) {
-                                $RestoreDir = $DestinationFileStreamDirectory
-                            } elseif ('' -ne $DataFileDirectory) {
-                                $RestoreDir = $DataFileDirectory
-                            }
-                        }
 
-                        $_.PhysicalName = $RestoreDir + $PathSep + $DatabaseFilePrefix + $Pname.BaseName + $DatabaseFileSuffix + $Pname.extension
-                        Write-Message -Message "PhysicalName = $($_.PhysicalName) " -Level Verbose
+            $History.FileList | ForEach-Object {
+                if ($null -ne $FileMapping ) {
+                    if ($null -ne $FileMapping[$_.LogicalName]) {
+                        $_.PhysicalName = $FileMapping[$_.LogicalName]
                     }
+                } else {
+                    if ($ReplaceDbNameInFile -eq $true) {
+                        $_.PhysicalName = $_.PhysicalName -Replace $History.OriginalDatabase, $History.Database
+                    }
+                    Write-Message -Message " 1 PhysicalName = $($_.PhysicalName) " -Level Verbose
+                    $Pname = [System.Io.FileInfo]$_.PhysicalName
+                    $RestoreDir = $Pname.DirectoryName
+                    if ($_.Type -eq 'D' -or $_.FileType -eq 'D') {
+                        if ('' -ne $DataFileDirectory) {
+                            $RestoreDir = $DataFileDirectory
+                        }
+                    } elseif ($_.Type -eq 'L' -or $_.FileType -eq 'L') {
+                        if ('' -ne $LogFileDirectory) {
+                            $RestoreDir = $LogFileDirectory
+                        } elseif ('' -ne $DataFileDirectory) {
+                            $RestoreDir = $DataFileDirectory
+                        }
+                    } elseif ($_.Type -eq 'S' -or $_.FileType -eq 'S') {
+                        if ('' -ne $DestinationFileStreamDirectory) {
+                            $RestoreDir = $DestinationFileStreamDirectory
+                        } elseif ('' -ne $DataFileDirectory) {
+                            $RestoreDir = $DataFileDirectory
+                        }
+                    }
+
+                    $_.PhysicalName = $RestoreDir + $PathSep + $DatabaseFilePrefix + $Pname.BaseName + $DatabaseFileSuffix + $Pname.extension
+                    Write-Message -Message "PhysicalName = $($_.PhysicalName) " -Level Verbose
                 }
-           # }
+            }
             if ('' -ne $RebaseBackupFolder -and $History.FullName[0] -notmatch 'http') {
                 Write-Message -Message 'Rebasing backup files' -Level Verbose
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4922)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
On a continue restore the destinationfolder in the output was not being updated properly and the original file location was being reported

### Approach
remove the test in Format-DbaBackup as the change will be overridden in Invoke-DbaAdvancedRestore anyway

