### PR TITLE
Fix add dbaagdatabase secondaries

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -171,8 +171,6 @@ function Add-DbaAgDatabase {
             foreach ($instance in $secondaryInstances) {
 
                 $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $instance.NetName
-				
-				write-host "$($Instance.name)"
 
                 if (!($agreplica))
                 {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -134,9 +134,14 @@ function Add-DbaAgDatabase {
             }
 
             if (-not $Secondary) {
-                $secondaryReplicas = $ag.AvailabilityReplicas | Where-Object Role -eq Secondary
+				try {
+					$secondaryInstances = ($ag.AvailabilityReplicas | Where-Object Role -eq Secondary).name | Connect-DbaInstance -SqlCredential $SecondarySqlCredential
+				}
+				catch {
+				    Stop-Function -Message "Failure connecting to secondary instance" -ErrorRecord $_ -Continue
+				}
             } else {
-                $secondaryReplicas = Get-DbaAgReplica -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential -AvailabilityGroup $ag.Name | Where-Object Role -eq Secondary
+                $secondaryInstances = Connect-DbaInstance -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential 
             }
 
             if ($SeedingMode -ne "Automatic") {
@@ -163,9 +168,16 @@ function Add-DbaAgDatabase {
                 }
             }
 
-            foreach ($replica in $secondaryReplicas) {
+            foreach ($instance in $secondaryInstances) {
 
-                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $replica.Name
+                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $instance.NetName
+				
+				write-host "$($Instance.name)"
+
+                if (!($agreplica))
+                {
+                    Stop-Function -Continue -Message "Could not connect to instance $($instance.Name)"
+                }
 
                 if ($SeedingMode) {
                     $agreplica.SeedingMode = $SeedingMode
@@ -190,20 +202,20 @@ function Add-DbaAgDatabase {
                         }
                         if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $Primary")) {
                             # keep going to ensure output is shown even if dbs aren't added well.
-                            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $replica.Parent.Parent -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
+                            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $instance.Name -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
                         }
                     } catch {
                         Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
                     }
                 }
 
-                $replicadb = Get-DbaAgDatabase -SqlInstance $replica.Parent.Parent -Database $db.Name -AvailabilityGroup $ag.Name   #credential of secondary !!
+                $replicadb = Get-DbaAgDatabase -SqlInstance $instance.Name -Database $db.Name -AvailabilityGroup $ag.Name -SqlCredential $SecondarySqlCredential
                 if (-not $replicadb.IsJoined) {
                     if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Joining availability group $db to $($db.Parent.Name)")) {
                         $timeout = 1
                         do {
                             try {
-                                Write-Progress -Activity "Trying to add $($replicadb.Name) to $($replica.Name)" -Id 1 -PercentComplete ($timeout * 10)
+                                Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -PercentComplete ($timeout * 10)
                                 $timeout++
                                 if ($timeout -ne 1) {
                                     Start-Sleep -Seconds 3
@@ -214,12 +226,12 @@ function Add-DbaAgDatabase {
                                 Write-Message -Level Verbose -Message "Error joining database to availability group" -ErrorRecord $_
                             }
                         } while (-not $replicadb.IsJoined -and $timeout -lt 10)
-                        Write-Progress -Activity "Trying to add $($replicadb.Name) to $($replica.Name)" -Id 1 -Complete
+                        Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -Complete
 
                         if ($replicadb.IsJoined) {
                             $replicadb
                         } else {
-                            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $($replica.Name)"
+                            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $($instance.Name)"
                         }
                     }
                 } else {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -134,108 +134,106 @@ function Add-DbaAgDatabase {
             }
 
             if (-not $Secondary) {
-				try {
-					$secondaryInstances = ($ag.AvailabilityReplicas | Where-Object Role -eq Secondary).name | Connect-DbaInstance -SqlCredential $SecondarySqlCredential
-				}
-				catch {
-				    Stop-Function -Message "Failure connecting to secondary instance" -ErrorRecord $_ -Continue
-				}
-            } else {
-                $secondaryInstances = Connect-DbaInstance -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential 
-            }
-
-            if ($SeedingMode -ne "Automatic") {
-                if ((Get-DbaDatabase -SqlInstance $ag.Parent -Database $db.Name).LastFullBackup -eq 'Monday, January 1, 0001 12:00:00 AM') {
-                    Stop-Function -Message "Cannot add $($db.Name) to $($ag.Name) on $($ag.Parent.Name). An initial full backup must be created first." -Continue
-                }
-            }
-
-            if ($SeedingMode -eq "Automatic") {
-                # first check
-                if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {
-                    $null = Backup-DbaDatabase -BackupFileName NUL -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db
-                }
-            }
-
-            if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Adding availability group $db to $($db.Parent.Name)")) {
                 try {
-                    $agdb = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityDatabase($ag, $db.Name)
-                    # something is up with .net create(), force a stop
-                    Invoke-Create -Object $agdb
-                    Get-DbaAgDatabase -SqlInstance $ag.Parent -Database $db.Name
-                } catch {
-                    Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
-                }
-            }
+                    $secondaryInstances = ($ag.AvailabilityReplicas | Where-Object Role -eq Secondary).name | Connect-DbaInstance -SqlCredential $SecondarySqlCredential
+        } catch {
+            Stop-Function -Message "Failure connecting to secondary instance" -ErrorRecord $_ -Continue
+        }
+    } else {
+        $secondaryInstances = Connect-DbaInstance -SqlInstance $Secondary -SqlCredential $SecondarySqlCredential
+    }
 
-            foreach ($instance in $secondaryInstances) {
-
-                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $instance.NetName
-
-                if (!($agreplica))
-                {
-                    Stop-Function -Continue -Message "Could not connect to instance $($instance.Name)"
-                }
-
-                if ($SeedingMode) {
-                    $agreplica.SeedingMode = $SeedingMode
-                    $agreplica.Alter()
-                }
-                $agreplica.Refresh()
-                $SeedingModeReplica = $agreplica.SeedingMode
-
-                $primarydb = Get-DbaDatabase -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db.name
-
-                if ($SeedingModeReplica -ne 'Automatic') {
-                    try {
-                        if (-not $allbackups[$db]) {
-                            if ($UseLastBackup) {
-                                $allbackups[$db] = Get-DbaBackupHistory -SqlInstance $primarydb.Parent -Database $primarydb.Name -IncludeCopyOnly -Last -EnableException
-                            } else {
-                                $fullbackup = $primarydb | Backup-DbaDatabase -BackupDirectory $SharedPath -Type Full -EnableException
-                                $logbackup = $primarydb | Backup-DbaDatabase -BackupDirectory $SharedPath -Type Log -EnableException
-                                $allbackups[$db] = $fullbackup, $logbackup
-                            }
-                            Write-Message -Level Verbose -Message "Backups still exist on $SharedPath"
-                        }
-                        if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $Primary")) {
-                            # keep going to ensure output is shown even if dbs aren't added well.
-                            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $instance.Name -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
-                        }
-                    } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
-                    }
-                }
-
-                $replicadb = Get-DbaAgDatabase -SqlInstance $instance.Name -Database $db.Name -AvailabilityGroup $ag.Name -SqlCredential $SecondarySqlCredential
-                if (-not $replicadb.IsJoined) {
-                    if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Joining availability group $db to $($db.Parent.Name)")) {
-                        $timeout = 1
-                        do {
-                            try {
-                                Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -PercentComplete ($timeout * 10)
-                                $timeout++
-                                if ($timeout -ne 1) {
-                                    Start-Sleep -Seconds 3
-                                }
-                                $replicadb.Refresh()
-                                $replicadb.JoinAvailablityGroup()
-                            } catch {
-                                Write-Message -Level Verbose -Message "Error joining database to availability group" -ErrorRecord $_
-                            }
-                        } while (-not $replicadb.IsJoined -and $timeout -lt 10)
-                        Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -Complete
-
-                        if ($replicadb.IsJoined) {
-                            $replicadb
-                        } else {
-                            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $($instance.Name)"
-                        }
-                    }
-                } else {
-                    $replicadb
-                }
-            }
+    if ($SeedingMode -ne "Automatic") {
+        if ((Get-DbaDatabase -SqlInstance $ag.Parent -Database $db.Name).LastFullBackup -eq 'Monday, January 1, 0001 12:00:00 AM') {
+            Stop-Function -Message "Cannot add $($db.Name) to $($ag.Name) on $($ag.Parent.Name). An initial full backup must be created first." -Continue
         }
     }
