### PR TITLE
Fix Get-DBAAvailabilityGroup IsPrimary

### DIFF
--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -98,7 +98,7 @@ function Get-DbaAvailabilityGroup {
 
                 if ($IsPrimary) {
                     $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name as AvailabilityGroup', 'IsPrimary'
-                    Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name IsPrimary -Value ($ag.PrimaryReplicaServerName -eq $server.Name)
+                    Add-Member -Force -InputObject $ag -MemberType NoteProperty -Name IsPrimary -Value ($ag.LocalReplicaRole -eq "Primary")
                     Select-DefaultView -InputObject $ag -Property $defaults
                 } else {
                     $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'LocalReplicaRole', 'Name as AvailabilityGroup', 'PrimaryReplicaServerName as PrimaryReplica', 'ClusterType', 'DtcSupportEnabled', 'AutomatedBackupPreference', 'AvailabilityReplicas', 'AvailabilityDatabases', 'AvailabilityGroupListeners'


### PR DESCRIPTION
Fix to ensure the primary server is returned correctly

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5435)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- To fix issue 5435 --> 

### Approach
<!-- We check the property of the replica rather than checking that two name properties match - a more direct approach -->

### Commands to test
<!-- Get-DBAAvailabilityGroup -IsPrimary -SQLInstance "INSTANCE,1234" (note the port number)-->

### Screenshots
<!-- -->

**BEFORE**
![image](https://user-images.githubusercontent.com/30286771/56959591-d01d3000-6b45-11e9-9b59-38d1156c8bc6.png)

**AFTER**
![image](https://user-images.githubusercontent.com/30286771/56959603-df9c7900-6b45-11e9-87c5-882ecd5af4aa.png)



