### PR TITLE
NetName -> ComputerName

### DIFF
--- a/functions/Clear-DbaLatchStatistics.ps1
+++ b/functions/Clear-DbaLatchStatistics.ps1
@@ -82,7 +82,7 @@ function Clear-DbaLatchStatistics {
                 }
 
                 [PSCustomObject]@{
-                    ComputerName = $server.NetName
+                    ComputerName = $server.ComputerName
                     InstanceName = $server.ServiceName
                     SqlInstance  = $server.DomainInstanceName
                     Status       = $status

--- a/functions/Get-DbaCpuRingBuffer.ps1
+++ b/functions/Get-DbaCpuRingBuffer.ps1
@@ -125,7 +125,7 @@ function Get-DbaCpuRingBuffer {
             Write-Message -Level Verbose -Message "Executing Sql Staement: $sql"
             foreach ($row in $server.Query($sql)) {
                 [PSCustomObject]@{
-                    ComputerName            = $server.NetName
+                    ComputerName            = $server.ComputerName
                     InstanceName            = $server.ServiceName
                     SqlInstance             = $server.DomainInstanceName
                     RecordId                = $row.record_id

--- a/functions/Get-DbaFilestream.ps1
+++ b/functions/Get-DbaFilestream.ps1
@@ -124,7 +124,7 @@ function Get-DbaFilestream {
             $servicelevel = [int]$serviceFS.AccessLevel
 
             [PsCustomObject]@{
-                ComputerName        = $server.NetName
+                ComputerName        = $server.ComputerName
                 InstanceName        = $server.ServiceName
                 SqlInstance         = $server.DomainInstanceName
                 InstanceAccess      = $idInstanceFS[$runvalue]

--- a/functions/Get-DbaIoLatency.ps1
+++ b/functions/Get-DbaIoLatency.ps1
@@ -135,7 +135,7 @@ function Get-DbaIoLatency {
 
             foreach ($row in $server.Query($sql)) {
                 [PSCustomObject]@{
-                    ComputerName         = $server.NetName
+                    ComputerName         = $server.ComputerName
                     InstanceName         = $server.ServiceName
                     SqlInstance          = $server.DomainInstanceName
                     DatabaseId           = $row.database_id

--- a/functions/Get-DbaLatchStatistic.ps1
+++ b/functions/Get-DbaLatchStatistic.ps1
@@ -125,7 +125,7 @@ function Get-DbaLatchStatistic {
 
             foreach ($row in $server.Query($sql)) {
                 [PSCustomObject]@{
-                    ComputerName       = $server.NetName
+                    ComputerName       = $server.ComputerName
                     InstanceName       = $server.ServiceName
                     SqlInstance        = $server.DomainInstanceName
                     WaitType           = $row.LatchClass

--- a/functions/Get-DbaSpinLockStatistic.ps1
+++ b/functions/Get-DbaSpinLockStatistic.ps1
@@ -94,7 +94,7 @@ function Get-DbaSpinLockStatistic {
 
             foreach ($row in $server.Query($sql)) {
                 [PSCustomObject]@{
-                    ComputerName      = $server.NetName
+                    ComputerName      = $server.ComputerName
                     InstanceName      = $server.ServiceName
                     SqlInstance       = $server.DomainInstanceName
                     SpinLockName      = $row.name

--- a/functions/Test-DbaInstanceName.ps1
+++ b/functions/Test-DbaInstanceName.ps1
@@ -85,15 +85,15 @@ function Test-DbaInstanceName {
             $instance = $server.InstanceName
 
             if ($instance.Length -eq 0) {
-                $serverInstanceName = $server.NetName
+                $serverInstanceName = $server.ComputerName
                 $instance = "MSSQLSERVER"
             } else {
-                $netname = $server.NetName
+                $netname = $server.ComputerName
                 $serverInstanceName = "$netname\$instance"
             }
 
             $serverInfo = [PSCustomObject]@{
-                ComputerName   = $server.NetName
+                ComputerName   = $server.ComputerName
                 ServerName     = $sqlInstanceName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName


### PR DESCRIPTION
ComputerName is now figured out in Connect-DbaInstance 👍 NetName does not work in Azure, so we worked around that for Azure and Linux.

NetName is used for Windows and $instance.ComputerName is used for Azure/Linux. So basically, Windows resolves the name via SQL Server and Azure and Linux use the name given to `-SqlInstance` /cc @sqllensman 