### PR TITLE
Fix bug in Get-DbaDbFile NextGrowthEventSize

### DIFF
--- a/functions/Get-DbaDbFile.ps1
+++ b/functions/Get-DbaDbFile.ps1
@@ -212,9 +212,9 @@ ON fd.Drive = LEFT(df.physical_name, 1);
                     }
                 }
                 if ($result.GrowthType -eq "Percent") {
-                    $nextgrowtheventadd = [dbasize]($result.size * ($result.Growth * 0.01) * 1024)
+                    $nextgrowtheventadd = [dbasize]($result.size * 8 * ($result.Growth * 0.01) * 1024)
                 } else {
-                    $nextgrowtheventadd = [dbasize]($result.Growth * 8 * 1024)
+                    $nextgrowtheventadd = [dbasize]($result.Growth * 1024)
                 }
                 if (($nextgrowtheventadd.Byte -gt ($MaxSize.Byte - $size.Byte)) -and $maxsize -gt 0) {
                     [dbasize]$nextgrowtheventadd = 0


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #5147)
 
### Purpose
The $nextgrowtheventadd variable used to return NextGrowthEventSize in Get-DbaDbFile is incorrectly accounting for pages. 

For Percent growth types, pages are not currently accounted for and for non-Percent growth types pages are accounted for twice - once in the initial T-SQL call and again in the calculation for $nextgrowtheventadd.

### Approach
Line 215 - Update $nextgrowtheventadd calculation for Percent growth types to account for file size being returned in pages.

Line 217 - Update $nextgrowtheventadd calculation for non-Percent growth types to not account for file size being returned in pages as the "* 8" calculation is already performed in the T-SQL calls when growth is not percent-based. 

### Screenshots
Current version 

- mdf file is set to 64 MB growth but is showing 512 MB for the NextGrowthEventSize
- ldf file is set to 10% growth but is showing 3.20 MB for the NextGrowthEventSize

![bug](https://user-images.githubusercontent.com/33128934/53818731-c69c9080-3f25-11e9-8a92-3af0038ded5f.jpg)

Fixed version 

- 256 MB .mdf file is set to 64 MB growth and is showing 64 MB for the NextGrowthEventSize
- 256 MB .ldf file is set to 10% growth and is showing 25.60 MB for the NextGrowthEventSize

![fixed](https://user-images.githubusercontent.com/33128934/53818700-bab0ce80-3f25-11e9-942f-6c16a3abcc5b.JPG)
