### PR TITLE
Add Missing Integration Tests for Find- cmdlets

### DIFF
--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -58,24 +58,24 @@ function Find-DbaCommand {
         For rigorous typers: finds all commands searching the entire help for "snapshot"
 
     .EXAMPLE
-        PS C:\> Find-DbaCommand -Tag copy
+        PS C:\> Find-DbaCommand -Tag Job
 
-        Finds all commands tagged with "copy"
-
-    .EXAMPLE
-        PS C:\> Find-DbaCommand -Tag copy,user
-
-        Finds all commands tagged with BOTH "copy" and "user"
+        Finds all commands tagged with "Job"
 
     .EXAMPLE
-        PS C:\> Find-DbaCommand -Author chrissy
+        PS C:\> Find-DbaCommand -Tag Job,Owner
 
-        Finds every command whose author contains our beloved "chrissy"
+        Finds all commands tagged with BOTH "Job" and "Owner"
 
     .EXAMPLE
-        PS C:\> Find-DbaCommand -Author chrissy -Tag copy
+        PS C:\> Find-DbaCommand -Author Chrissy
 
-        Finds every command whose author contains our beloved "chrissy" and it tagged as "copy"
+        Finds every command whose author contains our beloved "Chrissy"
+
+    .EXAMPLE
+        PS C:\> Find-DbaCommand -Author Chrissy -Tag AG
+
+        Finds every command whose author contains our beloved "Chrissy" and it tagged as "AG"
 
     .EXAMPLE
         PS C:\> Find-DbaCommand -Pattern snapshot -Rebuild

--- a/tests/Find-DbaAgentJob.Tests.ps1
+++ b/tests/Find-DbaAgentJob.Tests.ps1
@@ -5,15 +5,68 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','JobName','ExcludeJobName','StepName','LastUsed','IsDisabled','IsFailed','IsNotScheduled','IsNoEmailNotification','Category','Owner','Since','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'JobName', 'ExcludeJobName', 'StepName', 'LastUsed', 'IsDisabled', 'IsFailed', 'IsNotScheduled', 'IsNoEmailNotification', 'Category', 'Owner', 'Since', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds jobs using all parameters" {
+        BeforeAll {
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_testjob' -OwnerLogin 'sa'
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job 'dbatoolsci_testjob' -StepId 1 -StepName 'dbatoolsci Failed' -Subsystem TransactSql -SubsystemServer $script:instance2 -Command "RAISERROR (15600,-1,-1, 'dbatools_error');" -CmdExecSuccessCode 0 -OnSuccessAction QuitWithSuccess -OnFailAction QuitWithFailure -Database master -DatabaseUser sa -RetryAttempts 1 -RetryInterval 2
+            $null = Start-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_testjob'
+            $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci_job_category' -CategoryType LocalJob
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_testjob_disabled' -Category 'dbatoolsci_job_category' -Disabled
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job 'dbatoolsci_testjob_disabled' -StepId 1 -StepName 'dbatoolsci Test Step' -Subsystem TransactSql -SubsystemServer $script:instance2 -Command 'SELECT * FROM master.sys.all_columns' -CmdExecSuccessCode 0 -OnSuccessAction QuitWithSuccess -OnFailAction QuitWithFailure -Database master -DatabaseUser sa -RetryAttempts 1 -RetryInterval 2
+        }
+        AfterAll {
+            $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob, dbatoolsci_testjob_disabled
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci_job_category'
+        }
+
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob
+        It "Should find a specific job" {
+            $results.name | Should Be "dbatoolsci_testjob"
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -Job *dbatoolsci* -Exclude dbatoolsci_testjob_disabled
+        It "Should find a specific job but not an excldued job" {
+            $results.name | Should Not Be "dbatoolsci_testjob_disabled"
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -StepName 'dbatoolsci Test Step'
+        It "Should find a specific job with a specific step" {
+            $results.name | Should Be "dbatoolsci_testjob_disabled"
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -LastUsed 10
+        It "Should find jobs not used in the last 10 days" {
+            $results | Should not be null
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -IsDisabled
+        It "Should find jobs disabled from running" {
+            $results.name | Should be "dbatoolsci_testjob_disabled"
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -IsNotScheduled
+        It "Should find jobs that have not been scheduled" {
+            $results | Should not be null
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -IsNoEmailNotification
+        It "Should find jobs that have no email notification" {
+            $results | Should not be null
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -Category 'dbatoolsci_job_category'
+        It "Should find jobs that have a category of dbatoolsci_job_category" {
+            $results.name | Should be "dbatoolsci_testjob_disabled"
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -Owner 'sa'
+        It "Should find jobs that are owned by sa" {
+            $results | Should not be null
+        }
+        $results = Find-DbaAgentJob -SqlInstance $script:instance2 -IsFailed -Since '2016-07-01 10:47:00'
+        It "Should find jobs that have been failed since July of 2016" {
+            $results | Should not be null
+        }
+    }
+}

--- a/tests/Find-DbaCommand.Tests.ps1
+++ b/tests/Find-DbaCommand.Tests.ps1
@@ -5,15 +5,39 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Pattern','Tag','Author','MinimumVersion','MaximumVersion','Rebuild','EnableException'
+        [object[]]$knownParameters = 'Pattern', 'Tag', 'Author', 'MinimumVersion', 'MaximumVersion', 'Rebuild', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds jobs using all parameters" {
+        $results = Find-DbaCommand -Pattern "snapshot"
+        It "Should find more than 5 snapshot commands" {
+            $results.Count | Should BeGreaterThan 5
+        }
+        $results = Find-DbaCommand -Tag Job
+        It "Should find more than 20 commands tagged as job" {
+            $results.Count | Should BeGreaterThan 20
+        }
+        $results = Find-DbaCommand -Tag Job, Owner
+        It "Should find a command that has both Job and Owner tags" {
+            $results.CommandName | Should Contain "Test-DbaAgentJobOwner"
+        }
+        $results = Find-DbaCommand -Author chrissy
+        It "Should find more than 250 commands authored by Chrissy" {
+            $results.Count | Should BeGreaterThan 250
+        }
+        $results = Find-DbaCommand -Author chrissy -Tag AG
+        It "Should find more than 15 commands for AGs authored by Chrissy" {
+            $results.Count | Should BeGreaterThan 15
+        }
+        $results = Find-DbaCommand -Pattern snapshot -Rebuild
+        It "Should find more than 5 snapshot commands after Rebuilding the index" {
+            $results.Count | Should BeGreaterThan 5
+        }
+    }
+}

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -5,15 +5,59 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','Pattern','IncludeSystemObjects','IncludeSystemDatabases','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Pattern', 'IncludeSystemObjects', 'IncludeSystemDatabases', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds Procedures in a System Database" {
+        BeforeAll {
+            $ServerProcedure = @"
+CREATE PROCEDURE dbo.cp_dbatoolsci_sysadmin
+AS
+    SET NOCOUNT ON;
+    SELECT [sid],[loginname],[sysadmin]
+    FROM [master].[sys].[syslogins];
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $ServerProcedure
+        }
+        AfterAll {
+            $DropProcedure = "DROP PROCEDURE dbo.cp_dbatoolsci_sysadmin;"
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $DropProcedure
+        }
+        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -IncludeSystemDatabases
+        It "Should find a specific StoredProcedure named cp_dbatoolsci_sysadmin" {
+            $results.Name | Should Be "cp_dbatoolsci_sysadmin"
+        }
+    }
+    Context "Command finds Procedures in a User Database" {
+        BeforeAll {
+            $null = New-DbaDatabase -SqlInstance $script:instance2 -Name 'dbatoolsci_storedproceduredb'
+            $StoredProcedure = @"
+CREATE PROCEDURE dbo.sp_dbatoolsci_custom
+AS
+    SET NOCOUNT ON;
+    PRINT 'Dbatools Rocks';
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'dbatoolsci_storedproceduredb' -Query $StoredProcedure
+        }
+        AfterAll {
+            $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database 'dbatoolsci_storedproceduredb' -Confirm:$false
+        }
+        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -Database 'dbatoolsci_storedproceduredb'
+        It "Should find a specific StoredProcedure named sp_dbatoolsci_custom" {
+            $results.Name | Should Be "sp_dbatoolsci_custom"
+        }
+        It "Should find sp_dbatoolsci_custom in dbatoolsci_storedproceduredb" {
+            $results.Database | Should Be "dbatoolsci_storedproceduredb"
+        }
+        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -ExcludeDatabase 'dbatoolsci_storedproceduredb'
+        It "Should find no results when Excluding dbatoolsci_storedproceduredb" {
+            $results | Should Be $null
+        }
+    }
+}

--- a/tests/Find-DbaTrigger.Tests.ps1
+++ b/tests/Find-DbaTrigger.Tests.ps1
@@ -5,15 +5,109 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','Pattern','TriggerLevel','IncludeSystemObjects','IncludeSystemDatabases','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Pattern', 'TriggerLevel', 'IncludeSystemObjects', 'IncludeSystemDatabases', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Pattern', 'TriggerLevel', 'IncludeSystemObjects', 'IncludeSystemDatabases', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds Triggers at the Server Level" {
+        BeforeAll {
+            ## All Triggers adapted from examples on:
+            ## https://docs.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql?view=sql-server-2017
+
+            $ServerTrigger = @"
+CREATE TRIGGER dbatoolsci_ddl_trig_database
+ON ALL SERVER
+FOR CREATE_DATABASE
+AS
+    PRINT 'dbatoolsci Database Created.'
+    SELECT EVENTDATA().value('(/EVENT_INSTANCE/TSQLCommand/CommandText)[1]','nvarchar(max)')
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Query $ServerTrigger
+        }
+        AfterAll {
+            $DropTrigger = @"
+DROP TRIGGER dbatoolsci_ddl_trig_database
+ON ALL SERVER;
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $DropTrigger
+        }
+
+        $results = Find-DbaTrigger -SqlInstance $script:instance2 -Pattern dbatoolsci* -IncludeSystemDatabases -IncludeSystemObjects -TriggerLevel Server
+        It "Should find a specific Trigger at the Server Level" {
+            $results.TriggerLevel | Should Be "Server"
+        }
+        It "Should find a specific Trigger named dbatoolsci_ddl_trig_database" {
+            $results.Name | Should Be "dbatoolsci_ddl_trig_database"
+        }
+    }
+    Context "Command finds Triggers at the Database and Object Level" {
+        BeforeAll {
+            ## All Triggers adapted from examples on:
+            ## https://docs.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql?view=sql-server-2017
+
+            $null = New-DbaDatabase -SqlInstance $script:instance2 -Name 'dbatoolsci_triggerdb'
+            $DatabaseTrigger = @"
+CREATE TRIGGER dbatoolsci_safety
+ON DATABASE
+FOR DROP_SYNONYM
+AS
+IF (@@ROWCOUNT = 0)
+RETURN;
+   RAISERROR ('You must disable Trigger "safety" to drop synonyms!',10, 1)
+   ROLLBACK
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'dbatoolsci_triggerdb' -Query $DatabaseTrigger
+            $TableTrigger = @"
+CREATE TABLE dbo.Customer (id int, PRIMARY KEY (id));
+GO
+CREATE TRIGGER dbatoolsci_reminder1
+ON dbo.Customer
+AFTER INSERT, UPDATE
+AS RAISERROR ('Notify Customer Relations', 16, 10);
+GO
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'dbatoolsci_triggerdb' -Query $TableTrigger
+        }
+        AfterAll {
+            $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database 'dbatoolsci_triggerdb' -Confirm:$false
+        }
+
+        $results = Find-DbaTrigger -SqlInstance $script:instance2 -Pattern dbatoolsci* -Database 'dbatoolsci_triggerdb' -TriggerLevel Database
+        It "Should find a specific Trigger at the Database Level" {
+            $results.TriggerLevel | Should Be "Database"
+        }
+        It "Should find a specific Trigger named dbatoolsci_safety" {
+            $results.Name | Should Be "dbatoolsci_safety"
+        }
+
+        $results = Find-DbaTrigger -SqlInstance $script:instance2 -Pattern dbatoolsci* -Database 'dbatoolsci_triggerdb' -ExcludeDatabase Master -TriggerLevel Object
+        It "Should find a specific Trigger at the Object Level" {
+            $results.TriggerLevel | Should Be "Object"
+        }
+        It "Should find a specific Trigger named dbatoolsci_reminder1" {
+            $results.Name | Should Be "dbatoolsci_reminder1"
+        }
+        It "Should find a specific Trigger on the Table [dbo].[Customer]" {
+            $results.Object | Should Be "[dbo].[Customer]"
+        }
+    }
+}

--- a/tests/Find-DbaTrigger.Tests.ps1
+++ b/tests/Find-DbaTrigger.Tests.ps1
@@ -58,6 +58,10 @@ ON ALL SERVER;
         It "Should find a specific Trigger named dbatoolsci_ddl_trig_database" {
             $results.Name | Should Be "dbatoolsci_ddl_trig_database"
         }
+        $results = Find-DbaTrigger -SqlInstance $script:instance2 -Pattern dbatoolsci* -TriggerLevel All
+        It "Should find a specific Trigger when TriggerLevel is All" {
+            $results.Name | Should Be "dbatoolsci_ddl_trig_database"
+        }
     }
     Context "Command finds Triggers at the Database and Object Level" {
         BeforeAll {
@@ -108,6 +112,10 @@ GO
         }
         It "Should find a specific Trigger on the Table [dbo].[Customer]" {
             $results.Object | Should Be "[dbo].[Customer]"
+        }
+        $results = Find-DbaTrigger -SqlInstance $script:instance2 -Pattern dbatoolsci* -TriggerLevel All
+        It "Should find 2 Triggers when TriggerLevel is All" {
+            $results.name | Should Be @('dbatoolsci_safety', 'dbatoolsci_reminder1')
         }
     }
 }

