### PR TITLE
fixes #5379

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2019-05-28T00:00:00",
+    "LastUpdated": "2019-06-03T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",
@@ -919,10 +919,7 @@
             "Version": "8.0.2026"
         },
         {
-            "SP": [
-                "SP4",
-                "LATEST"
-            ],
+            "SP": "SP4",
             "Version": "8.0.2039",
             "SupportedUntil": "2013-04-09T00:00:00",
             "KBList": "306908"
@@ -1989,10 +1986,7 @@
             "Version": "9.0.4912"
         },
         {
-            "SP": [
-                "SP4",
-                "LATEST"
-            ],
+            "SP": "SP4",
             "Version": "9.0.5000",
             "SupportedUntil": "2016-04-12T00:00:00",
             "KBList": "2463332"
@@ -2452,10 +2446,7 @@
             "KBList": "3135244"
         },
         {
-            "SP": [
-                "SP4",
-                "LATEST"
-            ],
+            "SP": "SP4",
             "Version": "10.0.6000",
             "SupportedUntil": "2019-07-09T00:00:00",
             "KBList": "2979596"
@@ -2770,10 +2761,7 @@
             "KBList": "3135244"
         },
         {
-            "SP": [
-                "SP3",
-                "LATEST"
-            ],
+            "SP": "SP3",
             "Version": "10.50.6000",
             "SupportedUntil": "2019-07-09T00:00:00",
             "KBList": "2979597"
@@ -3215,10 +3203,7 @@
             "KBList": "4057121"
         },
         {
-            "SP": [
-                "SP4",
-                "LATEST"
-            ],
+            "SP": "SP4",
             "SupportedUntil": "2022-07-12T00:00:00",
             "Version": "11.0.7001",
             "KBList": "4018073"
@@ -3602,10 +3587,7 @@
             "KBList": "4482967"
         },
         {
-            "SP": [
-                "SP3",
-                "LATEST"
-            ],
+            "SP": "SP3",
             "Version": "12.0.6024",
             "SupportedUntil": "2024-07-09T00:00:00",
             "KBList": "4022619"
@@ -3869,10 +3851,7 @@
             "KBList": "4495257"
         },
         {
-            "SP": [
-                "SP2",
-                "LATEST"
-            ],
+            "SP": "SP2",
             "Version": "13.0.5026",
             "SupportedUntil": "2026-07-14T00:00:00",
             "KBList": "4052908"
@@ -3957,10 +3936,7 @@
             "Version": "14.0.900"
         },
         {
-            "SP": [
-                "RTM",
-                "LATEST"
-            ],
+            "SP": "RTM",
             "Version": "14.0.1000",
             "SupportedUntil": "2027-10-12T00:00:00"
         },

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -82,11 +82,11 @@ Describe "$CommandName Unit Test" -Tags Unittest {
         }
     }
     # These are groups by major release (aka "Name")
-    $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+    $IdxRef = Get-Content $idxfile -Raw | ConvertFrom-Json
     $Groups = @{ }
     $OrderedKeys = @()
     foreach ($el in $IdxRef.Data) {
-        $ver = $el.Version.split('.')[0 .. 1] -join '.'
+        $ver = $el.Version.Split('.')[0 .. 1] -join '.'
         if (!($Groups.ContainsKey($ver))) {
             $Groups[$ver] = New-Object System.Collections.ArrayList
             $OrderedKeys += $ver
@@ -116,7 +116,7 @@ Describe "$CommandName Unit Test" -Tags Unittest {
             }
             It "SPs are ordered correctly" {
                 $SPs = $Versions.SP | Where-Object { $_ }
-                $SPs[0] | Should Be 'RTM'
+                ($SPs | Select-Object -First 1) | Should Be 'RTM'
                 $ActualSPs = $SPs | Where-Object { $_ -match '^SP[\d]+$' }
                 $OrderedActualSPs = $ActualSPs | Sort-Object
                 ($ActualSPs -join ',') | Should Be ($OrderedActualSPs -join ',')

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Build','Kb','MajorVersion','ServicePack','CumulativeUpdate','SqlInstance','SqlCredential','Update','EnableException'
+        [object[]]$knownParameters = 'Build', 'Kb', 'MajorVersion', 'ServicePack', 'CumulativeUpdate', 'SqlInstance', 'SqlCredential', 'Update', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -105,11 +105,8 @@ Describe "$CommandName Unit Test" -Tags Unittest {
             It "has a single version tagged as RTM" {
                 ($Versions.SP -eq 'RTM').Count | Should Be 1
             }
-            It "has a single version tagged as LATEST" {
-                ($Versions.SP -eq 'LATEST').Count | Should Be 1
-            }
             It "SP Property is formatted correctly" {
-                $Versions.SP | Where-Object { $_ } | Should Match '^RTM$|^LATEST$|^SP[\d]+$'
+                $Versions.SP | Where-Object { $_ } | Should Match '^RTM$|^SP[\d]+$'
             }
             It "CU Property is formatted correctly" {
                 $CUMatch = $Versions.CU | Where-Object { $_ }
@@ -120,14 +117,9 @@ Describe "$CommandName Unit Test" -Tags Unittest {
             It "SPs are ordered correctly" {
                 $SPs = $Versions.SP | Where-Object { $_ }
                 $SPs[0] | Should Be 'RTM'
-                $SPs[-1] | Should Be 'LATEST'
                 $ActualSPs = $SPs | Where-Object { $_ -match '^SP[\d]+$' }
                 $OrderedActualSPs = $ActualSPs | Sort-Object
                 ($ActualSPs -join ',') | Should Be ($OrderedActualSPs -join ',')
-            }
-            It "LATEST is on PAR with a SP" {
-                $LATEST = $Versions | Where-Object SP -contains "LATEST"
-                $LATEST.SP.Count | Should Be 2
             }
             # see https://github.com/sqlcollaborative/dbatools/pull/2466
             It "KBList has only numbers on it" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5379 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Removing "LATEST" needs, PS code is already compatible, it was mostly needed for the old logic of get-dbabuildreference and the webpage (https://sqlcollaborative.github.io/builds)

### Approach
I just updated the webpage code to avoid considering LATEST, so for all intents and purposes this is not breaking behaviours in both the PS code (Get-DbaBuildReference, Test-DbaBuild) and the webpage. 
Everything works with the index carrying "LATEST" and the one not carrying it, so IMHO it's safe to merge as soon as tests pass. Other than modifying the buildreference I just stripped the test that were checking that a LATEST was in the correct place, since it's not needed anymore.

BEWARE: once merging this it'd be better to update https://github.com/sqlcollaborative/sqlcollaborative.github.io/blob/master/assets/dbatools-buildref-index.json too.
