### PR TITLE
Pssa/new dba db data generator config

### DIFF
--- a/functions/New-DbaDbDataGeneratorConfig.ps1
+++ b/functions/New-DbaDbDataGeneratorConfig.ps1
@@ -38,6 +38,12 @@ function New-DbaDbDataGeneratorConfig {
     .PARAMETER Force
         Forcefully execute commands when needed
 
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -65,7 +71,7 @@ function New-DbaDbDataGeneratorConfig {
         Process only table Customer with all the columns
 
     #>
-    [CmdLetBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [CmdLetBinding()]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -354,17 +360,17 @@ function New-DbaDbDataGeneratorConfig {
                 if (-not $script:isWindows) {
                     $temppath = $temppath.Replace("\", "/")
                 }
-                if (Test-Path -Path $temppath -PathType Leaf) {
-                    if ($Pscmdlet.ShouldProcess("$temppath", "Saving results to json")) {
-                        Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
-                    }
-                } else {
-                    Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
-                    Get-ChildItem -Path $temppath
-                }
+
+                Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
+                Get-ChildItem -Path $temppath
             } catch {
                 Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -Continue -ErrorRecord $_
             }
+        } else {
+            Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose
+        }
+    }
+}           }
         } else {
             Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose
         }

--- a/functions/New-DbaDbDataGeneratorConfig.ps1
+++ b/functions/New-DbaDbDataGeneratorConfig.ps1
@@ -65,7 +65,7 @@ function New-DbaDbDataGeneratorConfig {
         Process only table Customer with all the columns
 
     #>
-    [CmdLetBinding()]
+    [CmdLetBinding(SupportsShouldProcess)]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -354,9 +354,10 @@ function New-DbaDbDataGeneratorConfig {
                 if (-not $script:isWindows) {
                     $temppath = $temppath.Replace("\", "/")
                 }
-
-                Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
-                Get-ChildItem -Path $temppath
+                if ($Pscmdlet.ShouldProcess("$temppath", "Saving results to json")) {
+                    Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
+                    Get-ChildItem -Path $temppath
+                }
             } catch {
                 Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -Continue -ErrorRecord $_
             }

--- a/functions/New-DbaDbDataGeneratorConfig.ps1
+++ b/functions/New-DbaDbDataGeneratorConfig.ps1
@@ -71,7 +71,7 @@ function New-DbaDbDataGeneratorConfig {
         Process only table Customer with all the columns
 
     #>
-    [CmdLetBinding()]
+    [CmdLetBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -360,17 +360,17 @@ function New-DbaDbDataGeneratorConfig {
                 if (-not $script:isWindows) {
                     $temppath = $temppath.Replace("\", "/")
                 }
-
-                Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
-                Get-ChildItem -Path $temppath
+                if (Test-Path -Path $temppath -PathType Leaf) {
+                    if ($Pscmdlet.ShouldProcess("$temppath", "Saving results to json")) {
+                        Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
+                    }
+                } else {
+                    Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
+                    Get-ChildItem -Path $temppath
+                }
             } catch {
                 Stop-Function -Message "Something went wrong writing the results to the Path" -Target $Path -Continue -ErrorRecord $_
             }
-        } else {
-            Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose
-        }
-    }
-}           }
         } else {
             Write-Message -Message "No tables to save for database $($db.Name) on $($server.Name)" -Level Verbose
         }

--- a/functions/New-DbaDbDataGeneratorConfig.ps1
+++ b/functions/New-DbaDbDataGeneratorConfig.ps1
@@ -65,7 +65,7 @@ function New-DbaDbDataGeneratorConfig {
         Process only table Customer with all the columns
 
     #>
-    [CmdLetBinding(SupportsShouldProcess)]
+    [CmdLetBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
@@ -354,7 +354,11 @@ function New-DbaDbDataGeneratorConfig {
                 if (-not $script:isWindows) {
                     $temppath = $temppath.Replace("\", "/")
                 }
-                if ($Pscmdlet.ShouldProcess("$temppath", "Saving results to json")) {
+                if (Test-Path -Path $temppath -PathType Leaf) {
+                    if ($Pscmdlet.ShouldProcess("$temppath", "Saving results to json")) {
+                        Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
+                    }
+                } else {
                     Set-Content -Path $temppath -Value ($results | ConvertTo-Json -Depth 5)
                     Get-ChildItem -Path $temppath
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
It'd be unfortunate to overwrite a perfectly good (albeit old) config, so in this case I think ShouldProcess should be used. It's once for db and only if a previous file is found so not-too-nagging. 
