### PR TITLE
Get-DbaRegisteredServer - add default configuration for CMS and IncludeLocal

### DIFF
--- a/functions/Get-DbaRegServer.ps1
+++ b/functions/Get-DbaRegServer.ps1
@@ -91,7 +91,7 @@ function Get-DbaRegServer {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
     param (
         [parameter(ValueFromPipeline)]
-        [DbaInstanceParameter[]]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance = (Get-DbatoolsConfigValue -FullName 'commands.get-dbaregserver.defaultcms'),
         [PSCredential]$SqlCredential,
         [string[]]$Name,
         [string[]]$ServerName,
@@ -100,7 +100,7 @@ function Get-DbaRegServer {
         [int[]]$Id,
         [switch]$IncludeSelf,
         [switch]$ResolveNetworkName,
-        [switch]$IncludeLocal,
+        [switch]$IncludeLocal = (Get-DbatoolsConfigValue -FullName 'commands.get-dbaregserver.includelocal'),
         [switch]$EnableException
     )
     begin {

--- a/internal/configurations/settings/commands.ps1
+++ b/internal/configurations/settings/commands.ps1
@@ -6,3 +6,7 @@ Set-DbatoolsConfig -FullName 'commands.Write-DbaDbTableData.raw' -Value $false -
 
 # Resolve-DbaNetworkName
 Set-DbatoolsConfig -FullName 'commands.resolve-dbanetworkname.bypass' -Value $false -Initialize -Validation bool -Description "Use input exactly as stated instead of attempting to resolve"
+
+# Get-DbaRegServer
+Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.defaultcms' -Value $null -Initialize -Validation string -Description "Use a default Central Management Server"
+Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.includelocal' -Value $false -Initialize -Validation bool -Description "Include local servers by default"


### PR DESCRIPTION
```powershell
Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.defaultcms' -Value sql2014  -PassThru | Register-DbatoolsConfig
Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.includelocal' -Value $true -PassThru | Register-DbatoolsConfig
```

![image](https://user-images.githubusercontent.com/8278033/58382137-b6e19500-7fc6-11e9-85cc-18f3b94c9df7.png)
