### PR TITLE
Fixed self-building process

### DIFF
--- a/bin/build-project.ps1
+++ b/bin/build-project.ps1
@@ -3,9 +3,10 @@ param (
     [string]$ProjectPath = (Resolve-Path -Path (Join-Path -Path $PSModuleRoot -ChildPath 'bin\projects\dbatools\dbatools.sln')),
     [ValidateSet('ps3', 'ps4', 'Release', 'Debug')]
     [string]$MsbuildConfiguration = "Release",
-    [string]$MsbuildOptions = "",
     [Parameter(HelpMessage = 'Target to run instead of build')]
-    [string]$MsbuildTarget = 'Build'
+	[string]$MsbuildTarget = 'Build',
+	[string]$DllRoot = $script:DllRoot,
+	[string]$LibraryBase = (Join-Path $PSModuleRoot "bin")
 )
 
 if (-not $PSBoundParameters.ContainsKey('MsbuildConfiguration')) {
@@ -24,53 +25,53 @@ if (-not $PSBoundParameters.ContainsKey('MsbuildConfiguration')) {
     $_MsbuildConfiguration = $MsbuildConfiguration
 }
 
-function Get-MsBuildPath {
+function Get-DotNetPath {
     [CmdletBinding()]
     [OutputType([string])]
     param ()
     process {
-        $rawPath = "$(Split-Path ([string].Assembly.Location))\msbuild.exe"
-        (Resolve-Path $rawPath).Path
+		if (Get-Command dotnet.exe -CommandType Application -ErrorAction SilentlyContinue) { return (Get-Command dotnet.exe -CommandType Application).Source }
+		"$($env:ProgramFiles)\dotnet\dotnet.exe"
     }
 }
 
 $start = Get-Date
-$msbuild = Get-MsBuildPath
+$dotnet = Get-DotNetPath
 
-if (-not (Test-Path $msbuild)) {
-    throw "msbuild not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
+if (-not (Test-Path $dotnet)) {
+    throw "dotnet application not found, cannot compile library! Download and install the dotnet SDK from https://dotnet.microsoft.com/download"
 }
 
 if ($env:APPVEYOR -eq 'True') {
-    $MsbuildOptions = $MsbuildOptions + '/logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" '
     $_MsbuildConfiguration = 'Debug'
-    
-    if (-not (Test-Path "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll")) {
-        throw "msbuild logger not found, cannot compile library! Check your .NET installation health, then try again. Path checked: $msbuild"
-    }
 }
-
-#$MsbuildOptions = $MsbuildOptions + '/logger:BinaryLogger,"{0}";"{1}" ' -f (Join-Path $PSScriptRoot 'StructuredLogger.dll'), (Resolve-Path '..\msbuild.bin.log').Path
 
 if (-not (Test-Path $ProjectPath)) {
     throw new-object 'System.IO.FileNotFoundException' 'Could not file project or solution', $ProjectPath
 }
 
-Write-Verbose -Message "Building the library with command $msbuild $ProjectPath /p:Configuration=$_MsbuildConfiguration $MsbuildOptions /t:$MsBuildTarget"
-& $msbuild $ProjectPath "/p:Configuration=$_MsbuildConfiguration" $MsbuildOptions "/t:$MsBuildTarget"
+Write-Verbose -Message "Building the library with command $dotnet build $ProjectPath -c $_MsbuildConfiguration"
+& $dotnet build $ProjectPath -c $_MsbuildConfiguration
 
-if ($MsbuildTarget -eq 'Build') {
-    try {
+if ($MsbuildTarget -eq 'Build')
+{
+	if ($PSVersionTable.PSVersion.Major -ge 6) {
+		$dll = (Resolve-Path -Path "$libraryBase\netcoreapp2.1\dbatools.dll" -ErrorAction Ignore)
+	}
+	else {
+		$dll = (Resolve-Path -Path "$libraryBase\net452\dbatools.dll" -ErrorAction Ignore)
+	}
+	try {
         Write-Verbose -Message "Found library, trying to copy & import"
         if ($script:alwaysBuildLibrary) {
-            Move-Item -Path (Resolve-Path -Path "$PSModuleRoot\bin\dbatools.dll") -Destination $script:DllRoot -Force -ErrorAction Stop
+			Move-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
         } else {
-            Copy-Item -Path (Resolve-Path -Path "$PSModuleRoot\bin\dbatools.dll") -Destination $script:DllRoot -Force -ErrorAction Stop
+			Copy-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
         }
-        Add-Type -Path (Resolve-Path -Path "$PSModuleRoot\dbatools.dll") -ErrorAction Stop
+        Add-Type -Path (Resolve-Path -Path "$DllRoot\dbatools.dll") -ErrorAction Stop
     } catch {
         Write-Verbose -Message "Failed to copy & import, attempting to import straight from the module directory"
-        Add-Type -Path (Resolve-Path -Path "$PSModuleRoot\bin\dbatools.dll") -ErrorAction Stop
+        Add-Type -Path $dll -ErrorAction Stop
     }
     Write-Verbose -Message "Total duration: $((Get-Date) - $start)"
 }

--- a/bin/build-project.ps1
+++ b/bin/build-project.ps1
@@ -4,9 +4,9 @@ param (
     [ValidateSet('ps3', 'ps4', 'Release', 'Debug')]
     [string]$MsbuildConfiguration = "Release",
     [Parameter(HelpMessage = 'Target to run instead of build')]
-	[string]$MsbuildTarget = 'Build',
-	[string]$DllRoot = $script:DllRoot,
-	[string]$LibraryBase = (Join-Path $PSModuleRoot "bin")
+    [string]$MsbuildTarget = 'Build',
+    [string]$DllRoot = $script:DllRoot,
+    [string]$LibraryBase = (Join-Path $PSModuleRoot "bin")
 )
 
 if (-not $PSBoundParameters.ContainsKey('MsbuildConfiguration')) {
@@ -30,8 +30,8 @@ function Get-DotNetPath {
     [OutputType([string])]
     param ()
     process {
-		if (Get-Command dotnet.exe -CommandType Application -ErrorAction SilentlyContinue) { return (Get-Command dotnet.exe -CommandType Application).Source }
-		"$($env:ProgramFiles)\dotnet\dotnet.exe"
+        if (Get-Command dotnet.exe -CommandType Application -ErrorAction SilentlyContinue) { return (Get-Command dotnet.exe -CommandType Application).Source }
+        "$($env:ProgramFiles)\dotnet\dotnet.exe"
     }
 }
 
@@ -55,18 +55,18 @@ Write-Verbose -Message "Building the library with command $dotnet build $Project
 
 if ($MsbuildTarget -eq 'Build')
 {
-	if ($PSVersionTable.PSVersion.Major -ge 6) {
-		$dll = (Resolve-Path -Path "$libraryBase\netcoreapp2.1\dbatools.dll" -ErrorAction Ignore)
-	}
-	else {
-		$dll = (Resolve-Path -Path "$libraryBase\net452\dbatools.dll" -ErrorAction Ignore)
-	}
-	try {
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $dll = (Resolve-Path -Path "$libraryBase\netcoreapp2.1\dbatools.dll" -ErrorAction Ignore)
+    }
+    else {
+        $dll = (Resolve-Path -Path "$libraryBase\net452\dbatools.dll" -ErrorAction Ignore)
+    }
+    try {
         Write-Verbose -Message "Found library, trying to copy & import"
         if ($script:alwaysBuildLibrary) {
-			Move-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
+            Move-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
         } else {
-			Copy-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
+            Copy-Item -Path $dll -Destination $DllRoot -Force -ErrorAction Stop
         }
         Add-Type -Path (Resolve-Path -Path "$DllRoot\dbatools.dll") -ErrorAction Stop
     } catch {

--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -81,13 +81,10 @@ if ($ImportLibrary) {
                 $hasCompiledDll = Test-Path -Path $dll -ErrorAction Stop
             }
 
-            $reslibdll = Resolve-Path -Path "$libraryBase\dbatools.dll"
-
-            if ((-not $script:alwaysBuildLibrary) -and $hasCompiledDll -and ([System.Diagnostics.FileVersionInfo]::GetVersionInfo($reslibdll).FileVersion -eq $currentLibraryVersion)) {
+            if ((-not $script:alwaysBuildLibrary) -and $hasCompiledDll -and ([System.Diagnostics.FileVersionInfo]::GetVersionInfo($dll).FileVersion -eq $currentLibraryVersion)) {
                 $start = Get-Date
 
                 try {
-                    $libraryBase = Resolve-Path -Path "$libraryBase\"
                     $script:DllRoot = Resolve-Path -Path $script:DllRoot
                     Write-Verbose -Message "Found library, trying to copy & import"
                     # this looks excessive but for some reason the explicit string to string is required


### PR DESCRIPTION
## Type of Change

 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [x] Build system
 
### Description

With using features of later C# versions we could no longer use the msbuild that ships with the .net framework to compile the dbatools dll.
This PR switches the build operation to use the `dotnet.exe` application that comes the dotnet SDK (Comes with Visual Studio but can be installed standalone).

### Notes

May cause some tests to fail, as the previous logging integration of msbuild.exe is unavailable in dotnet.exe