### PR TITLE
Export-DbaLogin - Allow Login and ExcludeLogin to work with SMO objects

### DIFF
--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -171,12 +171,42 @@ function Export-DbaLogin {
             }
         }
 
-        foreach ($sourceLogin in $server.Logins) {
-            $userName = $sourceLogin.name
+        $sourceLogins = $server.Logins
+        if ($Login) {
+            Write-Message -Level Verbose -Message "Including specific logins"
 
-            if ($Login -and $Login -notcontains $userName -or $ExcludeLogin -contains $userName) {
-                continue
+            if ($Login -is [array]) {
+                if ($Login[0].GetType().Name -eq 'Login') {
+                    $Login = $Login.Name
+                }
+            } else {
+                if ($Login.GetType().Name -eq 'Login') {
+                    $Login = $Login.Name
+                }
             }
+
+            $sourceLogins = $sourceLogins | Where-Object { $_.Name -in $Login }
+        }
+
+        if ($ExcludeLogin) {
+            Write-Message -Level Verbose -Message "Excluding logins"
+
+            if ($ExcludeLogin -is [array]) {
+                if ($ExcludeLogin[0].GetType().Name -eq 'Login') {
+                    $ExcludeLogin = $ExcludeLogin.Name
+                }
+            } else {
+                if ($ExcludeLogin.GetType().Name -eq 'Login') {
+                    $ExcludeLogin = $ExcludeLogin.Name
+                }
+            }
+
+            $sourceLogins = $sourceLogins | Where-Object { $_.Name -notin $ExcludeLogin }
+        }
+
+        foreach ($sourceLogin in $sourceLogins) {
+            $userName = $sourceLogin.Name
+            Write-Message -Level Verbose -Message "Processing login $userName"
 
             if ($userName.StartsWith("##") -or $userName -eq 'sa') {
                 Write-Message -Level Warning -Message "Skipping $userName"

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Login','ExcludeLogin','Database','Path','NoClobber','Append','ExcludeDatabases','ExcludeJobs','EnableException','ExcludeGoBatchSeparator','DestinationVersion'
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Login','ExcludeLogin','Database','Path','NoClobber','Append','ExcludeDatabases','ExcludeJobs','EnableException','ExcludeGoBatchSeparator','DestinationVersion','InputObject'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #4604 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issue where Login objects being passed in to Login or ExcludeLogin parameters don't get processed correctly due SMO Login's ToString method putting login names in square brackets.

### Approach
If Login is an array, check first item to see if it's a Login object. If it is, make Login the $Login.Name property value instead of $Login - this property does not include square brackets unlike when $Login is used and ToString() gets called. If it's not an array, we just use $Login.Name.

The same applies to ExcludeLogin.

### Commands to test
```powershell
Get-DbaLogin -SqlInstance 'MyServer' | Where-Object { $_.IsDisabled -eq $false } | % { Export-DbaLogin -SqlInstance 'MyServer' -Login $_ }
```