### PR TITLE
Add easy/proper Encoding support for Import-DbaCsv - fixes #5634

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -257,7 +257,6 @@ function Import-DbaCsv {
         [ValidateSet('ASCII', 'BigEndianUnicode', 'Byte', 'String', 'Unicode', 'UTF7', 'UTF8', 'Unknown')]
         [string]$Encoding,
         [string]$NullValue,
-        [int]$Threshold = 60,
         [int]$MaxQuotedFieldLength,
         [switch]$SkipEmptyLine,
         [switch]$SupportsMultiline,
@@ -577,7 +576,7 @@ function Import-DbaCsv {
                             Add-Member -Type NoteProperty -Name BufferSize -Value $BufferSize -Force -InputObject $reader
                         }
                         if ($PSBoundParameters.NullValue) {
-                           Add-Member -Type NoteProperty -Name NullValue -Value $NullValue -Force -InputObject $reader
+                            Add-Member -Type NoteProperty -Name NullValue -Value $NullValue -Force -InputObject $reader
                         }
                         if ($PSBoundParameters.FirstRowHeader) {
                             $reader.hasHeaders = $FirstRowHeader
@@ -595,7 +594,7 @@ function Import-DbaCsv {
                             Add-Member -Type NoteProperty -Name Comment -Value $Comment -Force -InputObject $reader
                         }
                         if ($PSBoundParameters.TrimmingOption) {
-                             Add-Member -Type NoteProperty -Name TrimmingOptions -Value [LumenWorks.Framework.IO.Csv.ValueTrimmingOptions]::$TrimmingOption -Force -InputObject $reader
+                            Add-Member -Type NoteProperty -Name TrimmingOptions -Value [LumenWorks.Framework.IO.Csv.ValueTrimmingOptions]::$TrimmingOption -Force -InputObject $reader
                         }
 
                         # Add rowcount output

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Path', 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Schema', 'Truncate', 'Delimiter', 'SingleColumn', 'BatchSize', 'NotifyAfter', 'TableLock', 'CheckConstraints', 'FireTriggers', 'KeepIdentity', 'KeepNulls', 'Column', 'ColumnMap', 'KeepOrdinalOrder', 'AutoCreateTable', 'NoProgress', 'NoHeaderRow', 'Quote', 'Escape', 'Comment', 'TrimmingOption', 'BufferSize', 'ParseErrorAction', 'Encoding', 'NullValue', 'Threshold', 'MaxQuotedFieldLength', 'SkipEmptyLine', 'SupportsMultiline', 'UseColumnDefault', 'EnableException', 'NoTransaction'
+        [object[]]$knownParameters = 'Path', 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Schema', 'Truncate', 'Delimiter', 'SingleColumn', 'BatchSize', 'NotifyAfter', 'TableLock', 'CheckConstraints', 'FireTriggers', 'KeepIdentity', 'KeepNulls', 'Column', 'ColumnMap', 'KeepOrdinalOrder', 'AutoCreateTable', 'NoProgress', 'NoHeaderRow', 'Quote', 'Escape', 'Comment', 'TrimmingOption', 'BufferSize', 'ParseErrorAction', 'Encoding', 'NullValue', 'MaxQuotedFieldLength', 'SkipEmptyLine', 'SupportsMultiline', 'UseColumnDefault', 'EnableException', 'NoTransaction'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
ridiculous test

```powershell
Get-ChildItem E:\csv\jmf*.csv |Import-DbaCsv -SqlInstance sql2016 -Database tempdb -AutoCreateTable -Encoding ASCII -MaxQuotedFieldLength 10 -Comment "#" -Escape "b" -Delimiter a -NoHeaderRow -NullValue b -BufferSize 10 -TrimmingOption All -ParseErrorAction AdvanceToNextLine -UseColumnDefault -SupportsMultiline -SkipEmptyLine
```