### PR TITLE
adding parameter for setting default database to specified db by parameter for all logins

### DIFF
--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -135,7 +135,7 @@ function Export-DbaLogin {
         [switch]$NoClobber,
         [switch]$Append,
         [switch]$ExcludeDatabases,
-        [switch]$SetDefaultTempdb,
+        [string]$DefaultDatabase,
         [switch]$ExcludeJobs,
         [Alias('Silent')]
         [switch]$EnableException,
@@ -273,8 +273,8 @@ function Export-DbaLogin {
 
                     $outsql += "`r`nUSE master`n"
                     # Getting some attributes
-                    if ($SetDefaultTempdb -eq true) {
-                        $defaultDb = "tempdb" } else {
+                    if ($DefaultDatabase) {
+                        $defaultDb = $DefaultDatabase } else {
                         $defaultDb = $sourceLogin.DefaultDatabase
                         }
                     $language = $sourceLogin.Language

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -274,9 +274,10 @@ function Export-DbaLogin {
                     $outsql += "`r`nUSE master`n"
                     # Getting some attributes
                     if ($DefaultDatabase) {
-                        $defaultDb = $DefaultDatabase } else {
+                        $defaultDb = $DefaultDatabase
+                    } else {
                         $defaultDb = $sourceLogin.DefaultDatabase
-                        }
+                    }
                     $language = $sourceLogin.Language
 
                     if ($sourceLogin.PasswordPolicyEnforced -eq $false) {

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -56,6 +56,10 @@ function Export-DbaLogin {
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
+    .PARAMETER SetDefaultMaster
+        If this switch is enabled, all logins will be scripted with default database 'master', 
+        that could help to successfuly import logins on server that is missing default database for login.   
+
     .NOTES
         Tags: Export, Login
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -131,6 +135,7 @@ function Export-DbaLogin {
         [switch]$NoClobber,
         [switch]$Append,
         [switch]$ExcludeDatabases,
+        [switch]$SetDefaultMaster,
         [switch]$ExcludeJobs,
         [Alias('Silent')]
         [switch]$EnableException,
@@ -268,7 +273,10 @@ function Export-DbaLogin {
 
                     $outsql += "`r`nUSE master`n"
                     # Getting some attributes
-                    $defaultDb = $sourceLogin.DefaultDatabase
+                    if ($SetDefaultMaster -eq true) {
+                        $defaultDb = "master" } else {
+                        $defaultDb = $sourceLogin.DefaultDatabase
+                        }
                     $language = $sourceLogin.Language
 
                     if ($sourceLogin.PasswordPolicyEnforced -eq $false) {

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -56,8 +56,8 @@ function Export-DbaLogin {
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-    .PARAMETER SetDefaultMaster
-        If this switch is enabled, all logins will be scripted with default database 'master', 
+    .PARAMETER SetDefaultTempdb
+        If this switch is enabled, all logins will be scripted with default database 'tempdb', 
         that could help to successfuly import logins on server that is missing default database for login.   
 
     .NOTES
@@ -135,7 +135,7 @@ function Export-DbaLogin {
         [switch]$NoClobber,
         [switch]$Append,
         [switch]$ExcludeDatabases,
-        [switch]$SetDefaultMaster,
+        [switch]$SetDefaultTempdb,
         [switch]$ExcludeJobs,
         [Alias('Silent')]
         [switch]$EnableException,
@@ -273,8 +273,8 @@ function Export-DbaLogin {
 
                     $outsql += "`r`nUSE master`n"
                     # Getting some attributes
-                    if ($SetDefaultMaster -eq true) {
-                        $defaultDb = "master" } else {
+                    if ($SetDefaultTempdb -eq true) {
+                        $defaultDb = "tempdb" } else {
                         $defaultDb = $sourceLogin.DefaultDatabase
                         }
                     $language = $sourceLogin.Language

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -56,9 +56,9 @@ function Export-DbaLogin {
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-    .PARAMETER SetDefaultTempdb
-        If this switch is enabled, all logins will be scripted with default database 'tempdb', 
-        that could help to successfuly import logins on server that is missing default database for login.   
+    .PARAMETER DefaultDatabase
+        If this switch is enabled, all logins will be scripted with specified default database,
+        that could help to successfuly import logins on server that is missing default database for login.
 
     .NOTES
         Tags: Export, Login

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Login','ExcludeLogin','Database','Path','NoClobber','Append','ExcludeDatabases','ExcludeJobs','EnableException','ExcludeGoBatchSeparator','DestinationVersion','InputObject'
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Login','ExcludeLogin','Database','Path','NoClobber','Append','ExcludeDatabases','ExcludeJobs','EnableException','ExcludeGoBatchSeparator','DestinationVersion','InputObject', 'DefaultDatabase'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
   .PARAMETER DefaultDatabase
        If this switch is enabled, all logins will be scripted with default database specified by parameter, 
        that could help to successfully import logins on server that is missing default database for login.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
   If this switch is enabled, all logins will be scripted with default database specified by parameter, 
        that could help to successfully import logins on server that is missing default database for login.
### Approach
<!-- How does this change solve that purpose -->
        adding switch and based on switch there is IF code block
### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
