### PR TITLE
Get-DbaLogin Include WindowsGroup login types

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -183,7 +183,7 @@ function Get-DbaLogin {
             }
 
             if ($Type -eq 'Windows') {
-                $serverLogins = $serverLogins | Where-Object LoginType -eq 'WindowsUser'
+                $serverLogins = $serverLogins | Where-Object LoginType -in @('WindowsUser', 'WindowsGroup')
             }
 
             if ($Type -eq 'SQL') {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5165 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Include WindowsGroup login types in Get-DbaLogin results.

### Approach
If Type = Windows include WindowsUser and WindowsGroup login types instead of just WindowsUser.

### Commands to test
Get-DbaLogin -SqlInstance MyServer -WindowsLogins

### Screenshots
![image](https://user-images.githubusercontent.com/7840633/54049083-949b6080-41a9-11e9-927c-0cdd344ed254.png)