### PR TITLE
Managed Instance restores

### DIFF
--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -306,7 +306,7 @@ function Invoke-DbaAdvancedRestore {
                                 Write-Progress -id 1 -Activity "Restoring $Database to $sqlinstance - Backup $BackupCnt of $($Backups.count)" -percentcomplete 0
                             }
                             Write-Progress -id 2 -ParentId 1 -Activity "Restore $($backup.FullName -Join ',')" -percentcomplete 0
-                            # $script = $Restore.Script($Server)
+                            $script = $Restore.Script($Server)
                             $percentcomplete = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
                                 Write-Progress -id 2 -ParentId 1 -Activity "Restore $($backup.FullName -Join ',')" -percentcomplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
                             }

--- a/functions/Invoke-DbaAdvancedRestore.ps1
+++ b/functions/Invoke-DbaAdvancedRestore.ps1
@@ -366,7 +366,7 @@ function Invoke-DbaAdvancedRestore {
                 $BackupCnt++
             }
             Write-Progress -id 2 -Activity "Finished" -Completed
-            if ($server.ConnsectionContext.exists) {
+            if ($server.ConnectionContext.exists) {
                 $server.ConnectionContext.Disconnect()
             }
             Write-Progress -id 1 -Activity "Finished" -Completed

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -384,6 +384,16 @@ function Restore-DbaDatabase {
             Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             return
         }
+
+        if ($RestoreInstnance.DatabaseEngineEdition -eq "SqlManagedInstance"){
+            Write-Message -Level Verbose -Message "Restore target is a Managed Instance, restricted feature set available"
+            $MiParams = ("DestinationDataDirectory","DestinationLogDirectory","DestinationFileStreamDirectoru","XpDirTree","FileMapping","UseDestintionDefaultDirectories","ReuseSourceFolderStructure","DestinationFilePrefix","StandbyDirecttory","ReplaceDbNameInFile","KeepCDC")
+            ForEach ($MiParam in $MiParams){
+                if (Test-Bound $MiParam){
+                    Write-Message -Leve Warning "Restoring to a Managed SQL Instance, parameter $MiParm is not supported"
+                }
+            }
+        }
         if ($PSCmdlet.ParameterSetName -eq "Restore") {
             $UseDestinationDefaultDirectories = $true
             $paramCount = 0

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -385,7 +385,7 @@ function Restore-DbaDatabase {
             return
         }
 
-        if ($RestoreInstnance.DatabaseEngineEdition -eq "SqlManagedInstance"){
+        if ($RestoreInstance.DatabaseEngineEdition -eq "SqlManagedInstance"){
             Write-Message -Level Verbose -Message "Restore target is a Managed Instance, restricted feature set available"
             $MiParams = ("DestinationDataDirectory","DestinationLogDirectory","DestinationFileStreamDirectoru","XpDirTree","FileMapping","UseDestintionDefaultDirectories","ReuseSourceFolderStructure","DestinationFilePrefix","StandbyDirecttory","ReplaceDbNameInFile","KeepCDC")
             ForEach ($MiParam in $MiParams){

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -385,12 +385,14 @@ function Restore-DbaDatabase {
             return
         }
 
-        if ($RestoreInstance.DatabaseEngineEdition -eq "SqlManagedInstance"){
+        if ($RestoreInstance.DatabaseEngineEdition -eq "SqlManagedInstance") {
             Write-Message -Level Verbose -Message "Restore target is a Managed Instance, restricted feature set available"
-            $MiParams = ("DestinationDataDirectory","DestinationLogDirectory","DestinationFileStreamDirectoru","XpDirTree","FileMapping","UseDestintionDefaultDirectories","ReuseSourceFolderStructure","DestinationFilePrefix","StandbyDirecttory","ReplaceDbNameInFile","KeepCDC")
-            ForEach ($MiParam in $MiParams){
-                if (Test-Bound $MiParam){
-                    Write-Message -Leve Warning "Restoring to a Managed SQL Instance, parameter $MiParm is not supported"
+            $MiParams = ("DestinationDataDirectory", "DestinationLogDirectory", "DestinationFileStreamDirectoru", "XpDirTree", "FileMapping", "UseDestintionDefaultDirectories", "ReuseSourceFolderStructure", "DestinationFilePrefix", "StandbyDirecttory", "ReplaceDbNameInFile", "KeepCDC")
+            ForEach ($MiParam in $MiParams) {
+                if (Test-Bound $MiParam) {
+                    # Write-Message -Level Warning "Restoring to a Managed SQL Instance, parameter $MiParm is not supported"
+                    Stop-Function -Category InvalidArgument -Message "The parameter $MiParam cannot be used with a Managed SQL Instance"
+                    return
                 }
             }
         }
@@ -490,9 +492,12 @@ function Restore-DbaDatabase {
         $BackupHistory = @()
     }
     process {
+        $test = "stuart3"
+        $test
         if (Test-FunctionInterrupt) {
             return
         }
+
         if ($RestoreInstance.VersionMajor -eq 8 -and $true -ne $TrustDbBackupHistory) {
             foreach ($file in $Path) {
                 $bh = Get-DbaBackupInformation -SqlInstance $RestoreInstance -Path $file
@@ -540,7 +545,8 @@ function Restore-DbaDatabase {
                             }
                         }
                     }
-
+                    $test = "stuart2"
+                    $test
                     if ($f.BackupPath -like 'http*') {
                         if ('' -ne $AzureCredential) {
                             Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
@@ -564,6 +570,8 @@ function Restore-DbaDatabase {
                             $_.Start -as [DateTime]
                         }
                     }
+                    $test = "stuart1"
+                    $test
                 }
             } else {
                 $files = @()
@@ -702,6 +710,7 @@ function Restore-DbaDatabase {
                 }
             }
             Write-Message -Message "Passing in to restore" -Level Verbose
+
             if ($PSCmdlet.ParameterSetName -eq "RestorePage" -and $RestoreInstance.Edition -notlike '*Enterprise*') {
                 Write-Message -Message "Taking Tail log backup for page restore for non-Enterprise" -Level Verbose
                 $TailBackup = Backup-DbaDatabase -SqlInstance $RestoreInstance -Database $DatabaseName -Type Log -BackupDirectory $PageRestoreTailFolder -Norecovery -CopyOnly

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -492,8 +492,6 @@ function Restore-DbaDatabase {
         $BackupHistory = @()
     }
     process {
-        $test = "stuart3"
-        $test
         if (Test-FunctionInterrupt) {
             return
         }
@@ -545,14 +543,12 @@ function Restore-DbaDatabase {
                             }
                         }
                     }
-                    $test = "stuart2"
-                    $test
                     if ($f.BackupPath -like 'http*') {
                         if ('' -ne $AzureCredential) {
                             Write-Message -Message "At least one Azure backup passed in with a credential, assume correct" -Level Verbose
                             Write-Message -Message "Storage Account Identity access means striped backups cannot be restore"
                         } else {
-                            $f.BackupPath -match 'https://.*/.*/'
+                            $null = $f.BackupPath -match 'https://.*/.*/'
                             if (Get-DbaCredential -SqlInstance $RestoreInstance -name $matches[0].trim('/') ) {
                                 Write-Message -Message "We have a SAS credential to use with $($f.BackupPath)" -Level Verbose
                             } else {
@@ -570,8 +566,6 @@ function Restore-DbaDatabase {
                             $_.Start -as [DateTime]
                         }
                     }
-                    $test = "stuart1"
-                    $test
                 }
             } else {
                 $files = @()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Implements #5297 and prevents non compatible parameters being pushed through to a managed instance

In draft as there's be some other bits to come as people spot issues or come up with other use cases. But only expecting it to be around a day or so.

### Approach
Check the DatabaseEngineEdition property of the restore server. If it's SqlManagedInstance then check parameters and stop if anything that MI won't touch aren't being used.

If withreplace is needed and specified then do a drop/restore as traditional WithReplace isn't supported

### Commands to test
```
$op = Get-DbaBackupHistory -SqlInstance localhost -database mitest | Restore-DbaDatabase -SqlCredential $cred -SqlInstance dbatoolsmi.cus19c972e4513d6.database.windows.net -TrustDbBackupHistory -DatabaseName tes3t  -verbose
```


