### PR TITLE
Improve Handling for TLS

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -16,9 +16,6 @@ function Get-DbaComputerSystem {
     .PARAMETER IncludeAws
         If computer is hosted in AWS Infrastructure as a Service (IaaS), additional information will be included.
 
-    .PARAMETER TimeoutSec
-        Default: 5 sec
-        Timeout in seconds for AWS related metaquery.
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -58,7 +55,6 @@ function Get-DbaComputerSystem {
         [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
         [PSCredential]$Credential,
         [switch]$IncludeAws,
-        [int]$TimeoutSec = 5,
         [switch][Alias('Silent')]
         $EnableException
     )
@@ -107,7 +103,7 @@ function Get-DbaComputerSystem {
 
                 if ($IncludeAws) {
                     try {
-                        $isAws = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ScriptBlock { ((Invoke-TlsRestMethod -TimeoutSec $TimeoutSec -Uri 'http://169.254.169.254').StatusCode) -eq 200 } -Raw
+                        $isAws = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ScriptBlock { ((Invoke-TlsRestMethod -TimeoutSec 15 -Uri 'http://169.254.169.254').StatusCode) -eq 200 } -Raw
                     } catch [System.Net.WebException] {
                         $isAws = $false
                         Write-Message -Level Warning -Message "$computerResolved was not found to be an EC2 instance. Verify http://169.254.169.254 is accessible on the computer."

--- a/internal/functions/Invoke-TlsRestMethod.ps1
+++ b/internal/functions/Invoke-TlsRestMethod.ps1
@@ -1,12 +1,10 @@
-function Invoke-TlsWebRequest {
-
+function Invoke-TlsRestMethod {
     <#
-    Internal utility that mimics invoke-webrequest
+    Internal utility that mimics invoke-RestMethod
     but enables all tls available version
     rather than the default, which on a lot
     of standard installations is just TLS 1.0
-
-       #>
+    #>
     $currentVersionTls = [Net.ServicePointManager]::SecurityProtocol
     $currentSupportableTls = [Math]::Max($currentVersionTls.value__, [Net.SecurityProtocolType]::Tls.value__)
     $availableTls = [enum]::GetValues('Net.SecurityProtocolType') | Where-Object { $_ -gt $currentSupportableTls }
@@ -14,7 +12,7 @@ function Invoke-TlsWebRequest {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_
     }
 
-    Invoke-WebRequest @Args
+    Invoke-RestMethod @Args
 
     [Net.ServicePointManager]::SecurityProtocol = $currentVersionTls
 }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix

### Purpose
AWS instances with restricted internet settings fail to process webrequest without basic parsing. A better practice for rest based requests is to use `Invoke-RestMethod`. 

### Approach
- Timeout parameter added for allowing override of AWS metadata
- New internal function cloned from `Invoke-TlsWebRequest` that is using `Invoke-RestMethod`
- Proper handling of failure to connect with `try{} catch{}` should ensure timeout exception handled properly and warned, bypassing attempt to connect to AWS metadata further.
- *new* added 3 properties related to CPU metrics to improve the results for Get-DbaComputerSystem in reviewing basics of OS performance specs

### Commands to test
1. Get-DbaComputerSystem
2. Invoke-TlsRestMethod *new internal helper*

# Note
1. Without AWS infrastructure can't verify this with pester test, and didn't see any `Invoke-TLS*` tests built. The new error handling worked, and confirmed on my own AWS instance that results pulled correctly, but you'll want to verify as well. 
2. Not sure of any other location to add detail to.