### PR TITLE
Add Integration Test

### DIFF
--- a/tests/Get-SqlDefaultSpConfigure.Tests.ps1
+++ b/tests/Get-SqlDefaultSpConfigure.Tests.ps1
@@ -1,0 +1,40 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+. "$PSScriptRoot\..\internal\functions\Get-SqlDefaultSPConfigure.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlVersion'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
+    Context "Try all versions of SQL" {
+        $versionName = @{8  = "2000"
+                        9  = "2005"
+                        10 = "2008/2008R2"
+                        11 = "2012"
+                        12 = "2014"
+                        13 = "2016"
+                        14 = "2017"
+                        15 = "2019"}
+
+        foreach ($version in 8..14){
+            $results = Get-SqlDefaultSPConfigure -SqlVersion $version
+
+            It "Should return results for $($versionName.item($version))" {
+                $results | Should  Not BeNullOrEmpty
+            }
+
+            It "Should return 'System.Management.Automation.PSCustomObject' object" {
+                $results.GetType().fullname | Should Be "System.Management.Automation.PSCustomObject"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Noticed there was some low hanging fruit for testing in Internal cmdlets. So decided to write a quick test for `Get-SqlDefaultSPConfigure.ps1`. This doesn't add much value beside possibly boosting the internal code coverage numbers, and my sense of accomplishment 😁 

### Approach
<!-- How does this change solve that purpose -->
Iterate through current versions of SQL supported by the cmdlet and check that those results are not Null and returns a PSCustomObject.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-Pester .\tests\Get-SqlDefaultSPConfigure.Tests.ps1`

### Screenshot
![image](https://user-images.githubusercontent.com/13426972/56629662-17726080-661c-11e9-8188-446835b55181.png)

