### PR TITLE
SQLSat818 - Changes to Export-DbaScript to resolve Issue 2914

### DIFF
--- a/functions/Set-DbaDbState.ps1
+++ b/functions/Set-DbaDbState.ps1
@@ -481,7 +481,7 @@ function Set-DbaDbState {
                     # we avoid reenumerating properties
                     $newstate = $db_status
                 } else {
-                    $newstate = Get-DbState -databaseName $db.Name -dbStatuses $stateCache[$server]
+                    $newstate = Get-DbState -databaseName $db.Name -dbStatuses $dbStatuses[$server]
                 }
 
                 [PSCustomObject]@{


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #2914)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issue 2914 

### Approach
Command had an undeclared variable $stateCache[$server] at line 484. Replaced with 


### Commands to test
Set-DbaDbState

### Learning
Done live as part of SQLSaturday 818 presentation on Git and Github
