### PR TITLE
Replaced "databases" to "indexes" in EXAMPLE

### DIFF
--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -46,17 +46,17 @@ function Find-DbaDbUnusedIndex {
     .EXAMPLE
         PS C:\> Find-DbaDbUnusedIndex -SqlInstance sql2016 -Database db1, db2
 
-        Finds unused databases on db1 and db2 on sql2016
+        Finds unused indexes on db1 and db2 on sql2016
 
     .EXAMPLE
         PS C:\> Find-DbaDbUnusedIndex -SqlInstance sql2016 -SqlCredential $cred
 
-        Finds unused databases on db1 and db2 on sql2016 using SQL Authentication to connect to the server
+        Finds unused indexes on db1 and db2 on sql2016 using SQL Authentication to connect to the server
 
     .EXAMPLE
         PS C:\> Get-DbaDatabase -SqlInstance sql2016 | Find-DbaDbUnusedIndex
 
-        Finds unused databases on all databases on sql2016
+        Finds unused indexes on all databases on sql2016
 
        #>
     [CmdletBinding()]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
EXAMPLE said "Finds unused databases..." - should be "Finds unused indexes..."

### Approach
Replaced text