### PR TITLE
Update Get-DbaUserPermission.ps1 to fix 5083

### DIFF
--- a/functions/Get-DbaUserPermission.ps1
+++ b/functions/Get-DbaUserPermission.ps1
@@ -189,6 +189,7 @@ function Get-DbaUserPermission {
             }
 
             $dbs = $server.Databases
+            $tempdb = $server.Databases['tempdb']
 
             if ($Database) {
                 $dbs = $dbs | Where-Object { $Database -contains $_.Name }
@@ -291,7 +292,7 @@ function Get-DbaUserPermission {
                 #Delete objects
                 Write-Message -Level Verbose -Message "Deleting objects"
                 try {
-                    $db.ExecuteNonQuery($endSQL)
+                    $tempdb.ExecuteNonQuery($endSQL)
                 } catch {
                     # here to avoid an empty catch
                     $null = 1


### PR DESCRIPTION
Changing the cleanup query to run on tempdb

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5083 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix 5083, remnant objects left behind in tempdb

### Approach
Changing the cleanup query to run on tempdb, as suggested by the issue reporter.
