### PR TITLE
New-DbaAgentJobStep - fixes #5812 and adds a little test coverage

### DIFF
--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -171,7 +171,7 @@ function New-DbaAgentJobStep {
 
     begin {
         if ($Force) {$ConfirmPreference = 'none'}
-        
+
         # Check the parameter on success step id
         if (($OnSuccessAction -ne 'GoToStep') -and ($OnSuccessStepId -ge 1)) {
             Stop-Function -Message "Parameter OnSuccessStepId can only be used with OnSuccessAction 'GoToStep'." -Target $SqlInstance
@@ -369,10 +369,10 @@ function New-DbaAgentJobStep {
                         } catch {
                             Stop-Function -Message "Something went wrong creating the job step" -Target $instance -ErrorRecord $_ -Continue
                         }
-                    }
 
-                    # Return the job step
-                    $JobStep
+                        # Return the job step
+                        $JobStep
+                    }
                 }
             } # foreach object job
         } # foreach object instance

--- a/tests/New-DbaAgentJobStep.Tests.ps1
+++ b/tests/New-DbaAgentJobStep.Tests.ps1
@@ -16,15 +16,39 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "New Agent Job Step is added properly" {
         AfterAll {
-            Remove-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job One"
+            Remove-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job One","dbatoolsci Job Two"
         }
         # Create job to add step to
         $job = New-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job One" -Description "Just another job"
+        $jobTwo = New-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job Two" -Description "Just another job"
 
         It "Should have the right name and description" {
             $results = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $job -StepName "Step One"
             $results.Name | Should -Be "Step One"
         }
+
+        It "Should have the right properties" {
+            $jobStep = @{
+                SqlInstance = $script:instance2
+                Job = $jobTwo
+                StepName = "Step X"
+                Subsystem = "TransactSql"
+                Command = "select 1"
+                Database = "master"
+                RetryAttempts = 2
+                RetryInterval = 5
+                OutputFileName = "log.txt"
+            }
+            $results = New-DbaAgentJobStep @jobStep
+            $results.Name | Should -Be "Step X"
+            $results.Subsystem | Should -Be "TransactSql"
+            $results.Command | Should -Be "Select 1"
+            $results.DatabaseName | Should -Be "master"
+            $results.RetryAttempts | Should -Be 2
+            $results.RetryInterval | Should -Be 5
+            $results.OutputFileName | Should -Be "log.txt"
+        }
+
 
         It "Should actually for sure exist" {
             $newresults = Get-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job One"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5812 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes #5812 - moves the output within the should process block
Adds a little test coverage - testing properties are set

### Approach
Moves output of jobstep within the should process block, it's throwing an error trying to output when the step wasn't created.

### Commands to test
see #5812 

