### PR TITLE
Changed testfile cleanup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ clone_depth: 100
 environment:
   environment: development
   version: 0.9.$(appveyor_build_number)
-  appveyor_rdp_password: 2odCuiKmYiem
+  #appveyor_rdp_password: 2odCuiKmYiem
   azurepasswd:
     secure: ZnF3fWSDfHraMCWlHaekvWrXf3sDqY5M28HMK4236PBbNSoqP29wEhsWMQioSSYGomzgIp9vuiwR8Fc9ViNLoqq0bVcErxEojBFTaPMEzOg2ZwO9OnOTiuUEc5JkoLBv6rEBBWef/DvkFfhr1r0K0xQu6OAPYHVTCRajTZbBRNfCTUM2X2o41t+cSa7681rtnJQnB/8cAfVVnPtJ+97s8w==
   azurelegacypasswd:

--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -14,7 +14,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     AfterAll {
-        $ExportedItems = Get-ChildItem "$env:USERPROFILE\Documents" | Where-Object { $_.Name -match "-\d{14}" -and $_.Attributes -eq 'Directory' }
+        $ExportedItems = Get-ChildItem "C:\Users\appveyor\Documents" | Where-Object { $_.Name -match "-\d{14}" -and $_.Attributes -eq 'Directory' }
         $null = Remove-Item -Path $($ExportedItems.FullName) -Force -Recurse -ErrorAction SilentlyContinue
     }
 

--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -14,18 +14,20 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     AfterAll {
-        $ExportedItems = Get-ChildItem "C:\Users\appveyor\Documents" | Where-Object { $_.Name -match "-\d{14}" -and $_.Attributes -eq 'Directory' }
+        $timenow = (Get-Date -uformat "%m%d%Y%H")
+        $ExportedItems = Get-ChildItem "$($env:USERPROFILE)\Documents" | Where-Object { $_.Name -match "-$timenow\d{4}" -and $_.Attributes -eq 'Directory' }
+        Write-Host $ExportedItems -Verbose
         $null = Remove-Item -Path $($ExportedItems.FullName) -Force -Recurse -ErrorAction SilentlyContinue
     }
 
     Context "Should Export all items from an instance" {
-        $results = Export-DbaInstance -SqlInstance $script:instance2
+        $results = Export-DbaInstance -SqlInstance $script:instance2 -Verbose
         It "Should execute with default settings" {
             $results | Should Not Be Null
         }
     }
     Context "Should exclude some items from an Export" {
-        $results = Export-DbaInstance -SqlInstance $script:instance2 -Exclude Databases, Logins, SysDbUserObjects
+        $results = Export-DbaInstance -SqlInstance $script:instance2 -Exclude Databases, Logins, SysDbUserObjects -Verbose
         It "Should execute with parameters excluding objects" {
             $results | Should Not Be Null
         }

--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -13,16 +13,19 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
 }
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    AfterAll {
+        $ExportedItems = Get-ChildItem "$env:USERPROFILE\Documents" | Where-Object { $_.Name -match "-\d{14}" -and $_.Attributes -eq 'Directory' }
+        $null = Remove-Item -Path $($ExportedItems.FullName) -Force -Recurse -ErrorAction SilentlyContinue
+    }
+
     Context "Should Export all items from an instance" {
         $results = Export-DbaInstance -SqlInstance $script:instance2
-        #$null = Remove-Item -Path $results -Force -Recurse
         It "Should execute with default settings" {
             $results | Should Not Be Null
         }
     }
     Context "Should exclude some items from an Export" {
         $results = Export-DbaInstance -SqlInstance $script:instance2 -Exclude Databases, Logins, SysDbUserObjects
-        #$null = Remove-Item -Path $results -Force -Recurse
         It "Should execute with parameters excluding objects" {
             $results | Should Not Be Null
         }

--- a/tests/Get-DbaAgentJobStep.Tests.ps1
+++ b/tests/Get-DbaAgentJobStep.Tests.ps1
@@ -82,3 +82,35 @@ Describe "$CommandName Unittests" -Tag 'UnitTests' {
         }
     }
 }
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Gets a job step" {
+        BeforeAll {
+            $jobName = "dbatoolsci_job_$(get-random)"
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName dbatoolsci_jobstep1 -Subsystem TransactSql -Command 'select 1'
+        }
+        AfterAll {
+            $null = Remove-DbaAgentJob -SqlInstance sqlpomf\sql2016 -Job $jobName -Confirm:$false
+        }
+
+        It "Successfully gets job when not using Job param" {
+            $results = Get-DbaAgentJobStep -SqlInstance $script:instance2
+            $results.Name | should contain 'dbatoolsci_jobstep1'
+        }
+        It "Successfully gets job when using Job param" {
+            $results = Get-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName
+            $results.Name | should contain 'dbatoolsci_jobstep1'
+        }
+        It "Successfully gets job when excluding some jobs" {
+            $results = Get-DbaAgentJobStep -SqlInstance $script:instance2 -ExcludeJob 'syspolicy_purge_history'
+            $results.Name | should contain 'dbatoolsci_jobstep1'
+        }
+        It "Successfully excludes disabled jobs" {
+            $null = Set-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName -Disabled
+            $results = Get-DbaAgentJobStep -SqlInstance $script:instance2 -ExcludeDisabledJobs
+            $results.Name | should not contain 'dbatoolsci_jobstep1'
+        }
+
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Figured out how to clean up reliably the folder and files left behind by `Export-DbaInstnace`. This had been causing a problem with this test.

### Approach
<!-- How does this change solve that purpose -->
Use an Afterall block and specifically look in the User Profile for the created folder which has the date in it.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-Pester .\tests\Export-DbaInstance.tests.ps1`
