### PR TITLE
Add-Dba-Ag-Database - Added fix for named instances

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -174,11 +174,17 @@ function Add-DbaAgDatabase {
             }
 
             foreach ($secondaryInstance in $secondaryInstances) {
-
-                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $secondaryInstance.NetName
+			
+				$secondaryInstanceReplicaName = $secondaryInstance.ComputerName
+				
+				if ($secondaryInstance.InstanceName){	
+					$secondaryInstanceReplicaName = $secondaryInstanceReplicaName, $secondaryInstance.InstanceName -join "\"
+				}
+				
+                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SecondarySqlCredential -AvailabilityGroup $ag.name -Replica $secondaryInstanceReplicaName
 
                 if (-not $agreplica) {
-                    Stop-Function -Continue -Message "Could not connect to instance $($secondaryInstance.Name)"
+                    Stop-Function -Continue -Message "Could not connect get secondary replica $($secondaryInstanceReplicaName) from $($Primary.Name)"
                 }
 
                 if ($SeedingMode -eq "Automatic" -and $secondaryInstance.VersionMajor -le 12) {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -174,13 +174,13 @@ function Add-DbaAgDatabase {
             }
 
             foreach ($secondaryInstance in $secondaryInstances) {
-			
-				$secondaryInstanceReplicaName = $secondaryInstance.ComputerName
-				
-				if ($secondaryInstance.InstanceName){	
-					$secondaryInstanceReplicaName = $secondaryInstanceReplicaName, $secondaryInstance.InstanceName -join "\"
-				}
-				
+
+                $secondaryInstanceReplicaName = $secondaryInstance.ComputerName
+
+                if ($secondaryInstance.InstanceName) {
+                    $secondaryInstanceReplicaName = $secondaryInstanceReplicaName, $secondaryInstance.InstanceName -join "\"
+                }
+
                 $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SecondarySqlCredential -AvailabilityGroup $ag.name -Replica $secondaryInstanceReplicaName
 
                 if (-not $agreplica) {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -175,7 +175,11 @@ function Add-DbaAgDatabase {
 
             foreach ($secondaryInstance in $secondaryInstances) {
 
-                $secondaryInstanceReplicaName = $secondaryInstance.ComputerName
+                try {
+                    $secondaryInstanceReplicaName = $secondaryInstance.NetName
+                } catch {
+                    $secondaryInstanceReplicaName = $secondaryInstance.ComputerName
+                }
 
                 if ($secondaryInstance.InstanceName) {
                     $secondaryInstanceReplicaName = $secondaryInstanceReplicaName, $secondaryInstance.InstanceName -join "\"


### PR DESCRIPTION
$SecondaryInstance.netname wasn't the correct AG replica name

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5808  )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix #5808

### Approach
Construct the secondary replica name using the ComputerName + InstanceName properties

### Commands to test
Add-DbaAgDatabase with a named instance as the secondary
