### PR TITLE
Invoke-DbaDbPiiScan, small reformat (do DbaDbPii)

### DIFF
--- a/functions/Invoke-DbaDbPiiScan.ps1
+++ b/functions/Invoke-DbaDbPiiScan.ps1
@@ -242,8 +242,7 @@ function Invoke-DbaDbPiiScan {
                 }
 
                 $tableNumber = 1
-                $progressStepText = "Scanning tables for database $dbName"
-                $progressStatusText = '"Table $($tableNumber.ToString().PadLeft($($tables.Count).Count.ToString().Length)) of $($tables.Count) | $progressStepText"'
+                $progressStatusText = '"Table $($tableNumber.ToString().PadLeft($($tables.Count).Count.ToString().Length)) of $($tables.Count) | Scanning tables for database $dbName"'
                 $progressStatusBlock = [ScriptBlock]::Create($progressStatusText)
 
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Small refactor on the trick of dotsourcing the progress message as a scriptblock instead of the usual pattern with "$using:varname" . Nice workaround but PSSA feels "tricked" on the original version, this instead is fine.
