### PR TITLE
Get-DbaLogin - Improve Speed for Lots of Logins

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -162,6 +162,8 @@ function Get-DbaLogin {
         if ($WindowsLogins) {
             $Type = "Windows"
         }
+
+        $loginTimeSql = "SELECT login_name, MAX(login_time) AS login_time FROM sys.dm_exec_sessions GROUP BY login_name"
     }
     process {
         foreach ($instance in $SqlInstance) {
@@ -222,18 +224,20 @@ function Get-DbaLogin {
                 $serverLogins = $serverLogins | Where-Object IsDisabled
             }
 
-            foreach ($serverLogin in $serverlogins) {
+            # There's no reliable method to get last login time with SQL Server 2000, so only show on 2005+
+            if ($server.VersionMajor -gt 9) {
+                Write-Message -Level Verbose -Message "Getting last login times"
+                $loginTimes = $server.ConnectionContext.ExecuteWithResults($loginTimeSql).Tables[0]
+            } else {
+                $loginTimes = $null
+            }
+
+            foreach ($serverLogin in $serverLogins) {
                 Write-Message -Level Verbose -Message "Processing $serverLogin on $instance"
 
-                if ($server.VersionMajor -gt 9) {
-                    # There's no reliable method to get last login time with SQL Server 2000, so only show on 2005+
-                    Write-Message -Level Verbose -Message "Getting last login time"
-                    $sql = "SELECT MAX(login_time) AS [login_time] FROM sys.dm_exec_sessions WHERE login_name = '$($serverLogin.name)'"
-                    Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $server.ConnectionContext.ExecuteScalar($sql)
-                } else {
-                    Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $null
-                }
+                $loginTime = $loginTimes | Where-Object { $_.login_name -eq $serverLogin.name } | Select-Object -ExpandProperty login_time
 
+                Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name LastLogin -Value $loginTime
                 Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                 Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Improve speed of Get-DbaLogin when there are a lot of logins.

### Approach
Get-DbaLogin was doing a query for every login to get the last login time. I changed it to get the last login times for all logins once per server and then locally lookup the login time instead of going back to SQL Server to get it. This approach took the time on a server with 150 logins from 600ms to 175ms. 

### Commands to test
```powershell
Get-DbaLogin -SqlInstance 'MyServer'
```