### PR TITLE
Update Appveyor.prep for Path.DbatoolsExport

### DIFF
--- a/tests/Export-DbaInstance.Tests.ps1
+++ b/tests/Export-DbaInstance.Tests.ps1
@@ -13,16 +13,20 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
 }
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    AfterAll {
+        $timenow = (Get-Date -uformat "%m%d%Y%H")
+        $ExportedItems = Get-ChildItem "$($env:USERPROFILE)\Documents" -Recurse | Where-Object { $_.Name -match "-$timenow\d{4}" -and $_.Attributes -eq 'Directory' }
+        $null = Remove-Item -Path $($ExportedItems.FullName) -Force -Recurse -ErrorAction SilentlyContinue
+    }
+
     Context "Should Export all items from an instance" {
         $results = Export-DbaInstance -SqlInstance $script:instance2
-        #$null = Remove-Item -Path $results -Force -Recurse
         It "Should execute with default settings" {
             $results | Should Not Be Null
         }
     }
     Context "Should exclude some items from an Export" {
-        $results = Export-DbaInstance -SqlInstance $script:instance2 -Exclude Databases, Logins, SysDbUserObjects
-        #$null = Remove-Item -Path $results -Force -Recurse
+        $results = Export-DbaInstance -SqlInstance $script:instance2 -Exclude Databases, Logins, SysDbUserObjects, ReplicationSettings
         It "Should execute with parameters excluding objects" {
             $results | Should Not Be Null
         }

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -19,6 +19,12 @@ if (-not(Test-Path 'C:\Program Files\WindowsPowerShell\Modules\Pester\4.4.2')) {
     Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 4.4.2 | Out-Null
 }
 
+#Setup DbatoolsConfig Path.DbatoolsExport path
+Write-Host -Object "appveyor.prep: Create Path.DbatoolsExport" -ForegroundColor DarkGreen
+if (-not(Test-Path 'C:\Users\appveyor\Documents\DbatoolsExport')) {
+    New-Item -Path C:\Users\appveyor\Documents\DbatoolsExport -ItemType Directory | Out-Null
+}
+
 
 #Get opencover.portable (to run DLL tests)
 Write-Host -Object "appveyor.prep: Install opencover.portable" -ForegroundColor DarkGreen


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure that the DbatoolsConfig `Path.DbatoolsExport` folder is present in appveyor so `Export-dba` tests don't fail. Also includes a file cleanup for `Export-DbaInstance`
### Approach
<!-- How does this change solve that purpose -->
Add the Static path to the Appveyor.prep.ps1 script. Since this runs before the Module is imported there is no good way to read the configured value, so if the default changes in the config then this will need to be changed manually.


