### PR TITLE
Import error fix - test for existence first - #5056

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -65,25 +65,27 @@ if ($ImportLibrary) {
             }
         }
         # Else we prioritize user convenience
-else {
+        else {
             try {
-                $sln = (Resolve-Path -Path "$libraryBase\projects\dbatools\dbatools.sln" -ErrorAction Stop)
-                $hasProject = Test-Path -Path $sln -ErrorAction Stop
+                if ((Test-Path -Path "$libraryBase/projects/dbatools/dbatools.sln")) {
+                    $sln = (Resolve-Path -Path "$libraryBase\projects\dbatools\dbatools.sln" -ErrorAction Stop)
+                    $hasProject = Test-Path -Path $sln -ErrorAction Stop
+                }
             } catch {
                 $null = 1
             }
-            
+
             if (-not $dll) {
                 $hasCompiledDll = $false
             } else {
                 $hasCompiledDll = Test-Path -Path $dll -ErrorAction Stop
             }
-            
+
             $reslibdll = Resolve-Path -Path "$libraryBase\dbatools.dll"
-            
+
             if ((-not $script:alwaysBuildLibrary) -and $hasCompiledDll -and ([System.Diagnostics.FileVersionInfo]::GetVersionInfo($reslibdll).FileVersion -eq $currentLibraryVersion)) {
                 $start = Get-Date
-                
+
                 try {
                     $libraryBase = Resolve-Path -Path "$libraryBase\"
                     $script:DllRoot = Resolve-Path -Path $script:DllRoot
@@ -104,7 +106,7 @@ else {
                 throw "No valid dbatools library found! Check your module integrity"
             }
         }
-        
+
         #region PowerShell TypeData
         Update-TypeData -TypeName "Sqlcollaborative.Dbatools.dbaSystem.DbatoolsException" -SerializationDepth 2 -ErrorAction Ignore
         Update-TypeData -TypeName "Sqlcollaborative.Dbatools.dbaSystem.DbatoolsExceptionRecord" -SerializationDepth 2 -ErrorAction Ignore


### PR DESCRIPTION
partial fix, we still have a lot of other import errors that revolve around the copy-item

```
opy-Item : The process cannot access the file 'C:\github\dbatools\bin\dbatools.dll' because it is being used by another process.
At line:93 char:25
+ ...             Copy-Item -Path $dll -Destination $script:DllRoot -Force  ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Copy-Item], IOException
    + FullyQualifiedErrorId : System.IO.IOException,Microsoft.PowerShell.Commands.CopyItemCommand

[105.01 ms] C:\github\dbatools> findshit 'Copy-Item -Path \$dll -Destination'

bin\library.ps1:93:                        Copy-Item -Path $dll -Destination $script:DllRoot -Force -ErrorAction Stop

```
/cc @FriedrichWeinmann 
