### PR TITLE
Export-DbaXECsv, param is not really mandatory (do DbaXECsv)

### DIFF
--- a/functions/Export-DbaXECsv.ps1
+++ b/functions/Export-DbaXECsv.ps1
@@ -47,7 +47,6 @@ function Export-DbaXECsv {
         [parameter(Mandatory, ValueFromPipeline)]
         [Alias('FullName')]
         [object[]]$InputObject,
-        [parameter(Mandatory)]
         [string]$Path = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
         [Alias("OutFile", "FileName")]
         [string]$FilePath,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
If the param is mandatory, doesn't need a default value. If it gets a default value, it's not mandatory
