### PR TITLE
Copy-DbaPolicyManagement - Include Categories

### DIFF
--- a/functions/Copy-DbaPolicyManagement.ps1
+++ b/functions/Copy-DbaPolicyManagement.ps1
@@ -311,7 +311,6 @@ function Copy-DbaPolicyManagement {
                         $destStore.Conditions.Refresh()
                         $destStore.Policies.Refresh()
                         $sql = $policy.ScriptCreate().GetScript() | Out-String
-                        #$sql = $policy.ScriptCreateWithDependencies().GetScript() | Out-String
                         Write-Message -Level Debug -Message $sql
                         Write-Message -Level Verbose -Message "Copying policy $policyName"
                         $null = $destServer.Query($sql)

--- a/functions/Copy-DbaPolicyManagement.ps1
+++ b/functions/Copy-DbaPolicyManagement.ps1
@@ -98,7 +98,7 @@ function Copy-DbaPolicyManagement {
         [Alias('Silent')]
         [switch]$EnableException
     )
-    
+
     begin {
         if (-not $script:isWindows) {
             Stop-Function -Message "Copy-DbaPolicyManagement does not support Linux - we're still waiting for the Core SMOs from Microsoft"
@@ -147,8 +147,57 @@ function Copy-DbaPolicyManagement {
             }
 
             <#
+                            Categories
+            #>
+
+            Write-Message -Level Verbose -Message "Migrating categories"
+            $uniquePolicyCategories = $storePolicies | Select-Object -ExpandProperty PolicyCategory -Unique
+            $storeCategories = $sourceStore.PolicyCategories | Where-Object { $_.Name -in $uniquePolicyCategories }
+            foreach ($category in $storeCategories) {
+                $categoryName = $category.Name
+
+                $copyCategoryStatus = [pscustomobject]@{
+                    SourceServer      = $sourceServer.Name
+                    DestinationServer = $destServer.Name
+                    Name              = $categoryName
+                    Type              = "Policy Category"
+                    Status            = $null
+                    Notes             = $null
+                    DateTime          = [DbaDateTime](Get-Date)
+                }
+
+                if ($null -ne $destStore.PolicyCategories['Database']) {
+                    Write-Message -Level Verbose -Message "Policy category '$categoryName' was skipped because it already exists on $destination."
+
+                    $copyCategoryStatus.Status = "Skipped"
+                    $copyCategoryStatus.Notes = "Already exists on destination"
+                    $copyCategoryStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                    continue
+                }
+
+                if ($Pscmdlet.ShouldProcess($destination, "Migrating policy category $categoryName") -and $copyCategoryStatus.Status -ne 'Skipped') {
+                    try {
+                        $sql = $category.ScriptCreate().GetScript() | Out-String
+                        Write-Message -Level Debug -Message $sql
+                        Write-Message -Level Verbose -Message "Copying policy category $categoryName"
+                        $null = $destServer.Query($sql)
+                        $destStore.PolicyCategories.Refresh()
+
+                        $copyCategoryStatus.Status = "Successful"
+                        $copyCategoryStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                    } catch {
+                        $copyCategoryStatus.Status = "Failed"
+                        $copyCategoryStatus.Notes = $_.Exception.Message
+                        $copyCategoryStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+
+                        Stop-Function -Message "Issue creating policy category on $destination" -Target $categoryName -ErrorRecord $_
+                    }
+                }
+            }
+
+            <#
                         Conditions
-        #>
+            #>
 
             Write-Message -Level Verbose -Message "Migrating conditions"
             foreach ($condition in $storeConditions) {
@@ -215,7 +264,7 @@ function Copy-DbaPolicyManagement {
 
             <#
                         Policies
-        #>
+            #>
 
             Write-Message -Level Verbose -Message "Migrating policies"
             foreach ($policy in $storePolicies) {
@@ -261,7 +310,8 @@ function Copy-DbaPolicyManagement {
                     try {
                         $destStore.Conditions.Refresh()
                         $destStore.Policies.Refresh()
-                        $sql = $policy.ScriptCreateWithDependencies().GetScript() | Out-String
+                        $sql = $policy.ScriptCreate().GetScript() | Out-String
+                        #$sql = $policy.ScriptCreateWithDependencies().GetScript() | Out-String
                         Write-Message -Level Debug -Message $sql
                         Write-Message -Level Verbose -Message "Copying policy $policyName"
                         $null = $destServer.Query($sql)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #1040 and #1049)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolve issues #1040 and #1049 by copying policy categories before copying the policy.

### Approach
Added section to get a list of categories that are required on the target server and create them if necessary. I also changed the policy creation scripting from ScriptCreateWithDependencies to just ScriptCreate - it seemed like that was causing issues as well (at least with my setup).

There aren't really any tests for this function and the PBM that I setup in my lab was pretty basic, so someone may want to test this out if they have a more complex PBM setup.

### Commands to test
```powershell
Copy-DbaPolicyManagement -Source 'MySourceServer' -Destination 'MyDestinationServer'
```

### Screenshots
![image](https://user-images.githubusercontent.com/7840633/54160833-ee5c8e80-4426-11e9-92f2-4b68f9ea4c10.png)

![image](https://user-images.githubusercontent.com/7840633/54160790-d422b080-4426-11e9-9886-74bdcfdbf0ed.png)


### Learning
It kind of seems like it's a bug in SMO that categories aren't included in the ScriptCreateWithDependencies() method. There also is no IsSystemObject property on the PolicyCategory object.