### PR TITLE
Resolving multithreading issues with Update-DbaInstance once and for all

### DIFF
--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -1,0 +1,200 @@
+Function Invoke-DbaAdvancedUpdate {
+    <#
+    .SYNOPSIS
+        Designed for internal use, implements parallel execution for Update-DbaInstance.
+
+    .DESCRIPTION
+        Invokes an update process for a single computer and restarts it if needed
+
+    .PARAMETER ComputerName
+        Target computer with SQL instance or instances.
+
+    .PARAMETER Action
+        An object containing the action plan
+
+    .PARAMETER Restart
+        Restart computer automatically after a successful installation of a patch and wait until it comes back online.
+        Using this parameter is the only way to chain-install more than 1 patch on a computer, since every single patch will require a restart of said computer.
+
+    .PARAMETER Credential
+        Windows Credential with permission to log on to the remote server.
+        Must be specified for any remote connection if update Repository is located on a network folder.
+
+    .PARAMETER Authentication
+        Chooses an authentication protocol for remote connections.
+        If the protocol fails to establish a connection
+
+        Defaults:
+        * CredSSP when -Credential is specified - due to the fact that repository Path is usually a network share and credentials need to be passed to the remote host
+          to avoid the double-hop issue.
+        * Default when -Credential is not specified. Will likely fail if a network path is specified.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .EXAMPLE
+    PS C:\> Invoke-DbaAdvancedUpdate -ComputerName SQL1 -Action $actions -RestartNeeded $true
+
+    Invokes update actions on SQL1 after restarting it.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    Param (
+        [string]$ComputerName,
+        [object[]]$Action,
+        [bool]$Restart,
+        [ValidateSet('Default', 'Basic', 'Negotiate', 'NegotiateWithImplicitCredential', 'Credssp', 'Digest', 'Kerberos')]
+        [string]$Authentication = 'Credssp',
+        [pscredential]$Credential,
+        [switch]$EnableException
+    )
+    $computer = $ComputerName
+    $activity = "Updating SQL Server components on $computer"
+    $restarted = $false
+    $restartParams = @{
+        ComputerName = $computer
+        ErrorAction  = 'Stop'
+        For          = 'WinRM'
+        Wait         = $true
+        Force        = $true
+    }
+    if ($Credential) {
+        $restartParams.Credential = $Credential
+    }
+    try {
+        $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential
+    } catch {
+        $restartNeeded = $false
+        Stop-Function -Message "Failed to get reboot status from $computer" -ErrorRecord $_
+    }
+    if ($restartNeeded -and $Restart) {
+        # Restart the computer prior to doing anything
+        Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Restarting computer $($computer) due to pending restart"
+        Write-Message -Level Verbose "Restarting computer $($computer) due to pending restart"
+        try {
+            $null = Restart-Computer @restartParams
+            $restarted = $true
+        } catch {
+            Stop-Function -Message "Failed to restart computer" -ErrorRecord $_
+        }
+    }
+    Write-Message -Level Debug -Message "Processing $($computer) with $(($Actions | Measure-Object).Count) actions"
+    #foreach action passed to the script for this particular computer
+    foreach ($currentAction in $Action) {
+        $output = $currentAction
+        $output.Successful = $false
+        $output.Restarted = $restarted
+        ## Start the installation sequence
+        Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Launching installation of $($currentAction.TargetLevel) KB$($currentAction.KB) ($($currentAction.Installer)) for SQL$($currentAction.MajorVersion) ($($currentAction.Build))"
+        $execParams = @{
+            ComputerName   = $computer
+            ErrorAction    = 'Stop'
+            Authentication = $Authentication
+        }
+        if ($Credential) {
+            $execParams.Credential = $Credential
+        } else {
+            if (Test-Bound -Not Authentication) {
+                # Use Default authentication instead of CredSSP when Authentication is not specified and Credential is null
+                $execParams.Authentication = "Default"
+            }
+        }
+        # Find a temporary folder to extract to - the drive that has most free space
+        try {
+            $chosenDrive = (Get-DbaDiskSpace -ComputerName $computer -Credential $Credential -EnableException:$true | Sort-Object -Property Free -Descending | Select-Object -First 1).Name
+            if (!$chosenDrive) {
+                # Fall back to the system drive
+                $chosenDrive = Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock { $env:SystemDrive } -Raw -ErrorAction Stop
+            }
+        } catch {
+            $msg = "Failed to retrieve a disk drive to extract the update"
+            $output.Notes += $msg
+            Stop-Function -Message $msg -ErrorRecord $_
+            return $output
+        }
+        $spExtractPath = $chosenDrive.TrimEnd('\') + "\dbatools_KB$($currentAction.KB)_Extract"
+        $output.ExtractPath = $spExtractPath
+        try {
+            # Extract file
+            Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Extracting $($currentAction.Installer) to $spExtractPath"
+            Write-Message -Level Verbose -Message "Extracting $($currentAction.Installer) to $spExtractPath"
+            $extractResult = Invoke-Program @execParams -Path $currentAction.Installer -ArgumentList "/x`:`"$spExtractPath`" /quiet" -Fallback
+            if (-not $extractResult.Successful) {
+                $msg = "Extraction failed with exit code $($extractResult.ExitCode)"
+                $output.Notes += $msg
+                Stop-Function -Message $msg
+                return $output
+            }
+            # Install the patch
+            if ($currentAction.InstanceName) {
+                $instanceClause = "/instancename=$($currentAction.InstanceName)"
+            } else {
+                $instanceClause = '/allinstances'
+            }
+            Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Now installing update SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel) from $spExtractPath"
+            Write-Message -Level Verbose -Message "Starting installation from $spExtractPath"
+            $updateResult = Invoke-Program @execParams -Path "$spExtractPath\setup.exe" -ArgumentList @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms') -WorkingDirectory $spExtractPath -Fallback
+            $output.ExitCode = $updateResult.ExitCode
+            if ($updateResult.Successful) {
+                $output.Successful = $true
+            } else {
+                $msg = "Update failed with exit code $($updateResult.ExitCode)"
+                $output.Notes += $msg
+                Stop-Function -Message $msg
+                return $output
+            }
+            $output.Log = $updateResult.stdout
+        } catch {
+            Stop-Function -Message "Upgrade failed" -ErrorRecord $_
+            $output.Notes += $_.Exception.Message
+            return $output
+        } finally {
+            ## Cleanup temp
+            Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Cleaning up extracted files from $spExtractPath"
+            try {
+                Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Removing temporary files"
+                $null = Invoke-CommandWithFallBack @execParams -ScriptBlock {
+                    if ($args[0] -like '*\dbatools_KB*_Extract' -and (Test-Path $args[0])) {
+                        Remove-Item -Recurse -Force -LiteralPath $args[0] -ErrorAction Stop
+                    }
+                } -Raw -ArgumentList $spExtractPath
+            } catch {
+                $message = "Failed to cleanup temp folder on computer $($computer)`: $($_.Exception.Message)"
+                Write-Message -Level Verbose -Message $message
+                $output.Notes += $message
+            }
+        }
+        #double check if restart is needed
+        try {
+            $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential
+        } catch {
+            $restartNeeded = $false
+            Stop-Function -Message "Failed to get reboot status from $computer" -ErrorRecord $_
+        }
+        if ($updateResult.ExitCode -eq 3010 -or $restartNeeded) {
+            if ($Restart) {
+                # Restart the computer
+                Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Restarting computer $($computer) and waiting for it to come back online"
+                Write-Message -Level Verbose "Restarting computer $($computer) and waiting for it to come back online"
+                try {
+                    $null = Restart-Computer @restartParams
+                    $output.Restarted = $true
+                } catch {
+                    Stop-Function -Message "Failed to restart computer" -ErrorRecord $_
+                    return $output
+                }
+            } else {
+                $output.Notes += "Restart is required for computer $($computer) to finish the installation of SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel)"
+            }
+        }
+        $output
+        Write-Progress -Activity $activity -Completed
+    }
+}

