### PR TITLE
Sqlwatch prerelease

### DIFF
--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -92,7 +92,7 @@ function Install-DbaSqlWatch {
         $tempFolder = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
         $zipfile = "$tempFolder\SqlWatch.zip"
 
-        $releasetxt = $(if($PreRelease){"pre-release"} else {"release"})
+        $releasetxt = $(if ($PreRelease) {"pre-release"} else {"release"})
 
         if (-not $LocalFile) {
             if ($PSCmdlet.ShouldProcess($env:computername, "Downloading latest $releasetxt from GitHub")) {

--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -78,6 +78,7 @@ function Install-DbaSqlWatch {
         [PSCredential]$SqlCredential,
         [string]$Database = "SQLWATCH",
         [string]$LocalFile,
+        [switch]$PreRelease,
         [switch]$Force,
         [switch]$EnableException
     )
@@ -96,7 +97,7 @@ function Install-DbaSqlWatch {
                 $DownloadBase = "https://github.com/marcingminski/sqlwatch/releases/download/"
 
                 Write-Message -Level Verbose -Message "Checking GitHub for the latest release."
-                $LatestReleaseUrl = (Invoke-TlsWebRequest -UseBasicParsing -Uri $ReleasesUrl | ConvertFrom-Json)[0].assets[0].browser_download_url
+                $LatestReleaseUrl = ((Invoke-TlsWebRequest -UseBasicParsing -Uri $ReleasesUrl | ConvertFrom-Json) | Where-Object { $_.prerelease -eq $PreRelease })[0].assets[0].browser_download_url
 
                 Write-Message -Level VeryVerbose -Message "Latest release is available at $LatestReleaseUrl"
                 $LocallyCachedZip = Join-Path -Path $DbatoolsData -ChildPath $($LatestReleaseUrl -replace $DownloadBase, '');

--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -24,6 +24,9 @@ function Install-DbaSqlWatch {
     .PARAMETER Force
         If this switch is enabled, SqlWatch will be downloaded from the internet even if previously cached.
 
+    .PARAMETER PreRelease
+        If specified, a pre-release (beta) will be downloaded rather than a stable release
+
     .PARAMETER Confirm
         Prompts to confirm actions
 

--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -92,17 +92,19 @@ function Install-DbaSqlWatch {
         $tempFolder = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
         $zipfile = "$tempFolder\SqlWatch.zip"
 
+        $releasetxt = $(if($PreRelease){"pre-release"} else {"release"})
+
         if (-not $LocalFile) {
-            if ($PSCmdlet.ShouldProcess($env:computername, "Downloading latest release from GitHub")) {
+            if ($PSCmdlet.ShouldProcess($env:computername, "Downloading latest $releasetxt from GitHub")) {
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Downloading latest release from GitHub"
                 # query the releases to find the latest, check and see if its cached
                 $ReleasesUrl = "https://api.github.com/repos/marcingminski/sqlwatch/releases"
                 $DownloadBase = "https://github.com/marcingminski/sqlwatch/releases/download/"
 
-                Write-Message -Level Verbose -Message "Checking GitHub for the latest release."
+                Write-Message -Level Verbose -Message "Checking GitHub for the latest $releasetxt."
                 $LatestReleaseUrl = ((Invoke-TlsWebRequest -UseBasicParsing -Uri $ReleasesUrl | ConvertFrom-Json) | Where-Object { $_.prerelease -eq $PreRelease })[0].assets[0].browser_download_url
 
-                Write-Message -Level VeryVerbose -Message "Latest release is available at $LatestReleaseUrl"
+                Write-Message -Level VeryVerbose -Message "Latest $releasetxt is available at $LatestReleaseUrl"
                 $LocallyCachedZip = Join-Path -Path $DbatoolsData -ChildPath $($LatestReleaseUrl -replace $DownloadBase, '');
 
                 # if local cached copy exists, use it, otherwise download a new one

--- a/tests/Install-DbaSqlWatch.Tests.ps1
+++ b/tests/Install-DbaSqlWatch.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','LocalFile','Force','EnableException'
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','LocalFile','Force','PreRelease','EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
The purpose of this PR is to enable `Install-DbaSqlWatch` to install GitHub's prereleases. Currently, I release beta versions of SQLWATCH as source code for people to manually install. This is not ideal and being able to deploy beta versions with dbatools would be beneficial for myself and the end users.
### Approach
<!-- How does this change solve that purpose -->
GitHub prereleases are identified in the API with a true/false prerelease tag which can be seen here:
https://api.github.com/repos/marcingminski/sqlwatch/releases

```
"prerelease": false,
"prerelease": true,
```

This functionality was achieved by adding the following logic to the existing function:
```
[switch]$PreRelease
...
Where-Object { $_.prerelease -eq $PreRelease } 
```

If switch is set to true, it will filter API's output to show prereleases only. If no switch is given it will default to $false and thus return releases. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
I have marked an old SQLWATCH 1.3.20 release as pre-release so there is no risk of current version of Install-DbaSqlWatch downloading this test pre-release before this PR is approved.
https://github.com/marcingminski/sqlwatch/releases

Deploy stable release as usual (no changes):
```
Install-DbaSqlWatch -SqlInstance 192.168.1.121 -SqlCredential $cred -Database SQLWATCH -verbose 
```
Expected output, should return release 1.3.3:
```
VERBOSE: Performing the operation "Downloading latest release from GitHub" on target "VM-MBPWIN10-1".
VERBOSE: [22:19:13][Install-DbaSqlWatch] Checking GitHub for the latest release.
VERBOSE: GET https://api.github.com/repos/marcingminski/sqlwatch/releases with 0-byte payload
VERBOSE: received 12981-byte response of content type application/json; charset=utf-8
VERBOSE: [22:19:14][Install-DbaSqlWatch] Latest release is available at https://github.com/marcingminski/sqlwatch/releases/download/1.3.3/SQLWATCH_1.3.3.zip
```

Deploy pre-release (new functionality):
```
Install-DbaSqlWatch -SqlInstance 192.168.1.121 -SqlCredential $cred -Database SQLWATCH -verbose -PreRelease
```
Expected output, should return release 1.3.20:
```
VERBOSE: Performing the operation "Downloading latest pre-release from GitHub" on target "VM-MBPWIN10-1".
VERBOSE: [22:23:46][Install-DbaSqlWatch] Checking GitHub for the latest pre-release.
VERBOSE: GET https://api.github.com/repos/marcingminski/sqlwatch/releases with 0-byte payload
VERBOSE: received 12981-byte response of content type application/json; charset=utf-8
VERBOSE: [22:23:46][Install-DbaSqlWatch] Latest pre-release is available at https://github.com/marcingminski/sqlwatch/releases/download/SQLWATCH-v1.3.20/SQLWATCH_1.3.20.zip

```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->