### PR TITLE
Add support for SQL Server 2000 and piping to Restore-DbaDatabase

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -299,7 +299,7 @@ function Get-DbaBackupInformation {
                 $historyObject.Start = [DateTime]$group.Group[0].BackupStartDate
                 $historyObject.End = [DateTime]$group.Group[0].BackupFinishDate
                 $historyObject.Duration = ([DateTime]$group.Group[0].BackupFinishDate - [DateTime]$group.Group[0].BackupStartDate)
-                $historyObject.Path = [string[]]$group.Group.BackupPath
+                $historyObject.Path = ([string[]]$group.Group.BackupPath | Sort-Object -Unique)
                 $historyObject.FileList = ($group.Group.FileList | Select-Object Type, LogicalName, PhysicalName -Unique)
                 $historyObject.TotalSize = ($group.Group.BackupSize.Byte | Measure-Object -Sum).Sum
                 $HistoryObject.CompressedBackupSize = ($group.Group.CompressedBackupSize.Byte | Measure-Object -Sum).Sum

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -326,8 +326,12 @@ function Restore-DbaDatabase {
     param (
         [parameter(Mandatory)][DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")][parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")][object[]]$Path,
-        [parameter(ValueFromPipeline)][Alias("Name")][object[]]$DatabaseName,
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Restore")]
+        [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "RestorePage")]
+        [object[]]$Path,
+        [parameter(ValueFromPipeline)]
+        [Alias("Name")]
+        [string[]]$DatabaseName,
         [parameter(ParameterSetName = "Restore")][String]$DestinationDataDirectory,
         [parameter(ParameterSetName = "Restore")][String]$DestinationLogDirectory,
         [parameter(ParameterSetName = "Restore")][String]$DestinationFileStreamDirectory,
@@ -637,8 +641,8 @@ function Restore-DbaDatabase {
             return
         }
         if ($PSCmdlet.ParameterSetName -like "Restore*") {
-            if ($BackupHistory.Count -eq 0) {
-                Write-Message -Level Warning -Message "No backups passed through. `n This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
+            if ($BackupHistory.Count -eq 0 -and $RestoreInstance.VersionMajor -ne 8) {
+                Write-Message -Level Warning -Message "No backups passed through. This could mean the SQL instance cannot see the referenced files, the file's headers could not be read or some other issue"
                 return
             }
             Write-Message -message "Processing DatabaseName - $DatabaseName" -Level Verbose


### PR DESCRIPTION
Previously, it kept saying "No backups passed through". This ignores the check which doesn't work only on sql2000 and I also saw sql2000 had some dupes so I added a Sort-Object -Unique to ensure there were no dupes. 

Code used to test: `Get-DbaDatabase -SqlInstance sql2000 -Database pubs32 |Backup-DbaDatabase -Path C:\temp |Restore-DbaDatabase -SqlInstance sql2000 -WithReplace`