### PR TITLE
Exportt-DbaScript updates  to honor ScriptingOptions

### DIFF
--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -8,8 +8,10 @@ function Export-DbaScript {
 
     .PARAMETER InputObject
         A SQL Management Object such as the one returned from Get-DbaLogin
+
     .PARAMETER Path
         Specifies the directory where the file or files will be exported.
+        Will default to Path.DbatoolsExport Configuration entry
 
     .PARAMETER FilePath
         Specifies the full file path of the output file.
@@ -32,9 +34,10 @@ function Export-DbaScript {
 
     .PARAMETER ScriptingOptionsObject
         An SMO Scripting Object that can be used to customize the output - see New-DbaScriptingOption
+        Options set in the ScriptingOptionsObject may override other parameter values
 
     .PARAMETER BatchSeparator
-        Specifies the Batch Separator to use. Default is None
+        Specifies the Batch Separator to use. Uses the value from configuration Formatting.BatchSeparator by default. This is normally "GO"
 
     .PARAMETER NoPrefix
         Do not include a Prefix
@@ -70,21 +73,21 @@ function Export-DbaScript {
     .EXAMPLE
         PS C:\> Get-DbaAgentJob -SqlInstance sql2016 | Export-DbaScript
 
-        Exports all jobs on the SQL Server sql2016 instance using a trusted connection - automatically determines filename as .\sql2016-Job-Export-date.sql
+        Exports all jobs on the SQL Server sql2016 instance using a trusted connection - automatically determines filename based on the Path.DbatoolsExport configuration setting, current time and server name.
 
     .EXAMPLE
-        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 | Export-DbaScript -Path C:\temp\export.sql -Append
+        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 | Export-DbaScript -FilePath C:\temp\export.sql -Append
 
         Exports all jobs on the SQL Server sql2016 instance using a trusted connection - Will append the output to the file C:\temp\export.sql if it already exists
-        Script does not include Batch Separator and will not compile
+        Inclusion of Batch Separator in script depends on the configuration s not include Batch Separator and will not compile
 
     .EXAMPLE
-        PS C:\> Get-DbaDbTable -SqlInstance sql2016 -Database MyDatabase -Table 'dbo.Table1', 'dbo.Table2' -SqlCredential sqladmin | Export-DbaScript -Path C:\temp\export.sql
+        PS C:\> Get-DbaDbTable -SqlInstance sql2016 -Database MyDatabase -Table 'dbo.Table1', 'dbo.Table2' -SqlCredential sqladmin | Export-DbaScript -FilePath C:\temp\export.sql
 
         Exports only script for 'dbo.Table1' and 'dbo.Table2' in MyDatabase to C:temp\export.sql and uses the SQL login "sqladmin" to login to sql2016
 
     .EXAMPLE
-        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 -Job syspolicy_purge_history, 'Hourly Log Backups' -SqlCredential sqladmin | Export-DbaScript -Path C:\temp\export.sql -NoPrefix
+        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 -Job syspolicy_purge_history, 'Hourly Log Backups' -SqlCredential sqladmin | Export-DbaScript -FilePath C:\temp\export.sql -NoPrefix
 
         Exports only syspolicy_purge_history and 'Hourly Log Backups' to C:temp\export.sql and uses the SQL login "sqladmin" to login to sql2016
         Suppress the output of a Prefix
@@ -97,10 +100,10 @@ function Export-DbaScript {
         PS C:\> $Options.NoCommandTerminator = $false
         PS C:\> $Options.ScriptBatchTerminator = $true
         PS C:\> $Options.AnsiFile = $true
-        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 -Job syspolicy_purge_history, 'Hourly Log Backups' -SqlCredential sqladmin | Export-DbaScript -Path C:\temp\export.sql -ScriptingOptionsObject $options
+        PS C:\> Get-DbaAgentJob -SqlInstance sql2016 -Job syspolicy_purge_history, 'Hourly Log Backups' -SqlCredential sqladmin | Export-DbaScript -FilePath C:\temp\export.sql -ScriptingOptionsObject $options
 
         Exports only syspolicy_purge_history and 'Hourly Log Backups' to C:temp\export.sql and uses the SQL login "sqladmin" to login to sql2016
-        Appends a batch separator at end of each script.
+        Uses Scripting options to ensure Batch Terminator is set
 
     .EXAMPLE
         PS C:\> Get-DbaAgentJob -SqlInstance sql2014 | Export-DbaScript -Passthru | ForEach-Object { $_.Replace('sql2014','sql2016') } | Set-Content -Path C:\temp\export.sql
@@ -117,7 +120,7 @@ function Export-DbaScript {
         PS C:\> $Options.AnsiFile = $true
         PS C:\> $Databases = Get-DbaDatabase -SqlInstance sql2016 -ExcludeDatabase master, model, msdb, tempdb
         PS C:\> foreach ($db in $Databases) {
-        >>        Export-DbaScript -InputObject $db -Path C:\temp\export.sql -Append -Encoding UTF8 -ScriptingOptionsObject $options -NoPrefix
+        >>        Export-DbaScript -InputObject $db -FilePath C:\temp\export.sql -Append -Encoding UTF8 -ScriptingOptionsObject $options -NoPrefix
         >> }
 
         Exports Script for each database on sql2016 excluding system databases
@@ -136,7 +139,7 @@ function Export-DbaScript {
         [string]$FilePath,
         [ValidateSet('ASCII', 'BigEndianUnicode', 'Byte', 'String', 'Unicode', 'UTF7', 'UTF8', 'Unknown')]
         [string]$Encoding = 'UTF8',
-        [string]$BatchSeparator = '',
+        [string]$BatchSeparator = (Get-DbatoolsConfigValue -FullName 'Formatting.BatchSeparator'),
         [switch]$NoPrefix,
         [switch]$Passthru,
         [switch]$NoClobber,
@@ -148,6 +151,20 @@ function Export-DbaScript {
         $executingUser = [Security.Principal.WindowsIdentity]::GetCurrent().Name
         $commandName = $MyInvocation.MyCommand.Name
         $prefixArray = @()
+
+        $appendToScript = $Append
+        if ($ScriptingOptionsObject) {
+            # Check if BatchTerminator is consistent
+            if (($($ScriptingOptionsObject.ScriptBatchTerminator)) -and ([string]::IsNullOrWhitespace($BatchSeparator))) {
+                Write-Message -Level Warning -Message "Setting ScriptBatchTerminator to true and also having BatchSeperarator as an empty or null string may produce unintended results."
+            }
+
+            if ($ScriptingOptionsObject.AppendToFile) {
+                Write-Message -Level Verbose -Message "The ScriptingOptionsObject AppendToFile setting of true will override Append parameter."
+                $appendToScript = $true
+            }
+        }
+
     }
 
     process {
@@ -188,18 +205,21 @@ function Export-DbaScript {
 
             try {
                 $server = $parent
-                if (-not $server) {
-                    $server = $object.Parent
-                }
                 $serverName = $server.Name.Replace('\', '$')
 
+                $scripter = New-Object Microsoft.SqlServer.Management.Smo.Scripter $server
                 if ($ScriptingOptionsObject) {
-                    $scripter = New-Object Microsoft.SqlServer.Management.Smo.Scripter $server
                     $scripter.Options = $ScriptingOptionsObject
+                    $scriptBatchTerminator = $ScriptingOptionsObject.ScriptBatchTerminator
+                    $soAppendToFile = $ScriptingOptionsObject.AppendToFile
+                    $soToFileOnly = $ScriptingOptionsObject.ToFileOnly
+                    $soFileName = $ScriptingOptionsObject.FileName
                 }
 
                 if (-not $passthru) {
-                    $FilePath = Get-ExportFilePath -Path $PSBoundParameters.Path -FilePath $PSBoundParameters.FilePath -Type sql -ServerName $serverName
+                    $scriptPath = Get-ExportFilePath -Path $PSBoundParameters.Path -FilePath $PSBoundParameters.FilePath -Type sql -ServerName $serverName
+                } else {
+                    $scriptPath = 'Console'
                 }
 
                 if ($NoPrefix) {
@@ -213,75 +233,80 @@ function Export-DbaScript {
                         $prefix | Out-String
                     }
                 } else {
-                    if ($prefixArray -notcontains $FilePath) {
-                        if ((Test-Path -Path $FilePath) -and $NoClobber) {
-                            Stop-Function -Message "File already exists. If you want to overwrite it remove the -NoClobber parameter. If you want to append data, please Use -Append parameter." -Target $FilePath -Continue
+                    if ($prefixArray -notcontains $scriptPath) {
+                        if ((Test-Path -Path $scriptPath) -and $NoClobber) {
+                            Stop-Function -Message "File already exists. If you want to overwrite it remove the -NoClobber parameter. If you want to append data, please Use -Append parameter." -Target $scriptPath -Continue
                         }
                         #Only at the first output we use the passed variables Append & NoClobber. For this execution the next ones need to buse -Append
                         if ($null -ne $prefix) {
-                            $prefix | Out-File -FilePath $FilePath -Encoding $encoding -Append:$Append -NoClobber:$NoClobber
-                            $prefixArray += $FilePath
+                            $prefix | Out-File -FilePath $scriptPath -Encoding $encoding -Append:$appendToScript -NoClobber:$NoClobber
+                            $prefixArray += $scriptPath
+                            Write-Message -Level Verbose -Message "Writing prefix to file $scriptPath"
                         }
                     }
                 }
 
-                if ($Pscmdlet.ShouldProcess($env:computername, "Exporting $object from $server to $FilePath")) {
+                if ($Pscmdlet.ShouldProcess($env:computername, "Exporting $object from $server to $scriptPath")) {
                     Write-Message -Level Verbose -Message "Exporting $object"
 
                     if ($passthru) {
                         if ($ScriptingOptionsObject) {
+                            $ScriptingOptionsObject.FileName = $null
                             foreach ($scriptpart in $scripter.EnumScript($object)) {
-                                if ($BatchSeparator -ne "") {
+                                if ($scriptBatchTerminator) {
                                     $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
                                 }
                                 $scriptpart | Out-String
                             }
                         } else {
-                            if (Get-Member -Name ScriptCreate -InputObject $object) {
-                                $scriptpart = $object.ScriptCreate().GetScript()
-                            } else {
-                                $scriptpart = $object.Script()
+                            foreach ($scriptpart in $scripter.EnumScript($object)) {
+                                if ($BatchSeparator) {
+                                    $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
+                                } else {
+                                    $scriptpart = "$scriptpart`r`n"
+                                }
+                                $scriptpart  | Out-String
                             }
-
-                            if ($BatchSeparator -ne "") {
-                                $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
-                            }
-                            $scriptpart  | Out-String
                         }
                     } else {
                         if ($ScriptingOptionsObject) {
-                            if ($ScriptingOptionsObject.ScriptBatchTerminator) {
-                                $ScriptingOptionsObject.AppendToFile = $true
+                            if ($scriptBatchTerminator) {
+                                # Option to script batch terminator via ScriptingOptionsObject needs to write to file only
+                                $ScriptingOptionsObject.AppendToFile = (($null -ne $prefix) -or $appendToScript )
                                 $ScriptingOptionsObject.ToFileOnly = $true
                                 if (-not  $ScriptingOptionsObject.FileName) {
-                                    $ScriptingOptionsObject.FileName = $FilePath
+                                    $ScriptingOptionsObject.FileName = $scriptPath
                                 }
-                                $object.Script($ScriptingOptionsObject)
+                                $null = $object.Script($ScriptingOptionsObject)
+                                # Reset the changed values of the $ScriptingOptionsObject in case it is reused later
+                                $ScriptingOptionsObject.AppendToFile = $soAppendToFile
+                                $ScriptingOptionsObject.ToFileOnly = $soToFileOnly
+                                $ScriptingOptionsObject.FileName = $soFileName
                             } else {
+                                $ScriptingOptionsObject.FileName = $null
                                 foreach ($scriptpart in $scripter.EnumScript($object)) {
-                                    if ($BatchSeparator -ne "") {
+                                    if ($scriptBatchTerminator) {
                                         $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
                                     }
-                                    $scriptpart | Out-File -FilePath $FilePath -Encoding $encoding -Append
+                                    $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                                 }
+                                $ScriptingOptionsObject.FileName = $soFileName
                             }
-
                         } else {
-                            if (Get-Member -Name ScriptCreate -InputObject $object) {
-                                $scriptpart = $object.ScriptCreate().GetScript()
-                            } else {
-                                $scriptpart = $object.Script()
+                            foreach ($scriptpart in $scripter.EnumScript($object)) {
+                                if ($BatchSeparator) {
+                                    $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
+                                } else {
+                                    $scriptpart = "$scriptpart`r`n"
+                                }
+                                $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                             }
-                            if ($BatchSeparator -ne "") {
-                                $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
-                            }
-                            $scriptpart | Out-File -FilePath $FilePath -Encoding $encoding -Append
                         }
                     }
 
                     if (-not $passthru) {
-                        Write-Message -Level Verbose -Message "Exported $object on $($server.Name) to $FilePath"
-                        Get-ChildItem -Path $FilePath
+                        Write-Message -Level Verbose -Message "Exported $object on $($server.Name) to $scriptPath"
+                        Get-ChildItem -Path $scriptPath
                     }
                 }
             } catch {

--- a/tests/Export-DbaScript.Tests.ps1
+++ b/tests/Export-DbaScript.Tests.ps1
@@ -19,6 +19,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "should export some text matching create table" {
             $script:results -match "CREATE TABLE"
         }
+        It "should include BatchSeparator based on the Formatting.BatchSeparator configuration" {
+            $script:results -match "(Get-DbatoolsConfigValue -FullName 'Formatting.BatchSeparator')"
+        }
+
+        $script:results = Get-DbaDbTable -SqlInstance $script:instance2 -Database msdb | Select -First 1 | Export-DbaScript -Passthru -BatchSeparator "MakeItSo"
+        It "should include the defined BatchSeparator" {
+            $script:results -match "MakeItSo"
+        }
         $null = [pscustomobject]@{ Invalid = $true } | Export-DbaScript -WarningVariable invalid -WarningAction Continue
         It "should not accept non-SMO objects" {
             $invalid -match "not a SQL Management Object"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5679 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing issues with Export-DbaScript to resolve

(a) Conflicts between ScriptBatchTerminator in Scripting options and BatchSeparator parameter
(b) Not adding a Prefix when scripting to a file via scripting options
(c) Issues with changing the scripting options inside function
(d) Examples still referring to Path parameter rather than FilePath
(e) Using Formatting.BatchSeparator configuration to Standize use of BatchSeparator  #5514 
(f) Conflict between AppendToFile in Scripting options and Append parameter

### Approach
Modifies code to give precedence to the settings passed via Scripting Options object
There are still potential conflicts with the Encoding parameter and settings in the Scripting options object

### Commands to test
Export-DbaScript 


