### PR TITLE
fix example - fixes #5323

### DIFF
--- a/functions/Get-DbaClientProtocol.ps1
+++ b/functions/Get-DbaClientProtocol.ps1
@@ -47,7 +47,7 @@ function Get-DbaClientProtocol {
         Gets the SQL Server related client protocols on computers sql1 and sql2, and shows them in a grid view.
 
     .EXAMPLE
-        PS C:\> (Get-DbaClientProtocol -ComputerName sql2 | Where-Object { $_.DisplayName = 'via' }).Disable()
+        PS C:\> (Get-DbaClientProtocol -ComputerName sql2 | Where-Object { $_.DisplayName -eq 'Named Pipes' }).Disable()
 
         Disables the VIA ClientNetworkProtocol on computer sql2.
         If successful, return code 0 is shown.

--- a/functions/Get-DbaServerProtocol.ps1
+++ b/functions/Get-DbaServerProtocol.ps1
@@ -47,7 +47,7 @@ function Get-DbaServerProtocol {
         Gets the SQL Server related server protocols on computers sql1 and sql2, and shows them in a grid view.
 
     .EXAMPLE
-        PS C:\> (Get-DbaServerProtocol -ComputerName sql1 | Where-Object { $_.DisplayName = 'via' }).Disable()
+        PS C:\> (Get-DbaServerProtocol -ComputerName sql1 | Where-Object { $_.DisplayName -eq 'Named Pipes' }).Disable()
 
         Disables the VIA ServerNetworkProtocol on computer sql1.
         If successful, return code 0 is shown.


### PR DESCRIPTION
also updated the protcol name to something on modern machines so that the example doesnt fail as often.

this would actually be a nice opportunity for enable and disable commands for those protocols.