### PR TITLE
Import-DbaCsv - auto-map Column Names

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -519,7 +519,7 @@ function Import-DbaCsv {
                         $bulkCopy.NotifyAfter = $NotifyAfter
                         $bulkCopy.EnableStreaming = $true
 
-                        if ($AutoMapColumns) {
+                        if ($AutoColumnMap) {
                             if ($ColumnMap) {
                                 Write-Message -Level Verbose -Message "ColumnMap was supplied. Additional auto-mapping will not be attempted."
                             } else {

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -242,6 +242,7 @@ function Import-DbaCsv {
         [switch]$KeepNulls,
         [string[]]$Column,
         [hashtable[]]$ColumnMap,
+        [switch]$AutoColumnMap,
         [switch]$AutoCreateTable,
         [switch]$NoProgress,
         [switch]$NoHeaderRow,
@@ -514,6 +515,18 @@ function Import-DbaCsv {
                         $bulkCopy.BatchSize = $BatchSize
                         $bulkCopy.NotifyAfter = $NotifyAfter
                         $bulkCopy.EnableStreaming = $true
+
+                        if ($AutoMapColumns) {
+                            if ($ColumnMap) {
+                                Write-Message -Level Verbose -Message "ColumnMap was supplied. Additional auto-mapping will not be attempted."
+                            } else {
+                                $ColumnMap = New-Object -TypeName "System.Collections.Hashtable"
+
+                                $firstline -split $Delimiter | ForEach-Object {
+                                    $ColumnMap.Add($PSItem,$PSItem)
+                                }
+                            }
+                        }
 
                         if ($ColumnMap) {
                             foreach ($columnname in $ColumnMap) {

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -61,6 +61,9 @@ function Import-DbaCsv {
     .PARAMETER ColumnMap
         By default, the bulk copy tries to automap columns. When it doesn't work as desired, this parameter will help. Check out the examples for more information.
 
+    .PARAMETER AutoColumnMap
+        If this switch is enabled, bcp will attempt to map exact-match columns names from the source document to the target table.
+
     .PARAMETER AutoCreateTable
         Creates a table if it does not already exist. The table will be created with sub-optimal data types such as nvarchar(max)
 

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -526,7 +526,7 @@ function Import-DbaCsv {
                                 $ColumnMap = New-Object -TypeName "System.Collections.Hashtable"
 
                                 $firstline -split $Delimiter | ForEach-Object {
-                                    $ColumnMap.Add($PSItem,$PSItem)
+                                    $ColumnMap.Add($PSItem, $PSItem)
                                 }
                             }
                         }

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -29,7 +29,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Works as expected" {
         $results = $path | Import-DbaCsv -SqlInstance $script:instance1 -Database tempdb -Delimiter `t -NotifyAfter 50000 -WarningVariable warn
         It "accepts piped input and doesn't add rows if the table does not exist" {
-            $resulst | Should -Be $null
+            $results | Should -Be $null
         }
 
         if (-not $env:appveyor) {

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Path', 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Schema', 'Truncate', 'Delimiter', 'SingleColumn', 'BatchSize', 'NotifyAfter', 'TableLock', 'CheckConstraints', 'FireTriggers', 'KeepIdentity', 'KeepNulls', 'Column', 'ColumnMap', 'AutoCreateTable', 'NoProgress', 'NoHeaderRow', 'Quote', 'Escape', 'Comment', 'TrimmingOption', 'BufferSize', 'ParseErrorAction', 'Encoding', 'NullValue', 'Threshold', 'MaxQuotedFieldLength', 'SkipEmptyLine', 'SupportsMultiline', 'UseColumnDefault', 'EnableException', 'NoTransaction'
+        [object[]]$knownParameters = 'Path', 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Schema', 'Truncate', 'Delimiter', 'SingleColumn', 'BatchSize', 'NotifyAfter', 'TableLock', 'CheckConstraints', 'FireTriggers', 'KeepIdentity', 'KeepNulls', 'Column', 'ColumnMap', 'AutoColumnMap', 'AutoCreateTable', 'NoProgress', 'NoHeaderRow', 'Quote', 'Escape', 'Comment', 'TrimmingOption', 'BufferSize', 'ParseErrorAction', 'Encoding', 'NullValue', 'Threshold', 'MaxQuotedFieldLength', 'SkipEmptyLine', 'SupportsMultiline', 'UseColumnDefault', 'EnableException', 'NoTransaction'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

```powershell
(Get-Help Import-DbaCsv).Parameters.Parameter | Where Name -EQ "ColumnMap"
````

The parameter help for `ColumnMap` states...

>By default, the bulk copy tries to automap columns. When it doesn't work as desired, this parameter will help. Check out the examples for more information.

...but does it though? Consider the following scenario:

```powershell
# (Get-Module dbatools).Version -eq '0.9.798'
$myDb = "YUNoBcpGud"
New-DbaDatabase -SqlInstance "." -Name $myDb -Verbose

$tblName = "foo"

$mkTbl = @"
create table dbo.$tblName (
     id int not null primary key identity
    ,foo varchar(100) 
    ,baz varchar(100) 
    ,bin varchar(100) 
    ,bar varchar(100) 
);
"@

Invoke-DbaQuery -ServerInstance "." -Database $myDb -Query $mkTbl -Verbose

$myTxt = @"
foo,bar,baz
aaa,111,1900-01-01
bbb,222,1900-02-02
ccc,333,1900-03-03
"@

$fileName = "foo.csv"
$myTxt | Set-Content $fileName

$importSpec = @{
    Path        = $fileName
    SqlInstance = "." 
    Database    = $myDb
    Schema      = "dbo"
    Table       = $tblName
}

Import-DbaCsv @importSpec -Verbose

Import-Csv $fileName
Invoke-DbaQuery -ServerInstance "." -Database $myDb -Query "select * from $tblName" | ft

<#
foo bar baz       
--- --- ---       
aaa 111 1900-01-01
bbb 222 1900-02-02
ccc 333 1900-03-03



id foo baz        bin bar
-- --- ---        --- ---
 1 111 1900-01-01        
 2 222 1900-02-02        
 3 333 1900-03-03        
#>
```

...some pro-level "mapping" there, huh? "`foo`" data has been lost. "`bar`" data have been transposed. [We can do better](https://youtu.be/SLILjDx0SO0).

### Approach
<!-- How does this change solve that purpose -->

Using the cached `$firstline` object from earlier in the function, we build the `$ColumnMap` object for the user. 

At this time it is exact-match only. Fuzzy-matching, exclude-cols, and other validations can be conceived of, but I'm not certain at this time if those are more likely to be helpful additions or confusing noise. 

The current implementation is to require the user to supply the new `-AutoColumnMap` switch to access this, but it might be worth considering this as the default behavior instead? In the event that the current default is desirable, the switch name is discoverable to intellisense for sensibly similar params. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

```powershell
$autoSpec = @{
    Path        = $fileName
    SqlInstance = "." 
    Database    = $myDb
    Schema      = "dbo"
    Table       = $tblName
    AutoColumnMap = $true
    Truncate    = $true
}
Import-DbaCsv @betterSpec -Verbose

Invoke-DbaQuery -ServerInstance "." -Database $myDb -Query "select * from $tblName" | ft
<#

id foo baz        bin bar
-- --- ---        --- ---
 1 aaa 1900-01-01     111
 2 bbb 1900-02-02     222
 3 ccc 1900-03-03     333
#>
```

Currently, `bcp` bails out if the supplied mapping is invalid (mapped col does not exist in source for example)

> VERBOSE: Performing the operation "Performing import from C:\Users\peter\Desktop\foo.csv" on target "NP:.".
> WARNING: [07:19:49][Import-DbaCsv] Failure | 'baz' field header not found.
> Parameter name: name


<!--### Screenshots
 pictures say a thousand words without typing any of it -->

<!-- ### Learning
Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