--- a/tests/Find-DbaUserObject.Tests.ps1
+++ b/tests/Find-DbaUserObject.Tests.ps1
@@ -5,15 +5,29 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Pattern','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Pattern', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds User Objects" {
+        BeforeAll {
+            $null = New-DbaDatabase -SqlInstance $script:instance2 -Name 'dbatoolsci_userObject' -Owner 'sa'
+        }
+        AfterAll {
+            $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database 'dbatoolsci_userObject' -Confirm:$false
+        }
+
+        $results = Find-DbaUserObject -SqlInstance $script:instance2 -Pattern sa
+        It "Should find a specific Database Owned by sa" {
+            $results.Where( {$_.name -eq 'dbatoolsci_userobject'}).Type | Should Be "Database"
+        }
+        It "Should find more than 10 objects Owned by sa" {
+            $results.Count | Should BeGreaterThan 10
+        }
+    }
+}

--- a/tests/Find-DbaUserObject.Tests.ps1
+++ b/tests/Find-DbaUserObject.Tests.ps1
@@ -14,7 +14,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
-    Context "Command finds User Objects" {
+    Context "Command finds User Objects for SA" {
         BeforeAll {
             $null = New-DbaDatabase -SqlInstance $script:instance2 -Name 'dbatoolsci_userObject' -Owner 'sa'
         }
@@ -28,6 +28,12 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         It "Should find more than 10 objects Owned by sa" {
             $results.Count | Should BeGreaterThan 10
+        }
+    }
+    Context "Command finds User Objects" {
+        $results = Find-DbaUserObject -SqlInstance $script:instance2
+        It "Should find resutls" {
+            $results | Should Not Be Null
         }
     }
 }

