### PR TITLE
Use $SqlCredential if passed to Get/New-DbaDbMasterKey

### DIFF
--- a/functions/Get-DbaDbMasterKey.ps1
+++ b/functions/Get-DbaDbMasterKey.ps1
@@ -66,7 +66,7 @@ function Get-DbaDbMasterKey {
 
     process {
         if ($SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase
+            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase -SqlCredential $SqlCredential
         }
 
         foreach ($db in $InputObject) {

--- a/functions/New-DbaDbMasterKey.ps1
+++ b/functions/New-DbaDbMasterKey.ps1
@@ -84,7 +84,7 @@ function New-DbaDbMasterKey {
     }
     process {
         if ($SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase
+            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -Database $Database -ExcludeDatabase $ExcludeDatabase -SqlCredential $SqlCredential
         }
 
         foreach ($db in $InputObject) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5381 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
`Get-DbaDbMasterKey` and `New-DbaDbMasterKey` did not use `-SqlCredential` if supplied.

### Approach
<!-- How does this change solve that purpose -->
Pass the `$SqlCredential` parameter to the `Get-DbaDatabase` command

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
