### PR TITLE
Pass -Force through From Copy-DbaDatabase o Set-DbaDbState (Fixes #5055)

### DIFF
--- a/functions/Copy-DbaDatabase.ps1
+++ b/functions/Copy-DbaDatabase.ps1
@@ -120,7 +120,9 @@ function Copy-DbaDatabase {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .PARAMETER Force
-        If this switch is enabled, existing databases on Destination with matching names from Source will be dropped. If using -DetachReattach, mirrors will be broken and the database(s) dropped from Availability Groups.
+        If this switch is enabled, existing databases on Destination with matching names from Source will be dropped.
+        If using -DetachReattach, mirrors will be broken and the database(s) dropped from Availability Groups.
+        If using -SetSourceReadonly, this will instantly roll back any open transactions that may be stopping the process.
 
     .NOTES
         Tags: Migration, Backup, Restore
@@ -1113,7 +1115,7 @@ function Copy-DbaDatabase {
                         If ($Pscmdlet.ShouldProcess($source, "Set $dbName to read-only")) {
                             Write-Message -Level Verbose -Message "Setting database to read-only."
                             try {
-                                $result = Set-DbaDbState -SqlInstance $sourceServer -Database $dbName -ReadOnly -EnableException
+                                $result = Set-DbaDbState -SqlInstance $sourceServer -Database $dbName -ReadOnly -EnableException -Force:$Force
                             } catch {
                                 Stop-Function -Continue -Message "Couldn't set database to read-only. Aborting routine for this database" -ErrorRecord $_
                             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5055 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When running `Copy-DbaDatabase -SetSourceReadonly -Force`, force the database into read-only.

### Approach
<!-- How does this change solve that purpose -->
Pass the `$Force` switch to the `Set-DbaDbState` command

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```powershell
Copy-DbaDatabase -Source $source -Destination $dest -SharedPath $share -BackupRestore -AllDatabases -WithReplace  -Force
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
