### PR TITLE
Remove-DbaDatabase - Remove IncludeSystemDb parameter

### DIFF
--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -1,10 +1,10 @@
 function Remove-DbaDatabase {
     <#
     .SYNOPSIS
-        Drops a database, hopefully even the really stuck ones.
+        Drops a user database, hopefully even the really stuck ones.
 
     .DESCRIPTION
-        Tries a bunch of different ways to remove a database or two or more.
+        Tries a bunch of different ways to remove a user created database or two or more.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.You must have sysadmin access and server version must be SQL Server version 2000 or higher.
@@ -17,9 +17,6 @@ function Remove-DbaDatabase {
 
     .PARAMETER InputObject
         A collection of databases (such as returned by Get-DbaDatabase), to be removed.
-
-    .PARAMETER IncludeSystemDb
-        Use this switch to disable any kind of verbose messages
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
@@ -59,12 +56,12 @@ function Remove-DbaDatabase {
         Does not prompt and swiftly removes containeddb on SQL Server sql2016
 
     .EXAMPLE
-        PS C:\> Get-DbaDatabase -SqlInstance server\instance -ExcludeSystem | Remove-DbaDatabase
+        PS C:\> Get-DbaDatabase -SqlInstance server\instance | Remove-DbaDatabase
 
         Removes all the user databases from server\instance
 
     .EXAMPLE
-        PS C:\> Get-DbaDatabase -SqlInstance server\instance -ExcludeSystem | Remove-DbaDatabase -Confirm:$false
+        PS C:\> Get-DbaDatabase -SqlInstance server\instance | Remove-DbaDatabase -Confirm:$false
 
         Removes all the user databases from server\instance without any confirmation
     #>
@@ -81,7 +78,6 @@ function Remove-DbaDatabase {
         [object[]]$Database,
         [Parameter(ValueFromPipeline, Mandatory, ParameterSetName = "databases")]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
-        [switch]$IncludeSystemDb,
         [Alias('Silent')]
         [switch]$EnableException
     )
@@ -97,11 +93,9 @@ function Remove-DbaDatabase {
             $InputObject += $server.Databases | Where-Object { $_.Name -in $Database }
         }
 
+        # Excludes system databases as these cannot be deleted
         $system_dbs = @( "master", "model", "tempdb", "resource", "msdb" )
-
-        if (-not($IncludeSystemDb)) {
-            $InputObject = $InputObject | Where-Object { $_.Name -notin $system_dbs}
-        }
+        $InputObject = $InputObject | Where-Object { $_.Name -notin $system_dbs}
 
         foreach ($db in $InputObject) {
             try {

--- a/tests/Remove-DbaDatabase.Tests.ps1
+++ b/tests/Remove-DbaDatabase.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Database','InputObject','IncludeSystemDb','EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -14,7 +14,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    Context "Should not munge system databases unless explicitly told to." {
+    Context "Should not munge system databases." {
 
         $dbs = @( "master", "model", "tempdb", "msdb" )
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [X] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The IncludeSystemDb switch would potentially allow for dropping System Databases on a live Server
This is not a supported action

Also updated examples that actually referenced non existent parameter

### Approach
Removed switch and updated description and examples to reference only User databases


