### PR TITLE
Update Copy-DbaAgentAlert to fix #5300

### DIFF
--- a/functions/Copy-DbaAgentAlert.ps1
+++ b/functions/Copy-DbaAgentAlert.ps1
@@ -135,6 +135,8 @@ function Copy-DbaAgentAlert {
                 }
             }
 
+            $destServerOperators = $destServer.JobServer.Operators
+
             foreach ($serverAlert in $serverAlerts) {
                 $alertName = $serverAlert.name
                 $copyAgentAlertStatus = [pscustomobject]@{


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5300 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Approach
This is a one line fix to set $destServerOperators which was previously null.
I ran before and after tests on multiple servers in my VM lab. I tested for both a single operator and multiple operators, tested for both missing and not missing conditions.

### Commands to test
`copy-dbaagentalert -Source "SERVER1,PORT" -destination "SERVER2,port"`

