### PR TITLE
Backup-DbaDatabase - fixes piping issue

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -287,44 +287,43 @@ function Backup-DbaDatabase {
 
         Write-Message -Level Verbose -Message "$($InputObject.Count) database to backup"
 
-        foreach ($Database in $InputObject) {
+        foreach ($db in $InputObject) {
             $ProgressId = Get-Random
             $failures = @()
-            $dbname = $Database.Name
+            $dbname = $db.Name
+            $server = $db.Parent
 
             if ($dbname -eq "tempdb") {
                 Stop-Function -Message "Backing up tempdb not supported" -Continue
             }
 
-            if ('Normal' -notin ($Database.Status -split ',')) {
+            if ('Normal' -notin ($db.Status -split ',')) {
                 Stop-Function -Message "Database status not Normal. $dbname skipped." -Continue
             }
 
-            if ($Database.DatabaseSnapshotBaseName) {
+            if ($db.DatabaseSnapshotBaseName) {
                 Stop-Function -Message "Backing up snapshots not supported. $dbname skipped." -Continue
             }
 
-            if ($null -eq $server) { $server = $Database.Parent }
+            Write-Message -Level Verbose -Message "Backup database $db"
 
-            Write-Message -Level Verbose -Message "Backup database $database"
-
-            if ($null -eq $Database.RecoveryModel) {
-                $Database.RecoveryModel = $server.Databases[$Database.Name].RecoveryModel
-                Write-Message -Level Verbose -Message "$dbname is in $($Database.RecoveryModel) recovery model"
+            if ($null -eq $db.RecoveryModel) {
+                $db.RecoveryModel = $server.Databases[$db.Name].RecoveryModel
+                Write-Message -Level Verbose -Message "$dbname is in $($db.RecoveryModel) recovery model"
             }
 
             # Fixes one-off cases of StackOverflowException crashes, see issue 1481
-            $dbRecovery = $Database.RecoveryModel.ToString()
+            $dbRecovery = $db.RecoveryModel.ToString()
             if ($dbRecovery -eq 'Simple' -and $Type -eq 'Log') {
-                $failreason = "$database is in simple recovery mode, cannot take log backup"
+                $failreason = "$db is in simple recovery mode, cannot take log backup"
                 $failures += $failreason
                 Write-Message -Level Warning -Message "$failreason"
             }
 
-            $lastfull = $database.Refresh().LastBackupDate.Year
+            $lastfull = $db.Refresh().LastBackupDate.Year
 
             if ($Type -notin @("Database", "Full") -and $lastfull -eq 1) {
-                $failreason = "$database does not have an existing full backup, cannot take log or differentialbackup"
+                $failreason = "$db does not have an existing full backup, cannot take log or differentialbackup"
                 $failures += $failreason
                 Write-Message -Level Warning -Message "$failreason"
             }
@@ -335,11 +334,11 @@ function Backup-DbaDatabase {
 
             $server.ConnectionContext.StatementTimeout = 0
             $backup = New-Object Microsoft.SqlServer.Management.Smo.Backup
-            $backup.Database = $Database.Name
+            $backup.Database = $db.Name
             $Suffix = "bak"
 
             if ($CompressBackup) {
-                if ($database.EncryptionEnabled) {
+                if ($db.EncryptionEnabled) {
                     Write-Message -Level Warning -Message "$dbname is enabled for encryption, will not compress"
                     $backup.CompressionOption = 2
                 } elseif ($server.Edition -like 'Express*' -or ($server.VersionMajor -eq 10 -and $server.VersionMinor -eq 0 -and $server.Edition -notlike '*enterprise*') -or $server.VersionMajor -lt 10) {
@@ -530,12 +529,14 @@ function Backup-DbaDatabase {
                             if ($server.VersionMajor -eq '8') {
                                 $HeaderInfo = Get-BackupAncientHistory -SqlInstance $server -Database $dbname
                             } else {
-                                $HeaderInfo = Get-DbaBackupHistory -SqlInstance $server -Database $dbname @gbhSwitch -IncludeCopyOnly -RecoveryFork $database.RecoveryForkGuid  | Sort-Object -Property End -Descending | Select-Object -First 1
+                                $HeaderInfo = Get-DbaBackupHistory -SqlInstance $server -Database $dbname @gbhSwitch -IncludeCopyOnly -RecoveryFork $db.RecoveryForkGuid  | Sort-Object -Property End -Descending | Select-Object -First 1
                             }
                             $Verified = $false
                             if ($Verify) {
                                 $verifiedresult = [PSCustomObject]@{
-                                    SqlInstance          = $server.name
+                                    ComputerName         = $server.ComputerName
+                                    InstanceName         = $server.ServiceName
+                                    SqlInstance          = $server.DomainInstanceName
                                     DatabaseName         = $dbname
                                     BackupComplete       = $BackupComplete
                                     BackupFilesCount     = $FinalBackupPath.Count


### PR DESCRIPTION
Before, the $server instance was reused when database objects were piped in.

![image](https://user-images.githubusercontent.com/8278033/52179379-32ca8e00-27da-11e9-8aab-c80e8501ae40.png)

Now, it works.

![image](https://user-images.githubusercontent.com/8278033/52179670-71157c80-27dd-11e9-9288-535c2619d911.png)
