### PR TITLE
Fix exception when setting agent job schedule start/end dates

### DIFF
--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -392,12 +392,12 @@ function Set-DbaAgentSchedule {
 
                         if ($StartDate) {
                             Write-Message -Message "Setting job schedule start date to $StartDate for schedule $ScheduleName" -Level Verbose
-                            $JobSchedule.StartDate = $StartDate
+                            $JobSchedule.ActiveStartDate = $StartDate
                         }
 
                         if ($EndDate) {
                             Write-Message -Message "Setting job schedule end date to $EndDate for schedule $ScheduleName" -Level Verbose
-                            $JobSchedule.EndDate = $EndDate
+                            $JobSchedule.ActiveEndDate = $EndDate
                         }
 
                         if ($StartTime) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4908 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Correctly set start & end dates for job schedules

### Approach
Uses correct property names for job start and end. See https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.agent.jobschedule?view=sql-smo-140.17283.0

### Commands to test
`Set-DbaAgentSchedule`