### PR TITLE
fixed issue 5803

### DIFF
--- a/internal/functions/Get-SqlInstanceUpdate.ps1
+++ b/internal/functions/Get-SqlInstanceUpdate.ps1
@@ -112,7 +112,7 @@ function Get-SqlInstanceUpdate {
                     $targetKB = Get-DbaBuildReference -Build $latestCU.BuildTarget
                     $targetSP = $targetKB.SPLevel | Where-Object { $_ -ne 'LATEST' } | Select-Object -First 1
                     if ($Type -eq 'CumulativeUpdate') {
-                        if ($currentVersion.SPLevel -notcontains 'LATEST') {
+                        if ($currentVersion.SPLevel -ne $targetSP) {
                             $currentSP = $currentVersion.SPLevel | Where-Object { $_ -ne 'LATEST' } | Select-Object -First 1
                             Stop-Function -Message "Current SP version $currentMajorVersion$currentSP is not the latest available. Make sure to upgade to latest SP level before applying latest CU." -Continue
                         }


### PR DESCRIPTION
 - [X] Bug fix (non-breaking change, fixes #5803


I have changed `if ($currentVersion.SPLevel -notcontains 'LATEST')` to `if ($currentVersion.SPLevel -ne $targetSP)`

tested:
Just updated a SQL Server 2016 SP2 CU6 to CU7 and all looks ok.
ComputerName : ZZZZZZZ.ZZZZZZZ.ZZZZZ
MajorVersion : 2016
TargetLevel  : SP2CU7
KB           : 4495256
Successful   : True
Restarted    : True
InstanceName :
Installer    : \\share\SQL Server
               2016\SP2_CU7\SQLServer2016-KB4495256-x64.exe
Notes        : {}