### PR TITLE
Fix masking commands

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,6 +76,7 @@ environment:
 clone_folder: c:\github\dbatools
 
 before_test:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # turn tests\ (at least) to CRLF, as it's faster to do this on the zipball rather than checking out the repo
   - cmd: pushd C:\github\dbatools\tests & unix2dos -q  *.ps1 & popd
   # grab appveyor lab files and needed requirements for tests in CI
@@ -96,4 +97,4 @@ after_test:
   - ps: .\Tests\appveyor.post.ps1
 
 # on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ shallow_clone: true
 environment:
   environment: development
   version: 0.9.$(appveyor_build_number)
-  #appveyor_rdp_password: 2odCuiKmYiem
+  appveyor_rdp_password: 2odCuiKmYiem
   azurepasswd:
     secure: ZnF3fWSDfHraMCWlHaekvWrXf3sDqY5M28HMK4236PBbNSoqP29wEhsWMQioSSYGomzgIp9vuiwR8Fc9ViNLoqq0bVcErxEojBFTaPMEzOg2ZwO9OnOTiuUEc5JkoLBv6rEBBWef/DvkFfhr1r0K0xQu6OAPYHVTCRajTZbBRNfCTUM2X2o41t+cSa7681rtnJQnB/8cAfVVnPtJ+97s8w==
   azurelegacypasswd:
@@ -96,4 +96,4 @@ after_test:
   - ps: .\Tests\appveyor.post.ps1
 
 # on_finish:
-#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,6 @@ environment:
 clone_folder: c:\github\dbatools
 
 before_test:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   # turn tests\ (at least) to CRLF, as it's faster to do this on the zipball rather than checking out the repo
   - cmd: pushd C:\github\dbatools\tests & unix2dos -q  *.ps1 & popd
   # grab appveyor lab files and needed requirements for tests in CI

