### PR TITLE
Use ProviderPath property to allow for UNC paths

### DIFF
--- a/bin/library.ps1
+++ b/bin/library.ps1
@@ -48,9 +48,9 @@ if (([System.Management.Automation.PSTypeName]'Sqlcollaborative.Dbatools.Configu
 $libraryBase = (Resolve-Path -Path ($ExecutionContext.SessionState.Module.ModuleBase + "\bin"))
 
 if ($PSVersionTable.PSVersion.Major -ge 6) {
-    $dll = (Resolve-Path -Path "$libraryBase\netcoreapp2.1\dbatools.dll" -ErrorAction Ignore)
+    $dll = (Resolve-Path -Path "$libraryBase\netcoreapp2.1\dbatools.dll" -ErrorAction Ignore).ProviderPath
 } else {
-    $dll = (Resolve-Path -Path "$libraryBase\net452\dbatools.dll" -ErrorAction Ignore)
+    $dll = (Resolve-Path -Path "$libraryBase\net452\dbatools.dll" -ErrorAction Ignore).ProviderPath
 }
 
 if ($ImportLibrary) {

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -37,7 +37,7 @@ function Import-ModuleFile {
     if ($script:doDotSource) {
         . (Resolve-Path -Path $Path)
     } else {
-        $ExecutionContext.InvokeCommand.InvokeScript($false, ([scriptblock]::Create([io.file]::ReadAllText((Resolve-Path -Path $Path)))), $null, $null)
+        $ExecutionContext.InvokeCommand.InvokeScript($false, ([scriptblock]::Create([io.file]::ReadAllText((Resolve-Path -Path $Path).ProviderPath))), $null, $null)
     }
 }
 
@@ -149,7 +149,7 @@ if (($PSVersionTable.PSVersion.Major -le 5) -or $script:isWindows) {
 }
 
 
-$script:DllRoot = (Resolve-Path -Path "$script:PSModuleRoot\bin\")
+$script:DllRoot = (Resolve-Path -Path "$script:PSModuleRoot\bin\").ProviderPath
 
 <#
 # Removed this because it doesn't seem to work well xplat and on win7 and it doesn't provide enough value


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5131 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow importing the module from UNC paths. 

### Approach
When using Resolve-Path the Path object contains "Microsoft.PowerShell.Core\FileSystem::" at the beginning of the path. Some areas aren't expecting that. Changing to ProviderPath changes it back to the traditional UNC path format "\\server\share". When this is a local path these values are the same.

### Commands to test
`Import-Module`

### Learning
Friedrich fixed this same issue in PSFramework in [this PR](https://github.com/PowershellFrameworkCollective/psframework/pull/232).