### PR TITLE
Startup procs

### DIFF
--- a/functions/Get-DbaStartupProcedure.ps1
+++ b/functions/Get-DbaStartupProcedure.ps1
@@ -1,0 +1,86 @@
+function Get-DbaStartupProcedure {
+    <#
+    .SYNOPSIS
+        Get-DbaStartupProcedure gets startup procedures (user defined procedures within master database) from a SQL Server.
+
+    .DESCRIPTION
+        By default, this command returns for each SQL Server instance passed in, the name and schema for all procedures in the master database that are marked as a startup procedure.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+        To connect to SQL Server as a different Windows user, run PowerShell as that user.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Procedure, Startup, StartupProcedure
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaStartupProcedure
+
+    .EXAMPLE
+        PS C:\> Get-DbaStartupProcedure -SqlInstance SqlBox1\Instance2
+
+        Returns an object with all startup procedures for the Instance2 instance on SqlBox1
+
+    .EXAMPLE
+        PS C:\> Get-DbaStartupProcedure -SqlInstance winserver\sqlexpress, sql2016
+
+        Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for the sqlexpress instance on host winserver  and the default instance on host sql2016
+
+    .EXAMPLE
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaStartupProcedure
+
+        Returns an object with all startup procedures for every server listed in the Central Management Server on sql2014
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+            Write-Message -Level Verbose -Message "Getting startup procedures for $servername"
+
+            $startupProcs = $server.EnumStartupProcedures()
+
+            if ($startupProcs.Rows.Count -gt 0) {
+                foreach ($proc in $startupProcs) {
+                    [PSCustomObject]@{
+                        ComputerName = $server.ComputerName
+                        SqlInstance  = $server.DomainInstanceName
+                        InstanceName = $server.ServiceName
+                        Schema       = $proc.Schema
+                        Name         = $proc.Name
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Set-DbaStartupProcedure.ps1
+++ b/functions/Set-DbaStartupProcedure.ps1
@@ -31,6 +31,12 @@ function Set-DbaStartupProcedure {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
     .NOTES
         Tags: Procedure, Startup, StartupProcedure
         Author: Patrick Flynn (@sqllensman)

--- a/functions/Set-DbaStartupProcedure.ps1
+++ b/functions/Set-DbaStartupProcedure.ps1
@@ -52,11 +52,6 @@ function Set-DbaStartupProcedure {
 
         Attempts to clear the automatic execution of the procedure '[dbo].[StartUpProc1]' in the master database of the sqlexpress instance on host winserver  and the default instance on host sql2016 when the instance is started.
 
-    .EXAMPLE
-        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Set-DbaStartupProcedure
-
-        Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for every server listed in the Central Management Server on sql2014
-
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = 'High')]
     param (

--- a/functions/Set-DbaStartupProcedure.ps1
+++ b/functions/Set-DbaStartupProcedure.ps1
@@ -1,0 +1,228 @@
+function Set-DbaStartupProcedure {
+    <#
+    .SYNOPSIS
+        Returns the uptime of the SQL Server instance, and if required the hosting windows server
+
+    .DESCRIPTION
+        By default, this command returns for each SQL Server instance passed in:
+        SQL Instance last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
+        Hosting Windows server last startup time, Uptime as a PS TimeSpan, Uptime as a formatted string
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+        To connect to SQL Server as a different Windows user, run PowerShell as that user.
+
+    .PARAMETER StartupProcedure
+        The Procedure(s) to process.
+
+    .PARAMETER Disable
+        If this switch is enabled, listed procedures will be disabled.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Procedure, Startup, StartupProcedure
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Set-DbaStartupProcedure
+
+    .EXAMPLE
+        PS C:\> Set-DbaStartupProcedure -SqlInstance SqlBox1\Instance2 -StartupProcedure '[dbo].[StartUpProc1]'
+
+        Attempts to set the procedure '[dbo].[StartUpProc1]' in the master database of SqlBox1\Instance2 for automatic execution when the instance is started.
+
+    .EXAMPLE
+        PS C:\> Set-DbaStartupProcedure -SqlInstance winserver\sqlexpress, sql2016 -StartupProcedure '[dbo].[StartUpProc1]' -Disable
+
+        Attempts to clear the automatic execution of the procedure '[dbo].[StartUpProc1]' in the master database of the sqlexpress instance on host winserver  and the default instance on host sql2016 when the instance is started.
+
+    .EXAMPLE
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Set-DbaStartupProcedure
+
+        Returns an object with SQL Server start time, uptime as TimeSpan object, uptime as a string, and Windows host boot time, host uptime as TimeSpan objects and host uptime as a string for every server listed in the Central Management Server on sql2014
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$StartupProcedure,
+        [switch]$Disable,
+        [switch]$EnableException
+    )
+    begin {
+        if ($Disable -eq $false) {
+            $action = 'Enable'
+            $startup = $true
+        } else {
+            $action = 'Disable'
+            $startup = $false
+        }
+        function Get-ObjectParts {
+            <#
+            .SYNOPSIS
+                Parse a one or two part object name into seperate paths
+
+            .EXAMPLE
+                Get-ObjectParts 'ProcName'
+
+                Parses a two-part name into its constitute parts.
+
+            .EXAMPLE
+            Get-ObjectParts '[Schema.With.Dots]]].[Another .Silly]] Name..]'
+
+                Parses a two-part name into its constitute parts. Uses square brackets to enclose special characters.
+            #>
+            param (
+                [string]$ObjectName
+            )
+            process {
+                $fqtns = @()
+                #Objects with a ']' charcter in name need to be handeled
+                #Require charcter to be escaped by being duplicated as per T-SQL QuoteName function
+                #These need to be temporarily replaced to allow name to be parsed.
+                $t = $ObjectName
+                if ($t.Contains(']]')) {
+                    for ($i = 0; $i -le 65535; $i++) {
+                        $hexStr = '{0:X4}' -f $i
+                        $char = [regex]::Unescape("\u$($HexStr)")
+                        if (!$ObjectName.Contains($Char)) {
+                            $fixChar = $Char
+                            $t = $t.Replace(']]', $fixChar)
+                            Break
+                        }
+                    }
+                } else {
+                    $fixChar = $null
+                }
+
+                Write-Message -Level Verbose -Message "Splitting parts for $t"
+                $splitName = [regex]::Matches($t, "(\[.+?\])|([^\.]+)").Value
+                $dotcount = $splitName.Count
+                Write-Message -Level Debug -Message "Parts: $dotcount"
+
+                $schema = $proc = $null
+
+                switch ($dotcount) {
+                    1 {
+                        $schema = 'dbo'
+                        $proc = $t
+                        $parsed = $true
+                    }
+                    2 {
+                        $schema = $splitName[0]
+                        $proc = $splitName[1]
+                        $parsed = $true
+                    }
+                    default {
+                        $parsed = $false
+                    }
+                }
+
+                Write-Message -Level Debug -Message "Schema: $schema"
+                if ($schema -like "[[]*[]]") {
+                    $schema = $schema.Substring(1, ($schema.Length - 2))
+                    if ($fixChar) {
+                        $schema = $schema.Replace($fixChar, ']')
+                    }
+                }
+
+                Write-Message -Level Debug -Message "Proc: $proc"
+                if ($proc -like "[[]*[]]") {
+                    $proc = $proc.Substring(1, ($proc.Length - 2))
+                    if ($fixChar) {
+                        $proc = $proc.Replace($fixChar, ']')
+                    }
+                }
+                $fqtns = [PSCustomObject] @{
+                    InputValue = $ObjectName
+                    Schema     = $schema
+                    ProcName   = $proc
+                    Parsed     = $parsed
+                }
+                return $fqtns
+            }
+        }
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
+            }
+            Write-Message -Level Verbose -Message "Getting startup procedures for $instance"
+
+            $db = $server.Databases['master']
+
+            foreach ($proc in $StartupProcedure) {
+                Write-Message -Level Verbose -Message "Preparing to get object parts for $proc"
+                $procParts = Get-ObjectParts $proc
+
+                if ($procParts.Parsed) {
+                    $sp = $db.StoredProcedures.Item($procParts.ProcName, $procParts.Schema)
+
+                    if ($null -eq $sp) {
+                        $status = $false
+                        $note = "Requested procedure does not exist"
+                    } else {
+                        try {
+                            if ($sp.Startup -eq $startup) {
+                                $status = $true
+                                $note = "Requested status already set."
+
+                            } else {
+                                if ($Pscmdlet.ShouldProcess("$instance", "Setting Startup status of $proc to $startup")) {
+                                    $sp.Startup = $startup
+                                    $sp.Alter()
+                                    $status = $true
+                                    $note = "$action succeded"
+                                } else {
+                                    $status = $false
+                                    $note = "$action skipped"
+                                }
+                            }
+
+                        } catch {
+                            $status = $false
+                            $note = "$action failed"
+                        }
+                    }
+
+                } else {
+                    $status = $false
+                    $note = "Unable to split procedure"
+                }
+
+                [PSCustomObject]@{
+                    ComputerName     = $server.ComputerName
+                    SqlInstance      = $server.DomainInstanceName
+                    InstanceName     = $server.ServiceName
+                    StartupProcedure = $proc
+                    Action           = $action
+                    Status           = $status
+                    Note             = $note
+                }
+            }
+        }
+    }
+}

--- a/tests/Get-DbaStartupParameter.Tests.ps1
+++ b/tests/Get-DbaStartupParameter.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','Credential','Simple','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Simple', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -1,0 +1,38 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+Describe "$commandname Integration Test" -Tag "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $random = Get-Random
+        $startupProc = "dbo.StartUpProc$random" 
+        $dbname = 'master'
+
+        $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
+        $null = $server.Query("EXEC sp_procoption N'$startupProc', 'startup', '1'", $dbname)
+    }
+    AfterAll {
+        $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+    }
+
+    Context "Validate returns correct output" {
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2
+
+        It "returns correct results" {
+            $result.Schema -eq 'dbo' | Should Be $true
+            $result.Name -eq "StartUpProc$random" | Should Be $true
+        }
+    }
+
+}

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -16,7 +16,7 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $random = Get-Random
-        $startupProc = "dbo.StartUpProc$random" 
+        $startupProc = "dbo.StartUpProc$random"
         $dbname = 'master'
 
         $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
