### PR TITLE
Fix Set-DbaAgentJobStep 

### DIFF
--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -163,7 +163,6 @@ function Set-DbaAgentJobStep {
         [string[]]$Flag,
         [string]$ProxyName,
         [parameter(ValueFromPipeline)]
-        #[Microsoft.SqlServer.Management.Smo.Agent.JobStep[]]$InputObject,
         [Microsoft.SqlServer.Management.Smo.Agent.JobStep[]]$InputObject,
         [Alias('Silent')]
         [switch]$EnableException,
@@ -209,7 +208,7 @@ function Set-DbaAgentJobStep {
             foreach ($j in $Job) {
 
                 # Check if the job exists
-                if ($server.JobServer.Jobs.Name -notcontains $j) {
+                if ($server.JobServer.Jobs.Name -notcontains $j.Name) {
                     Stop-Function -Message "Job $j doesn't exists on $instance" -Target $instance
                 } else {
                     # Get the job step

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -26,6 +26,9 @@ function Set-DbaAgentJobStep {
         The subsystem used by the SQL Server Agent service to execute command.
         Allowed values 'ActiveScripting','AnalysisCommand','AnalysisQuery','CmdExec','Distribution','LogReader','Merge','PowerShell','QueueReader','Snapshot','Ssis','TransactSql'
 
+    .PARAMETER SubSystemServer
+        The subsystems AnalysisScripting, AnalysisCommand, AnalysisQuery ned the server property to be able to apply
+
     .PARAMETER Command
         The commands to be executed by SQLServerAgent service through subsystem.
 
@@ -146,6 +149,7 @@ function Set-DbaAgentJobStep {
         [string]$NewName,
         [ValidateSet('ActiveScripting', 'AnalysisCommand', 'AnalysisQuery', 'CmdExec', 'Distribution', 'LogReader', 'Merge', 'PowerShell', 'QueueReader', 'Snapshot', 'Ssis', 'TransactSql')]
         [string]$Subsystem,
+        [string]$SubsystemServer,
         [string]$Command,
         [int]$CmdExecSuccessCode,
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
@@ -290,6 +294,15 @@ function Set-DbaAgentJobStep {
                     } else {
                         Write-Message -Message "Setting job step subsystem to $($currentJobStep.SubSystem)" -Level Verbose
                         $JobStep.Subsystem = $currentJobStep.Subsystem
+                    }
+
+                    if ($SubsystemServer) {
+                        Write-Message -Message "Setting job step subsystem server to $SubsystemServer" -Level Verbose
+                        $JobStep.Server = $SubsystemServer
+                    }
+                    else {
+                        Write-Message -Message "Setting job step subsystem server to $($currentJobStep.Server)" -Level Verbose
+                        $JobStep.Server = $currentJobStep.Server
                     }
 
                     if ($Command) {

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -224,11 +224,11 @@ function Set-DbaAgentJobStep {
             }
         }
 
-        if($Job){
+        if ($Job) {
             $InputObject = $InputObject | Where-Object {$_.Parent.Name -in $Job}
         }
 
-        if($StepName){
+        if ($StepName) {
             $InputObject = $InputObject | Where-Object Name -in $StepName
         }
 
@@ -241,14 +241,13 @@ function Set-DbaAgentJobStep {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            foreach($currentJobStep in $InputObject){
+            foreach ($currentJobStep in $InputObject) {
                 if (-not $Force -and ($Server.JobServer.Jobs[$currentJobStep.Parent.Name].JobSteps.Name -notcontains $currentJobStep.Name)) {
                     Stop-Function -Message "Step $StepName doesn't exists for job $j" -Target $instance -Continue
-                }
-                elseif($Force -and ($Server.JobServer.Jobs[$currentJobStep.Parent.Name].JobSteps.Name -notcontains $currentJobStep.Name)) {
+                } elseif ($Force -and ($Server.JobServer.Jobs[$currentJobStep.Parent.Name].JobSteps.Name -notcontains $currentJobStep.Name)) {
                     Write-Message -Message "Adding job step $($currentJobStep.Name) to $($currentJobStep.Parent.Name) on $instance" -Level Verbose
 
-                    try{
+                    try {
                         New-DbaAgentJobStep -SqlInstance $instance -SqlCredential $SqlCredential `
                             -Job $currentJobStep.Parent.Name `
                             -StepId $currentJobStep.ID `
@@ -269,13 +268,11 @@ function Set-DbaAgentJobStep {
                             -Flag $currentJobStep.Flag `
                             -ProxyName $currentJobStep.ProxyName `
                             -EnableException
-                    }
-                    catch{
+                    } catch {
                         Stop-Function -Message "Something went wrong creating the job step" -Target $instance -ErrorRecord $_ -Continue
                     }
 
-                }
-                else{
+                } else {
                     $JobStep = $server.JobServer.Jobs[$currentJobStep.Parent.Name].JobSteps[$currentJobStep.Name]
 
                     Write-Message -Message "Modifying job $j on $instance" -Level Verbose
@@ -290,8 +287,7 @@ function Set-DbaAgentJobStep {
                     if ($Subsystem) {
                         Write-Message -Message "Setting job step subsystem to $Subsystem" -Level Verbose
                         $JobStep.Subsystem = $Subsystem
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step subsystem to $($currentJobStep.SubSystem)" -Level Verbose
                         $JobStep.Subsystem = $currentJobStep.Subsystem
                     }
@@ -299,8 +295,7 @@ function Set-DbaAgentJobStep {
                     if ($Command) {
                         Write-Message -Message "Setting job step command to $Command" -Level Verbose
                         $JobStep.Command = $Command
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step command to $($currentJobStep.Command)" -Level Verbose
                         $JobStep.Command = $currentJobStep.Command
                     }
@@ -308,8 +303,7 @@ function Set-DbaAgentJobStep {
                     if ($CmdExecSuccessCode) {
                         Write-Message -Message "Setting job step command exec success code to $CmdExecSuccessCode" -Level Verbose
                         $JobStep.CommandExecutionSuccessCode = $CmdExecSuccessCode
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step command exec success code to $($currentJobStep.CommandExecutionSuccessCode)" -Level Verbose
                         $JobStep.CommandExecutionSuccessCode = $currentJobStep.CommandExecutionSuccessCode
                     }
@@ -317,8 +311,7 @@ function Set-DbaAgentJobStep {
                     if ($OnSuccessAction) {
                         Write-Message -Message "Setting job step success action to $OnSuccessAction" -Level Verbose
                         $JobStep.OnSuccessAction = $OnSuccessAction
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step success action to $($currentJobStep.OnSuccessAction)" -Level Verbose
                         $JobStep.OnSuccessAction = $currentJobStep.OnSuccessAction
                     }
@@ -326,8 +319,7 @@ function Set-DbaAgentJobStep {
                     if ($OnSuccessStepId) {
                         Write-Message -Message "Setting job step success step id to $OnSuccessStepId" -Level Verbose
                         $JobStep.OnSuccessStep = $OnSuccessStepId
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step success step id to $($currentJobStep.OnSuccessStep)" -Level Verbose
                         $JobStep.OnSuccessStep = $currentJobStep.OnSuccessStep
                     }
@@ -335,8 +327,7 @@ function Set-DbaAgentJobStep {
                     if ($OnFailAction) {
                         Write-Message -Message "Setting job step fail action to $OnFailAction" -Level Verbose
                         $JobStep.OnFailAction = $OnFailAction
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step fail action to $($currentJobStep.OnFailAction)" -Level Verbose
                         $JobStep.OnFailAction = $currentJobStep.OnFailAction
                     }
@@ -344,8 +335,7 @@ function Set-DbaAgentJobStep {
                     if ($OnFailStepId) {
                         Write-Message -Message "Setting job step fail step id to $OnFailStepId" -Level Verbose
                         $JobStep.OnFailStep = $OnFailStepId
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step fail step id to $($currentJobStep.OnFailStep)" -Level Verbose
                         $JobStep.OnFailStep = $currentJobStep.OnFailStep
                     }
@@ -358,8 +348,7 @@ function Set-DbaAgentJobStep {
                         } else {
                             Stop-Function -Message "The database is not present on instance $instance." -Target $instance -Continue
                         }
-                    }
-                    else {
+                    } else {
                         # Check if the database is present on the server
                         if ($server.Databases.Name -contains $currentJobStep.DatabaseName) {
                             Write-Message -Message "Setting job step database name to $($currentJobStep.DatabaseName)" -Level Verbose
@@ -371,28 +360,26 @@ function Set-DbaAgentJobStep {
 
                     if (($DatabaseUser) -and ($Database)) {
                         # Check if the username is present in the database
-                        if ($Server.Databases[$Database].Users.Name -contains $DatabaseUser) {
+                        if ($Server.Databases[$currentJobStep.DatabaseName].Users.Name -contains $DatabaseUser) {
                             Write-Message -Message "Setting job step database username to $DatabaseUser" -Level Verbose
                             $JobStep.DatabaseUserName = $DatabaseUser
                         } else {
-                            Stop-Function -Message "The database user is not present in the database $Database on instance $instance." -Target $instance -Continue
+                            Stop-Function -Message "The database user is not present in the database $($currentJobStep.DatabaseName) on instance $instance." -Target $instance -Continue
                         }
-                    }
-                    else {
+                    } elseif($currentJobStep.DatabaseUserName) {
                         # Check if the username is present in the database
-                        if ($Server.Databases[$Database].Users.Name -contains $currentJobStep.DatabaseUserName) {
+                        if ($Server.Databases[$currentJobStep.DatabaseName].Users.Name -contains $currentJobStep.DatabaseUserName) {
                             Write-Message -Message "Setting job step database username to $($currentJobStep.DatabaseUserName)" -Level Verbose
                             $JobStep.DatabaseUserName = $currentJobStep.DatabaseUserName
                         } else {
-                            Stop-Function -Message "The database user is not present in the database $Database on instance $instance." -Target $instance -Continue
+                            Stop-Function -Message "The database user is not present in the database $($currentJobStep.DatabaseName) on instance $instance." -Target $instance -Continue
                         }
                     }
 
                     if ($RetryAttempts) {
                         Write-Message -Message "Setting job step retry attempts to $RetryAttempts" -Level Verbose
                         $JobStep.RetryAttempts = $RetryAttempts
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step retry attempts to $($currentJobStep.RetryAttempts)" -Level Verbose
                         $JobStep.RetryAttempts = $currentJobStep.RetryAttempts
                     }
@@ -400,8 +387,7 @@ function Set-DbaAgentJobStep {
                     if ($RetryInterval) {
                         Write-Message -Message "Setting job step retry interval to $RetryInterval" -Level Verbose
                         $JobStep.RetryInterval = $RetryInterval
-                    }
-                   else {
+                    } else {
                         Write-Message -Message "Setting job step retry interval to $($currentJobStep.RetryInterval)" -Level Verbose
                         $JobStep.RetryInterval = $currentJobStep.RetryInterval
                     }
@@ -409,8 +395,7 @@ function Set-DbaAgentJobStep {
                     if ($OutputFileName) {
                         Write-Message -Message "Setting job step output file name to $OutputFileName" -Level Verbose
                         $JobStep.OutputFileName = $OutputFileName
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step output file name to $($currentJobStep.OutputFileName)" -Level Verbose
                         $JobStep.OutputFileName = $currentJobStep.OutputFileName
                     }
@@ -423,22 +408,20 @@ function Set-DbaAgentJobStep {
                         } else {
                             Stop-Function -Message "The proxy name $ProxyName doesn't exist on instance $instance." -Target $instance -Continue
                         }
-                    }
-                    else {
+                    } elseif($currentJobStep.ProxyName) {
                         # Check if the proxy exists
-                        if ($Server.JobServer.ProxyAccounts.Name -contains $ProxyName) {
+                        if ($Server.JobServer.ProxyAccounts.Name -contains $currentJobStep.ProxyName) {
                             Write-Message -Message "Setting job step proxy name to $($currentJobStep.ProxyName)" -Level Verbose
                             $JobStep.ProxyName = $ProxyName
                         } else {
-                            Stop-Function -Message "The proxy name $ProxyName doesn't exist on instance $instance." -Target $instance -Continue
+                            Stop-Function -Message "The proxy name $($currentJobStep.ProxyName) doesn't exist on instance $instance." -Target $instance -Continue
                         }
                     }
 
                     if ($Flag.Count -ge 1) {
                         Write-Message -Message "Setting job step flag(s) to $($Flags -join ',')" -Level Verbose
                         $JobStep.JobStepFlags = $Flag
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step flag(s) to $($currentJobStep.JobStepFlags -join ',')" -Level Verbose
                         $JobStep.JobStepFlags = $currentJobStep.JobStepFlags
                     }

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -88,6 +88,9 @@ function Set-DbaAgentJobStep {
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
+    .PARAMETER InputObject
+        Enables piping job objects
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -299,7 +299,7 @@ function Set-DbaAgentJobStep {
                     if ($SubsystemServer) {
                         Write-Message -Message "Setting job step subsystem server to $SubsystemServer" -Level Verbose
                         $JobStep.Server = $SubsystemServer
-                    } else {
+                    } elseif($currentJobStep.Server) {
                         Write-Message -Message "Setting job step subsystem server to $($currentJobStep.Server)" -Level Verbose
                         $JobStep.Server = $currentJobStep.Server
                     }

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -299,8 +299,7 @@ function Set-DbaAgentJobStep {
                     if ($SubsystemServer) {
                         Write-Message -Message "Setting job step subsystem server to $SubsystemServer" -Level Verbose
                         $JobStep.Server = $SubsystemServer
-                    }
-                    else {
+                    } else {
                         Write-Message -Message "Setting job step subsystem server to $($currentJobStep.Server)" -Level Verbose
                         $JobStep.Server = $currentJobStep.Server
                     }
@@ -379,7 +378,7 @@ function Set-DbaAgentJobStep {
                         } else {
                             Stop-Function -Message "The database user is not present in the database $($currentJobStep.DatabaseName) on instance $instance." -Target $instance -Continue
                         }
-                    } elseif($currentJobStep.DatabaseUserName) {
+                    } elseif ($currentJobStep.DatabaseUserName) {
                         # Check if the username is present in the database
                         if ($Server.Databases[$currentJobStep.DatabaseName].Users.Name -contains $currentJobStep.DatabaseUserName) {
                             Write-Message -Message "Setting job step database username to $($currentJobStep.DatabaseUserName)" -Level Verbose
@@ -421,7 +420,7 @@ function Set-DbaAgentJobStep {
                         } else {
                             Stop-Function -Message "The proxy name $ProxyName doesn't exist on instance $instance." -Target $instance -Continue
                         }
-                    } elseif($currentJobStep.ProxyName) {
+                    } elseif ($currentJobStep.ProxyName) {
                         # Check if the proxy exists
                         if ($Server.JobServer.ProxyAccounts.Name -contains $currentJobStep.ProxyName) {
                             Write-Message -Message "Setting job step proxy name to $($currentJobStep.ProxyName)" -Level Verbose

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -283,35 +283,63 @@ function Set-DbaAgentJobStep {
                         Write-Message -Message "Setting job step subsystem to $Subsystem" -Level Verbose
                         $JobStep.Subsystem = $Subsystem
                     }
+                    else {
+                        Write-Message -Message "Setting job step subsystem to $($currentJobStep.SubSystem)" -Level Verbose
+                        $JobStep.Subsystem = $currentJobStep.Subsystem
+                    }
 
                     if ($Command) {
                         Write-Message -Message "Setting job step command to $Command" -Level Verbose
                         $JobStep.Command = $Command
+                    }
+                    else {
+                        Write-Message -Message "Setting job step command to $($currentJobStep.Command)" -Level Verbose
+                        $JobStep.Command = $currentJobStep.Command
                     }
 
                     if ($CmdExecSuccessCode) {
                         Write-Message -Message "Setting job step command exec success code to $CmdExecSuccessCode" -Level Verbose
                         $JobStep.CommandExecutionSuccessCode = $CmdExecSuccessCode
                     }
+                    else {
+                        Write-Message -Message "Setting job step command exec success code to $($currentJobStep.CommandExecutionSuccessCode)" -Level Verbose
+                        $JobStep.CommandExecutionSuccessCode = $currentJobStep.CommandExecutionSuccessCode
+                    }
 
                     if ($OnSuccessAction) {
                         Write-Message -Message "Setting job step success action to $OnSuccessAction" -Level Verbose
                         $JobStep.OnSuccessAction = $OnSuccessAction
+                    }
+                    else {
+                        Write-Message -Message "Setting job step success action to $($currentJobStep.OnSuccessAction)" -Level Verbose
+                        $JobStep.OnSuccessAction = $currentJobStep.OnSuccessAction
                     }
 
                     if ($OnSuccessStepId) {
                         Write-Message -Message "Setting job step success step id to $OnSuccessStepId" -Level Verbose
                         $JobStep.OnSuccessStep = $OnSuccessStepId
                     }
+                    else {
+                        Write-Message -Message "Setting job step success step id to $($currentJobStep.OnSuccessStep)" -Level Verbose
+                        $JobStep.OnSuccessStep = $currentJobStep.OnSuccessStep
+                    }
 
                     if ($OnFailAction) {
                         Write-Message -Message "Setting job step fail action to $OnFailAction" -Level Verbose
                         $JobStep.OnFailAction = $OnFailAction
                     }
+                    else {
+                        Write-Message -Message "Setting job step fail action to $($currentJobStep.OnFailAction)" -Level Verbose
+                        $JobStep.OnFailAction = $currentJobStep.OnFailAction
+                    }
 
                     if ($OnFailStepId) {
                         Write-Message -Message "Setting job step fail step id to $OnFailStepId" -Level Verbose
                         $JobStep.OnFailStep = $OnFailStepId
+                    }
+                    else {
+                        Write-Message -Message "Setting job step fail step id to $($currentJobStep.OnFailStep)" -Level Verbose
+                        $JobStep.OnFailStep = $currentJobStep.OnFailStep
                     }
 
                     if ($Database) {
@@ -319,6 +347,15 @@ function Set-DbaAgentJobStep {
                         if ($Server.Databases.Name -contains $Database) {
                             Write-Message -Message "Setting job step database name to $Database" -Level Verbose
                             $JobStep.DatabaseName = $Database
+                        } else {
+                            Stop-Function -Message "The database is not present on instance $instance." -Target $instance -Continue
+                        }
+                    }
+                    else {
+                        # Check if the database is present on the server
+                        if ($Server.Databases.Name -contains $Database) {
+                            Write-Message -Message "Setting job step database name to $($currentJobStep.DatabaseName)" -Level Verbose
+                            $JobStep.DatabaseName = $currentJobStep.DatabaseName
                         } else {
                             Stop-Function -Message "The database is not present on instance $instance." -Target $instance -Continue
                         }
@@ -333,20 +370,41 @@ function Set-DbaAgentJobStep {
                             Stop-Function -Message "The database user is not present in the database $Database on instance $instance." -Target $instance -Continue
                         }
                     }
+                    else {
+                        # Check if the username is present in the database
+                        if ($Server.Databases[$Database].Users.Name -contains $DatabaseUser) {
+                            Write-Message -Message "Setting job step database username to $($currentJobStep.DatabaseUserName)" -Level Verbose
+                            $JobStep.DatabaseUserName = $currentJobStep.DatabaseUserName
+                        } else {
+                            Stop-Function -Message "The database user is not present in the database $Database on instance $instance." -Target $instance -Continue
+                        }
+                    }
 
                     if ($RetryAttempts) {
                         Write-Message -Message "Setting job step retry attempts to $RetryAttempts" -Level Verbose
                         $JobStep.RetryAttempts = $RetryAttempts
+                    }
+                    else {
+                        Write-Message -Message "Setting job step retry attempts to $($currentJobStep.RetryAttempts)" -Level Verbose
+                        $JobStep.RetryAttempts = $currentJobStep.RetryAttempts
                     }
 
                     if ($RetryInterval) {
                         Write-Message -Message "Setting job step retry interval to $RetryInterval" -Level Verbose
                         $JobStep.RetryInterval = $RetryInterval
                     }
+                   else {
+                        Write-Message -Message "Setting job step retry interval to $($currentJobStep.RetryInterval)" -Level Verbose
+                        $JobStep.RetryInterval = $currentJobStep.RetryInterval
+                    }
 
                     if ($OutputFileName) {
                         Write-Message -Message "Setting job step output file name to $OutputFileName" -Level Verbose
                         $JobStep.OutputFileName = $OutputFileName
+                    }
+                    else {
+                        Write-Message -Message "Setting job step output file name to $($currentJobStep.OutputFileName)" -Level Verbose
+                        $JobStep.OutputFileName = $currentJobStep.OutputFileName
                     }
 
                     if ($ProxyName) {
@@ -358,10 +416,23 @@ function Set-DbaAgentJobStep {
                             Stop-Function -Message "The proxy name $ProxyName doesn't exist on instance $instance." -Target $instance -Continue
                         }
                     }
+                    else {
+                        # Check if the proxy exists
+                        if ($Server.JobServer.ProxyAccounts.Name -contains $ProxyName) {
+                            Write-Message -Message "Setting job step proxy name to $($currentJobStep.ProxyName)" -Level Verbose
+                            $JobStep.ProxyName = $ProxyName
+                        } else {
+                            Stop-Function -Message "The proxy name $ProxyName doesn't exist on instance $instance." -Target $instance -Continue
+                        }
+                    }
 
                     if ($Flag.Count -ge 1) {
                         Write-Message -Message "Setting job step flag(s) to $($Flags -join ',')" -Level Verbose
                         $JobStep.JobStepFlags = $Flag
+                    }
+                    else {
+                        Write-Message -Message "Setting job step flag(s) to $($currentJobStep.JobStepFlags -join ',')" -Level Verbose
+                        $JobStep.JobStepFlags = $currentJobStep.JobStepFlags
                     }
                     #region job step options
 

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -299,7 +299,7 @@ function Set-DbaAgentJobStep {
                     if ($SubsystemServer) {
                         Write-Message -Message "Setting job step subsystem server to $SubsystemServer" -Level Verbose
                         $JobStep.Server = $SubsystemServer
-                    } elseif($currentJobStep.Server) {
+                    } elseif ($currentJobStep.Server) {
                         Write-Message -Message "Setting job step subsystem server to $($currentJobStep.Server)" -Level Verbose
                         $JobStep.Server = $currentJobStep.Server
                     }

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -164,7 +164,7 @@ function Set-DbaAgentJobStep {
         [string]$ProxyName,
         [parameter(ValueFromPipeline)]
         #[Microsoft.SqlServer.Management.Smo.Agent.JobStep[]]$InputObject,
-        [object[]]$InputObject,
+        [Microsoft.SqlServer.Management.Smo.Agent.JobStep[]]$InputObject,
         [Alias('Silent')]
         [switch]$EnableException,
         [switch]$Force
@@ -235,10 +235,10 @@ function Set-DbaAgentJobStep {
             }
 
             foreach($currentJobStep in $InputObject){
-                if (-not $Force -and ($Server.JobServer.Jobs[$j].JobSteps.Name -notcontains $StepName)) {
+                if (-not $Force -and ($Server.JobServer.Jobs[$j].JobSteps.Name -notcontains $currentJobStep.Name)) {
                     Stop-Function -Message "Step $StepName doesn't exists for job $j" -Target $instance -Continue
                 }
-                elseif($Force -and ($Server.JobServer.Jobs[$j].JobSteps.Name -notcontains $StepName)) {
+                elseif($Force -and ($Server.JobServer.Jobs[$j].JobSteps.Name -notcontains $currentJobStep.Name)) {
                     Write-Message -Message "Adding job step $($currentJobStep.Name) to $($currentJobStep.Parent.Name) on $instance" -Level Verbose
 
                     try{

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -141,7 +141,6 @@ function Set-DbaAgentJobStep {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory)]
-        [Alias("ServerInstance", "SqlServer")]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Job,
@@ -168,7 +167,6 @@ function Set-DbaAgentJobStep {
         [string]$ProxyName,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Agent.JobStep[]]$InputObject,
-        [Alias('Silent')]
         [switch]$EnableException,
         [switch]$Force
     )

--- a/tests/Set-DbaAgentJobStep.Tests.ps1
+++ b/tests/Set-DbaAgentJobStep.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Job','StepName','NewName','Subsystem','Command','CmdExecSuccessCode','OnSuccessAction','OnSuccessStepId','OnFailAction','OnFailStepId','Database','DatabaseUser','RetryAttempts','RetryInterval','OutputFileName','Flag','ProxyName','EnableException','Force'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'StepName', 'NewName', 'Subsystem', 'SubSystemServer', 'Command', 'CmdExecSuccessCode', 'OnSuccessAction', 'OnSuccessStepId', 'OnFailAction', 'OnFailStepId', 'Database', 'DatabaseUser', 'RetryAttempts', 'RetryInterval', 'OutputFileName', 'Flag', 'ProxyName', 'EnableException', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Set-DbaAgentJobStep.Tests.ps1
+++ b/tests/Set-DbaAgentJobStep.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'StepName', 'NewName', 'Subsystem', 'SubSystemServer', 'Command', 'CmdExecSuccessCode', 'OnSuccessAction', 'OnSuccessStepId', 'OnFailAction', 'OnFailStepId', 'Database', 'DatabaseUser', 'RetryAttempts', 'RetryInterval', 'OutputFileName', 'Flag', 'ProxyName', 'EnableException', 'Force'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'StepName', 'NewName', 'Subsystem', 'SubSystemServer', 'Command', 'CmdExecSuccessCode', 'OnSuccessAction', 'OnSuccessStepId', 'OnFailAction', 'OnFailStepId', 'Database', 'DatabaseUser', 'RetryAttempts', 'RetryInterval', 'OutputFileName', 'Flag', 'ProxyName', 'EnableException', 'InputObject', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4350, #4715)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The changes enable the Set-DbaAgentJobStep to allow pipelines

### Approach
Added the pipeline feature and changed the process of assigning the values

### Commands to test
`Get-DbaAgentJobStep -SqlInstance server1-Job job1| Set-DbaAgentJobStep -SqlInstance Server2, Server3 `

`Get-DbaAgentJobStep -SqlInstance server1-Job job1| Set-DbaAgentJobStep -SqlInstance Server2, Server3 -StepName step1, step2`

### Screenshots
![image](https://user-images.githubusercontent.com/6154981/52052118-d9522d00-2555-11e9-81d6-539a761daadf.png)

