### PR TITLE
Fix striping issue from Rob and William

### DIFF
--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -211,26 +211,21 @@ function Select-DbaBackupInformation {
                 }
             }
 
-            if ($true -eq $IgnoreFull -and $true -eq $IgnoreDiffs) {
-                #Set a Fake starting LSN
-            }
-
             if ($false -eq $IgnoreLogs) {
                 $FilteredLogs = $DatabaseHistory | Where-Object {$_.Type -in ('Log', 'Transaction Log') -and $_.Start -le $RestoreTime -and $_.LastLSN -ge $LogBaseLsn -and $_.FirstLSN -ne $_.LastLSN}  | Sort-Object -Property LastLsn, FirstLsn
-                $GroupedLogs = $FilteredLogs | Group-Object -Property LastLSN, FirstLSN
+                $GroupedLogs = $FilteredLogs | Group-Object -Property BackupSetID
                 ForEach ($Group in $GroupedLogs) {
-                    $Log = $DatabaseHistory | Where-Object { $_.BackupSetID -eq $Group.group[0].BackupSetID } | select-object -First 1
-                    if ($Log.FullName) {
-                        $Log.FullName = ($DatabaseHistory | Where-Object { $_.BackupSetID -eq $Group.group[0].BackupSetID }).Fullname
-                    } else {
-                        Stop-Function -Message "Fullname property not found. This could mean that a full backup could not be found or the command must be re-run with the -Continue switch."
-                        return
-                    }
-                    #$dbhistory += $Log
-                    $dbhistory += $DatabaseHistory | Where-Object {$_.BackupSetID -eq $Group.group[0].BackupSetID}
+                    $Log = $Group.group[0]
+                    $Log.FullName = $Group.group.fullname
+                    $dbhistory += $Log
                 }
                 # Get Last T-log
-                $dbHistory += $DatabaseHistory | Where-Object {$_.Type -in ('Log', 'Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -eq $Full.CheckpointLSN} | Sort-Object -Property LastLsn, FirstLsn  | Select-Object -First 1
+
+                $lastLog = $DatabaseHistory | Where-Object {$_.Type -in ('Log', 'Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -eq $Full.CheckpointLSN} | Sort-Object -Property LastLsn, FirstLsn  | Select-Object -First 1
+                if ($null -ne $lastlog) {
+                    $lastLog.FullName = ($DatabaseHistory | Where-Object { $_.BackupSetID -eq $lastLog.BackupSetID }).Fullname
+                }
+                $dbHistory += $lastLog
             }
             $dbhistory
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5357 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Ensure that continuing a restore with striped log backups works

### Approach
Clean up the usage of groups in the log backup selection section in Select-DbaBackupInformation. At some point they'd moved to a single value that was throwing things off


