### PR TITLE
Several fixes for data masking

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -235,39 +235,12 @@ function Invoke-DbaDbDataMasking {
 
                                 # Loop through the index columns
                                 foreach ($indexColumn in $index.IndexedColumns) {
-                                    # Get the column mask info
-                                    $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
 
-                                    if ($columnMaskInfo) {
-                                        # Generate a new value
-                                        try {
-                                            if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
-                                                $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
-                                            } else {
-                                                $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
-                                            }
-
-                                        } catch {
-                                            Stop-Function -Message "Failure" -Target $columnMaskInfo -Continue -ErrorRecord $_
-                                        }
-
-                                        # Check if the value is already present as a property
-                                        if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
-                                            $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
-                                        }
-                                    }
-                                }
-
-                                # To be sure the values are unique, loop as long as long as needed to generate a unique value
-                                while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
-
-                                    $rowValue = New-Object PSCustomObject
-
-                                    # Loop through the index columns
-                                    foreach ($indexColumn in $index.IndexedColumns) {
+                                    if (-not $dbTable.Columns[$indexColumn.Name].Identity) {
                                         # Get the column mask info
                                         $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
-
+                                        $indexColumn.Name
+                                        $columnMaskInfo
                                         if ($columnMaskInfo) {
                                             # Generate a new value
                                             try {
@@ -286,9 +259,47 @@ function Invoke-DbaDbDataMasking {
                                                 $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
                                             }
                                         }
-
                                     }
                                 }
+
+
+                                # To be sure the values are unique, loop as long as long as needed to generate a unique value
+                                <# while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
+
+                                    $rowValue = New-Object PSCustomObject
+
+                                    # Loop through the index columns
+                                    foreach ($indexColumn in $index.IndexedColumns) {
+
+                                        if (-not $dbTable.Columns[$indexColumn.Name].Identity) {
+                                            # Get the column mask info
+                                            $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
+
+                                            if ($columnMaskInfo) {
+                                                # Generate a new value
+                                                try {
+                                                    if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
+                                                        $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                    } else {
+                                                        $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                    }
+
+                                                } catch {
+                                                    Stop-Function -Message "Failure" -Target $columnMaskInfo -Continue -ErrorRecord $_
+                                                }
+
+                                                # Check if the value is already present as a property
+                                                if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
+                                                    $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
+                                                }
+
+                                            }
+
+                                        }
+
+                                    }
+
+                                } #>
 
                             }
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -268,13 +268,23 @@ function Invoke-DbaDbDataMasking {
                                         # Get the column mask info
                                         $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
 
-                                        # Generate a new value
-                                        $newValue = $faker.$($columnMaskInfo.MaskingType).$($columnMaskInfo.SubType)()
+                                        if ($columnMaskInfo) {
+                                            # Generate a new value
+                                            try {
+                                                if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
+                                                    $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                } else {
+                                                    $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                }
 
-                                        # Check if the value is already present as a property
-                                        if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
-                                            $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
-                                            $uniqueValueColumns += $indexColumn.Name
+                                            } catch {
+                                                Stop-Function -Message "Failure" -Target $columnMaskInfo -Continue -ErrorRecord $_
+                                            }
+
+                                            # Check if the value is already present as a property
+                                            if (($rowValue | Get-Member -MemberType NoteProperty).Name -notcontains $indexColumn.Name) {
+                                                $rowValue | Add-Member -Name $indexColumn.Name -Type NoteProperty -Value $newValue
+                                            }
                                         }
 
                                     }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -241,7 +241,7 @@ function Invoke-DbaDbDataMasking {
                                     if ($columnMaskInfo) {
                                         # Generate a new value
                                         try {
-                                            if ($columnMaskInfo.SubType -in $supportedDataTypes) {
+                                            if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
                                                 $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
                                             } else {
                                                 $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
@@ -394,8 +394,7 @@ function Invoke-DbaDbDataMasking {
                                     try {
                                         $newValue = $null
 
-                                        if ($columnobject.SubType -in $supportedDataTypes) {
-                                            Write-Message -Level VeryVerbose -Message "`$newValue = Get-DbaRandomizedValue -DataType $($columnobject.ColumnType) -Min $min -Max $max -CharacterString $charstring -Locale $Locale"
+                                        if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
                                             $newValue = Get-DbaRandomizedValue -DataType $columnobject.ColumnType -Min $min -Max $max -CharacterString $charstring -Locale $Locale
                                         } else {
                                             $newValue = Get-DbaRandomizedValue -RandomizerType $columnobject.MaskingType -RandomizerSubtype $columnobject.SubType -Min $min -Max $max -CharacterString $charstring -Locale $Locale

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -261,7 +261,7 @@ function Invoke-DbaDbDataMasking {
                                     }
                                 }
 
-
+                                # Just keeping this in, in case we need it later on
                                 # To be sure the values are unique, loop as long as long as needed to generate a unique value
                                 <# while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -263,7 +263,7 @@ function Invoke-DbaDbDataMasking {
 
                                 # Just keeping this in, in case we need it later on
                                 # To be sure the values are unique, loop as long as long as needed to generate a unique value
-                                <# while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
+                                while (($uniqueValues | Select-Object -Property ($rowValue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name)) -match $rowValue) {
 
                                     $rowValue = New-Object PSCustomObject
 
@@ -278,9 +278,9 @@ function Invoke-DbaDbDataMasking {
                                                 # Generate a new value
                                                 try {
                                                     if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
-                                                        $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                        $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue -Locale $Locale
                                                     } else {
-                                                        $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                        $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue -Locale $Locale
                                                     }
 
                                                 } catch {
@@ -298,7 +298,7 @@ function Invoke-DbaDbDataMasking {
 
                                     }
 
-                                } #>
+                                }
 
                                 # Add the row value to the array
                                 $uniqueValues += $rowValue

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -418,18 +418,30 @@ function Invoke-DbaDbDataMasking {
 
                                 if ($null -eq $newValue -and $columnobject.Nullable -eq $true) {
                                     $updates += "[$($columnobject.Name)] = NULL"
-                                } elseif ($columnobject.ColumnType -eq 'xml') {
-                                    # nothing, unsure how i'll handle this
-                                } elseif ($columnobject.ColumnType -in 'uniqueidentifier') {
-                                    $updates += "[$($columnobject.Name)] = '$newValue'"
-                                } elseif ($columnobject.ColumnType -match 'int') {
-                                    $updates += "[$($columnobject.Name)] = $newValue"
                                 } elseif ($columnobject.ColumnType -in 'bit', 'bool') {
                                     if ($columnValue) {
                                         $updates += "[$($columnobject.Name)] = 1"
                                     } else {
                                         $updates += "[$($columnobject.Name)] = 0"
                                     }
+                                } elseif ($columnobject.ColumnType -like '*int*' -or $columnobject.ColumnType -in 'decimal') {
+                                    $updates += "[$($columnobject.Name)] = $newValue"
+                                } elseif ($columnobject.ColumnType -in 'uniqueidentifier') {
+                                    $updates += "[$($columnobject.Name)] = '$newValue'"
+                                } elseif ($columnobject.ColumnType -eq 'datetime') {
+                                    $newValue = ([datetime]$newValue).Tostring("yyyy-MM-dd HH:mm:ss.fff")
+                                    $updates += "[$($columnobject.Name)] = '$newValue'"
+                                } elseif ($columnobject.ColumnType -eq 'datetime2') {
+                                    $newValue = ([datetime]$newValue).Tostring("yyyy-MM-dd HH:mm:ss.fffffff")
+                                    $updates += "[$($columnobject.Name)] = '$newValue'"
+                                } elseif ($columnobject.ColumnType -like 'date') {
+                                    $newValue = ([datetime]$newValue).Tostring("yyyy-MM-dd")
+                                    $updates += "[$($columnobject.Name)] = '$newValue'"
+                                } elseif ($columnobject.ColumnType -like '*date*') {
+                                    $newValue = ([datetime]$newValue).Tostring("yyyy-MM-dd HH:mm:ss")
+                                    $updates += "[$($columnobject.Name)] = '$newValue'"
+                                } elseif ($columnobject.ColumnType -eq 'xml') {
+                                    # nothing, unsure how i'll handle this
                                 } else {
                                     $newValue = ($newValue).Tostring().Replace("'", "''")
                                     $updates += "[$($columnobject.Name)] = '$newValue'"
@@ -458,10 +470,10 @@ function Invoke-DbaDbDataMasking {
                                 } elseif ($itemColumnType -in 'text', 'ntext') {
                                     $oldValue = ($row.$item).Tostring().Replace("'", "''")
                                     $wheres += "CAST([$item] AS VARCHAR(MAX)) = '$oldValue'"
-                                } elseif ($itemColumnType -like 'datetime') {
+                                } elseif ($itemColumnType -eq 'datetime') {
                                     $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.fff")
                                     $wheres += "[$item] = '$oldValue'"
-                                } elseif ($itemColumnType -like 'datetime2') {
+                                } elseif ($itemColumnType -eq 'datetime2') {
                                     $oldValue = ($row.$item).Tostring("yyyy-MM-dd HH:mm:ss.fffffff")
                                     $wheres += "[$item] = '$oldValue'"
                                 } elseif ($itemColumnType -like 'date') {

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -239,15 +239,14 @@ function Invoke-DbaDbDataMasking {
                                     if (-not $dbTable.Columns[$indexColumn.Name].Identity) {
                                         # Get the column mask info
                                         $columnMaskInfo = $tableobject.Columns | Where-Object Name -eq $indexColumn.Name
-                                        $indexColumn.Name
-                                        $columnMaskInfo
+
                                         if ($columnMaskInfo) {
                                             # Generate a new value
                                             try {
                                                 if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
-                                                    $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                    $newValue = Get-DbaRandomizedValue -DataType $columnMaskInfo.SubType -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue -Locale $Locale
                                                 } else {
-                                                    $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $min -Max $max -Locale $Locale
+                                                    $newValue = Get-DbaRandomizedValue -RandomizerType $columnMaskInfo.MaskingType -RandomizerSubtype $columnMaskInfo.SubType -Min $columnMaskInfo.MinValue -Max $columnMaskInfo.MaxValue -Locale $Locale
                                                 }
 
                                             } catch {
@@ -301,10 +300,12 @@ function Invoke-DbaDbDataMasking {
 
                                 } #>
 
+                                # Add the row value to the array
+                                $uniqueValues += $rowValue
+
                             }
 
-                            # Add the row value to the array
-                            $uniqueValues += $rowValue
+
 
                         }
 

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -341,15 +341,18 @@ function New-DbaDbMaskingConfig {
                                 $MaxValue = 2147483647
                             }
                             "date" {
-                                $subType = "Date"
+                                $type = "Date"
+                                $subType = "Past"
                                 $MaxValue = $null
                             }
                             "datetime" {
-                                $subType = "Date"
+                                $type = "Date"
+                                $subType = "Past"
                                 $MaxValue = $null
                             }
                             "datetime2" {
-                                $subType = "Date"
+                                $type = "Date"
+                                $subType = "Past"
                                 $MaxValue = $null
                             }
                             "decimal" {

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -190,9 +190,10 @@ function New-DbaDbMaskingConfig {
                         continue
                     }
 
-                    $maskingType = $min = $null
+                    $maskingType = $columnType = $min = $null
                     $columnLength = $columnobject.Datatype.MaximumLength
-                    $columnType = $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant()
+                    #$columnType = $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant()
+                    #$columnType = $columnobject.DataType.Name.ToString().ToLowerInvariant()
 
                     if ($columnobject.InPrimaryKey -and $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant() -notmatch 'date') {
                         $min = 2
@@ -398,6 +399,9 @@ function New-DbaDbMaskingConfig {
                                     $min = [int]($columnLength / 2)
                                     $MaxValue = $columnLength
                                 }
+                            }
+                            "uniqueidentifier" {
+                                $subType = "Guid"
                             }
                             default {
                                 $subType = "String2"

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -191,9 +191,12 @@ function New-DbaDbMaskingConfig {
                     }
 
                     $maskingType = $columnType = $min = $null
-                    $columnLength = $columnobject.Datatype.MaximumLength
-                    #$columnType = $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant()
-                    #$columnType = $columnobject.DataType.Name.ToString().ToLowerInvariant()
+
+                    if ($columnobject.Datatype.Name -in 'date', 'datetime', 'datetime2', 'smalldatetime', 'time') {
+                        $columnLength = $columnobject.Datatype.NumericScale
+                    } else {
+                        $columnLength = $columnobject.Datatype.MaximumLength
+                    }
 
                     if ($columnobject.InPrimaryKey -and $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant() -notmatch 'date') {
                         $min = 2
@@ -381,6 +384,11 @@ function New-DbaDbMaskingConfig {
                             "text" {
                                 $subType = "String"
                                 $maxValue = 2147483647
+                            }
+                            "time" {
+                                $type = "Date"
+                                $subType = "Past"
+                                $MaxValue = $null
                             }
                             "tinyint" {
                                 $subType = "Number"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The purpose of this PR is to fix several issues with the masking.

### Approach
Fixes #5248: Changed the call for a randomized value to correct function
Fixes issues with check for column type for generating randomized value
Fixes way unique values are generated. 
Fixes how date data types are handles when creating a config
Fixes how time data types are handles when creating a config
Fixes how date data types are handles in the WHERE and SET clauses
Fixes how time data types are handles in the WHERE and SET clauses
Fixes incorrect masking types in config
Fixes the min and max values passed along the randomized value generation


### Commands to test
Invoke-DbaDbDataMasking
New-DbaDbMaskingConfig

### Screenshots
![image](https://user-images.githubusercontent.com/6154981/57304289-57871800-70df-11e9-813c-c919e0218ba1.png)


### Learning
I did find some things regarding CHECK constraints in the AdventureWorks database. You might get errors when there are check constraints that only allow certain ranges of values.
In those cases you need to go into the masking configuration and set the min and max values to prevent errors from occurring.
This will not be handled by the masking commands.