### PR TITLE
Fixes for Update-DbaInstance: parallelism, exceptions

### DIFF
--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -157,7 +157,7 @@ function Update-DbaInstance {
         [string[]]$KB,
         [Alias("Instance")]
         [string]$InstanceName,
-        [string[]]$Path,
+        [string[]]$Path = (Get-DbatoolsConfigValue -Name 'Path.SQLServerUpdates'),
         [switch]$Restart,
         [switch]$Continue,
         [ValidateNotNull()]
@@ -286,7 +286,11 @@ function Update-DbaInstance {
             $activity = "Preparing to update SQL Server on $resolvedName"
             ## Find the current version on the computer
             Write-ProgressHelper -ExcludePercent -Activity $activity -StepNumber 0 -Message "Gathering all SQL Server instance versions"
-            $components = Get-SQLInstanceComponent -ComputerName $resolvedName -Credential $Credential
+            try {
+                $components = Get-SQLInstanceComponent -ComputerName $resolvedName -Credential $Credential
+            } catch {
+                Stop-Function -Message "Error while looking for SQL Server installations on $resolvedName" -Continue -ErrorRecord $_
+            }
             if (!$components) {
                 Stop-Function -Message "No SQL Server installations found on $resolvedName" -Continue
             }
@@ -295,13 +299,17 @@ function Update-DbaInstance {
             if ($InstanceName) {
                 $components = $components | Where-Object {$_.InstanceName -eq $InstanceName }
             }
+            try {
+                $restartNeeded = Test-PendingReboot -ComputerName $resolvedName -Credential $Credential
+            } catch {
+                Stop-Function -Message "Failed to get reboot status from $resolvedName" -Continue -ErrorRecord $_
+            }
+            if ($restartNeeded -and (-not $Restart -or ([DbaInstanceParameter]$resolvedName).IsLocalHost)) {
+                #Exit the actions loop altogether - nothing can be installed here anyways
+                Stop-Function -Message "$resolvedName is pending a reboot. Reboot the computer before proceeding." -Continue
+            }
             $upgrades = @()
             :actions foreach ($currentAction in $actions) {
-                $restartNeeded = Test-PendingReboot -ComputerName $resolvedName
-                if ($restartNeeded -and (-not $Restart -or ([DbaInstanceParameter]$resolvedName).IsLocalHost)) {
-                    #Exit the actions loop altogether - nothing can be installed here anyways
-                    Stop-Function -Message "$resolvedName is pending a reboot. Reboot the computer before proceeding." -Continue -ContinueLabel computers
-                }
                 # Attempt to configure CredSSP for the remote host when credentials are defined
                 if ($Credential -and -not ([DbaInstanceParameter]$resolvedName).IsLocalHost -and $Authentication -eq 'Credssp') {
                     Write-Message -Level Verbose -Message "Attempting to configure CredSSP for remote connections"
@@ -350,7 +358,11 @@ function Update-DbaInstance {
                         Path           = $Path
                         KB             = $detail.KB
                     }
-                    $installer = Find-SqlServerUpdate @kbLookupParams
+                    try {
+                        $installer = Find-SqlServerUpdate @kbLookupParams
+                    } catch {
+                        Stop-Function -Message "Failed to enumerate files in -Path" -ErrorRecord $_ -Continue
+                    }
                     if ($installer) {
                         $detail.Installer = $installer.FullName
                     } else {
@@ -455,6 +467,7 @@ function Update-DbaInstance {
                         Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Now installing update SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel) from $spExtractPath"
                         Write-Message -Level Verbose -Message "Starting installation from $spExtractPath" -FunctionName Update-DbaInstance
                         $updateResult = Invoke-Program @execParams -Path "$spExtractPath\setup.exe" -ArgumentList @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms') -WorkingDirectory $spExtractPath -Fallback
+                        $output.ExitCode = $updateResult.ExitCode
                         if ($updateResult.Successful) {
                             $output.Successful = $true
                         } else {
@@ -486,7 +499,13 @@ function Update-DbaInstance {
                     }
                 }
                 #double check if restart is needed
-                if ($updateResult.ExitCode -eq 3010 -or (Test-PendingReboot -ComputerName $resolvedName)) {
+                try {
+                    $restartNeeded = Test-PendingReboot -ComputerName $resolvedName -Credential $Credential
+                } catch {
+                    $restartNeeded = $false
+                    Stop-Function -Message "Failed to get reboot status from $resolvedName" -ErrorRecord $_ -FunctionName Update-DbaInstance
+                }
+                if ($updateResult.ExitCode -eq 3010 -or $restartNeeded) {
                     if ($Restart) {
                         # Restart the computer
                         Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Restarting computer $($computer) and waiting for it to come back online"
@@ -510,7 +529,7 @@ function Update-DbaInstance {
         if ($installActions.Count -eq 1) {
             $installActions | ForEach-Object -Process $installScript | ForEach-Object -Process $outputHandler
         } elseif ($installActions.Count -ge 2) {
-            $installActions | Invoke-Parallel -ImportModules -ImportVariables -ScriptBlock $installScript -Throttle $Throttle | ForEach-Object -Process $outputHandler
+            $installActions | Invoke-Parallel -ImportModules -ImportVariables -ImportFunctions -ScriptBlock $installScript -Throttle $Throttle | ForEach-Object -Process $outputHandler
         }
     }
 }

--- a/internal/functions/Find-SqlServerUpdate.ps1
+++ b/internal/functions/Find-SqlServerUpdate.ps1
@@ -27,16 +27,14 @@ function Find-SqlServerUpdate {
         [string]$KB,
         [ValidateSet('x86', 'x64')]
         [string]$Architecture = 'x64',
-        [string[]]$Path = (Get-DbatoolsConfigValue -Name 'Path.SQLServerUpdates'),
-        [bool]$EnableException = $EnableException
+        [string[]]$Path = (Get-DbatoolsConfigValue -Name 'Path.SQLServerUpdates')
 
     )
     begin {
     }
     process {
         if (!$Path) {
-            Stop-Function -Message "Path to SQL Server updates folder is not set. Consider running Set-DbatoolsConfig -Name Path.SQLServerUpdates -Value '\\path\to\updates' or specify the path in the original command"
-            return
+            throw "Path to SQL Server updates folder is not set. Consider running Set-DbatoolsConfig -Name Path.SQLServerUpdates -Value '\\path\to\updates' or specify the path in the original command"
         }
         $filter = "SQLServer$MajorVersion*-KB$KB-*$Architecture*.exe"
         Write-Message -Level Verbose -Message "Using filter [$filter] to check for updates in $Path"
@@ -61,11 +59,6 @@ function Find-SqlServerUpdate {
             ErrorAction    = 'Stop'
             Raw            = $true
         }
-        try {
-            Invoke-CommandWithFallback @params
-        } catch {
-            Stop-Function -Message "Failed to enumerate files in $Path" -ErrorRecord $_
-            return
-        }
+        Invoke-CommandWithFallback @params
     }
 }

--- a/internal/functions/Get-SqlInstanceComponent.ps1
+++ b/internal/functions/Get-SqlInstanceComponent.ps1
@@ -297,11 +297,8 @@ function Get-SQLInstanceComponent {
     }
     process {
         foreach ($computer in $ComputerName) {
-            try {
-                $results = Invoke-Command2 -ComputerName $computer -ScriptBlock $regScript -Credential $Credential -ErrorAction Stop -Raw -ArgumentList @($Component) -RequiredPSVersion 3.0
-            } catch {
-                Stop-Function -Message "Failed to get instance components from $computer" -ErrorRecord $_ -Continue
-            }
+            $results = Invoke-Command2 -ComputerName $computer -ScriptBlock $regScript -Credential $Credential -ErrorAction Stop -Raw -ArgumentList @($Component) -RequiredPSVersion 3.0
+
             # Log is stored in the log property, pile it all into the debug log
             foreach ($logEntry in $results.Log) {
                 Write-Message -Level Debug -Message $logEntry
@@ -314,7 +311,7 @@ function Get-SQLInstanceComponent {
                 $newVersion = New-Object -TypeName System.Version -ArgumentList ($newVersion.Major , ($newVersion.Minor - $newVersion.Minor % 10), $newVersion.Build)
                 Write-Message -Level Debug -Message "Converted version $($result.Version) to $newVersion"
                 #Find a proper build reference and replace Version property
-                $result.Version = Get-DbaBuildReference -Build $newVersion
+                $result.Version = Get-DbaBuildReference -Build $newVersion -EnableException
                 $result | Select-Object -ExcludeProperty Log
             }
         }

--- a/internal/functions/Get-SqlInstanceComponent.ps1
+++ b/internal/functions/Get-SqlInstanceComponent.ps1
@@ -69,8 +69,7 @@ function Get-SQLInstanceComponent {
         [DbaInstanceParameter[]]$ComputerName = $Env:COMPUTERNAME,
         [ValidateSet('SSDS', 'SSAS', 'SSRS')]
         [string[]]$Component = @('SSDS', 'SSAS', 'SSRS'),
-        [pscredential]$Credential,
-        [bool]$EnableException = $EnableException
+        [pscredential]$Credential
     )
 
     begin {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4988 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing issue raised by @wsmelton as well as some annoying parallelism fix that can't be tested in Appveyor (adding `-ImportFunctions` to the `Invoke-Parallel` fixes inability to use internal commands inside the script block).

### Approach
no EnableException in the internals
try-catches everywhere

### Commands to test
Update-DbaInstance -ComputerName srv1, srv2

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