--- a/tests/Find-DbaView.Tests.ps1
+++ b/tests/Find-DbaView.Tests.ps1
@@ -5,15 +5,64 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','ExcludeDatabase','Pattern','IncludeSystemObjects','IncludeSystemDatabases','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Pattern', 'IncludeSystemObjects', 'IncludeSystemDatabases', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command finds Views in a System Database" {
+        BeforeAll {
+            $ServerView = @"
+CREATE VIEW dbo.v_dbatoolsci_sysadmin
+AS
+    SELECT [sid],[loginname],[sysadmin]
+    FROM [master].[sys].[syslogins];
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $ServerView
+        }
+        AfterAll {
+            $DropView = "DROP VIEW dbo.v_dbatoolsci_sysadmin;"
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $DropView
+        }
+
+        $results = Find-DbaView -SqlInstance $script:instance2 -Pattern dbatools* -IncludeSystemDatabases
+        It "Should find a specific View named v_dbatoolsci_sysadmin" {
+            $results.Name | Should Be "v_dbatoolsci_sysadmin"
+        }
+        It "Should find v_dbatoolsci_sysadmin in Master" {
+            $results.Database | Should Be "Master"
+        }
+    }
+    Context "Command finds View in a User Database" {
+        BeforeAll {
+            $null = New-DbaDatabase -SqlInstance $script:instance2 -Name 'dbatoolsci_viewdb'
+            $DatabaseView = @"
+CREATE VIEW dbo.v_dbatoolsci_sysadmin
+AS
+    SELECT [sid],[loginname],[sysadmin]
+    FROM [master].[sys].[syslogins];
+"@
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'dbatoolsci_viewdb' -Query $DatabaseView
+        }
+        AfterAll {
+            $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database 'dbatoolsci_viewdb' -Confirm:$false
+        }
+
+        $results = Find-DbaView -SqlInstance $script:instance2 -Pattern dbatools* -Database 'dbatoolsci_viewdb'
+        It "Should find a specific view named v_dbatoolsci_sysadmin" {
+            $results.Name | Should Be "v_dbatoolsci_sysadmin"
+        }
+        It "Should find v_dbatoolsci_sysadmin in dbatoolsci_viewdb Database" {
+            $results.Database | Should Be "dbatoolsci_viewdb"
+        }
+        $results = Find-DbaView -SqlInstance $script:instance2 -Pattern dbatools* -ExcludeDatabase 'dbatoolsci_viewdb'
+        It "Should find no results when Excluding dbatoolsci_viewdb" {
+            $results | Should Be $null
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #4982 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Include Tests for Find- cmdlets that previously had 0 code coverage.

### Approach
Either creating objects that need to be retrieved by a cmdlet, or executing the cmdlet with existing information

### Commands to test
`Invoke-Pester .\Find-DbaAgentJob.Tests.ps1` 
`Invoke-Pester .\Find-DbaCommand.Tests.ps1`
`Invoke-Pester .\Find-DbaTrigger.Tests.ps1`
`Invoke-Pester .\Find-DbaUserObject.Tests.ps1`
`Invoke-Pester .\Find-DbaStoredProcedure.Tests.ps1`
`Invoke-Pester .\Find-DbaView.Tests.ps1`