### PR TITLE
Sync-DbaLoginPermission - fixes #5452

### DIFF
--- a/internal/functions/Update-SqlPermission.ps1
+++ b/internal/functions/Update-SqlPermission.ps1
@@ -225,7 +225,7 @@ function Update-SqlPermission {
                 $destRoleName = $destRole.Name
                 $sourceRole = $sourceDb.Roles[$destRoleName]
                 if ($null -eq $sourceRole) {
-                    if ($sourceRole.EnumMembers() -notcontains $dbUsername -and $destRole.EnumMembers() -contains $dbUsername) {
+                    if ($destRole.EnumMembers() -contains $dbUsername) {
                         if ($dbUsername -ne "dbo") {
                             if ($Pscmdlet.ShouldProcess($destination, "Dropping user $userName from $destRoleName database role in $dbName.")) {
                                 try {


### PR DESCRIPTION
fixes - #5452 

logic issue. if its null, it cant be enumed