--- a/bin/datamasking/columntypes.json
+++ b/bin/datamasking/columntypes.json
@@ -1,35 +1,5 @@
 [
     {
-        "TypeName": "Firstname",
-        "Synonym": [
-            "Firstname",
-            "Forename"
-        ]
-    },
-    {
-        "TypeName": "Lastname",
-        "Synonym": [
-            "Lastname",
-            "Surname"
-        ]
-    },
-    {
-        "TypeName": "Fullname",
-        "Synonym": [
-            "Fullname",
-            "TypeName"
-        ]
-    },
-    {
-        "TypeName": "Phone",
-        "Synonym": [
-            "Phonenumber",
-            "Phone",
-            "Telephone",
-            "TelephoneNumber"
-        ]
-    },
-    {
         "TypeName": "Address",
         "Synonym": [
             "Address",
@@ -39,11 +9,46 @@
         ]
     },
     {
-        "TypeName": "Zipcode",
+        "TypeName": "Bic",
         "Synonym": [
-            "Zipcode",
-            "Zip",
-            "Postalcode"
+            "Bic",
+            "BicAddress"
+        ]
+    },
+    {
+        "TypeName": "Bitcoin",
+        "Synonym": [
+            "Bitcoin",
+            "BitcoinAddress"
+        ]
+    },
+    {
+        "TypeName": "Email",
+        "Synonym": [
+            "Email",
+            "E-mail",
+            "EmailAddress"
+        ]
+    },
+    {
+        "TypeName": "Ethereum",
+        "Synonym": [
+            "Ethereum",
+            "EthereumAddress"
+        ]
+    },
+    {
+        "TypeName": "Creditcard",
+        "Synonym": [
+            "Creditcard",
+            "CreditcardNumber"
+        ]
+    },
+    {
+        "TypeName": "CreditcardCVV",
+        "Synonym": [
+            "Cvv",
+            "CreditcardCvv"
         ]
     },
     {
@@ -53,9 +58,10 @@
         ]
     },
     {
-        "TypeName": "State",
+        "TypeName": "Company",
         "Synonym": [
-            "State"
+            "Company",
+            "CompanyName"
         ]
     },
     {
@@ -68,6 +74,34 @@
         "TypeName": "CountryCode",
         "Synonym": [
             "CountryCode"
+        ]
+    },
+    {
+        "TypeName": "Firstname",
+        "Synonym": [
+            "Firstname",
+            "Forename"
+        ]
+    },
+    {
+        "TypeName": "Fullname",
+        "Synonym": [
+            "Fullname",
+            "TypeName"
+        ]
+    },
+    {
+        "TypeName": "Iban",
+        "Synonym": [
+            "Iban",
+            "IbanNumber"
+        ]
+    },
+    {
+        "TypeName": "Lastname",
+        "Synonym": [
+            "Lastname",
+            "Surname"
         ]
     },
     {
@@ -85,19 +119,44 @@
         ]
     },
     {
-        "TypeName": "Creditcard",
+        "TypeName": "Phone",
         "Synonym": [
-            "Creditcard",
-            "CreditcardNumber"
+            "Fax",
+            "FaxNumber",
+            "Phonenumber",
+            "Phone",
+            "Telephone",
+            "TelephoneNumber"
+        ]
+    },
+    {
+        "TypeName": "State",
+        "Synonym": [
+            "State"
+        ]
+    },
+    {
+        "TypeName": "StateAbbr",
+        "Synonym": [
+            "StateAbbreviation",
+            "StateCode"
         ]
     },
     {
         "TypeName": "Username",
         "Synonym": [
             "Login",
-			"LoginId",
+            "LoginId",
             "User",
             "UserId"
+        ]
+    },
+    {
+        "TypeName": "Zipcode",
+        "Synonym": [
+            "Zipcode",
+            "Zip",
+            "Postalcode"
         ]
     }
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.773] - 2019-02-24
+### Fixed
+* `Install-DbaMaintenanceSolution` now removes jobs when `-SqlCredential` is used [#5096](https://github.com/sqlcollaborative/dbatools/issues/5096)
+* `Copy-DbaSsisCatalog` now properly resolves type names [#4821](https://github.com/sqlcollaborative/dbatools/issues/4821)
+* Can now set schedule start & end dates with `Set-DbaAgentSchedule` [#4908](https://github.com/sqlcollaborative/dbatools/issues/4908)
+
+## [0.9.772] - 2019-02-24
+### Fixed
+* `Invoke-DbaDbShrink` now properly excludes system databases when `-AllUserDatabase` is specified [#5108](https://github.com/sqlcollaborative/dbatools/issues/5108)
+
 ## [0.9.771] - 2019-02-19
 ### Fixed
 * Azure SQL DB support for creating SQL Logins in `New-DbaLogin` [#5100](https://github.com/sqlcollaborative/dbatools/issues/5100)

--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -11,7 +11,7 @@
     RootModule             = 'dbatools.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '0.9.772'
+    ModuleVersion          = '0.9.773'
 
     # ID used to uniquely identify this module
     GUID                   = '9d139310-ce45-41ce-8e8b-d76335aa1789'

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -590,8 +590,7 @@ function Invoke-DbaDbDataMasking {
                                 } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like 'datetime2') {
                                     $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.ffffff")
                                     $wheres += "[$item] = '$oldValue'"
-                                }
-                                elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like '*date*') {
+                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like '*date*') {
                                     $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss")
                                     $wheres += "[$item] = '$oldValue'"
                                 } else {
@@ -645,4 +644,3 @@ function Invoke-DbaDbDataMasking {
         }
     }
 }
-

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -132,6 +132,14 @@ function Invoke-DbaDbDataMasking {
         # Create the faker objects
         Add-Type -Path (Resolve-Path -Path "$script:PSModuleRoot\bin\datamasking\Bogus.dll")
         $faker = New-Object Bogus.Faker($Locale)
+
+        $supportedDataTypes = 'bit', 'bool', 'char', 'date', 'datetime', 'datetime2', 'decimal', 'int', 'money', 'nchar', 'ntext', 'nvarchar', 'smalldatetime', 'text', 'time', 'uniqueidentifier', 'userdefineddatatype', 'varchar'
+
+        $supportedFakerMaskingTypes = ($faker | Get-Member -MemberType Property | Select-Object Name -ExpandProperty Name)
+
+        $supportedFakerSubTypes = ($faker | Get-Member -MemberType Property) | ForEach-Object { ($faker.$($_.Name)) | Get-Member -MemberType Method | Where-Object {$_.Name -notlike 'To*' -and $_.Name -notlike 'Get*' -and $_.Name -notlike 'Trim*' -and $_.Name -notin 'Add', 'Equals', 'CompareTo', 'Clone', 'Contains', 'CopyTo', 'EndsWith', 'IndexOf', 'IndexOfAny', 'Insert', 'IsNormalized', 'LastIndexOf', 'LastIndexOfAny', 'Normalize', 'PadLeft', 'PadRight', 'Remove', 'Replace', 'Split', 'StartsWith', 'Substring', 'Letter', 'Lines', 'Paragraph', 'Paragraphs', 'Sentence', 'Sentences'} | Select-Object name -ExpandProperty Name }
+
+        $supportedFakerSubTypes += "Date"
     }
 
     process {
@@ -182,18 +190,23 @@ function Invoke-DbaDbDataMasking {
             }
 
             if ($Database) {
-                $dbs = Get-DbaDatabase -SqlInstance $server -Database $Database
+                $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -Database $Database
             } else {
-                $dbs = Get-DbaDatabase -SqlInstance $server -Database $tables.Name
+                $dbs = Get-DbaDatabase -SqlInstance $server -SqlCredential $SqlCredential -Database $tables.Name
             }
 
             $sqlconn = $server.ConnectionContext.SqlConnectionObject.PsObject.Copy()
             $sqlconn.Open()
 
             foreach ($db in $dbs) {
+
                 $stepcounter = $nullmod = 0
+
                 foreach ($tableobject in $tables.Tables) {
-                    if ($tableobject.Name -in $ExcludeTable -or ($Table -and $tableobject.Name -notin $Table)) {
+                    $uniqueValues = @()
+                    $uniqueValueColumns = @()
+
+                    if ($tableobject.Name -in $ExcludeTable) {
                         Write-Message -Level Verbose -Message "Skipping $($tableobject.Name) because it is explicitly excluded"
                         continue
                     }
@@ -201,17 +214,81 @@ function Invoke-DbaDbDataMasking {
                     if ($tableobject.Name -notin $db.Tables.Name) {
                         Stop-Function -Message "Table $($tableobject.Name) is not present in $db" -Target $db -Continue
                     }
+
+                    $dbTable = $db.Tables | Where-Object {$_.Schema -eq $tableobject.Schema -and $_.Name -eq $tableobject.Name}
+
                     try {
                         if (-not (Test-Bound -ParameterName Query)) {
-                            $query = "SELECT * FROM [$($tableobject.Schema)].[$($tableobject.Name)]"
+                            $columnString = "[" + (($dbTable.Columns | Where-Object DataType -in $supportedDataTypes | Select-Object Name -ExpandProperty Name) -join "],[") + "]"
+                            $query = "SELECT $($columnString) FROM [$($tableobject.Schema)].[$($tableobject.Name)]"
                         }
                         $data = $server.Databases[$($db.Name)].Query($query) | ConvertTo-DbaDataTable
                     } catch {
                         Stop-Function -Message "Failure retrieving the data from table $($tableobject.Name)" -Target $Database -ErrorRecord $_ -Continue
                     }
 
+                    # Check if the table contains unique indexes
+                    if ($tableobject.HasUniqueIndex) {
+
+                        # Loop through the rows and generate a unique value for each row
+                        Write-Message -Level Verbose -Message "Generating unique values for $($tableobject.Name)"
+
+                        for ($i = 0; $i -lt $data.Rows.Count; $i++) {
+                            $rowValue = New-Object PSCustomObject
+
+                            # Loop through each of the unique indexes
+                            foreach ($index in ($db.Tables[$($tableobject.Name)].Indexes | Where-Object IsUnique -eq $true )) {
+
+                                # Loop through the index columns
+                                foreach ($indexColumn in $index.IndexedColumns) {
+                                    # Get the column mask info
+                                    $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
+
+                                    # Generate a new value
+                                    $newValue = $faker.$($columnMaskInfo.MaskingType).$($columnMaskInfo.SubType)()
+
+                                    # Check if the value is already present as a property
+                                    if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
+                                        $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
+                                    }
+
+                                }
+
+                                # To be sure the values are unique, loop as long as long as needed to generate a unique value
+                                while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
+
+                                    $rowValue = New-Object PSCustomObject
+
+                                    # Loop through the index columns
+                                    foreach ($indexColumn in $index.IndexedColumns) {
+                                        # Get the column mask info
+                                        $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
+
+                                        # Generate a new value
+                                        $newValue = $faker.$($columnMaskInfo.MaskingType).$($columnMaskInfo.SubType)()
+
+                                        # Check if the value is already present as a property
+                                        if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
+                                            $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
+                                            $uniqueValueColumns += $indexColumn.Name
+                                        }
+
+                                    }
+                                }
+
+                            }
+
+                            # Add the row value to the array
+                            $uniqueValues += $rowValue
+
+                        }
+
+                    }
+
+                    $uniqueValueColumns = $uniqueValueColumns | Select-Object -Unique
+
                     $sqlconn.ChangeDatabase($db.Name)
-                    
+
                     $deterministicColumns = $tables.Tables.Columns | Where-Object Deterministic -eq $true
                     $tablecolumns = $tableobject.Columns
 
@@ -220,6 +297,10 @@ function Invoke-DbaDbDataMasking {
                     }
 
                     if ($ExcludeColumn) {
+                        if ([string]$uniqueIndex.Columns -match ($ExcludeColumn -join "|")) {
+                            Stop-Function -Message "Column present in -ExcludeColumn cannot be excluded because it's part of an unique index" -Target $ExcludeColumn -Continue
+                        }
+
                         $tablecolumns = $tablecolumns | Where-Object Name -notin $ExcludeColumn
                     }
 
@@ -229,18 +310,45 @@ function Invoke-DbaDbDataMasking {
                     }
 
                     if ($Pscmdlet.ShouldProcess($instance, "Masking $($tablecolumns.Name -join ', ') in $($data.Rows.Count) rows in $($db.Name).$($tableobject.Schema).$($tableobject.Name)")) {
+
                         $transaction = $sqlconn.BeginTransaction()
                         $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
                         Write-ProgressHelper -StepNumber ($stepcounter++) -TotalSteps $tables.Tables.Count -Activity "Masking data" -Message "Updating $($data.Rows.Count) rows in $($tableobject.Schema).$($tableobject.Name) in $($db.Name) on $instance"
 
                         # Loop through each of the rows and change them
+                        $rowNumber = 0
+
                         foreach ($row in $data.Rows) {
                             $updates = $wheres = @()
+                            $newValue = $null
 
                             foreach ($columnobject in $tablecolumns) {
+
+                                if ($columnobject.ColumnType -notin $supportedDataTypes) {
+                                    Stop-Function -Message "Unsupported data type '$($columnobject.ColumnType)' for column $($columnobject.Name)" -Target $columnobject -Continue
+                                }
+
+                                if ($columnobject.MaskingType -notin $supportedFakerMaskingTypes) {
+                                    Stop-Function -Message "Unsupported masking type '$($columnobject.MaskingType)' for column $($columnobject.Name)" -Target $columnobject -Continue
+                                }
+
+                                if ($columnobject.SubType -notin $supportedFakerSubTypes) {
+                                    Stop-Function -Message "Unsupported masking sub type '$($columnobject.SubType)' for column $($columnobject.Name)" -Target $columnobject -Continue
+                                }
+
                                 if ($columnobject.Nullable -and (($nullmod++) % $ModulusFactor -eq 0)) {
                                     $newValue = $null
+                                } elseif ($tableobject.HasUniqueIndex -and $columnobject.Name -in $uniqueValueColumns) {
+
+                                    if ($uniqueValues.Count -lt 1) {
+                                        Stop-Function -Message "Could not find any unique values in dictionary" -Target $tableobject
+                                        return
+                                    }
+
+                                    $newValue = $uniqueValues[$rowNumber].$($columnobject.Name)
+
                                 } else {
+
                                     # make sure max is good
                                     if ($MaxValue) {
                                         if ($columnobject.MaxValue -le $MaxValue) {
@@ -395,9 +503,13 @@ function Invoke-DbaDbDataMasking {
                                                     $faker.System.Random.Bool()
                                                 }
                                                 {
-                                                    $psitem -in 'name', 'address', 'finance'
+                                                    $psitem -in 'address', 'commerce', 'company', 'context', 'database', 'date', 'finance', 'hacker', 'hashids', 'image', 'internet', 'lorem', 'name', 'person', 'phone', 'random', 'rant', 'system'
                                                 } {
-                                                    $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
+                                                    if ($columnobject.Format) {
+                                                        $faker.$($columnobject.MaskingType).$($columnobject.SubType)("$($columnobject.Format)")
+                                                    } else {
+                                                        $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
+                                                    }
                                                 }
                                                 default {
                                                     if ($max -eq -1) {
@@ -410,7 +522,11 @@ function Invoke-DbaDbDataMasking {
                                                         $faker.System.Random.Bool()
                                                     } else {
                                                         try {
-                                                            $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
+                                                            if ($columnobject.Format) {
+                                                                $faker.$($columnobject.MaskingType).$($columnobject.SubType)("$($columnobject.Format)")
+                                                            } else {
+                                                                $faker.$($columnobject.MaskingType).$($columnobject.SubType)()
+                                                            }
                                                         } catch {
                                                             $faker.Random.String2($max, $charstring)
                                                         }
@@ -431,12 +547,21 @@ function Invoke-DbaDbDataMasking {
                                     } else {
                                         $updates += "[$($columnobject.Name)] = '$newValue'"
                                     }
-
                                 } elseif ($columnobject.ColumnType -match 'int') {
                                     if ($null -eq $newValue -and $columnobject.Nullable) {
                                         $updates += "[$($columnobject.Name)] = NULL"
                                     } else {
                                         $updates += "[$($columnobject.Name)] = $newValue"
+                                    }
+                                } elseif ($columnobject.ColumnType -in 'bit', 'bool') {
+                                    if ($null -eq $newValue -and $columnobject.Nullable) {
+                                        $updates += "[$($columnobject.Name)] = NULL"
+                                    } else {
+                                        if ($newValue) {
+                                            $updates += "[$($columnobject.Name)] = 1"
+                                        } else {
+                                            $updates += "[$($columnobject.Name)] = 0"
+                                        }
                                     }
                                 } else {
                                     if ($null -eq $newValue -and $columnobject.Nullable) {
@@ -447,17 +572,24 @@ function Invoke-DbaDbDataMasking {
                                     }
                                 }
 
-                                if ($columnobject.ColumnType -notin 'xml', 'geography', 'geometry') {
-                                    if (($row.$($columnobject.Name)).GetType().Name -match 'DBNull') {
-                                        $wheres += "[$($columnobject.Name)] IS NULL"
-                                    } else {
-                                        $oldValue = ($row.$($columnobject.Name)).Tostring().Replace("'", "''")
-                                        $wheres += "[$($columnobject.Name)] = '$oldValue'"
-                                    }
-                                }
-
                                 if ($columnobject.Deterministic -and ($row.$($columnobject.Name) -notin $dictionary.Keys)) {
                                     $dictionary.Add($row.$($columnobject.Name), $newValue)
+                                }
+                            }
+
+                            $rowItems = $row | Get-Member -MemberType Properties | Select-Object Name -ExpandProperty Name
+                            foreach ($item in $rowItems) {
+                                if (($row.$($item)).GetType().Name -match 'DBNull') {
+                                    $wheres += "[$item] IS NULL"
+                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -in 'text', 'ntext') {
+                                    $oldValue = ($row.$item).Tostring().Replace("'", "''")
+                                    $wheres += "CAST([$item] AS VARCHAR(MAX)) = '$oldValue'"
+                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like '*date*') {
+                                    $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.fffffff")
+                                    $wheres += "[$item] = '$oldValue'"
+                                } else {
+                                    $oldValue = ($row.$item).Tostring().Replace("'", "''")
+                                    $wheres += "[$item] = '$oldValue'"
                                 }
                             }
 
@@ -471,6 +603,9 @@ function Invoke-DbaDbDataMasking {
                                 $errormessage = $_.Exception.Message.ToString()
                                 Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $errormessage" -Target $updatequery -Continue -ErrorRecord $_
                             }
+
+                            # Increase the row number
+                            $rowNumber++
                         }
                         try {
                             $null = $transaction.Commit()
@@ -490,6 +625,9 @@ function Invoke-DbaDbDataMasking {
                             Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name)" -Target $updatequery -Continue -ErrorRecord $_
                         }
                     }
+
+                    # Empty the unique values array
+                    $uniqueValues = $null
                 }
             }
             try {
@@ -500,3 +638,4 @@ function Invoke-DbaDbDataMasking {
         }
     }
 }
+

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -584,8 +584,15 @@ function Invoke-DbaDbDataMasking {
                                 } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -in 'text', 'ntext') {
                                     $oldValue = ($row.$item).Tostring().Replace("'", "''")
                                     $wheres += "CAST([$item] AS VARCHAR(MAX)) = '$oldValue'"
-                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like '*date*') {
-                                    $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.fffffff")
+                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like 'datetime') {
+                                    $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.fff")
+                                    $wheres += "[$item] = '$oldValue'"
+                                } elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like 'datetime2') {
+                                    $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.ffffff")
+                                    $wheres += "[$item] = '$oldValue'"
+                                }
+                                elseif ($dbTable.Columns[$item].DataType.SqlDataType.ToString().ToLower() -like '*date*') {
+                                    $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss")
                                     $wheres += "[$item] = '$oldValue'"
                                 } else {
                                     $oldValue = ($row.$item).Tostring().Replace("'", "''")

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -96,7 +96,7 @@ function New-DbaDbMaskingConfig {
         try {
             $columnTypes = Get-Content -Path "$script:PSModuleRoot\bin\datamasking\columntypes.json" | ConvertFrom-Json
         } catch {
-            Stop-Function -Message "Something went wrong importing the column types" -Continue
+            Stop-Function -Message "Something went wrong importing the column types" -ErrorRecord $_ -Continue
         }
         # Check if the Path is accessible
         if (-not (Test-Path -Path $Path)) {
@@ -110,6 +110,8 @@ function New-DbaDbMaskingConfig {
                 Stop-Function -Message "$Path is not a directory"
             }
         }
+
+        $supportedDataTypes = 'bit', 'bool', 'char', 'date', 'datetime', 'datetime2', 'decimal', 'int', 'money', 'nchar', 'ntext', 'nvarchar', 'smalldatetime', 'text', 'time', 'uniqueidentifier', 'userdefineddatatype', 'varchar'
     }
 
     process {
@@ -141,6 +143,12 @@ function New-DbaDbMaskingConfig {
             foreach ($tableobject in $tablecollection) {
                 Write-Message -Message "Processing table $($tableobject.Name)" -Level Verbose
 
+                $hasUniqueIndex = $false
+
+                if ($tableobject.Indexes.IsUnique) {
+                    $hasUniqueIndex = $true
+                }
+
                 $columns = @()
 
                 # Get the columns
@@ -156,26 +164,27 @@ function New-DbaDbMaskingConfig {
                         Write-Message -Level Verbose -Message "Skipping $columnobject because it is an identity column"
                         continue
                     }
+
                     if ($columnobject.IsForeignKey) {
                         Write-Message -Level Verbose -Message "Skipping $columnobject because it is a foreign key"
                         continue
                     }
+
                     if ($columnobject.Computed) {
                         Write-Message -Level Verbose -Message "Skipping $columnobject because it is a computed column"
                         continue
                     }
-                    if ($columnobject.DataType.Name -eq 'hierarchyid') {
-                        Write-Message -Level Verbose -Message "Skipping $columnobject because it is a hierarchyid column"
+
+                    if ($columnobject.GeneratedAlwaysType -ne 'None') {
+                        Write-Message -Level Verbose -Message "Skipping $columnobject because it is a computed column for temporal tables"
                         continue
                     }
-                    if ($columnobject.DataType.Name -eq 'geography') {
-                        Write-Message -Level Verbose -Message "Skipping $columnobject because it is a geography column"
+
+                    if ($columnobject.DataType.Name -notin $supportedDataTypes) {
+                        Write-Message -Level Verbose -Message "Skipping $columnobject because it is not a supported data type"
                         continue
                     }
-                    if ($columnobject.DataType.Name -eq 'geometry') {
-                        Write-Message -Level Verbose -Message "Skipping $columnobject because it is a geometry column"
-                        continue
-                    }
+
                     if ($columnobject.DataType.SqlDataType.ToString().ToLower() -eq 'xml') {
                         Write-Message -Level Verbose -Message "Skipping $columnobject because it is a xml column"
                         continue
@@ -202,45 +211,6 @@ function New-DbaDbMaskingConfig {
                         $maskingType = $maskingType | Select-Object TypeName -ExpandProperty TypeName
 
                         switch ($maskingType.ToLower()) {
-                            "firstname" {
-                                $columns += [PSCustomObject]@{
-                                    Name            = $columnobject.Name
-                                    ColumnType      = $columnType
-                                    CharacterString = $null
-                                    MinValue        = $min
-                                    MaxValue        = $columnLength
-                                    MaskingType     = "Name"
-                                    SubType         = "Firstname"
-                                    Deterministic   = $false
-                                    Nullable        = $columnobject.Nullable
-                                }
-                            }
-                            "lastname" {
-                                $columns += [PSCustomObject]@{
-                                    Name            = $columnobject.Name
-                                    ColumnType      = $columnType
-                                    CharacterString = $null
-                                    MinValue        = $min
-                                    MaxValue        = $columnLength
-                                    MaskingType     = "Name"
-                                    SubType         = "Lastname"
-                                    Deterministic   = $false
-                                    Nullable        = $columnobject.Nullable
-                                }
-                            }
-                            "creditcard" {
-                                $columns += [PSCustomObject]@{
-                                    Name            = $columnobject.Name
-                                    ColumnType      = $columnType
-                                    CharacterString = $null
-                                    MinValue        = $min
-                                    MaxValue        = $columnLength
-                                    MaskingType     = "Finance"
-                                    SubType         = "CreditcardNumber"
-                                    Deterministic   = $false
-                                    Nullable        = $columnobject.Nullable
-                                }
-                            }
                             "address" {
                                 $columns += [PSCustomObject]@{
                                     Name            = $columnobject.Name
@@ -250,6 +220,77 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Address"
                                     SubType         = "StreetAddress"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "bic" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Finance"
+                                    SubType         = "Bic"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "bitcoin" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Finance"
+                                    SubType         = "BitcoinAddress"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "country" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "Country"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "countrycode" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "CountryCode"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "ethereum" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Finance"
+                                    SubType         = "EthereumAddress"
+                                    Format          = $null
                                     Deterministic   = $false
                                     Nullable        = $columnobject.Nullable
                                 }
@@ -263,19 +304,21 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Address"
                                     SubType         = "City"
+                                    Format          = $null
                                     Deterministic   = $false
                                     Nullable        = $columnobject.Nullable
                                 }
                             }
-                            "zipcode" {
+                            "creditcardcvv" {
                                 $columns += [PSCustomObject]@{
                                     Name            = $columnobject.Name
                                     ColumnType      = $columnType
                                     CharacterString = $null
                                     MinValue        = $min
                                     MaxValue        = $columnLength
-                                    MaskingType     = "Address"
-                                    SubType         = "Zipcode"
+                                    MaskingType     = "Finance"
+                                    SubType         = "CreditCardCvv"
+                                    Format          = $null
                                     Deterministic   = $false
                                     Nullable        = $columnobject.Nullable
                                 }
@@ -289,6 +332,175 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Company"
                                     SubType         = "CompanyName"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "creditcard" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Finance"
+                                    SubType         = "CreditcardNumber"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "email" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Internet"
+                                    SubType         = "Email"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "firstname" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Name"
+                                    SubType         = "Firstname"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "fullname" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Name"
+                                    SubType         = "FullName"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "iban" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Finance"
+                                    SubType         = "Iban"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "lastname" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Name"
+                                    SubType         = "Lastname"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "latitude" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "Latitude"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "longitude" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "Longitude"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "phone" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Phone"
+                                    SubType         = "PhoneNumber"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "state" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "State"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "stateabbr" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "StateAbbr"
+                                    Format          = $null
+                                    Deterministic   = $false
+                                    Nullable        = $columnobject.Nullable
+                                }
+                            }
+                            "zipcode" {
+                                $columns += [PSCustomObject]@{
+                                    Name            = $columnobject.Name
+                                    ColumnType      = $columnType
+                                    CharacterString = $null
+                                    MinValue        = $min
+                                    MaxValue        = $columnLength
+                                    MaskingType     = "Address"
+                                    SubType         = "Zipcode"
+                                    Format          = $null
                                     Deterministic   = $false
                                     Nullable        = $columnobject.Nullable
                                 }
@@ -302,6 +514,7 @@ function New-DbaDbMaskingConfig {
                                     MaxValue        = $columnLength
                                     MaskingType     = "Internet"
                                     SubType         = "UserName"
+                                    Format          = $null
                                     Deterministic   = $false
                                     Nullable        = $columnobject.Nullable
                                 }
@@ -335,6 +548,10 @@ function New-DbaDbMaskingConfig {
                             }
                             "datetime2" {
                                 $subType = "Date"
+                                $MaxValue = $null
+                            }
+                            "decimal" {
+                                $subType = "Decimal"
                                 $MaxValue = $null
                             }
                             "float" {
@@ -390,6 +607,7 @@ function New-DbaDbMaskingConfig {
                             MaxValue        = $MaxValue
                             MaskingType     = $type
                             SubType         = $subType
+                            Format          = $null
                             Deterministic   = $false
                             Nullable        = $columnobject.Nullable
                         }
@@ -400,9 +618,10 @@ function New-DbaDbMaskingConfig {
                 # Check if something needs to be generated
                 if ($columns) {
                     $tables += [PSCustomObject]@{
-                        Name    = $tableobject.Name
-                        Schema  = $tableobject.Schema
-                        Columns = $columns
+                        Name           = $tableobject.Name
+                        Schema         = $tableobject.Schema
+                        Columns        = $columns
+                        HasUniqueIndex = $hasUniqueIndex
                     }
                 } else {
                     Write-Message -Message "No columns match for masking in table $($tableobject.Name)" -Level Verbose
@@ -430,7 +649,7 @@ function New-DbaDbMaskingConfig {
                 Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
                 Get-ChildItem -Path $temppath
             } catch {
-                Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -Continue -ErrorRecord $_
+                Stop-Function -Message "Something went wrong writing the results to the $Path" -Target $Path -Continue -ErrorRecord $_
             }
         } else {
             Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -175,7 +175,7 @@ function New-DbaDbMaskingConfig {
                         continue
                     }
 
-                    if ($columnobject.GeneratedAlwaysType -ne 'None') {
+                    if ($server.VersionMajor -ge 13 -and $columnobject.GeneratedAlwaysType -ne 'None') {
                         Write-Message -Level Verbose -Message "Skipping $columnobject because it is a computed column for temporal tables"
                         continue
                     }

--- a/functions/Sync-DbaAvailabilityGroup.ps1
+++ b/functions/Sync-DbaAvailabilityGroup.ps1
@@ -232,7 +232,7 @@ function Sync-DbaAvailabilityGroup {
             if ($Exclude -notcontains "Logins") {
                 if ($PSCmdlet.ShouldProcess("Syncing logins from $primaryserver to $secondaryservers")) {
                     Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing logins"
-                    Copy-DbaLogin -Source $server -Destination $secondaries -ExcludeLogin $ExcludeLogin -Force:$Force
+                    Copy-DbaLogin -Source $server -Destination $secondaries -Login $Login -ExcludeLogin $ExcludeLogin -Force:$Force
                 }
             }
 

--- a/tests/Get-DbaDependency.Tests.ps1
+++ b/tests/Get-DbaDependency.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'InputObject','AllowSystemObjects','Parents','IncludeSelf','EnableException'
+        [object[]]$knownParameters = 'InputObject', 'AllowSystemObjects', 'Parents', 'IncludeSelf', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -15,5 +15,5 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 <#
     Integration test should appear below and are custom to the command you are writing.
     Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
+    for more guidance.
 #>

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -36,6 +36,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         New-DbaDatabase -SqlInstance $script:instance1 -Name $db
         Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query $sql
     }
+
     AfterAll {
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database $db -Confirm:$false
         $file | Remove-Item -Confirm:$false -ErrorAction Ignore
@@ -53,7 +54,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 $result.Rows | Should -Be 2
                 $result.Database | Should -Contain $db
             }
-            
+
         }
         It "masks the data and does not delete it" {
             Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people" | Should -Not -Be $null

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','FilePath','Locale','CharacterString','Table','Column','ExcludeTable','ExcludeColumn','Query','MaxValue','ModulusFactor','ExactLength','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'Query', 'MaxValue', 'ModulusFactor', 'ExactLength', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -33,23 +33,23 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                                 GO
                                 INSERT INTO people2 (fname, lname, dob) VALUES ('Layla','Schmoe','2/2/2000')
                                 INSERT INTO people2 (fname, lname, dob) VALUES ('Eric','Schmee','2/2/1950')"
-        New-DbaDatabase -SqlInstance $script:instance1 -Name $db
-        Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query $sql
+        New-DbaDatabase -SqlInstance $script:instance2 -Name $db
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query $sql
     }
 
     AfterAll {
-        Remove-DbaDatabase -SqlInstance $script:instance1 -Database $db -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance2 -Database $db -Confirm:$false
         $file | Remove-Item -Confirm:$false -ErrorAction Ignore
     }
 
     Context "Command works" {
         It "starts with the right data" {
-            Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people where fname = 'Joe'" | Should -Not -Be $null
-            Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query "select * from people where fname = 'Joe'" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Not -Be $null
         }
         It "returns the proper output" {
-            $file = New-DbaDbMaskingConfig -SqlInstance $script:instance1 -Database $db -Path C:\temp
-            $results = $file | Invoke-DbaDbDataMasking -SqlInstance $script:instance1 -Database $db -Confirm:$false
+            $file = New-DbaDbMaskingConfig -SqlInstance $script:instance2 -Database $db -Path C:\temp
+            $results = $file | Invoke-DbaDbDataMasking -SqlInstance $script:instance2 -Database $db -Confirm:$false
             foreach ($result in $results) {
                 $result.Rows | Should -Be 2
                 $result.Database | Should -Contain $db
@@ -57,9 +57,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         }
         It "masks the data and does not delete it" {
-            Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people" | Should -Not -Be $null
-            Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people where fname = 'Joe'" | Should -Be $null
-            Invoke-DbaQuery -SqlInstance $script:instance1 -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query "select * from people" | Should -Not -Be $null
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query "select * from people where fname = 'Joe'" | Should -Be $null
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $db -Query "select * from people where lname = 'Schmee'" | Should -Be $null
         }
     }
 }

--- a/tests/New-DbaDbMaskingConfig.Tests.ps1
+++ b/tests/New-DbaDbMaskingConfig.Tests.ps1
@@ -24,18 +24,18 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 GO
                 INSERT INTO people (fname, lname, dob) VALUES ('Joe','Schmoe','2/2/2000')
                 INSERT INTO people (fname, lname, dob) VALUES ('Jane','Schmee','2/2/1950')"
-        New-DbaDatabase -SqlInstance $script:instance2 -Name $db
-        Invoke-DbaQuery -SqlInstance $script:instance2 -Query $sql -Database $db
+        New-DbaDatabase -SqlInstance $script:instance1 -Name $db
+        Invoke-DbaQuery -SqlInstance $script:instance1 -Query $sql -Database $db
     }
     AfterAll {
-        Remove-DbaDatabase -SqlInstance $script:instance2 -Database $db -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance1 -Database $db -Confirm:$false
         $results | Remove-Item -Confirm:$false -ErrorAction Ignore
     }
 
     Context "Command works" {
 
         It "Should output a file with specific content" {
-            $results = New-DbaDbMaskingConfig -SqlInstance $script:instance2 -Database $db -Path C:\temp
+            $results = New-DbaDbMaskingConfig -SqlInstance $script:instance1 -Database $db -Path C:\temp
             $results.Directory.Name | Should -Be temp
             $results.FullName | Should -FileContentMatch $db
             $results.FullName | Should -FileContentMatch fname

--- a/tests/New-DbaDbMaskingConfig.Tests.ps1
+++ b/tests/New-DbaDbMaskingConfig.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','Table','Column','Path','Locale','Force','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Column', 'Path', 'Locale', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -24,18 +24,18 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
                 GO
                 INSERT INTO people (fname, lname, dob) VALUES ('Joe','Schmoe','2/2/2000')
                 INSERT INTO people (fname, lname, dob) VALUES ('Jane','Schmee','2/2/1950')"
-        New-DbaDatabase -SqlInstance $script:instance1 -Name $db
-        Invoke-DbaQuery -SqlInstance $script:instance1 -Query $sql -Database $db
+        New-DbaDatabase -SqlInstance $script:instance2 -Name $db
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Query $sql -Database $db
     }
     AfterAll {
-        Remove-DbaDatabase -SqlInstance $script:instance1 -Database $db -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance2 -Database $db -Confirm:$false
         $results | Remove-Item -Confirm:$false -ErrorAction Ignore
     }
 
     Context "Command works" {
 
         It "Should output a file with specific content" {
-            $results = New-DbaDbMaskingConfig -SqlInstance $script:instance1 -Database $db -Path C:\temp
+            $results = New-DbaDbMaskingConfig -SqlInstance $script:instance2 -Database $db -Path C:\temp
             $results.Directory.Name | Should -Be temp
             $results.FullName | Should -FileContentMatch $db
             $results.FullName | Should -FileContentMatch fname


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4910, #4970 )
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
A lot of fixes have been applied including the ones that were created as an issue.
- Added support for unique indexes
- Added properties to JSON table object
- Added extra options for different types of data
- Added known masking types
- Added format property to allow for special value formatting
- Added support for TEXT and NTEXT data types
- Added synonyms 
- Fixed decimal masking 
- Fixed boolean masking
- Fixed UPDATE statement to have all the table's columns in the WHERE clause

And a lot more

### Commands to test
New-DbaDbMaskingConfig
Invoke-DbaDbMasking

