### PR TITLE
Stop restore when mutiple dbs passed in and DatabaseName set

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -639,7 +639,7 @@ function Restore-DbaDatabase {
         if (Test-FunctionInterrupt) {
             return
         }
-        if (($BackupHistory.Database | select -unique).count -gt 1 -and (Test-Bound 'DatabaseName')) {
+        if (($BackupHistory.Database | Select-Object -unique).count -gt 1 -and ('' -ne $DatabaseName)) {
             Stop-Function -Message "Multiple Databases' backups passed in, but only 1 name to restore them under. Stopping as cannot work out how to proceed" -Category  InvalidArgument
             return
         }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -639,6 +639,10 @@ function Restore-DbaDatabase {
         if (Test-FunctionInterrupt) {
             return
         }
+        if (($BackupHistory.Database | select -unique).count -gt 1 -and (Test-Bound 'DatabaseName')) {
+            Stop-Function -Message "Multiple Databases' backups passed in, but only 1 name to restore them under. Stopping as cannot work out how to proceed" -Category  InvalidArgument
+            return
+        }
         if ($PSCmdlet.ParameterSetName -like "Restore*") {
             if ($BackupHistory.Count -eq 0) {
                 Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -238,6 +238,17 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
     }
 
+    Context "Should proceed if backups from multiple dbs passed in and databasename specified" {
+        $results = Get-ChildItem $script:appveyorlabrepo\sql2008-backups | Restore-DbaDatabase -SqlInstance $script:instance2 -DatabaseName test -WarningVariable warnvar
+        It "Should return nothing" {
+            $null -eq $results | Should be $True
+        }
+
+        It "Should have warned with the correct error" {
+            $warnvar -like "*Multiple Databases' backups passed in, but only 1 name to restore them under. Stopping as cannot work out how to proceed*" | Should Be $True
+        }
+    }
+
     Context "Database is properly removed again after ola pipe test" {
         Get-DbaProcess $script:instance2 -ExcludeSystemSpids | Stop-DbaProcess -WarningVariable warn -WarningAction SilentlyContinue
         $results = Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeSystem | Remove-DbaDatabase -Confirm:$false


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5364 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Used to be when multiple databases' backups were passed in and DatabaseName was specified the restore would stop as we wouldn't know which one of the many databases the user wanted restoring as x

Is documented in the CBH

### Approach
Make it do that again

And add a test to make sure a warning gets thrown so we don't forget again
