### PR TITLE
Update Backup-DbaDbCertificate.ps1 to fix 5106

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -235,7 +235,7 @@ function Backup-DbaDbCertificate {
         if (Test-FunctionInterrupt) { return }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+            $InputObject += Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $Certificate
         }
 
         foreach ($cert in $InputObject) {


### PR DESCRIPTION
adding the Certificate param to the call out to Get-DbaDbCertificate

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5106 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix for issue #5106 

### Approach
This adds the Certificate param to the call out to Get-DbaDbCertificate to get a single certificate if specified. Tested good in my local environment with and without the parameter and works as expected.
