### PR TITLE
Set-DbaDbState, churn empty notes

### DIFF
--- a/functions/Set-DbaDbState.ps1
+++ b/functions/Set-DbaDbState.ps1
@@ -458,7 +458,7 @@ function Set-DbaDbState {
 
             }
             if ($warn) {
-                $warn = $warn | Get-Unique
+                $warn = $warn | Where {$_} | Get-Unique
                 $warn = $warn -Join ';'
             } else {
                 $warn = $null


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Spit out empty notes instead of ';'. 
Catched while reviewing #4899, confirming also here that that behaviour is not reproduceable

