### PR TITLE
Fix error on manifest for Get-DbaDbBackupHistory

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -134,7 +134,7 @@
         'Get-DbaPermission',
         'Get-DbaLastBackup',
         'Connect-DbaInstance',
-        ' Get-DbaDbBackupHistory',
+        'Get-DbaDbBackupHistory',
         'Read-DbaBackupHeader',
         'Test-DbaLastBackup',
         'Get-DbaMaxMemory',


### PR DESCRIPTION
Leading space found in manifest for this command.