### PR TITLE
Azure restore changes 

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -170,6 +170,7 @@ function Backup-DbaDatabase {
 
         Performs a backup of master, but sends the output to the NUL device (ie; throws it away)
 
+    .EXAMPLE
         PS C:\ Backup-DbaDatabase -SqlInstance Sql2016 -Database stripetest -AzureBaseUrl https://az.blob.core.windows.net/sql,https://dbatools.blob.core.windows.net/sql
 
         Performs a backup of the database striptest, striping it across the 2 Azure blob containers at https://az.blob.core.windows.net/sql and https://dbatools.blob.core.windows.net/sql, assuming that Shared Access Signature credentials for both containers exist on the source instance

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -413,7 +413,7 @@ function Backup-DbaDatabase {
 
             $backup.CopyOnly = $copyonly
             $backup.Action = $SMOBackupType
-            if ('' -ne $AzureBaseUrl -and $null -ne $AzureCredential) {
+            if ($null -ne $AzureBaseUrl -and $null -ne $AzureCredential) {
                 $backup.CredentialName = $AzureCredential
             }
 
@@ -497,7 +497,7 @@ function Backup-DbaDatabase {
             }
 
 
-            if ('' -eq $AzureBaseUrl -and $BackupDirectory) {
+            if ($null -eq $AzureBaseUrl -and $BackupDirectory) {
                 $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
             }
 
@@ -510,7 +510,7 @@ function Backup-DbaDatabase {
 
                 foreach ($backupfile in $FinalBackupPath) {
                     $device = New-Object Microsoft.SqlServer.Management.Smo.BackupDeviceItem
-                    if ('' -ne $AzureBaseUrl) {
+                    if ($null -ne $AzureBaseUrl) {
                         $device.DeviceType = "URL"
                     } else {
                         $device.DeviceType = "File"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Whilst writing some stuff about backing up to azure with dbatools realised we didn't support striping with multiple block blobs

We also don't warn about the non-compatability of MaxTransferSize and BlockSize with page blobs.

Now we do both
