### PR TITLE
Remove fallbacks for Expand-Archive (do Get-DbaDatabase)

### DIFF
--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -155,20 +155,11 @@ function Install-DbaSqlWatch {
             $LocalCacheFolder = Split-Path $LocallyCachedZip -Parent
 
             Write-Message -Level Verbose "Extracting $LocallyCachedZip to $LocalCacheFolder"
-            if (Get-Command -ErrorAction SilentlyContinue -Name "Expand-Archive") {
-                try {
-                    Expand-Archive -Path $LocallyCachedZip -DestinationPath $LocalCacheFolder -Force
-                } catch {
-                    Stop-Function -Message "Unable to extract $LocallyCachedZip. Archive may not be valid." -ErrorRecord $_
-                    return
-                }
-            } else {
-                # Keep it backwards compatible
-                $shell = New-Object -ComObject Shell.Application
-                $zipPackage = $shell.NameSpace($LocallyCachedZip)
-                $destinationFolder = $shell.NameSpace($LocalCacheFolder)
-                Get-ChildItem "$LocalCacheFolder\SqlWatch.zip" | Remove-Item
-                $destinationFolder.CopyHere($zipPackage.Items())
+            try {
+                Expand-Archive -Path $LocallyCachedZip -DestinationPath $LocalCacheFolder -Force
+            } catch {
+                Stop-Function -Message "Unable to extract $LocallyCachedZip. Archive may not be valid." -ErrorRecord $_
+                return
             }
 
             Write-Message -Level VeryVerbose "Deleting $LocallyCachedZip"

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -134,21 +134,11 @@ function Install-DbaWhoIsActive {
             if ($PSCmdlet.ShouldProcess($env:computername, "Unpacking zipfile")) {
 
                 Unblock-File $zipfile -ErrorAction SilentlyContinue
-
-                if (Get-Command -ErrorAction SilentlyContinue -Name "Expand-Archive") {
-                    try {
-                        Expand-Archive -Path $zipfile -DestinationPath $temp -Force
-                    } catch {
-                        Stop-Function -Message "Unable to extract $zipfile. Archive may not be valid." -ErrorRecord $_
-                        return
-                    }
-                } else {
-                    # Keep it backwards compatible
-                    $shell = New-Object -ComObject Shell.Application
-                    $zipPackage = $shell.NameSpace($zipfile)
-                    $destinationFolder = $shell.NameSpace($temp)
-                    Get-ChildItem "$temp\who*active*.sql" | Remove-Item
-                    $destinationFolder.CopyHere($zipPackage.Items())
+                try {
+                    Expand-Archive -Path $zipfile -DestinationPath $temp -Force
+                } catch {
+                    Stop-Function -Message "Unable to extract $zipfile. Archive may not be valid." -ErrorRecord $_
+                    return
                 }
                 Remove-Item -Path $zipfile
             }

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -118,6 +118,17 @@ Describe "$ModuleName style" -Tag 'Compliance' {
             }
         }
     }
+    Context "Shell.Application" {
+        # Not every PS instance has Shell.Application
+        foreach ($f in $AllPublicFunctions) {
+            $NotAllowed = Select-String -Path $f -Pattern 'shell.application'
+            if ($NotAllowed.Count -gt 0) {
+                It "$f should not use Shell.Application (usually fallbacks for Expand-Archive, which dbatools ships), see #4800" {
+                    $NotAllowed.Count | Should -Be 0
+                }
+            }
+        }
+    }
 
 }
 


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes resurfacing things like #4800)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
We definitely import optional\ (for all import modes, allcommands.ps1 or not). So we do have everywhere Expand-Archive and Compress-Archive at our disposal.

### Approach
Remove any instance of shell.application and create a regression test to make sure it doesn't ever happen again
