### PR TITLE
Copy-DbaLogin - Force / Group issue

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -512,11 +512,15 @@ function Copy-DbaLogin {
 
             $destVersionMajor = $destServer.VersionMajor
             if ($sourceVersionMajor -gt 10 -and $destVersionMajor -lt 11) {
-                Stop-Function -Message "Login migration from version $sourceVersionMajor to $destVersionMajor is not supported." -Category InvalidOperation -ErrorRecord $_ -Target $sourceServer
+                Stop-Function -Message "Login migration from version $sourceVersionMajor to $destVersionMajor is not supported." -Target $sourceServer
             }
 
             if ($sourceVersionMajor -lt 8 -or $destVersionMajor -lt 8) {
-                Stop-Function -Message "SQL Server 7 and below are not supported." -Category InvalidOperation -ErrorRecord $_ -Target $sourceServer
+                Stop-Function -Message "SQL Server 7 and below are not supported." -Target $sourceServer
+            }
+
+            if ($destserver.ConnectionContext.TrueLogin -notin $destserver.Logins.Name -and $Force) {
+                Stop-Function -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
             }
 
             Write-Message -Level Verbose -Message "Attempting Login Migration."

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -520,8 +520,12 @@ function Copy-DbaLogin {
             }
 
             if ($destserver.ConnectionContext.TrueLogin -notin $destserver.Logins.Name -and $Force) {
-                Stop-Function -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
-                continue
+                if ($Login -or $ExcludeLogin) {
+                    Write-Message -Level Verbose -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) not found in logins list but an explicit Login or ExcludeLogin was specified, so we trust you won't drop the group that allows $($destserver.ConnectionContext.TrueLogin) access. Proceeding."
+                } else {
+                    Stop-Function -Message "Force was used, no explicit -Login or -ExcludeLogin was specified and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
+                    continue
+                }
             }
 
             Write-Message -Level Verbose -Message "Attempting Login Migration."

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -521,6 +521,7 @@ function Copy-DbaLogin {
 
             if ($destserver.ConnectionContext.TrueLogin -notin $destserver.Logins.Name -and $Force) {
                 Stop-Function -Message "Force was used and $($destserver.ConnectionContext.TrueLogin) cannot be found in the logins list. It may be part of a group. This will likely result in you being locked out of the server. To use Force, $($destserver.ConnectionContext.TrueLogin) must be added directly to logins before proceeding." -Target $destserver
+                continue
             }
 
             Write-Message -Level Verbose -Message "Attempting Login Migration."


### PR DESCRIPTION
If your account is part of a Windows group, using Copy-DbaLogin with Force can result in killing your own access. This can be fixed using Reset-DbaAdmin but it's not preferable. Add warning and stop functoin  to address.

![image](https://user-images.githubusercontent.com/8278033/59151562-99d0ab80-8a35-11e9-99fe-d608a59a04a7.png)
