### PR TITLE
Adding functions and Tests for Startup Procedures

### DIFF
--- a/functions/Disable-DbaStartupProcedure.ps1
+++ b/functions/Disable-DbaStartupProcedure.ps1
@@ -1,0 +1,155 @@
+function Disable-DbaStartupProcedure {
+    <#
+    .SYNOPSIS
+        Disables the automatic execution of procedure(s) that are set to execute automatically each time the SQL Server service is started
+
+    .DESCRIPTION
+         Used to revoke the designation of one or more stored procedures to automatically execute when the SQL Server service is started.
+         Equivalent to running the system stored procedure sp_procoption with @OptionValue = off
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+        To connect to SQL Server as a different Windows user, run PowerShell as that user.
+
+    .PARAMETER StartupProcedure
+        The Procedure(s) to process.
+
+   .PARAMETER InputObject
+        Piped objects from Get-DbaStartup
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .NOTES
+        Tags: Procedure, Startup, StartupProcedure
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Disable-DbaStartupProcedure
+
+    .EXAMPLE
+        PS C:\> Disable-DbaStartupProcedure -SqlInstance SqlBox1\Instance2 -StartupProcedure '[dbo].[StartUpProc1]'
+
+        Attempts to clear the automatic execution of the procedure '[dbo].[StartUpProc1]' in the master database of SqlBox1\Instance2 when the instance is started.
+
+  .EXAMPLE
+        PS C:\> $cred = Get-Credential sqladmin
+        PS C:\> Disable-DbaStartupProcedure -SqlInstance winserver\sqlexpress, sql2016 -SqlCredential $cred -StartupProcedure '[dbo].[StartUpProc1]'
+
+        Attempts to clear the automatic execution of the procedure '[dbo].[StartUpProc1]' in the master database of winserver\sqlexpress and sql2016 when the instance is started. Connects using sqladmin credential
+
+  .EXAMPLE
+        PS C:\> Get-DbaStartupProcedure -SqlInstance sql2016 | Disable-DbaStartupProcedure
+
+        Get all startup procedures for the sql2016 instance and disbales them by piping to Disable-DbaStartupProcedure
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$StartupProcedure,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [switch]$EnableException
+    )
+    begin {
+        $action = 'Disable'
+        $startup = $false
+    }
+
+    process {
+        if (Test-Bound -ParameterName InputObject -Not) {
+            if (Test-Bound -ParameterName SqlInstance) {
+                if ((Test-Bound -Not -ParameterName StartupProcedure)) {
+                    Stop-Function -Message "You must specify one or more Startup Procedures when using the SqlInstance parameter."
+                    return
+                }
+            } else {
+                Stop-Function -Message "You must supply either a SqlInstance or an InputObject ."
+                return
+            }
+
+            foreach ($instance in $SqlInstance) {
+                Write-Message -Level Verbose -Message "Getting startup procedures for $instance"
+                try {
+                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+                } catch {
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
+                }
+                $db = $server.Databases['master']
+
+                foreach ($proc in $StartupProcedure) {
+                    $procParts = Get-ObjectNameParts $proc
+                    if ($procParts.Parsed) {
+                        $sp = $db.StoredProcedures.Item($procParts.Name, $procParts.Schema)
+                        if ($null -eq $sp) {
+                            Stop-Function -Message "Requested procedure $proc does not exist." -Continue -Target $server -Category InvalidData
+                        } else {
+                            Write-Message -Level Verbose -Message "Adding $($procParts.Name) $($procParts.Schema) for $instance"
+                            $InputObject += $sp
+                        }
+                    } else {
+                        Stop-Function -Message "Requested procedure $proc could not be parsed." -Continue -Target $server -Category InvalidData
+                    }
+                }
+            }
+        }
+
+        foreach ($sp in $InputObject) {
+            $db = $sp.Parent
+            $server = $db.Parent
+
+            try {
+                if ($sp.Startup -eq $startup) {
+                    Stop-Function -Message "No work being performed." -Continue -Target $server -Category InvalidData
+                } else {
+                    if ($Pscmdlet.ShouldProcess("$instance", "Setting Startup status of $proc to $startup")) {
+                        $sp.Startup = $startup
+                        $sp.Alter()
+                        $status = $true
+                        $note = "$action succeded"
+                    } else {
+                        $status = $false
+                        $note = "$action skipped"
+                    }
+                }
+
+            } catch {
+                $status = $false
+                $note = "$action failed"
+            }
+            [PSCustomObject]@{
+                ComputerName = $server.ComputerName
+                SqlInstance  = $server.DomainInstanceName
+                InstanceName = $server.ServiceName
+                Schema       = $sp.Schema
+                Name         = $sp.Name
+                Action       = $action
+                Status       = $status
+                Note         = $note
+            }
+        }
+    }
+}

