### PR TITLE
Tweaks to the DbaTimeline 19/03/2019

### DIFF
--- a/functions/ConvertTo-DbaTimeline.ps1
+++ b/functions/ConvertTo-DbaTimeline.ps1
@@ -14,6 +14,11 @@ function ConvertTo-DbaTimeline {
 
         Pipe input, must an output from the above functions.
 
+    .PARAMETER ExcludeRowLabels
+        By default, the Timeline shows SqlInstance and item name (agent job or database) in row labels section of the chart.
+        When this parameter (ExcludeRowLabels) is set to true the row labels will not be shown which will maximise the chart area for better visualisation.
+        All relevant details are still available in the tooltip.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -61,7 +66,7 @@ function ConvertTo-DbaTimeline {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
-        [switch]$NoRowLabels,
+        [switch]$ExcludeRowLabels,
         [switch]$EnableException
     )
     begin {
@@ -190,7 +195,7 @@ function ConvertTo-DbaTimeline {
             timeline: {
                 rowLabelStyle: { },
                 barLabelStyle: { },
-                showRowLabels: $(if($NoRowLabels){'false'} else {'true'})
+                showRowLabels: $(if($ExcludeRowLabels){'false'} else {'true'})
             },
             hAxis: {
                 format: 'dd/MM HH:mm',

--- a/functions/ConvertTo-DbaTimeline.ps1
+++ b/functions/ConvertTo-DbaTimeline.ps1
@@ -14,9 +14,9 @@ function ConvertTo-DbaTimeline {
 
         Pipe input, must an output from the above functions.
 
-    .PARAMETER ExcludeRowLabels
+    .PARAMETER ExcludeRowLabel
         By default, the Timeline shows SqlInstance and item name (agent job or database) in row labels section of the chart.
-        When this parameter (ExcludeRowLabels) is set to true the row labels will not be shown which will maximise the chart area for better visualisation.
+        When this parameter (ExcludeRowLabel) is set to true the row labels will not be shown which will maximise the chart area for better visualisation.
         All relevant details are still available in the tooltip.
 
     .PARAMETER EnableException
@@ -66,7 +66,7 @@ function ConvertTo-DbaTimeline {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
-        [switch]$ExcludeRowLabels,
+        [switch]$ExcludeRowLabel,
         [switch]$EnableException
     )
     begin {
@@ -195,7 +195,7 @@ function ConvertTo-DbaTimeline {
             timeline: {
                 rowLabelStyle: { },
                 barLabelStyle: { },
-                showRowLabels: $(if($ExcludeRowLabels){'false'} else {'true'})
+                showRowLabels: $(if($ExcludeRowLabel){'false'} else {'true'})
             },
             hAxis: {
                 format: 'dd/MM HH:mm',

--- a/functions/ConvertTo-DbaTimeline.ps1
+++ b/functions/ConvertTo-DbaTimeline.ps1
@@ -61,6 +61,7 @@ function ConvertTo-DbaTimeline {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [object[]]$InputObject,
+        [switch]$NoRowLabels,
         [switch]$EnableException
     )
     begin {
@@ -149,10 +150,10 @@ function ConvertTo-DbaTimeline {
         #>
         if ($InputObject[0].TypeName -eq 'AgentJobHistory') {
             $CallerName = "Get-DbaAgentJobHistory"
-            $data = $InputObject | Select-Object @{ Name = "SqlInstance"; Expression = { $_.SqlInstance } }, @{ Name = "InstanceName"; Expression = { $_.InstanceName } }, @{ Name = "vLabel"; Expression = { "[" + $_.SqlInstance + "] " + $_.Job -replace "\'", ''} }, @{ Name = "hLabel"; Expression = { $_.Status } }, @{ Name = "Style"; Expression = { $(Convert-DbaTimelineStatusColor($_.Status)) } }, @{ Name = "StartDate"; Expression = { $(ConvertTo-JsDate($_.StartDate)) } }, @{ Name = "EndDate"; Expression = { $(ConvertTo-JsDate($_.EndDate)) } }
+            $data = $InputObject | Select-Object @{ Name = "SqlInstance"; Expression = { $_.SqlInstance } }, @{ Name = "InstanceName"; Expression = { $_.InstanceName } }, @{ Name = "vLabel"; Expression = { "[" + $($_.SqlInstance -replace "\\", "\\\") + "] " + $_.Job -replace "\'", ''} }, @{ Name = "hLabel"; Expression = { $_.Status } }, @{ Name = "Style"; Expression = { $(Convert-DbaTimelineStatusColor($_.Status)) } }, @{ Name = "StartDate"; Expression = { $(ConvertTo-JsDate($_.StartDate)) } }, @{ Name = "EndDate"; Expression = { $(ConvertTo-JsDate($_.EndDate)) } }
         } elseif ($InputObject[0] -is [Sqlcollaborative.Dbatools.Database.BackupHistory]) {
             $CallerName = "Get-DbaBackupHistory"
-            $data = $InputObject | Select-Object @{ Name = "SqlInstance"; Expression = { $_.SqlInstance } }, @{ Name = "InstanceName"; Expression = { $_.InstanceName } }, @{ Name = "vLabel"; Expression = { "[" + $_.SqlInstance + "] " + $_.Database } }, @{ Name = "hLabel"; Expression = { $_.Type } }, @{ Name = "StartDate"; Expression = { $(ConvertTo-JsDate($_.Start)) } }, @{ Name = "EndDate"; Expression = { $(ConvertTo-JsDate($_.End)) } }
+            $data = $InputObject | Select-Object @{ Name = "SqlInstance"; Expression = { $_.SqlInstance } }, @{ Name = "InstanceName"; Expression = { $_.InstanceName } }, @{ Name = "vLabel"; Expression = { "[" + $($_.SqlInstance -replace "\\", "\\\") + "] " + $_.Database } }, @{ Name = "hLabel"; Expression = { $_.Type } }, @{ Name = "StartDate"; Expression = { $(ConvertTo-JsDate($_.Start)) } }, @{ Name = "EndDate"; Expression = { $(ConvertTo-JsDate($_.End)) } }
         } else {
             # sorry to be so formal, can't help it ;)
             Stop-Function -Message "Unsupported input data. To request support for additional commands, please file an issue at dbatools.io/issues and we'll take a look"
@@ -189,6 +190,7 @@ function ConvertTo-DbaTimeline {
             timeline: {
                 rowLabelStyle: { },
                 barLabelStyle: { },
+                showRowLabels: $(if($NoRowLabels){'false'} else {'true'})
             },
             hAxis: {
                 format: 'dd/MM HH:mm',

--- a/tests/ConvertTo-DbaTimeline.Tests.ps1
+++ b/tests/ConvertTo-DbaTimeline.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'InputObject', 'ExcludeRowLabels', 'EnableException'
+        [object[]]$knownParameters = 'InputObject', 'ExcludeRowLabel', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/ConvertTo-DbaTimeline.Tests.ps1
+++ b/tests/ConvertTo-DbaTimeline.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'InputObject','EnableException'
+        [object[]]$knownParameters = 'InputObject', 'ExcludeRowLabels', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
There are two improvements in this PR:

1. Cosmetic change to how JavaScript is handling backslashes. For named instances the backslash will currently not be shown on the timeline: 
`[SQL-TEST-1SQL2016] ContosoRetailDW` 
and after the tweak: 
`[SQL-TEST-1\SQL2016] ContosoRetailDW`

2. New switch `-NoRowLabels` to hide row labels and to maximise timeline area: `ConvertTo-DbaTimeline -NoRowLabels`

Please note that the job details are still available in the tooltip

### Approach
<!-- How does this change solve that purpose -->
1. The backslash is now being correctly escaped (JS needs two backslashes to show one):
`"[" + $($_.SqlInstance -replace "\\", "\\\") + "] "`
2. The `NoRowLabels` switch is being used to dynamically build JS array as per the Google Docs: https://developers.google.com/chart/interactive/docs/gallery/timeline : 
```
        var options = {
            timeline: {
                rowLabelStyle: { },
                barLabelStyle: { },
                showRowLabels: $(if($NoRowLabels){'false'} else {'true'})
            },
            hAxis: {
                format: 'dd/MM HH:mm',
            },
```
### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
Get-DbaAgentJobHistory -SqlInstance sql-test-1\sql2016,sql-test-1\sql2017 -ExcludeJobSteps | ConvertTo-DbaTimeline -NoRowLabels | Out-File C:\temp\DbaAgentJobHistory1.html -Encoding ascii
Get-DbaAgentJobHistory -SqlInstance sql-test-1\sql2016 -ExcludeJobSteps | ConvertTo-DbaTimeline | Out-File C:\temp\DbaAgentJobHistory2.html -Encoding ascii


Get-DbaBackupHistory -SqlInstance sql-test-1\sql2016,sql-test-1\sql2017 | ConvertTo-DbaTimeline | Out-File C:\temp\DbaAgentJobHistory3.html -Encoding ascii
Get-DbaBackupHistory -SqlInstance sql-test-1\sql2016 | ConvertTo-DbaTimeline | Out-File C:\temp\DbaAgentJobHistory4.html -Encoding ascii
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Before the backslash escape tweak:
![image](https://user-images.githubusercontent.com/8288333/54650423-50ac3380-4aa6-11e9-9c19-7d045dd3330d.png)


After the backslash escape tweak:
![image](https://user-images.githubusercontent.com/8288333/54650445-7a655a80-4aa6-11e9-8d07-0685ff7fa2dc.png)


NoRowLabels option:
![image](https://user-images.githubusercontent.com/8288333/54649101-c7463280-4aa0-11e9-95ee-5ba3fc3da107.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->