### PR TITLE
Update from fred - fixes #5036 - Restore-DbaDatabase

### DIFF
--- a/functions/Format-DbaBackupInformation.ps1
+++ b/functions/Format-DbaBackupInformation.ps1
@@ -144,7 +144,7 @@ function Format-DbaBackupInformation {
 
     process {
 
-        foreach ($History in $BackupHistory) {
+        foreach ($History in ($BackupHistory | Select-Object *)) {
             if ("OriginalDatabase" -notin $History.PSobject.Properties.name) {
                 $History | Add-Member -Name 'OriginalDatabase' -Type NoteProperty -Value $History.Database
             }


### PR DESCRIPTION
re: Restore-DbaDatabase changes paths in the backup history object

```
I'll admit I was being a bit martial and it _is_ a breaking change for `Format-DbaBackupInformation` (by hopefully breaking that habit)

"breaking" light. Basically the issue complained about could also be seen as a feature by some - updating the existing object.

Since it also returns them, we don't really have much breakage here (I hope) as workflows are concerned
```