### PR TITLE
Change DATEDIFF function datepart

### DIFF
--- a/functions/Get-DbaSsisExecutionHistory.ps1
+++ b/functions/Get-DbaSsisExecutionHistory.ps1
@@ -189,7 +189,7 @@ function Get-DbaSsisExecutionHistory {
                     , s.code AS StatusCode
                     , start_time as StartTime
                     , end_time as EndTime
-                    , ElapsedMinutes = DATEDIFF(ss, e.start_time, e.end_time)
+                    , ElapsedMinutes = DATEDIFF(mi, e.start_time, e.end_time)
                     , l.LoggingLevel
             FROM
                 [catalog].executions e


### PR DESCRIPTION
Currently ElapsedMinutes computed column uses ss as the datepart for the DATEDIFF function in Get-DbaSsisExecutionHistory.ps1. This returns elapsed seconds rather than minutes. Changed to mi tsql datepart to return accurate elapsed minutes.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
Change the seconds datepart in Get-DbaSsisExecutionHistory.ps1 to return minutes instead as computed column in query is explicitly called ElapsedMinutes.