@@ -34,5 +34,4 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
             $result.Name -eq "StartUpProc$random" | Should Be $true
         }
     }
-
 }

--- a/tests/Set-DbaStartupProcedure.Tests.ps1
+++ b/tests/Set-DbaStartupProcedure.Tests.ps1
@@ -22,7 +22,7 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $random = Get-Random
-        $startupProc = "dbo.StartUpProc$random" 
+        $startupProc = "dbo.StartUpProc$random"
         $dbname = 'master'
 
         $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
@@ -74,5 +74,4 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
             $result.Note -eq "Requested procedure does not exist" | Should Be $true
         }
     }
-
 }

--- a/tests/Set-DbaStartupProcedure.Tests.ps1
+++ b/tests/Set-DbaStartupProcedure.Tests.ps1
@@ -1,0 +1,78 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('WhatIf', 'Confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'StartupProcedure', 'Disable', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+
+    }
+}
+<#
+    Integration test should appear below and are custom to the command you are writing.
+    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
+    for more guidence.
+#>
+Describe "$commandname Integration Test" -Tag "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $random = Get-Random
+        $startupProc = "dbo.StartUpProc$random" 
+        $dbname = 'master'
+
+        $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
+    }
+    AfterAll {
+        $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+    }
+
+    Context "Validate returns correct output for enable" {
+        $result = Set-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $result.StartupProcedure -eq "$startupProc" | Should Be $true
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Enable succeded" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for already existing state" {
+        $result = Set-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $result.StartupProcedure -eq "$startupProc" | Should Be $true
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Requested status already set." | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for disable" {
+        $result = Set-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Disable -Confirm:$false
+
+        It "returns correct results" {
+            $result.StartupProcedure -eq "$startupProc" | Should Be $true
+            $result.Action -eq "Disable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Disable succeded" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for missing procedures" {
+        $result = Set-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure "Unknown.NotHere" -Confirm:$false
+
+        It "returns correct results" {
+            $result.StartupProcedure -eq "Unknown.NotHere" | Should Be $true
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $false
+            $result.Note -eq "Requested procedure does not exist" | Should Be $true
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Change #5265 added new command Copy-DbaStartupProcedure
This adds the matching Get-DbaStartupProcedure and Set-DbaStartupProcedure commands to provide complete coverage.

### Commands to test
Get-DbaStartupProcedure 
Set-DbaStartupProcedure 

