### PR TITLE
Invoke-DbatoolsFormatter, fix #5790

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -45,6 +45,10 @@ function Invoke-DbatoolsFormatter {
         $CBHRex = [regex]'(?smi)\s+<#[^#]*#>'
         $CBHStartRex = [regex]'(?<spaces>[ ]+)<#'
         $CBHEndRex = [regex]'(?<spaces>[ ]*)#>'
+        $OSEOL = "`n"
+        if ($psVersionTable.Platform -ne 'Unix') {
+            $OSEOL = "`r`n"
+        }
     }
     process {
         if (Test-FunctionInterrupt) { return }
@@ -57,7 +61,7 @@ function Invoke-DbatoolsFormatter {
 
             $content = Get-Content -Path $realPath -Raw -Encoding UTF8
             #strip ending empty lines
-            $content = $content -replace "(?s)`r`n\s*$"
+            $content = $content -replace "(?s)$OSEOL\s*$"
             try {
                 $content = Invoke-Formatter -ScriptDefinition $content -Settings CodeFormattingOTBS -ErrorAction Stop
             } catch {
@@ -83,7 +87,7 @@ function Invoke-DbatoolsFormatter {
             foreach ($line in $content.Split("`n")) {
                 $realContent += $line.TrimEnd()
             }
-            [System.IO.File]::WriteAllText($realPath, ($realContent -Join "`r`n"), $Utf8NoBomEncoding)
+            [System.IO.File]::WriteAllText($realPath, ($realContent -Join "$OSEOL"), $Utf8NoBomEncoding)
         }
     }
 }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5790)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Make Invoke-DbaToolsFormatter multiplatform (still waiting for PSSA to release a fix about OTSB, last working version is 1.17.0, but that's another story)
