### PR TITLE
Restore-DbaDbCertificate - fix for folder issue

### DIFF
--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -81,43 +81,52 @@ function Restore-DbaDbCertificate {
             return
         }
 
-        foreach ($fullname in $Path) {
-            if (-not $SqlInstance.IsLocalHost -and -not $fullname.StartsWith('\')) {
-                Stop-Function -Message "Path ($fullname) must be a UNC share when SQL instance is not local." -Continue -Target $fullname
+        foreach ($dir in $Path) {
+            if (-not $SqlInstance.IsLocalHost -and -not $dir.StartsWith('\')) {
+                Stop-Function -Message "Path ($dir) must be a UNC share when SQL instance is not local." -Continue -Target $fullname
             }
 
-            if (-not (Test-DbaPath -SqlInstance $server -Path $fullname)) {
-                Stop-Function -Message "$SqlInstance cannot access $fullname" -Continue -Target $fullname
+            if (-not (Test-DbaPath -SqlInstance $server -Path $dir)) {
+                Stop-Function -Message "$SqlInstance cannot access $dir" -Continue -Target $dir
             }
 
-            $directory = Split-Path $fullname
-            $filename = Split-Path $fullname -Leaf
-            $certname = [io.path]::GetFileNameWithoutExtension($filename)
+            if (Test-Path $dir -PathType Container) {
+                Write-Message -Level Verbose -Message "Path is a directory - processing all cer's within"
+                $path = Get-ChildItem $dir "*.cer" | Select-Object -expand FullName
+            }
 
-            if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
-                $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
-                $smocert.Name = $certname
-                $smocert.Parent = $server.Databases[$Database]
-                Write-Message -Level Verbose -Message "Creating Certificate: $certname"
-                $fullcertname = "$directory\$certname.cer"
-                $privatekey = "$directory\$certname.pvk"
-                Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
-                Write-Message -Level Verbose -Message "Private key: $privatekey"
-                try {
-                    if ($EncryptionPassword) {
-                        $smocert.Create($fullcertname, 1, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($EncryptionPassword)))
-                    } else {
-                        $smocert.Create($fullcertname, 1, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)))
-                    }
-                } catch {
+            foreach ($fullname in $path) {
+                Write-Message -Level Verbose -Message ("Processing {0}" -f $fullname)
+
+                $directory = Split-Path $fullname
+                $filename = Split-Path $fullname -Leaf
+                $certname = [io.path]::GetFileNameWithoutExtension($filename)
+
+                if ($Pscmdlet.ShouldProcess("$certname on $SqlInstance", "Importing Certificate")) {
+                    $smocert = New-Object Microsoft.SqlServer.Management.Smo.Certificate
+                    $smocert.Name = $certname
+                    $smocert.Parent = $server.Databases[$Database]
+                    Write-Message -Level Verbose -Message "Creating Certificate: $certname"
+                    $fullcertname = "$directory\$certname.cer"
+                    $privatekey = "$directory\$certname.pvk"
+                    Write-Message -Level Verbose -Message "Full certificate path: $fullcertname"
+                    Write-Message -Level Verbose -Message "Private key: $privatekey"
                     try {
                         if ($EncryptionPassword) {
-                            $smocert.Create($fullcertname, $([Microsoft.SqlServer.Management.Smo.CertificateSourceType]::"File"), $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($EncryptionPassword)))
+                            $smocert.Create($fullcertname, 1, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($EncryptionPassword)))
                         } else {
-                            $smocert.Create($fullcertname, $([Microsoft.SqlServer.Management.Smo.CertificateSourceType]::"File"), $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)))
+                            $smocert.Create($fullcertname, 1, $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)))
                         }
                     } catch {
-                        Stop-Function -Message $_ -ErrorRecord $_ -Target $instance -Continue
+                        try {
+                            if ($EncryptionPassword) {
+                                $smocert.Create($fullcertname, $([Microsoft.SqlServer.Management.Smo.CertificateSourceType]::"File"), $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)), [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($EncryptionPassword)))
+                            } else {
+                                $smocert.Create($fullcertname, $([Microsoft.SqlServer.Management.Smo.CertificateSourceType]::"File"), $privatekey, [System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword)))
+                            }
+                        } catch {
+                            Stop-Function -Message $_ -ErrorRecord $_ -Target $instance -Continue
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5256 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes #5256 - if you pass in a folder it doesn't currently work.

### Approach
If it's a folder GCI to get the .cer files and process them.

### Commands to test
```
Restore-DbaDbCertificate -SqlInstance server1 -Path '\\server1\Certs\' -SecurePassword $SecurePassword 
```