+
+    if ($SeedingMode -eq "Automatic") {
+        # first check
+        if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {
+            $null = Backup-DbaDatabase -BackupFileName NUL -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db
+        }
+    }
+
+    if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Adding availability group $db to $($db.Parent.Name)")) {
+        try {
+            $agdb = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityDatabase($ag, $db.Name)
+            # something is up with .net create(), force a stop
+            Invoke-Create -Object $agdb
+            Get-DbaAgDatabase -SqlInstance $ag.Parent -Database $db.Name
+        } catch {
+            Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+        }
+    }
+
+    foreach ($instance in $secondaryInstances) {
+
+        $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $instance.NetName
+
+        if (!($agreplica)) {
+            Stop-Function -Continue -Message "Could not connect to instance $($instance.Name)"
+        }
+
+        if ($SeedingMode) {
+            $agreplica.SeedingMode = $SeedingMode
+            $agreplica.Alter()
+        }
+        $agreplica.Refresh()
+        $SeedingModeReplica = $agreplica.SeedingMode
+
+        $primarydb = Get-DbaDatabase -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db.name
+
+        if ($SeedingModeReplica -ne 'Automatic') {
+            try {
+                if (-not $allbackups[$db]) {
+                    if ($UseLastBackup) {
+                        $allbackups[$db] = Get-DbaBackupHistory -SqlInstance $primarydb.Parent -Database $primarydb.Name -IncludeCopyOnly -Last -EnableException
+                    } else {
+                        $fullbackup = $primarydb | Backup-DbaDatabase -BackupDirectory $SharedPath -Type Full -EnableException
+                    $logbackup = $primarydb | Backup-DbaDatabase -BackupDirectory $SharedPath -Type Log -EnableException
+                $allbackups[$db] = $fullbackup, $logbackup
+            }
+            Write-Message -Level Verbose -Message "Backups still exist on $SharedPath"
+        }
+        if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $Primary")) {
+            # keep going to ensure output is shown even if dbs aren't added well.
+            $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $instance.Name -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
+    }
+} catch {
+    Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
+}
+}
+
+$replicadb = Get-DbaAgDatabase -SqlInstance $instance.Name -Database $db.Name -AvailabilityGroup $ag.Name -SqlCredential $SecondarySqlCredential
+if (-not $replicadb.IsJoined) {
+    if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Joining availability group $db to $($db.Parent.Name)")) {
+        $timeout = 1
+        do {
+            try {
+                Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -PercentComplete ($timeout * 10)
+                $timeout++
+                if ($timeout -ne 1) {
+                    Start-Sleep -Seconds 3
+                }
+                $replicadb.Refresh()
+                $replicadb.JoinAvailablityGroup()
+            } catch {
+                Write-Message -Level Verbose -Message "Error joining database to availability group" -ErrorRecord $_
+            }
+        } while (-not $replicadb.IsJoined -and $timeout -lt 10)
+        Write-Progress -Activity "Trying to add $($replicadb.Name) to $($instance.Name)" -Id 1 -Complete
+
+        if ($replicadb.IsJoined) {
+            $replicadb
+        } else {
+            Stop-Function -Continue -Message "Could not join $($replicadb.Name) to $($instance.Name)"
+        }
+    }
+} else {
+    $replicadb
+}
+}
+}
+}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5682 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix an issue where the Add-DbaAgDatabase command was targeting the Primary server for a restore operation rather than the secondary

### Approach
Changed the function to pass Instance SMO objects around rather than AG objects, and convert between the two only when needed. This means we don't need to reconnect to the secondary AG later on in the function and we can be sure we've got the correct server

### Commands to test
Commands in the help