--- a/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
@@ -1,0 +1,177 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+$exeDir = "C:\Temp\dbatools_$CommandName"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    BeforeAll {
+        # Prevent the functions from executing dangerous stuff and getting right responses where needed
+        Mock -CommandName Invoke-Program -MockWith { [pscustomobject]@{ Successful = $true; ExitCode = [uint32[]]3010 } } -ModuleName dbatools
+        Mock -CommandName Test-PendingReboot -MockWith { $false } -ModuleName dbatools
+        Mock -CommandName Test-ElevationRequirement -MockWith { $null } -ModuleName dbatools
+        Mock -CommandName Restart-Computer -MockWith { $null } -ModuleName dbatools
+        Mock -CommandName Register-RemoteSessionConfiguration -ModuleName dbatools -MockWith {
+            [pscustomobject]@{ 'Name' = 'dbatoolsInstallSqlServerUpdate' ; Successful = $true ; Status = 'Dummy' }
+        }
+        Mock -CommandName Unregister-RemoteSessionConfiguration -ModuleName dbatools -MockWith {
+            [pscustomobject]@{ 'Name' = 'dbatoolsInstallSqlServerUpdate' ; Successful = $true ; Status = 'Dummy' }
+        }
+        Mock -CommandName Get-DbaDiskSpace -MockWith { [pscustomobject]@{ Name = 'C:\'; Free = 1 } } -ModuleName dbatools
+    }
+    BeforeEach {
+        $singleAction = [pscustomobject]@{
+            ComputerName  = $env:COMPUTERNAME
+            MajorVersion  = "2017"
+            Build         = "14.0.3038"
+            Architecture  = 'x64'
+            TargetVersion = [pscustomobject]@{
+                "SqlInstance" = $null
+                "Build"       = "14.0.3045"
+                "NameLevel"   = "2017"
+                "SPLevel"     = "RTM", "LATEST"
+                "CULevel"     = 'CU12'
+                "KBLevel"     = "4464082"
+                "BuildLevel"  = [version]'14.0.3045'
+                "MatchType"   = "Exact"
+            }
+            TargetLevel   = 'RTMCU12'
+            KB            = '4464082'
+            Successful    = $true
+            Restarted     = $false
+            InstanceName  = ""
+            Installer     = "dummy"
+            ExtractPath   = $null
+            Notes         = @()
+            ExitCode      = $null
+            Log           = $null
+        }
+        $doubleAction = @(
+            [pscustomobject]@{
+                ComputerName  = $env:COMPUTERNAME
+                MajorVersion  = "2008"
+                Build         = "10.0.4279"
+                Architecture  = 'x64'
+                TargetVersion = [pscustomobject]@{
+                    "SqlInstance" = $null
+                    "Build"       = "10.0.5500"
+                    "NameLevel"   = "2008"
+                    "SPLevel"     = "SP3"
+                    "CULevel"     = ''
+                    "KBLevel"     = "2546951"
+                    "BuildLevel"  = [version]'10.0.5500'
+                    "MatchType"   = "Exact"
+                }
+                TargetLevel   = 'SP3'
+                KB            = '2546951'
+                Successful    = $true
+                Restarted     = $false
+                InstanceName  = ""
+                Installer     = "dummy"
+                ExtractPath   = $null
+                Notes         = @()
+                ExitCode      = $null
+                Log           = $null
+            },
+            [pscustomobject]@{
+                ComputerName  = $env:COMPUTERNAME
+                MajorVersion  = "2008"
+                Build         = "10.0.5500"
+                Architecture  = 'x64'
+                TargetVersion = [pscustomobject]@{
+                    "SqlInstance" = $null
+                    "Build"       = "10.0.5794"
+                    "NameLevel"   = "2008"
+                    "SPLevel"     = "SP3"
+                    "CULevel"     = 'CU7'
+                    "KBLevel"     = "2738350"
+                    "BuildLevel"  = [version]'10.0.5794'
+                    "MatchType"   = "Exact"
+                }
+                TargetLevel   = 'SP3CU7'
+                KB            = '2738350'
+                Successful    = $true
+                Restarted     = $false
+                InstanceName  = ""
+                Installer     = "dummy"
+                ExtractPath   = $null
+                Notes         = @()
+                ExitCode      = $null
+                Log           = $null
+            }
+        )
+    }
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'ComputerName', 'Action', 'Credential', 'Restart', 'Authentication', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+    Context "Validate upgrades to a latest version" {
+        It "Should mock-upgrade SQL2017\LAB0 to SP0CU12 thinking it's latest" {
+            $result = Invoke-DbaAdvancedUpdate -ComputerName $env:COMPUTERNAME -EnableException -Action $singleAction
+            Assert-MockCalled -CommandName Invoke-Program -Exactly 2 -Scope It -ModuleName dbatools
+            Assert-MockCalled -CommandName Restart-Computer -Exactly 0 -Scope It -ModuleName dbatools
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.MajorVersion | Should -Be 2017
+            $result.TargetLevel | Should -Be RTMCU12
+            $result.KB | Should -Be 4464082
+            $result.Successful | Should -Be $true
+            $result.Restarted | Should -Be $false
+            $result.Installer | Should -Be 'dummy'
+            $result.Notes | Should -Be 'Restart is required for computer PRGLT10059 to finish the installation of SQL2017RTMCU12'
+            $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract'
+        }
+        It "Should mock-upgrade 2008 to SP3CU7" {
+            $results = Invoke-DbaAdvancedUpdate -ComputerName $env:COMPUTERNAME -Restart $true -EnableException -Action $doubleAction
+            Assert-MockCalled -CommandName Invoke-Program -Exactly 4 -Scope It -ModuleName dbatools
+            Assert-MockCalled -CommandName Restart-Computer -Exactly 2 -Scope It -ModuleName dbatools
+
+            ($results | Measure-Object).Count | Should -Be 2
+            #2008SP3
+            $result = $results | Select-Object -First 1
+            $result.MajorVersion | Should -Be 2008
+            $result.TargetLevel | Should -Be SP3
+            $result.KB | Should -Be 2546951
+            $result.Successful | Should -Be $true
+            $result.Restarted | Should -Be $true
+            $result.Installer | Should -Be 'dummy'
+            $result.Notes | Should -BeNullOrEmpty
+            $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract'
+
+            #2008SP3CU7
+            $result = $results | Select-Object -First 1 -Skip 1
+            $result.MajorVersion | Should -Be 2008
+            $result.TargetLevel | Should -Be SP3CU7
+            $result.KB | Should -Be 2738350
+            $result.Successful | Should -Be $true
+            $result.Restarted | Should -Be $true
+            $result.Installer | Should -Be 'dummy'
+            $result.Notes | Should -BeNullOrEmpty
+            $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract'
+        }
+    }
+    Context "Negative tests" {
+        It "fails when update execution has failed" {
+            #override default mock
+            Mock -CommandName Invoke-Program -MockWith { [pscustomobject]@{ Successful = $false; ExitCode = 12345 } } -ModuleName dbatools
+            { Invoke-DbaAdvancedUpdate -ComputerName $env:COMPUTERNAME -EnableException -Action $singleAction } | Should throw 'failed with exit code 12345'
+            $result = Invoke-DbaAdvancedUpdate -ComputerName $env:COMPUTERNAME -Action $singleAction -WarningVariable warVar 3>$null
+            $result | Should -Not -BeNullOrEmpty
+            $result.MajorVersion | Should -Be 2017
+            $result.TargetLevel | Should -Be RTMCU12
+            $result.KB | Should -Be 4464082
+            $result.Successful | Should -Be $false
+            $result.Restarted | Should -Be $false
+            $result.Installer | Should -Be 'dummy'
+            $result.Notes | Should -BeLike '*failed with exit code 12345'
+            $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract'
+            $warVar | Should -BeLike '*failed with exit code 12345'
+            #revert default mock
+            Mock -CommandName Invoke-Program -MockWith { [pscustomobject]@{ Successful = $true } } -ModuleName dbatools
+        }
+    }
+}

--- a/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
@@ -122,7 +122,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             $result.Successful | Should -Be $true
             $result.Restarted | Should -Be $false
             $result.Installer | Should -Be 'dummy'
-            $result.Notes | Should -Be 'Restart is required for computer PRGLT10059 to finish the installation of SQL2017RTMCU12'
+            $result.Notes | Should -BeLike 'Restart is required for computer * to finish the installation of SQL2017RTMCU12'
             $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract'
         }
         It "Should mock-upgrade 2008 to SP3CU7" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, from slack)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When imported without multifile import, the function would fail to run because internal functions are not exposed in such cases.

### Approach
New public function Invoke-DbaAdvancedUpdate to support multithreading.

### Commands to test
Tested it by loading the module from allcommands.ps1 and without custom exports. It works.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
Install-DbaInstance should undergo the same change
