### PR TITLE
Copy-DbaLinkedServer - check ProductName

### DIFF
--- a/functions/Copy-DbaLinkedServer.ps1
+++ b/functions/Copy-DbaLinkedServer.ps1
@@ -119,12 +119,14 @@ function Copy-DbaLinkedServer {
                 }
 
                 $linkedServerName = $currentLinkedServer.Name
+                $linkedServerProductName = $currentLinkedServer.ProductName
                 $linkedServerDataSource = $currentLinkedServer.DataSource
 
                 $copyLinkedServer = [pscustomobject]@{
                     SourceServer      = $sourceServer.Name
                     DestinationServer = $destServer.Name
                     Name              = $linkedServerName
+                    ProductName       = $linkedServerProductName
                     DataSource        = $linkedServerDataSource
                     Type              = "Linked Server"
                     Status            = $null
@@ -183,7 +185,7 @@ function Copy-DbaLinkedServer {
 
                         $destServer.Query($sql)
 
-                        if ($copyLinkedServer.Name -ne $copyLinkedServer.DataSource) {
+                        if ($copyLinkedServer.ProductName -eq 'SQL Server' -and $copyLinkedServer.Name -ne $copyLinkedServer.DataSource) {
                             $sql2 = "EXEC sp_setnetname '$($copyLinkedServer.Name)', '$($copyLinkedServer.DataSource)'; "
                             $destServer.Query($sql2)
                         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4087)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Fix case where ProductName is not equal to 'SQL Server'.

### Commands to test

Create linked servers:
USE [master]
GO
EXEC master.dbo.sp_addlinkedserver @server = N'LINKTEST1', @srvproduct=N'SQL Server'
EXEC master.dbo.sp_addlinkedserver @server = N'LINKTEST2', @srvproduct=N'SQL Server'
EXEC master.dbo.sp_addlinkedserver @server = N'LINKTEST3', @srvproduct=N'SQL', @provider = 'SQLNCLI'
GO
--update network name
exec sp_setnetname 'LINKTEST2','SRV01'

Copy

Copy-DBALinkedServer -Source 'localhost\SQL2016' -Destination 'localhost\SQL2'

Check

select * from sys.servers where server_id > 0