### PR TITLE
Restore Tests fixed

### DIFF
--- a/tests/Copy-DbaDatabase.Tests.ps1
+++ b/tests/Copy-DbaDatabase.Tests.ps1
@@ -34,7 +34,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
         Remove-DbaDatabase -Confirm:$false -SqlInstance $script:instance2, $script:instance3 -Database $backuprestoredb, $detachattachdb, $backuprestoredb2
     }
-<#
+
     # if failed Disable-NetFirewallRule -DisplayName 'Core Networking - Group Policy (TCP-Out)'
     Context "Detach Attach" {
         It "Should be success" {
@@ -210,7 +210,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $Warnvar | Should -BeLike "*Cannot use NewName when copying multiple databases"
         }
     }
-    #>
+
     if ($env:azurepasswd) {
         Context "Copying via Azure storage" {
             BeforeAll {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -318,7 +318,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Start-Sleep -Seconds 1
 
     Context "RestoreTime point in time" {
-        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2017-06-01 13:22:44")
+        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2017-06-01 13:22:44") -WarningVariable warnvar -ErrorVariable errvar
         $sqlResults = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from RestoreTimeClean.dbo.steps"
         It "Should have restored 4 files" {
             $results.count | Should be 4
@@ -377,27 +377,32 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             }
             return
         }
-        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2017-06-01 13:22:44") -StandbyDirectory c:\temp
+        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2019-05-02 21:23:58") -StandbyDirectory c:\temp -WarningVariable warnvar -ErrorVariable errvar -ErrorAction SilentlyContinue
         $sqlResults = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from RestoreTimeClean.dbo.steps"
+        $warnvar
+        It "Should not warn or error" {
+            $null -eq (Get-Variable | Where-Object {$_.Name -eq 'warnvar'}) -or '' -eq $warmvar | Should Be $True
+            $null -eq (Get-Variable | Where-Object {$_.Name -eq 'errvar'}) | Should Be $True
+        }
         It "Should have restored 4 files" {
             $results.count | Should be 4
         }
-        It "Should have restored from 2017-06-01 12:59:12" {
-            $sqlResults.mindt | Should be (get-date "2017-06-01 12:59:12")
+        It "Should have restored from 05/02/2019 21:00:55" {
+            $sqlResults.mindt | Should be (get-date "02 May 2019 21:00:55")
         }
-        It "Should have restored to 2017-06-01 13:22:43" {
-            $sqlResults.maxdt | Should be (get-date "2017-06-01 13:22:43")
+        It "Should have restored to 05/02/2019 21:23:56" {
+            $sqlResults.maxdt | Should be (get-date "02 May 2019 21:23:56")
         }
         $results2 = Restore-DbaDatabase -SqlInstance $script:instance2 -path $script:appveyorlabrepo\RestoreTimeClean -Continue
         $sqlResults2 = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from RestoreTimeClean.dbo.steps"
         It "Should have restored 2 files" {
             $results2.count | Should be 2
         }
-        It "Should have restored from 2017-06-01 12:59:12" {
-            $sqlResults2.mindt | Should be (get-date "2017-06-01 12:59:12")
+        It "Should have restored from 02 May 2019 21:00:55" {
+            $sqlResults2.mindt | Should be (get-date "02 May 2019 21:00:55")
         }
-        It "Should have restored to 2017-06-01 13:28:43" {
-            $sqlResults2.maxdt | Should be (get-date "2017-06-01 13:28:43")
+        It "Should have restored to 02 May 2019 21:30:26" {
+            $sqlResults2.maxdt | Should be (get-date "02 May 2019 21:30:26")
         }
 
     }
@@ -413,29 +418,28 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             }
             return
         }
-        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -Databasename contest -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2017-06-01 13:22:44") -StandbyDirectory c:\temp
+        $results = Restore-DbaDatabase -SqlInstance $script:instance2 -Databasename contest -path $script:appveyorlabrepo\RestoreTimeClean -RestoreTime (get-date "2019-05-02 21:23:58") -StandbyDirectory c:\temp
         $sqlResults = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from contest.dbo.steps"
         It "Should have restored 4 files" {
             $results.count | Should be 4
         }
-        It "Should have restored from 2017-06-01 12:59:12" {
-            $sqlResults.mindt | Should be (get-date "2017-06-01 12:59:12")
+        It "Should have restored from 05/02/2019 21:00:55" {
+            $sqlResults.mindt | Should be (get-date "02 May 2019 21:00:55")
         }
-        It "Should have restored to 2017-06-01 13:22:43" {
-            $sqlResults.maxdt | Should be (get-date "2017-06-01 13:22:43")
+        It "Should have restored to 05/02/2019 21:23:56" {
+            $sqlResults.maxdt | Should be (get-date "02 May 2019 21:23:56")
         }
         $results2 = Restore-DbaDatabase -SqlInstance $script:instance2 -Databasename contest -path $script:appveyorlabrepo\RestoreTimeClean -Continue
         $sqlResults2 = Invoke-DbaQuery -SqlInstance $script:instance2 -Query "select convert(datetime,convert(varchar(20),max(dt),120)) as maxdt, convert(datetime,convert(varchar(20),min(dt),120)) as mindt from contest.dbo.steps"
         It "Should have restored 2 files" {
             $results2.count | Should be 2
         }
-        It "Should have restored from 2017-06-01 12:59:12" {
-            $sqlResults2.mindt | Should be (get-date "2017-06-01 12:59:12")
+        It "Should have restored from 02 May 2019 21:00:55" {
+            $sqlResults2.mindt | Should be (get-date "02 May 2019 21:00:55")
         }
-        It "Should have restored to 2017-06-01 13:28:43" {
-            $sqlResults2.maxdt | Should be (get-date "2017-06-01 13:28:43")
+        It "Should have restored to 02 May 2019 21:30:26" {
+            $sqlResults2.maxdt | Should be (get-date "02 May 2019 21:30:26")
         }
-
     }
 
     Context "Continue Restore with Differentials" {

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -373,7 +373,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $Should_Run = (Connect-DbaInstance -SqlInstance $script:instance2).Version.ToString() -like '13.*'
         if (-not ($Should_Run)) {
             It "The test can run" {
-                Set-TestInconclusive -Message "a 2008R2 is strictly needed"
+                Set-TestInconclusive -Message "a 2016 is strictly needed"
             }
             return
         }
@@ -414,7 +414,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $Should_Run = (Connect-DbaInstance -SqlInstance $script:instance2).Version.ToString() -like '13.*'
         if (-not ($Should_Run)) {
             It "The test can run" {
-                Set-TestInconclusive -Message "a 2008R2 is strictly needed"
+                Set-TestInconclusive -Message "a 2016 is strictly needed"
             }
             return
         }

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -1,7 +1,7 @@
 Add-AppveyorTest -Name "appveyor.prep" -Framework NUnit -FileName "appveyor.prep.ps1" -Outcome Running
 $sw = [system.diagnostics.stopwatch]::startNew()
 Write-Host -Object "appveyor.prep: Cloning lab materials"  -ForegroundColor DarkGreen
-git clone -q --branch=master --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
+git clone -q --branch=restclean --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
 
 #Get codecov (to upload coverage results)
 Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -1,7 +1,7 @@
 Add-AppveyorTest -Name "appveyor.prep" -Framework NUnit -FileName "appveyor.prep.ps1" -Outcome Running
 $sw = [system.diagnostics.stopwatch]::startNew()
 Write-Host -Object "appveyor.prep: Cloning lab materials"  -ForegroundColor DarkGreen
-git clone -q --branch=restclean --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
+git clone -q --branch=master --depth=1 https://github.com/sqlcollaborative/appveyor-lab.git C:\github\appveyor-lab
 
 #Get codecov (to upload coverage results)
 Write-Host -Object "appveyor.prep: Install codecov" -ForegroundColor DarkGreen


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Someone decied that the restore point in time tests should run against 2016 without checking that thy would. backups were fro 2008r2 and you can't use standby across versions

### Approach
Added new test backups