--- a/functions/Disable-DbaStartupProcedure.ps1
+++ b/functions/Disable-DbaStartupProcedure.ps1
@@ -61,7 +61,7 @@ function Disable-DbaStartupProcedure {
   .EXAMPLE
         PS C:\> Get-DbaStartupProcedure -SqlInstance sql2016 | Disable-DbaStartupProcedure
 
-        Get all startup procedures for the sql2016 instance and disbales them by piping to Disable-DbaStartupProcedure
+        Get all startup procedures for the sql2016 instance and disables them by piping to Disable-DbaStartupProcedure
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = 'High')]

--- a/functions/Enable-DbaStartupProcedure.ps1
+++ b/functions/Enable-DbaStartupProcedure.ps1
@@ -1,0 +1,133 @@
+function Enable-DbaStartupProcedure {
+    <#
+    .SYNOPSIS
+        Sets a procedure to execute automatically each time the SQL Server service is started
+
+    .DESCRIPTION
+         Used to designate one or more stored procedures to automatically execute when the SQL Server service is started.
+         Equivalent to running the system stored procedure sp_procoption with @OptionValue = on
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+        To connect to SQL Server as a different Windows user, run PowerShell as that user.
+
+    .PARAMETER StartupProcedure
+        The Procedure(s) to process.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .NOTES
+        Tags: Procedure, Startup, StartupProcedure
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Enable-DbaStartupProcedure
+
+    .EXAMPLE
+        PS C:\> Enable-DbaStartupProcedure -SqlInstance SqlBox1\Instance2 -StartupProcedure '[dbo].[StartUpProc1]'
+
+        Attempts to set the procedure '[dbo].[StartUpProc1]' in the master database of SqlBox1\Instance2 for automatic execution when the instance is started.
+
+    .EXAMPLE
+        PS C:\> $cred = Get-Credential sqladmin
+        PS C:\> Enable-DbaStartupProcedure -SqlInstance winserver\sqlexpress, sql2016 -SqlCredential $cred -StartupProcedure '[dbo].[StartUpProc1]'
+
+        Attempts to set the procedure '[dbo].[StartUpProc1]' in the master database of winserver\sqlexpress and sql2016 for automatic execution when the instance is started. Connects using sqladmin credential
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$StartupProcedure,
+        [switch]$EnableException
+    )
+    begin {
+        $action = 'Enable'
+        $startup = $true
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
+            }
+            Write-Message -Level Verbose -Message "Getting startup procedures for $instance"
+
+            $db = $server.Databases['master']
+
+            foreach ($proc in $StartupProcedure) {
+                Write-Message -Level Verbose -Message "Preparing to get object parts for $proc"
+                $procParts = Get-ObjectNameParts $proc
+
+                if ($procParts.Parsed) {
+                    $sp = $db.StoredProcedures.Item($procParts.Name, $procParts.Schema)
+
+                    if ($null -eq $sp) {
+                        Stop-Function -Message "Requested procedure $proc does not exist." -Continue -Target $server -Category InvalidData
+                    } else {
+                        try {
+                            if ($sp.Startup -eq $startup) {
+                                Stop-Function -Message "No work being performed." -Continue -Target $server -Category InvalidData
+                            } else {
+                                if ($Pscmdlet.ShouldProcess("$instance", "Setting Startup status of $proc to $startup")) {
+                                    $sp.Startup = $startup
+                                    $sp.Alter()
+                                    $status = $true
+                                    $note = "$action succeded"
+                                } else {
+                                    $status = $false
+                                    $note = "$action skipped"
+                                }
+                            }
+
+                        } catch {
+                            $status = $false
+                            $note = "$action failed"
+                        }
+                    }
+
+                } else {
+                    $status = $false
+                    $note = "Unable to split procedure"
+                }
+
+                [PSCustomObject]@{
+                    ComputerName = $server.ComputerName
+                    SqlInstance  = $server.DomainInstanceName
+                    InstanceName = $server.ServiceName
+                    Schema       = $sp.Schema
+                    Name         = $sp.Name
+                    Action       = $action
+                    Status       = $status
+                    Note         = $note
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaStartupProcedure.ps1
+++ b/functions/Get-DbaStartupProcedure.ps1
@@ -1,0 +1,114 @@
+function Get-DbaStartupProcedure {
+    <#
+    .SYNOPSIS
+        Get-DbaStartupProcedure gets startup procedures (user defined procedures within master database) from a SQL Server.
+
+    .DESCRIPTION
+        By default, this command returns for each SQL Server instance passed in, the name and schema for all procedures in the master database that are marked as a startup procedure.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Allows you to login to servers using SQL Logins instead of Windows Authentication (AKA Integrated or Trusted). To use:
+
+        $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
+
+        Windows Authentication will be used if SqlCredential is not specified. SQL Server does not accept Windows credentials being passed as credentials.
+
+        To connect to SQL Server as a different Windows user, run PowerShell as that user.
+
+    .PARAMETER StartupProcedure
+        Use this filter to check if specific procedure(s) are set as startup procedures.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Procedure, Startup, StartupProcedure
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaStartupProcedure
+
+    .EXAMPLE
+        PS C:\> Get-DbaStartupProcedure -SqlInstance SqlBox1\Instance2
+
+        Returns an object with all startup procedures for the Instance2 instance on SqlBox1
+
+    .EXAMPLE
+        PS C:\> Get-DbaStartupProcedure -SqlInstance SqlBox1\Instance2 -StartupProcedure 'dbo.StartupProc'
+
+        Returns an object with a startup procedure named 'dbo.StartupProc' for the Instance2 instance on SqlBox1
+
+    .EXAMPLE
+        PS C:\> Get-DbaCmsRegServer -SqlInstance sql2014 | Get-DbaStartupProcedure
+
+        Returns an object with all startup procedures for every server listed in the Central Management Server on sql2014
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [Alias("ServerInstance", "SqlServer")]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$StartupProcedure,
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+            Write-Message -Level Verbose -Message "Getting startup procedures for $servername"
+
+            $startupProcs = $server.EnumStartupProcedures()
+
+            if ($startupProcs.Rows.Count -gt 0) {
+                $db = $server.Databases['master']
+                foreach ($startupProc in $startupProcs) {
+                    if (Test-Bound -ParameterName StartupProcedure) {
+                        $returnProc = $false
+                        foreach ($proc in $StartupProcedure) {
+                            $procParts = Get-ObjectNameParts $proc
+                            if (-not $procParts.Parsed) {
+                                Write-Message -Level Verbose -Message "Requested procedure $proc could not be parsed."
+                                Continue
+                            }
+                            if (($procParts.Name -eq $startupProc.Name) -and ($procParts.Schema -eq $startupProc.Schema)) {
+                                $returnProc = $true
+                                Break
+                            }
+                        }
+
+                    } else {
+                        $returnProc = $true
+                    }
+                    if (!$returnProc) {
+                        Continue
+                    }
+                    $proc = $db.StoredProcedures.Item($startupProc.Name, $startupProc.Schema)
+
+                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
+                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name
+
+                    $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ID as ObjectId', 'CreateDate',
+                    'DateLastModified', 'Name', 'ImplementationType', 'Startup'
+                    Select-DefaultView -InputObject $proc -Property $defaults
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaStartupProcedure.ps1
+++ b/functions/Get-DbaStartupProcedure.ps1
@@ -4,7 +4,8 @@ function Get-DbaStartupProcedure {
         Get-DbaStartupProcedure gets startup procedures (user defined procedures within master database) from a SQL Server.
 
     .DESCRIPTION
-        By default, this command returns for each SQL Server instance passed in, the name and schema for all procedures in the master database that are marked as a startup procedure.
+        By default, this command returns for each SQL Server instance passed in, the SMO StoredProcedure object for all procedures in the master database that are marked as a startup procedure.
+        Can be filtered to check only specific procedures
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.

--- a/tests/Disable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Disable-DbaStartupProcedure.Tests.ps1
@@ -1,0 +1,64 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('WhatIf', 'Confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'StartupProcedure', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+
+    }
+}
+
+Describe "$commandname Integration Test" -Tag "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $random = Get-Random
+        $startupProcName = "StartUpProc$random"
+        $startupProc = "dbo.$startupProcName"
+        $dbname = 'master'
+
+        $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
+        $null = $server.Query("EXEC sp_procoption '$startupProc', 'startup', 'on'", $dbname)
+    }
+    AfterAll {
+        $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+    }
+
+    Context "Validate returns correct output for disable" {
+        $result = Disable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $result.Schema -eq "dbo" | Should Be $true
+            $result.Name -eq "$startupProcName" | Should Be $true
+            $result.Action -eq "Disable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Disable succeded" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for already existing state" {
+        $result = Disable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $null -eq $result | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct results for piped input" {
+        $null = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 | Disable-DbaStartupProcedure -Confirm:$false
+
+        It "returns correct results" {
+            $result.Schema -eq "dbo" | Should Be $true
+            $result.Name -eq "$startupProcName" | Should Be $true
+            $result.Action -eq "Disable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Disable succeded" | Should Be $true
+        }
+    }
+}

--- a/tests/Disable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Disable-DbaStartupProcedure.Tests.ps1
@@ -45,7 +45,11 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
         $result = Disable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
 
         It "returns correct results" {
-            $null -eq $result | Should Be $true
+            $result.Schema -eq "dbo" | Should Be $true
+            $result.Name -eq "$startupProcName" | Should Be $true
+            $result.Action -eq "Disable" | Should Be $true
+            $result.Status | Should Be $false
+            $result.Note -eq "Action Disable already performed" | Should Be $true
         }
     }
 

--- a/tests/Enable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Enable-DbaStartupProcedure.Tests.ps1
@@ -1,0 +1,67 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('WhatIf', 'Confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'StartupProcedure', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+
+    }
+}
+Describe "$commandname Integration Test" -Tag "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $random = Get-Random
+        $startupProcName = "StartUpProc$random"
+        $startupProc = "dbo.$startupProcName"
+        $dbname = 'master'
+
+        $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
+    }
+    AfterAll {
+        $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+    }
+
+    Context "Validate returns correct output for enable" {
+        $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $result.Schema -eq "dbo" | Should Be $true
+            $result.Name -eq "$startupProcName" | Should Be $true
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $true
+            $result.Note -eq "Enable succeded" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for already existing state" {
+        $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
+
+        It "returns correct results" {
+            $null -eq $result | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for missing procedures" {
+        $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure "Unknown.NotHere" -Confirm:$false
+
+        It "returns correct results" {
+            $null -eq $result | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for incorrectly formed procedures" {
+        $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure "Four.Part.Schema.Name" -Confirm:$false
+
+        It "returns correct results" {
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $false
+            $result.Note -eq "Unable to split procedure" | Should Be $true
+        }
+    }
+}

--- a/tests/Enable-DbaStartupProcedure.Tests.ps1
+++ b/tests/Enable-DbaStartupProcedure.Tests.ps1
@@ -43,7 +43,11 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
         $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc -Confirm:$false
 
         It "returns correct results" {
-            $null -eq $result | Should Be $true
+            $result.Schema -eq "dbo" | Should Be $true
+            $result.Name -eq "$startupProcName" | Should Be $true
+            $result.Action -eq "Enable" | Should Be $true
+            $result.Status | Should Be $false
+            $result.Note -eq "Action Enable already performed" | Should Be $true
         }
     }
 
