### PR TITLE
Update Get-DbaCmsRegServer.ps1 to fix #5367

### DIFF
--- a/functions/Get-DbaCmsRegServer.ps1
+++ b/functions/Get-DbaCmsRegServer.ps1
@@ -188,11 +188,11 @@ function Get-DbaCmsRegServer {
 
         if ($IncludeSelf -and $servers) {
             Write-Message -Level Verbose -Message "Adding CMS instance"
-            $self = $servers[0].PsObject.Copy()
+            $self = $servers[0].PsObject.Copy() | Select-Object -Property $defaults
             $self | Add-Member -MemberType NoteProperty -Name Name -Value "CMS Instance" -Force
             $self.ServerName = $instance
+            $self.Group = $null
             $self.Description = $null
-            $self.SecureConnectionString = $null
             Select-DefaultView -InputObject $self -Property $defaults
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5367 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issue reported in #5367 and incorrect group name discovered during this work
### Approach
Making sure that $self is a byVal copy not a reference to solve the reported issue. 
I also nulled out the Group name property for the CMS instance as it is not applicable.

### Commands to test
```
$CMS = "CMSServer"
Get-DbaCmsRegServer -SqlInstance $CMS -IncludeSelf
```
vs.
```
$CMS = "CMSServer"
$Servers = Get-DbaCmsRegServer -SqlInstance $CMS -IncludeSelf
$Servers
```
The output was different before, now it will be the same.