### PR TITLE
Find-DbaLoginInGroup Wrong Domain Name

### DIFF
--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -84,8 +84,8 @@ function Find-DbaLoginInGroup {
                     $group = [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity($ads, $groupName);
                     $subgroups = @()
                     foreach ($member in $group.Members) {
-                        $memberDomain = $member.DistinguishedName -Split "," | Where-Object { $_ -like "DC=*" } | Select-Object -first 1 | ForEach-Object { $_.ToUpper() -replace "DC=", '' }
-                        if ($member.StructuralObjectClass -eq "group") {
+                        $memberDomain = $ads.Name
+                        if ($member.StructuralObjectClass -eq 'group') {
                             $fullName = $memberDomain + "\" + $member.SamAccountName
                             if ($fullName -in $discard) {
                                 Write-Message -Level Verbose -Message "skipping $fullName, already enumerated"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #3608 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Return the appropriate domain name for a group.

### Approach
Instead of parsing the NETBIOS name from the group's DN - get the name from the a PrincipalContext object. This should? be the correct domain if the DNS name and NETBIOS name differ.

In my situation, our DNS name is `mycompany.local`. The NETBIOS name is `MY_COMPANY`. Before making this change `Find-DbaLoginInGroup` returned logins with `MYCOMPANY\GroupName`, which is invalid. After making this change `Find-DbaLoginInGroup` returns `MY_COMPANY\GroupName`, which is valid and matches what the group is defined as in SQL Server.

### Commands to test
```powershell
Find-DbaLoginInGroup -SqlInstance MyServer
```