### PR TITLE
Start-DbaAgentJob Verbose shoe

### DIFF
--- a/functions/Start-DbaAgentJob.ps1
+++ b/functions/Start-DbaAgentJob.ps1
@@ -165,7 +165,7 @@ function Start-DbaAgentJob {
                 # Wait for the job
                 if (Test-Bound -ParameterName Wait) {
                     while ($currentjob.CurrentRunStatus -ne 'Idle') {
-                        Write-Message -Level Verbose -Message "$currentjob is $($currentjob.CurrentRunStatus)", currently on Job Step $($currentjob.CurrentRunStep) / $($currentjob.JobSteps).Count, and has tried $($currentjob.CurrentRunRetryAttempt) / $($currentjob.RetryAttempts) retry attempts" }
+                        Write-Message -Level Verbose -Message "$currentjob is $($currentjob.CurrentRunStatus)", currently on Job Step $($currentjob.CurrentRunStep) / $($currentjob.JobSteps).Count, and has tried $($currentjob.CurrentRunRetryAttempt) / $($currentjob.RetryAttempts) retry attempts"
                         Start-Sleep -Seconds $WaitPeriod
                         $currentjob.Refresh()
                     }

--- a/functions/Start-DbaAgentJob.ps1
+++ b/functions/Start-DbaAgentJob.ps1
@@ -165,7 +165,7 @@ function Start-DbaAgentJob {
                 # Wait for the job
                 if (Test-Bound -ParameterName Wait) {
                     while ($currentjob.CurrentRunStatus -ne 'Idle') {
-                        Write-Message -Level Verbose -Message "$currentjob is $($currentjob.CurrentRunStatus)"
+                        Write-Message -Level Verbose -Message "$currentjob is $($currentjob.CurrentRunStatus)", currently on Job Step $($currentjob.CurrentRunStep) / $($currentjob.JobSteps).Count, and has tried $($currentjob.CurrentRunRetryAttempt) / $($currentjob.RetryAttempts) retry attempts" }
                         Start-Sleep -Seconds $WaitPeriod
                         $currentjob.Refresh()
                     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adds additional verbose messaging to the existing verbose messaging during the wait of a job.
Added:

- which step it is currently on  `# (step name)`
- out of how many job steps
- how many retry attempts have been tried
- out of how many retry attempts is set in the job step

### Commands to test
`Start-DbaAgentJob ... -Wait -WaitPeriod xx -Verbose`
