### PR TITLE
Get-DbaDbccMemoryStatus - remove dependency on system.data objects and use standard constructs

### DIFF
--- a/functions/Get-DbaDbccMemoryStatus.ps1
+++ b/functions/Get-DbaDbccMemoryStatus.ps1
@@ -64,13 +64,13 @@ function Get-DbaDbccMemoryStatus {
 
             Write-Message -Level Verbose -Message "Collecting $query data from server: $instance"
             try {
-                $datatable = $server.ConnectionContext.ExecuteWithResults($query)
+                $datatable = $server.query($query, 'master', $true)
 
                 $recordset = 0
                 $rowId = 0
                 $recordsetId = 0
 
-                foreach ($dataset in $datatable.Tables) {
+                foreach ($dataset in $datatable) {
                     $dataSection = $dataset.Columns[0].ColumnName
                     $dataType = $dataset.Columns[1].ColumnName
                     $recordset = $recordset + 1

--- a/functions/Get-DbaDbccMemoryStatus.ps1
+++ b/functions/Get-DbaDbccMemoryStatus.ps1
@@ -64,13 +64,7 @@ function Get-DbaDbccMemoryStatus {
 
             Write-Message -Level Verbose -Message "Collecting $query data from server: $instance"
             try {
-                $sqlconnection = New-Object System.Data.SqlClient.SqlConnection
-                $sqlconnection.ConnectionString = $server.ConnectionContext.ConnectionString
-                $sqlconnection.Open()
-
-                $datatable = New-Object system.Data.DataSet
-                $dataadapter = New-Object system.Data.SqlClient.SqlDataAdapter($query, $sqlconnection)
-                $dataadapter.fill($datatable) | Out-Null
+                $datatable = $Server.ConnectionContext.ExecuteWithResults($query)
 
                 $recordset = 0
                 $rowId = 0

--- a/functions/Get-DbaDbccMemoryStatus.ps1
+++ b/functions/Get-DbaDbccMemoryStatus.ps1
@@ -64,7 +64,7 @@ function Get-DbaDbccMemoryStatus {
 
             Write-Message -Level Verbose -Message "Collecting $query data from server: $instance"
             try {
-                $datatable = $Server.ConnectionContext.ExecuteWithResults($query)
+                $datatable = $server.ConnectionContext.ExecuteWithResults($query)
 
                 $recordset = 0
                 $rowId = 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adopt standard constructs and simplify code

### Approach
Update of Get-DbaDbccMemoryStatus to use more standard approach to execute SQL Statement
In initial Pull request #4698 comments were made around using $server.Query() instead of the system.data objects. This would not work as multiple data sets need to be returned. However subsequent testing found that $server.ConnectionContext.ExecuteWithResults($query) will return the required data 

### Commands to test
Get-DbaDbccMemoryStatus 