@@ -59,9 +63,7 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
         $result = Enable-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure "Four.Part.Schema.Name" -Confirm:$false
 
         It "returns correct results" {
-            $result.Action -eq "Enable" | Should Be $true
-            $result.Status | Should Be $false
-            $result.Note -eq "Unable to split procedure" | Should Be $true
+            $null -eq $result | Should Be $true
         }
     }
 }

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -1,0 +1,54 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'StartupProcedure', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+Describe "$commandname Integration Test" -Tag "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $random = Get-Random
+        $startupProc = "dbo.StartUpProc$random"
+        $dbname = 'master'
+
+        $null = $server.Query("CREATE PROCEDURE $startupProc AS Select 1", $dbname)
+        $null = $server.Query("EXEC sp_procoption N'$startupProc', 'startup', '1'", $dbname)
+    }
+    AfterAll {
+        $null = $server.Query("DROP PROCEDURE $startupProc", $dbname)
+    }
+
+    Context "Validate returns correct output" {
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2
+
+        It "returns correct results" {
+            $result.Schema -eq 'dbo' | Should Be $true
+            $result.Name -eq "StartUpProc$random" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for StartupProcedure parameter " {
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc 
+
+        It "returns correct results" {
+            $result.Schema -eq 'dbo' | Should Be $true
+            $result.Name -eq "StartUpProc$random" | Should Be $true
+        }
+    }
+
+    Context "Validate returns correct output for incorrect StartupProcedure parameter " {
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure 'Not.Here' 
+
+        It "returns correct results" {
+            $null -eq $result | Should Be $true
+        }
+    }
+}

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -36,7 +36,7 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
     }
 
     Context "Validate returns correct output for StartupProcedure parameter " {
-        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc 
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc
 
         It "returns correct results" {
             $result.Schema -eq 'dbo' | Should Be $true
@@ -45,7 +45,7 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
     }
 
     Context "Validate returns correct output for incorrect StartupProcedure parameter " {
-        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure 'Not.Here' 
+        $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure 'Not.Here'
 
         It "returns correct results" {
             $null -eq $result | Should Be $true

--- a/tests/Get-DbaStartupProcedure.Tests.ps1
+++ b/tests/Get-DbaStartupProcedure.Tests.ps1
@@ -28,7 +28,6 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
 
     Context "Validate returns correct output" {
         $result = Get-DbaStartupProcedure -SqlInstance $script:instance2
-
         It "returns correct results" {
             $result.Schema -eq 'dbo' | Should Be $true
             $result.Name -eq "StartUpProc$random" | Should Be $true
@@ -37,7 +36,6 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
 
     Context "Validate returns correct output for StartupProcedure parameter " {
         $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure $startupProc
-
         It "returns correct results" {
             $result.Schema -eq 'dbo' | Should Be $true
             $result.Name -eq "StartUpProc$random" | Should Be $true
@@ -46,7 +44,6 @@ Describe "$commandname Integration Test" -Tag "IntegrationTests" {
 
     Context "Validate returns correct output for incorrect StartupProcedure parameter " {
         $result = Get-DbaStartupProcedure -SqlInstance $script:instance2 -StartupProcedure 'Not.Here'
-
         It "returns correct results" {
             $null -eq $result | Should Be $true
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [X] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Purpose
Change #5265 added new command Copy-DbaStartupProcedure
This adds the matching Get-DbaStartupProcedure and commands to Disable or Enable Startup Procedures to provide complete coverage.
This is an update from #5326


Commands to test:

Get-DbaStartupProcedure
Enable-DbaStartupProcedure
Disable-DbaStartupProcedure
