### PR TITLE
Add Integration Tests - Copy-DbaDbMail

### DIFF
--- a/functions/Copy-DbaDbMail.ps1
+++ b/functions/Copy-DbaDbMail.ps1
@@ -19,7 +19,7 @@ function Copy-DbaDbMail {
         Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
 
     .PARAMETER Type
-        Specifies the object type to migrate. Valid options are "Job", "Alert" and "Operator". When Type is specified, all categories from the selected type will be migrated.
+        Specifies the object type to migrate. Valid options are 'ConfigurationValues', 'Profiles', 'Accounts', and 'MailServers'. When Type is specified, all categories from the selected type will be migrated.
 
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
@@ -76,7 +76,7 @@ function Copy-DbaDbMail {
         [parameter(Mandatory)]
         [DbaInstanceParameter[]]$Destination,
         [Parameter(ParameterSetName = 'SpecificTypes')]
-        [ValidateSet('ConfigurationValues', 'Profiles', 'Accounts', 'mailServers')]
+        [ValidateSet('ConfigurationValues', 'Profiles', 'Accounts', 'MailServers')]
         [string[]]$Type,
         [PSCredential]$SourceSqlCredential,
         [PSCredential]$DestinationSqlCredential,

--- a/functions/New-DbaDbMailAccount.ps1
+++ b/functions/New-DbaDbMailAccount.ps1
@@ -74,7 +74,7 @@ function New-DbaDbMailAccount {
         [string]$EmailAddress,
         [string]$ReplyToAddress,
         [string]$MailServer,
-        [swithc]$Force,
+        [switch]$Force,
         [switch]$EnableException
     )
     process {

--- a/functions/New-DbaDbMailAccount.ps1
+++ b/functions/New-DbaDbMailAccount.ps1
@@ -36,6 +36,9 @@ function New-DbaDbMailAccount {
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
+    .PARAMETER Force
+        If this switch is enabled, the Mail Account will be created even if the mail server is not present.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -71,6 +74,7 @@ function New-DbaDbMailAccount {
         [string]$EmailAddress,
         [string]$ReplyToAddress,
         [string]$MailServer,
+        [swithc]$Force,
         [switch]$EnableException
     )
     process {
@@ -82,9 +86,8 @@ function New-DbaDbMailAccount {
             }
 
             if (Test-Bound -ParameterName MailServer) {
-                if (-not (Get-DbaDbMailServer -SqlInstance $server -Server $MailServer)) {
-                    # Perhaps we should add a force to auto create the mail server
-                    Stop-Function -Message "The mail server '$MailServer' does not exist on $instance" -ErrorRecord $_ -Target $instance -Continue
+                if (-not (Get-DbaDbMailServer -SqlInstance $server -Server $MailServer) -and -not (Test-Bound -ParameterName Force)) {
+                    Stop-Function -Message "The mail server '$MailServer' does not exist on $instance. Use -Force if you need to create it anyway." -ErrorRecord $_ -Target $instance -Continue
                 }
             }
 

--- a/tests/Copy-DbaDbMail.Tests.ps1
+++ b/tests/Copy-DbaDbMail.Tests.ps1
@@ -12,8 +12,95 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $servers = Connect-DbaInstance -SqlInstance $script:instance2, $script:instance3
+        foreach ($s in $servers) {
+            if ( (Get-DbaSpConfigure -SqlInstance $s -Name 'Database Mail XPs').RunningValue -ne 1 ) {
+                Set-DbaSpConfigure -SqlInstance $s -Name 'Database Mail XPs' -Value 1
+            }
+        }
+
+        $accountName = "dbatoolsci_test_$(get-random)"
+        $account_display_name = 'dbatoolsci mail alerts'
+        $account_description = 'Mail account for email alerts'
+        $profilename = "dbatoolsci_test_$(get-random)"
+        $profile_description = 'Mail profile for email alerts'
+
+        $email_address = 'dbatoolssci@dbatools.io'
+        $mailserver_name = 'smtp.dbatools.io'
+        $replyto_address = 'no-reply@dbatools.io'
+        $mailaccountpriority = 1
+
+
+        $splat1 = @{
+            SqlInstance    = $script:instance2
+            Name           = $accountName
+            Description    = $account_description
+            EmailAddress   = $email_address
+            DisplayName    = $account_display_name
+            ReplyToAddress = $replyto_address
+            MailServer     = $mailserver_name
+        }
+        $null = New-DbaDbMailAccount @splat1 -Force
+
+        $splat2 = @{
+            SqlInstance         = $script:instance2
+            Name                = $profilename
+            Description         = $profile_description
+            MailAccountName     = $email_address
+            MailAccountPriority = $mailaccountpriority
+        }
+        $null = New-DbaDbMailProfile @splat2
+
+    }
+    AfterAll {
+        $servers = Connect-DbaInstance -SqlInstance $script:instance2, $script:instance3
+
+        foreach ($s in $servers) {
+            $mailAccountSettings = "EXEC msdb.dbo.sysmail_delete_account_sp @account_name = '$accountname';"
+            Invoke-DbaQuery -SqlInstance $s -Query $mailAccountSettings -Database msdb
+            $mailProfileSettings = "EXEC msdb.dbo.sysmail_delete_profile_sp @profile_name = '$profilename';"
+            Invoke-DbaQuery -SqlInstance $s -Query $mailProfileSettings -Database msdb
+
+        }
+    }
+
+    Context "Copy DbMail to $script:instance3" {
+        $results = Copy-DbaDbMail -Source $script:instance2 -Destination $script:instance3
+
+        It "Should have copied database mailitems" {
+            $results | Should Not Be $null
+        }
+        foreach ($r in $results) {
+            if ($r.type -in @('Mail Configuration', 'Mail Account', 'Mail Profile')) {
+                It "Should have copied $($r.type) from $script:instance2" {
+                    $r.SourceServer | Should Be "$script:instance2"
+                }
+                It "Should have copied $($r.type) to $script:instance3" {
+                    $r.DestinationServer | Should Be "$script:instance3"
+                }
+            }
+        }
+    }
+
+    Context "Copy MailServers specifically" {
+        $results = Copy-DbaDbMail -Source $script:instance2 -Destination $script:instance3 -Type MailServers
+
+        It "Should have copied database mailitems" {
+            $results | Should Not Be $null
+        }
+
+        foreach ($r in $results) {
+            It "Should have $($r.status) $($r.type) from $script:instance2" {
+                $r.SourceServer | Should Be "$script:instance2"
+                $r.status | Should Be 'Skipped'
+            }
+            It "Should have $($r.status) $($r.type) to $script:instance3" {
+                $r.DestinationServer | Should Be "$script:instance3"
+                $r.status | Should Be 'Skipped'
+            }
+        }
+    }
+}

--- a/tests/New-DbaDbMailAccount.Tests.ps1
+++ b/tests/New-DbaDbMailAccount.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('WhatIf', 'Confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'DisplayName', 'Description', 'EmailAddress', 'ReplyToAddress', 'MailServer', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'DisplayName', 'Description', 'EmailAddress', 'ReplyToAddress', 'MailServer', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Adding Integration Test to existing cmdlet. 
Add `-Force` parameter to `Add-DbaDbMailAccount` as suggested in the comments of code. It would not create an account with a  mail server because of a check that looked at existing accounts with mail servers (i.e. it had a loop). 
Corrected some help in `Copy-DbaDbMail` that had incorrect values.

### Approach
<!-- How does this change solve that purpose -->
Create MailAccounts, and Mail Profiles. Copy these items to a second instance. Remove the items after validating that they were copied.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Invoke-Pester .\tests\Copy-DbaDbMail.Tests.ps1`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/13426972/59559412-c99f2680-8fd4-11e9-87c8-ca224a86c2c3.png)


