### PR TITLE
Add DbaAgentSchedule tests

### DIFF
--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -82,9 +82,6 @@ function New-DbaAgentSchedule {
 
         If force is used the start time will be '23:59:59'
 
-    .PARAMETER Owner
-        The name of the server principal that owns the schedule. If no value is given the schedule is owned by the creator.
-
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 

--- a/functions/Set-DbaAgentSchedule.ps1
+++ b/functions/Set-DbaAgentSchedule.ps1
@@ -69,9 +69,6 @@ function Set-DbaAgentSchedule {
         Example: '010000' for 01:00:00 AM.
         Example: '140000' for 02:00:00 PM.
 
-    .PARAMETER Owner
-        The name of the server principal that owns the schedule. If no value is given the schedule is owned by the creator.
-
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 

--- a/tests/New-DbaAgentSchedule.Tests.ps1
+++ b/tests/New-DbaAgentSchedule.Tests.ps1
@@ -5,15 +5,208 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Job','Schedule','Disabled','FrequencyType','FrequencyInterval','FrequencySubdayType','FrequencySubdayInterval','FrequencyRelativeInterval','FrequencyRecurrenceFactor','StartDate','EndDate','StartTime','EndTime','Force','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'Schedule', 'Disabled', 'FrequencyType', 'FrequencyInterval', 'FrequencySubdayType', 'FrequencySubdayInterval', 'FrequencyRelativeInterval', 'FrequencyRecurrenceFactor', 'StartDate', 'EndDate', 'StartTime', 'EndTime', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_newschedule' -OwnerLogin 'sa'
+        $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job 'dbatoolsci_newschedule' -StepId 1 -StepName 'dbatoolsci Test Select' -Subsystem TransactSql -SubsystemServer $script:instance2 -Command "SELECT * FROM master.sys.all_columns;" -CmdExecSuccessCode 0 -OnSuccessAction QuitWithSuccess -OnFailAction QuitWithFailure -Database master -DatabaseUser sa
+
+        $start = (Get-Date).AddDays(2).ToString('yyyyMMdd')
+        $end = (Get-Date).AddDays(4).ToString('yyyyMMdd')
+    }
+    AfterAll {
+        $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_newschedule'
+    }
+
+    Context "Should create schedules based on static frequency" {
+        BeforeAll {
+            $results = New-Object System.collections.arraylist
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+            Remove-Variable -Name results
+        }
+
+        foreach ($frequency in ('Once', 'AgentStart', 'IdleComputer')) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$frequency"
+                Job                       = 'dbatoolsci_newschedule'
+                FrequencyType             = $frequency
+                FrequencyRecurrenceFactor = '1'
+            }
+
+            if ($frequency -ne 'IdleComputer') {
+                $results.add($(New-DbaAgentSchedule -StartDate $start -StartTime '010000' -EndDate $end -EndTime '020000' @variables))
+            } else {
+                $results.add($(New-DbaAgentSchedule -Disabled -Force @variables))
+            }
+        }
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should be a schedule on an existing job" {
+                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+            }
+        }
+    }
+
+    Context "Should create schedules based on calendar frequency" {
+        BeforeAll {
+            $results = New-Object System.collections.arraylist
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+            Remove-Variable -Name results
+        }
+
+        foreach ($frequency in ('Daily', 'Weekly', 'Monthly', 'MonthlyRelative')) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$frequency"
+                Job                       = 'dbatoolsci_newschedule'
+                FrequencyType             = $frequency
+                FrequencyRecurrenceFactor = '1'
+                FrequencyInterval         = '1'
+                FrequencyRelativeInterval = 'First'
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+
+            $results.add( $(New-DbaAgentSchedule @variables))
+        }
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should be a schedule on an existing job" {
+                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+            }
+        }
+    }
+
+    Context "Should create schedules with various frequency interval" {
+        BeforeAll {
+            $results = New-Object System.collections.arraylist
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+            Remove-Variable -Name results
+        }
+
+        foreach ($frequencyinterval in ('EveryDay', 'Weekdays', 'Weekend', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$frequencyinterval"
+                Job                       = 'dbatoolsci_newschedule'
+                FrequencyType             = 'Daily'
+                FrequencyRecurrenceFactor = '1'
+                FrequencyInterval         = $frequencyinterval
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+
+            $results.add( $(New-DbaAgentSchedule @variables))
+        }
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should be a schedule on an existing job" {
+                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+            }
+        }
+    }
+
+    Context "Should create schedules with various frequency subday type" {
+        BeforeAll {
+            $results = New-Object System.collections.arraylist
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+            Remove-Variable -Name results
+        }
+
+        foreach ($FrequencySubdayType in ('Time', 'Seconds', 'Minutes', 'Hours')) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$FrequencySubdayType"
+                Job                       = 'dbatoolsci_newschedule'
+                FrequencyRecurrenceFactor = '1'
+                FrequencySubdayInterval   = '1'
+                FrequencySubdayType       = $FrequencySubdayType
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+
+            $results.add( $(New-DbaAgentSchedule @variables))
+        }
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should be a schedule on an existing job" {
+                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+            }
+        }
+    }
+
+    Context "Should create schedules with various frequency relative interval" {
+        BeforeAll {
+            $results = New-Object System.collections.arraylist
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+            Remove-Variable -Name results
+        }
+
+        foreach ($FrequencyRelativeInterval in ('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$FrequencyRelativeInterval"
+                Job                       = 'dbatoolsci_newschedule'
+                FrequencyRecurrenceFactor = '1'
+                FrequencyRelativeInterval = $FrequencyRelativeInterval
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+
+            $results.add( $(New-DbaAgentSchedule @variables))
+        }
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should be a schedule on an existing job" {
+                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+            }
+        }
+    }
+}

