### PR TITLE
Get-DbaOperatingSystem - Caption was blank

### DIFF
--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -114,7 +114,7 @@ function Get-DbaOperatingSystem {
             }
 
             try {
-                $powerPlan = Get-DbaCmObject @splatDbaCmObject -ClassName Win32_PowerPlan -Namespace "root\cimv2\power"  | Select-Object ElementName, InstanceId, IsActive
+                $powerPlan = Get-DbaCmObject @splatDbaCmObject -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" | Select-Object ElementName, InstanceId, IsActive
             } catch {
                 Write-Message -Level Warning -Message "Power plan information not available on $computer."
                 $powerPlan = $null
@@ -130,7 +130,7 @@ function Get-DbaOperatingSystem {
 
             try {
                 $ss = Get-DbaCmObject @splatDbaCmObject -Class Win32_SystemServices
-                if ($ss | Select-Object PartComponent | Where-Object {$_ -like "*ClusSvc*"}) {
+                if ($ss | Select-Object PartComponent | Where-Object { $_ -like "*ClusSvc*" }) {
                     $IsWsfc = $true
                 } else {
                     $IsWsfc = $false
@@ -147,8 +147,8 @@ function Get-DbaOperatingSystem {
                 Architecture             = $os.OSArchitecture
                 Version                  = $os.Version
                 Build                    = $os.BuildNumber
-                OSVersion                = $os.caption;
-                SPVersion                = $os.servicepackmajorversion;
+                OSVersion                = $os.caption
+                SPVersion                = $os.servicepackmajorversion
                 InstallDate              = [DbaDateTime]$os.InstallDate
                 LastBootTime             = [DbaDateTime]$os.LastBootUpTime
                 LocalDateTime            = [DbaDateTime]$os.LocalDateTime
@@ -178,7 +178,7 @@ function Get-DbaOperatingSystem {
                 CountryCode              = $os.CountryCode
                 Locale                   = $os.Locale
                 IsWsfc                   = $IsWsfc
-            } | Select-DefaultView -Property ComputerName, Manufacturer, Organization, Architecture, Version, Caption, LastBootTime, LocalDateTime, PowerShellVersion, TimeZone, TotalVisibleMemory, ActivePowerPlan, LanguageNative
+            } | Select-DefaultView -Property ComputerName, Manufacturer, Organization, Architecture, Version, OSVersion, LastBootTime, LocalDateTime, PowerShellVersion, TimeZone, TotalVisibleMemory, ActivePowerPlan, LanguageNative
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5549
 - [ ] New feature (non-breaking change, adds functionality)
 - [X] Breaking change (effects multiple commands or functionality)
    - Output property name change
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes #5549 - the property in the PSCustomObject built in the function is OsVersion. I changed the `Select-Object` to return that instead of `Caption`.
Could be a breaking change if people are expecting `Caption`, we could instead change the PSCustomObject to name the property `Caption` and leave the output the same. Let me know - I can easily change it.

### Commands to test
`Get-DbaOperatingSystem -ComputerName ServerName`

### Screenshots
![image](https://user-images.githubusercontent.com/981370/57929344-1205e000-7881-11e9-937e-05b47fd7e882.png)
