### PR TITLE
Sync-DbaLoginPermission - Removed bad logic - fixes #5452

### DIFF
--- a/internal/functions/Update-SqlPermission.ps1
+++ b/internal/functions/Update-SqlPermission.ps1
@@ -224,7 +224,7 @@ function Update-SqlPermission {
                 $destRoleName = $destRole.Name
                 $sourceRole = $sourceDb.Roles[$destRoleName]
                 if ($null -eq $sourceRole) {
-                    if ($sourceRole.EnumMembers() -notcontains $dbUsername -and $destRole.EnumMembers() -contains $dbUsername) {
+                    if ($destRole.EnumMembers() -contains $dbUsername) {
                         if ($dbUsername -ne "dbo") {
                             if ($Pscmdlet.ShouldProcess($destination, "Dropping user $userName from $destRoleName database role in $dbName.")) {
                                 try {


### PR DESCRIPTION
if null eq sourcerole then sourcerole cant enum