--- a/tests/Remove-DbaAgentSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentSchedule.Tests.ps1
@@ -5,15 +5,52 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Schedule','InputObject','EnableException','Force'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'InputObject', 'EnableException', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $start = (Get-Date).AddDays(2).ToString('yyyyMMdd')
+        $end = (Get-Date).AddDays(4).ToString('yyyyMMdd')
+
+        foreach ($FrequencySubdayType in ('Time', 'Seconds', 'Minutes', 'Hours')) {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = "dbatoolsci_$FrequencySubdayType"
+                FrequencyRecurrenceFactor = '1'
+                FrequencySubdayInterval   = '1'
+                FrequencySubdayType       = $FrequencySubdayType
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+            $null = New-DbaAgentSchedule @variables
+        }
+    }
+
+    Context "Should remove schedules" {
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+            Where-Object {$_.name -like 'dbatools*'}
+        It "Should find all created schedule" {
+            $results | Should Not BeNullOrEmpty
+        }
+
+        Remove-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyRelative -Confirm:$false
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyRelative
+        It "Should not find dbatoolsci_MonthlyRelative" {
+            $results | Should BeNullOrEmpty
+        }
+
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+            Where-Object {$_.name -like 'dbatools*'} |
+            Remove-DbaAgentSchedule -Confirm:$false -Force
+        It "Should not find any created schedule" {
+            $results | Should BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Set-DbaAgentSchedule.Tests.ps1
+++ b/tests/Set-DbaAgentSchedule.Tests.ps1
@@ -5,15 +5,288 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Job','ScheduleName','NewName','Enabled','Disabled','FrequencyType','FrequencyInterval','FrequencySubdayType','FrequencySubdayInterval','FrequencyRelativeInterval','FrequencyRecurrenceFactor','StartDate','EndDate','StartTime','EndTime','EnableException','Force'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ScheduleName', 'NewName', 'Enabled', 'Disabled', 'FrequencyType', 'FrequencyInterval', 'FrequencySubdayType', 'FrequencySubdayInterval', 'FrequencyRelativeInterval', 'FrequencyRecurrenceFactor', 'StartDate', 'EndDate', 'StartTime', 'EndTime', 'EnableException', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_setschedule1' -OwnerLogin 'sa'
+        $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_setschedule2' -OwnerLogin 'sa'
+        $start = (Get-Date).AddDays(2).ToString('yyyyMMdd')
+        $end = (Get-Date).AddDays(4).ToString('yyyyMMdd')
+        $altstart = (Get-Date).AddDays(3).ToString('yyyyMMdd')
+        $altend = (Get-Date).AddDays(5).ToString('yyyyMMdd')
+    }
+    AfterAll {
+        $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_setschedule1', 'dbatoolsci_setschedule2'
+    }
+    Context "Should rename schedule" {
+        BeforeAll {
+            $variables = @{SqlInstance    = $script:instance2
+                Schedule                  = 'dbatoolsci_oldname'
+                Job                       = 'dbatoolsci_setschedule1'
+                FrequencyRecurrenceFactor = '1'
+                FrequencySubdayInterval   = '5'
+                FrequencySubdayType       = 'Time'
+                StartDate                 = $start
+                StartTime                 = '010000'
+                EndDate                   = $end
+                EndTime                   = '020000'
+            }
+
+            $null = New-DbaAgentSchedule @variables
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+        }
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+        $variables = @{SqlInstance    = $script:instance2
+            Schedule                  = "dbatoolsci_oldname"
+            NewName                   = "dbatoolsci_newname"
+            Job                       = 'dbatoolsci_setschedule1'
+            FrequencyRecurrenceFactor = '6'
+            FrequencySubdayInterval   = '4'
+            StartDate                 = $altstart
+            StartTime                 = '113300'
+            EndDate                   = $altend
+            EndTime                   = '221100'
+        }
+
+        $null = Set-DbaAgentSchedule @variables
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should have different name" {
+                $($r.name) | Should Not Be "$($schedules.where({$_.id -eq $r.id}).name)"
+            }
+        }
+    }
+
+    Context "Should set schedules based on static frequency" {
+        BeforeAll {
+            foreach ($frequency in ('Once', 'AgentStart', 'IdleComputer')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequency"
+                    Job                       = 'dbatoolsci_setschedule1'
+                    FrequencyType             = $frequency
+                    FrequencyRecurrenceFactor = '1'
+                }
+
+                if ($frequency -ne 'IdleComputer') {
+                    $null = New-DbaAgentSchedule -StartDate $start -StartTime '010000' -EndDate $end -EndTime '020000' @variables
+                } else {
+                    $null = New-DbaAgentSchedule -Disabled -Force @variables
+                }
+            }
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+        }
+
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+        foreach ($schedule in $schedules) {
+            foreach ($frequency in ('Once', '1' , 'AgentStart', '64', 'IdleComputer', '128')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "$($schedule.name)"
+                    Job                       = 'dbatoolsci_setschedule1'
+                    FrequencyType             = $frequency
+                    FrequencyRecurrenceFactor = '5'
+                }
+
+                if ($frequency -notin ('IdleComputer', '128')) {
+                    $null = Set-DbaAgentSchedule -StartDate $altstart -StartTime '113300' -EndDate $altend -EndTime '221100' -Disabled @variables
+                } else {
+                    $null = Set-DbaAgentSchedule -Enabled -Force @variables
+                }
+            }
+        }
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should have a frequency of OnIdle" {
+                $($r.FrequencyTypes) | Should Be 'OnIdle'
+            }
+            It "$($r.name) Should be Enabled" {
+                $($r.isEnabled) | Should Be 'True'
+            }
+        }
+    }
+
+    Context "Should set schedules based on calendar frequency" {
+        BeforeAll {
+            foreach ($frequency in ('Daily', 'Weekly', 'Monthly', 'MonthlyRelative')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequency"
+                    Job                       = 'dbatoolsci_setschedule2'
+                    FrequencyType             = $frequency
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencyInterval         = '1'
+                    FrequencyRelativeInterval = 'First'
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $null = New-DbaAgentSchedule @variables
+            }
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+        }
+
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+        foreach ($schedule in $schedules) {
+            foreach ($frequency in ('Daily', '4', 'Weekly', '8', 'Monthly', '16', 'MonthlyRelative', '32')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "$($schedule.name)"
+                    Job                       = 'dbatoolsci_setschedule2'
+                    FrequencyType             = $frequency
+                    FrequencyRecurrenceFactor = '6'
+                    FrequencyInterval         = '4'
+                    FrequencyRelativeInterval = 'Second'
+                    StartDate                 = $altstart
+                    StartTime                 = '113300'
+                    EndDate                   = $altend
+                    EndTime                   = '221100'
+                }
+
+                $null = Set-DbaAgentSchedule @variables
+            }
+        }
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should have a frequency of MonthlyRelative" {
+                $($r.FrequencyTypes) | Should Be 'MonthlyRelative'
+            }
+            It "$($r.name) Should have different StartTime" {
+                $($r.StartTime) | Should Not Be "$($schedules.where({$_.id -eq $r.id}).StartTime)"
+            }
+        }
+    }
+
+    Context "Should set schedules with various frequency subday type" {
+        BeforeAll {
+            foreach ($FrequencySubdayType in ('Time', 'Seconds', 'Minutes', 'Hours')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$FrequencySubdayType"
+                    Job                       = 'dbatoolsci_setschedule1'
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencySubdayInterval   = '5'
+                    FrequencySubdayType       = $FrequencySubdayType
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $null = New-DbaAgentSchedule @variables
+            }
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+        }
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+        foreach ($schedule in $schedules) {
+            foreach ($FrequencySubdayType in ('Time', '1', 'Seconds', '2', 'Minutes', '4', 'Hours', '8')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "$schedule"
+                    Job                       = 'dbatoolsci_setschedule1'
+                    FrequencyRecurrenceFactor = '6'
+                    FrequencySubdayInterval   = '4'
+                    FrequencySubdayType       = $FrequencySubdayType
+                    StartDate                 = $altstart
+                    StartTime                 = '113300'
+                    EndDate                   = $altend
+                    EndTime                   = '221100'
+                }
+
+                $null = Set-DbaAgentSchedule @variables
+            }
+        }
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should have different EndDate" {
+                $($r.EndDate) | Should Not Be "$($schedules.where({$_.id -eq $r.id}).EndDate)"
+            }
+        }
+    }
+
+    Context "Should set schedules with various frequency relative interval" {
+        BeforeAll {
+            foreach ($FrequencyRelativeInterval in ('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$FrequencyRelativeInterval"
+                    Job                       = 'dbatoolsci_setschedule2'
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencyRelativeInterval = $FrequencyRelativeInterval
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $null = New-DbaAgentSchedule @variables
+            }
+        }
+        AfterAll {
+            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
+                Where-Object {$_.name -like 'dbatools*'} |
+                Remove-DbaAgentSchedule -Confirm:$false -Force
+        }
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+        foreach ($schedule in $schedules) {
+            foreach ($FrequencyRelativeInterval in ('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "$schedule"
+                    Job                       = 'dbatoolsci_setschedule2'
+                    FrequencyRecurrenceFactor = '4'
+                    FrequencyRelativeInterval = $FrequencyRelativeInterval
+                    StartDate                 = $altstart
+                    StartTime                 = '113300'
+                    EndDate                   = $altend
+                    EndTime                   = '221100'
+                }
+
+                $null = Set-DbaAgentSchedule @variables
+            }
+        }
+        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 | Where-Object {$_.name -like 'dbatools*'}
+
+        It "Should have Results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        foreach ($r in $results) {
+            It "$($r.name) Should have different EndTime" {
+                $($r.EndTime) | Should Not Be "$($schedules.where({$_.id -eq $r.id}).EndTime)"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Include Tests for cmdlets with the noun DbaAgentSchedule which previously had 0 code coverage.

### Approach
<!-- How does this change solve that purpose -->
Created a bunch of schedules to iterate through all options on parameters.

### Commands to test
`Invoke-Pester .\New-DbaAgentSchedule.Tests.ps1`
`Invoke-Pester .\Remove-DbaAgentSchedule.Tests.ps1`
`Invoke-Pester .\Set-DbaAgentSchedule.Tests.ps1`

