### PR TITLE
Azure Support

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -242,6 +242,39 @@ function Connect-DbaInstance {
     }
     process {
         foreach ($instance in $SqlInstance) {
+            if ($instance.ComputerName -match "database\.windows\.net" -and -not $instance.InputObject.ConnectionContext.IsOpen) {
+                if (-not (Test-Bound -ParameterName ConnectTimeout)) {
+                    $ConnectTimeout = 30
+                }
+                $isAzure = $true
+                <#
+                DONE: detects: database.windows.net
+                DONE: detect: windows
+                DONE: detect: sql login
+                DONE: detect integrated if no credential is passed
+                #>
+                if ($SqlCredential) {
+                    $azureconnstring = "Server=tcp:$($instance.ComputerName),$($instance.Port);Initial Catalog=$Database;Persist Security Info=False;User ID=$($SqlCredential.UserName);Password=$($($SqlCredential.GetNetworkCredential()).Password);MultipleActiveResultSets=$MultipleActiveResultSets;Encrypt=True;TrustServerCertificate=$TrustServerCertificate;Connection Timeout=$ConnectTimeout;"
+
+                    if ($username -like "*\*" -or $username -like "*@*") {
+                        $azureconnstring = $azureconnstring + 'Authentication="Active Directory Password"'
+                    }
+                }
+                else {
+                    $azureconnstring = "Server=tcp:$($instance.ComputerName),$($instance.Port);Initial Catalog=$Database;Persist Security Info=False;User ID=$($SqlCredential.UserName);MultipleActiveResultSets=$MultipleActiveResultSets;Encrypt=True;TrustServerCertificate=$TrustServerCertificate;Connection Timeout=$ConnectTimeout;"
+                    $azureconnstring = $azureconnstring + 'Authentication="Active Directory Integrated"'
+                }
+                try {
+                    #$sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
+                    #$serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
+                    #$instance = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
+                    #return $azureconnstring
+                    $instance = [DbaInstanceParameter]$azureconnstring
+                }
+                catch {
+                    Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+                }
+            }
             #region Safely convert input into instance parameters
             if ($instance.GetType() -eq [Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter]) {
                 [DbaInstanceParameter]$ConvertedSqlInstance = $instance
@@ -288,8 +321,9 @@ function Connect-DbaInstance {
             }
 
             if ($instance.IsConnectionString) {
+                write-warning connstring
                 $server = New-Object Microsoft.SqlServer.Management.Smo.Server($instance.InputObject)
-            } else {
+            } elseif (-not $isAzure) {
                 $server = New-Object Microsoft.SqlServer.Management.Smo.Server $instance.FullSmoName
             }
 
@@ -369,7 +403,7 @@ function Connect-DbaInstance {
                 }
 
                 try {
-                    if ($null -ne $SqlCredential.UserName) {
+                    if ($null -ne $SqlCredential.UserName -and -not $isAzure) {
                         $username = ($SqlCredential.UserName).TrimStart("\")
 
                         # support both ad\username and username@ad
@@ -407,7 +441,9 @@ function Connect-DbaInstance {
                             $server.ConnectionContext.Connect()
                         }
                     } else {
-                        $server.ConnectionContext.SqlConnectionObject.Open()
+                        if (-not $isAzure) {
+                            $server.ConnectionContext.SqlConnectionObject.Open()
+                        }
                     }
                 } catch {
                     $originalException = $_.Exception
@@ -424,7 +460,7 @@ function Connect-DbaInstance {
                 }
             }
 
-            if ($loadedSmoVersion -ge 11) {
+            if ($loadedSmoVersion -ge 11 -and -not $isAzure) {
                 if ($server.VersionMajor -eq 8) {
                     # 2000
                     $initFieldsDb = New-Object System.Collections.Specialized.StringCollection

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -250,7 +250,7 @@ function Connect-DbaInstance {
                 if ($SqlCredential) {
                     $azureconnstring = "Server=tcp:$($instance.ComputerName),$($instance.Port);Initial Catalog=$Database;Persist Security Info=False;User ID=$($SqlCredential.UserName);Password=$($($SqlCredential.GetNetworkCredential()).Password);MultipleActiveResultSets=$MultipleActiveResultSets;Encrypt=True;TrustServerCertificate=$TrustServerCertificate;Connection Timeout=$ConnectTimeout;"
 
-                    if ($username -like "*\*" -or $username -like "*@*") {
+                    if ($SqlCredential.UserName -like "*\*" -or $SqlCredential.UserName -like "*@*") {
                         $azureconnstring = $azureconnstring + 'Authentication="Active Directory Password"'
                     }
                 }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -253,8 +253,7 @@ function Connect-DbaInstance {
                     if ($SqlCredential.UserName -like "*\*" -or $SqlCredential.UserName -like "*@*") {
                         $azureconnstring = $azureconnstring + 'Authentication="Active Directory Password"'
                     }
-                }
-                else {
+                } else {
                     $azureconnstring = "Server=tcp:$($instance.ComputerName),$($instance.Port);Initial Catalog=$Database;Persist Security Info=False;User ID=$($SqlCredential.UserName);MultipleActiveResultSets=$MultipleActiveResultSets;Encrypt=True;TrustServerCertificate=$TrustServerCertificate;Connection Timeout=$ConnectTimeout;"
                     $azureconnstring = $azureconnstring + 'Authentication="Active Directory Integrated"'
                 }
@@ -262,8 +261,7 @@ function Connect-DbaInstance {
                     $sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
                     $serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
                     $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
-                }
-                catch {
+                } catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
                 }
             }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -247,12 +247,6 @@ function Connect-DbaInstance {
                     $ConnectTimeout = 30
                 }
                 $isAzure = $true
-                <#
-                DONE: detects: database.windows.net
-                DONE: detect: windows
-                DONE: detect: sql login
-                DONE: detect integrated if no credential is passed
-                #>
                 if ($SqlCredential) {
                     $azureconnstring = "Server=tcp:$($instance.ComputerName),$($instance.Port);Initial Catalog=$Database;Persist Security Info=False;User ID=$($SqlCredential.UserName);Password=$($($SqlCredential.GetNetworkCredential()).Password);MultipleActiveResultSets=$MultipleActiveResultSets;Encrypt=True;TrustServerCertificate=$TrustServerCertificate;Connection Timeout=$ConnectTimeout;"
 

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -265,11 +265,9 @@ function Connect-DbaInstance {
                     $azureconnstring = $azureconnstring + 'Authentication="Active Directory Integrated"'
                 }
                 try {
-                    #$sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
-                    #$serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
-                    #$instance = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
-                    #return $azureconnstring
-                    $instance = [DbaInstanceParameter]$azureconnstring
+                    $sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
+                    $serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
+                    $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
                 }
                 catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
@@ -331,7 +329,7 @@ function Connect-DbaInstance {
                 $connstring = $server.ConnectionContext.ConnectionString
                 $server.ConnectionContext.ConnectionString = "$connstring;$appendconnectionstring"
                 $server.ConnectionContext.Connect()
-            } else {
+            } elseif (-not $isAzure) {
 
                 $server.ConnectionContext.ApplicationName = $ClientName
 

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -1,88 +1,88 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Types>
-    <!--Microsoft.SqlServer.Management.Smo.Database -->
-    <Type>
-        <Name>Microsoft.SqlServer.Management.Smo.Database</Name>
-        <Members>
-            <ScriptMethod>
-                <Name>Query</Name>
-                <Script>
-                    param (
-                        $Query,
+<!--Microsoft.SqlServer.Management.Smo.Database -->
+<Type>
+<Name>Microsoft.SqlServer.Management.Smo.Database</Name>
+<Members>
+<ScriptMethod>
+<Name>Query</Name>
+<Script>
+param (
+    $Query,
 
-                        $AllTables = $false
-                    )
+    $AllTables = $false
+)
 
-                    if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
-                    else { ($this.ExecuteWithResults($Query)).Tables[0] }
-                </Script>
-            </ScriptMethod>
-            <ScriptMethod>
-                <Name>Invoke</Name>
-                <Script>
-                    param (
-                        $Command
-                    )
+if ($AllTables) { ($this.ExecuteWithResults($Query)).Tables }
+else { ($this.ExecuteWithResults($Query)).Tables[0] }
+</Script>
+</ScriptMethod>
+<ScriptMethod>
+<Name>Invoke</Name>
+<Script>
+param (
+    $Command
+)
 
-                    $this.ExecuteNonQuery($Command)
-                </Script>
-            </ScriptMethod>
-        </Members>
-    </Type>
-    
-    <!--Microsoft.SqlServer.Management.Smo.Server -->
-    <Type>
-        <Name>Microsoft.SqlServer.Management.Smo.Server</Name>
-        <Members>
-            <ScriptMethod>
-                <Name>Query</Name>
-                <Script>
-                    param (
-                        $Query,
+$this.ExecuteNonQuery($Command)
+</Script>
+</ScriptMethod>
+</Members>
+</Type>
 
-                        $Database,
+<!--Microsoft.SqlServer.Management.Smo.Server -->
+<Type>
+<Name>Microsoft.SqlServer.Management.Smo.Server</Name>
+<Members>
+<ScriptMethod>
+<Name>Query</Name>
+<Script>
+param (
+    $Query,
 
-                        $AllTables = $false
-                    )
-					if (-not $Database) {
-						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
-							$Database = $this.ConnectionContext.CurrentDatabase
-							if (-not $Database) {
-								$Database = $this.ConnectionContext.SqlConnectionObject.Database
-							}
-						}
-						if (-not $Database) {
-							$Database = "master"
-						}
-					}
-                    if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
-                    else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
-                </Script>
-            </ScriptMethod>
-            <ScriptMethod>
-                <Name>Invoke</Name>
-                <Script>
-                    param (
-                        $Command,
+    $Database,
 
-                        $Database
-                    )
+    $AllTables = $false
+)
+if (-not $Database) {
+    if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
+        $Database = $this.ConnectionContext.CurrentDatabase
+        if (-not $Database) {
+            $Database = $this.ConnectionContext.SqlConnectionObject.Database
+        }
+    }
+    if (-not $Database) {
+        $Database = "master"
+    }
+}
+if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
+else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
+</Script>
+</ScriptMethod>
+<ScriptMethod>
+<Name>Invoke</Name>
+<Script>
+param (
+    $Command,
 
-					if (-not $Database) {
-						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
-							$Database = $this.ConnectionContext.CurrentDatabase
-							if (-not $Database) {
-								$Database = $this.ConnectionContext.SqlConnectionObject.Database
-							}
-						} 
-						if (-not $Database) {
-							$Database = "master"
-						}
-					}
-					
-                    $this.Databases[$Database].ExecuteNonQuery($Command)
-                </Script>
-            </ScriptMethod>
-        </Members>
-    </Type>
+    $Database
+)
+
+if (-not $Database) {
+    if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
+        $Database = $this.ConnectionContext.CurrentDatabase
+        if (-not $Database) {
+            $Database = $this.ConnectionContext.SqlConnectionObject.Database
+        }
+    }
+    if (-not $Database) {
+        $Database = "master"
+    }
+}
+
+$this.Databases[$Database].ExecuteNonQuery($Command)
+</Script>
+</ScriptMethod>
+</Members>
+</Type>
 </Types>

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -40,11 +40,17 @@
                     param (
                         $Query,
 
-                        $Database = "master",
+                        $Database,
 
                         $AllTables = $false
                     )
-
+					if (-not $Database) {
+						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
+							$Database = $this.ConnectionContext.CurrentDatabase
+						} else {
+							$Database = "master"
+						}
+					}
                     if ($AllTables) { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables }
                     else { ($this.Databases[$Database].ExecuteWithResults($Query)).Tables[0] }
                 </Script>

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -61,9 +61,17 @@
                     param (
                         $Command,
 
-                        $Database = "master"
+                        $Database
                     )
 
+					if (-not $Database) {
+						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
+							$Database = $this.ConnectionContext.CurrentDatabase
+						} else {
+							$Database = "master"
+						}
+					}
+					
                     $this.Databases[$Database].ExecuteNonQuery($Command)
                 </Script>
             </ScriptMethod>

--- a/xml/dbatools.Types.ps1xml
+++ b/xml/dbatools.Types.ps1xml
@@ -47,7 +47,11 @@
 					if (-not $Database) {
 						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
 							$Database = $this.ConnectionContext.CurrentDatabase
-						} else {
+							if (-not $Database) {
+								$Database = $this.ConnectionContext.SqlConnectionObject.Database
+							}
+						}
+						if (-not $Database) {
 							$Database = "master"
 						}
 					}
@@ -67,7 +71,11 @@
 					if (-not $Database) {
 						if ($this.ConnectionContext.DatabaseEngineType -eq "SqlAzureDatabase") {
 							$Database = $this.ConnectionContext.CurrentDatabase
-						} else {
+							if (-not $Database) {
+								$Database = $this.ConnectionContext.SqlConnectionObject.Database
+							}
+						} 
+						if (-not $Database) {
 							$Database = "master"
 						}
 					}


### PR DESCRIPTION
still need to:

* let people know that many parameters wont be supported (starting around 332) OR support them somehow

added support for .Query as well.

This should work for:

DONE: detects: database.windows.net
DONE: detect: windows
DONE: detect: sql login
DONE: detect integrated if no credential is passed

does not work for MFA yet

`ActiveDirectoryInteractive`

https://docs.microsoft.com/bs-latn-ba/azure/sql-database/active-directory-interactive-connect-azure-sql-db?view=azurermps-6.8.1  

> Starting in .NET Framework version 4.7.2, the enum SqlAuthenticationMethod has a new value - ActiveDirectoryInteractive. In a client C# program, the enum value directs the system to use the Azure AD interactive mode supporting MFA to connect to an Azure SQL Database. The user who runs the program sees the following dialog boxes:

The example C# program relies on the Microsoft.IdentityModel.Clients.ActiveDirectory DLL assembly.

