### PR TITLE
Azure AccessToken Support

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -328,6 +328,9 @@ function Connect-DbaInstance {
                     # this is the way, as recommended by Microsoft
                     # https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/configure-always-encrypted-using-powershell?view=sql-server-2017
                     $sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
+                    if ($PSBoundParameters.AccessToken) {
+                        $sqlconn.AccessToken = $AccessToken
+                    }
                     $serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
                     $null = $serverconn.Connect()
                     $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -457,9 +457,6 @@ function Connect-DbaInstance {
                 # It's okay to skip Azure because this is addressed above with New-DbaConnectionString
                 $server.ConnectionContext.ApplicationName = $ClientName
 
-                if (Test-Bound -ParameterName 'AccessToken') {
-                    $server.ConnectionContext.AccessToken = $AccessToken
-                }
                 if (Test-Bound -ParameterName 'BatchSeparator') {
                     $server.ConnectionContext.BatchSeparator = $BatchSeparator
                 }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -328,10 +328,12 @@ function Connect-DbaInstance {
                     # this is the way, as recommended by Microsoft
                     # https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/configure-always-encrypted-using-powershell?view=sql-server-2017
                     $sqlconn = New-Object System.Data.SqlClient.SqlConnection $azureconnstring
+                    Write-Message -Level Debug -Message $sqlconn.ConnectionString
                     if ($PSBoundParameters.AccessToken) {
                         $sqlconn.AccessToken = $AccessToken
                     }
                     $serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
+                    Write-Message -Level Verbose -Message "Connecting to Azure: $instance"
                     $null = $serverconn.Connect()
                     $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
                     # Make ComputerName easily available in the server object

--- a/functions/New-DbaConnectionString.ps1
+++ b/functions/New-DbaConnectionString.ps1
@@ -16,9 +16,6 @@ function New-DbaConnectionString {
     .PARAMETER Credential
         Credential object used to connect to the SQL Server as a different user be it Windows or SQL Server. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
 
-    .PARAMETER AccessToken
-        Gets or sets the access token for the connection.
-
     .PARAMETER AppendConnectionString
         Appends to the current connection string. Note that you cannot pass authentication information using this method. Use -SqlInstance and, optionally, -SqlCredential to set authentication information.
 
@@ -170,7 +167,6 @@ function New-DbaConnectionString {
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("SqlCredential")]
         [PSCredential]$Credential,
-        [string]$AccessToken,
         [ValidateSet('ReadOnly', 'ReadWrite')]
         [string]$ApplicationIntent,
         [string]$BatchSeparator,
@@ -205,7 +201,7 @@ function New-DbaConnectionString {
                     if ($instance.InputObject.GetType() -eq [Microsoft.SqlServer.Management.Smo.Server]) {
                         $connstring = $instance.InputObject.ConnectionContext.ConnectionString
                         if ($Database) {
-                            $olddb = $connstring -split ';' | Where-Object { $_.StartsWith("Initial Catalog")}
+                            $olddb = $connstring -split ';' | Where-Object { $_.StartsWith("Initial Catalog") }
                             $newdb = "Initial Catalog=$Database"
                             if ($olddb) {
                                 $connstring = $connstring.Replace("$olddb", "$newdb")
@@ -245,7 +241,6 @@ function New-DbaConnectionString {
 
                         $server.ConnectionContext.ApplicationName = $clientname
 
-                        if ($AccessToken) { $server.ConnectionContext.AccessToken = $AccessToken }
                         if ($BatchSeparator) { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
                         if ($ConnectTimeout) { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
                         if ($Database) { $server.ConnectionContext.DatabaseName = $Database }

--- a/functions/New-DbaConnectionString.ps1
+++ b/functions/New-DbaConnectionString.ps1
@@ -16,6 +16,9 @@ function New-DbaConnectionString {
     .PARAMETER Credential
         Credential object used to connect to the SQL Server as a different user be it Windows or SQL Server. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
 
+    .PARAMETER AccessToken
+        Basically tells the connection string to ignore authentication. Does not include the AccessToken in the resulting connecstring.
+
     .PARAMETER AppendConnectionString
         Appends to the current connection string. Note that you cannot pass authentication information using this method. Use -SqlInstance and, optionally, -SqlCredential to set authentication information.
 
@@ -167,6 +170,7 @@ function New-DbaConnectionString {
         [DbaInstanceParameter[]]$SqlInstance,
         [Alias("SqlCredential")]
         [PSCredential]$Credential,
+        [string]$AccessToken,
         [ValidateSet('ReadOnly', 'ReadWrite')]
         [string]$ApplicationIntent,
         [string]$BatchSeparator,
@@ -239,8 +243,7 @@ function New-DbaConnectionString {
                         $server.ConnectionContext.ConnectionString
                     } else {
 
-                        $server.ConnectionContext.ApplicationName = $clientname
-
+                        $server.ConnectionContext.ApplicationName = $ClientName
                         if ($BatchSeparator) { $server.ConnectionContext.BatchSeparator = $BatchSeparator }
                         if ($ConnectTimeout) { $server.ConnectionContext.ConnectTimeout = $ConnectTimeout }
                         if ($Database) { $server.ConnectionContext.DatabaseName = $Database }
@@ -295,8 +298,12 @@ function New-DbaConnectionString {
                                     $server.ConnectionContext.set_SecurePassword($Credential.Password)
                                 }
                             } else {
-                                $connstring = $connstring.Replace("Integrated Security=True;", "")
-                                $connstring = "$connstring;Authentication=`"Active Directory Integrated`""
+                                if ($AccessToken) {
+                                    $connstring = $connstring.Replace("Integrated Security=True;", "")
+                                } else {
+                                    $connstring = $connstring.Replace("Integrated Security=True;", "")
+                                    $connstring = "$connstring;Authentication=`"Active Directory Integrated`""
+                                }
                             }
                         }
 

--- a/tests/New-DbaConnectionString.Tests.ps1
+++ b/tests/New-DbaConnectionString.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'Database', 'EncryptConnection', 'FailoverPartner', 'IsActiveDirectoryUniversalAuth', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'AccessToken', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'Database', 'EncryptConnection', 'FailoverPartner', 'IsActiveDirectoryUniversalAuth', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/New-DbaConnectionString.Tests.ps1
+++ b/tests/New-DbaConnectionString.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'AccessToken', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'Database', 'EncryptConnection', 'FailoverPartner', 'IsActiveDirectoryUniversalAuth', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'ApplicationIntent', 'BatchSeparator', 'ClientName', 'ConnectTimeout', 'Database', 'EncryptConnection', 'FailoverPartner', 'IsActiveDirectoryUniversalAuth', 'LockTimeout', 'MaxPoolSize', 'MinPoolSize', 'MultipleActiveResultSets', 'MultiSubnetFailover', 'NetworkProtocol', 'NonPooledConnection', 'PacketSize', 'PooledConnectionLifetime', 'SqlExecutionModes', 'StatementTimeout', 'TrustServerCertificate', 'WorkstationId', 'AppendConnectionString'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
- adds working accesstoken support for azure and managed identities
- refer a lil bit to: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-sql

sample code to execute, probably on the azure network itself, courtesy of @wsmelton :

```powershell
$params = @{
    Uri     = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-04-02&resource=https://database.windows.net/"
    Method  = "GET"
    Headers = @{Metadata ="true" }
}
$response = Invoke-WebRequest @params -UseBasicParsing
$token = ($response.Content | ConvertFrom-Json).access_token

$s = Connect-DbaInstance -SqlInstance YOURSERVER.database.windows.net -Database YOURDB -AccessToken $token -DisableException
$s.Name
```
