### PR TITLE
Alert category

### DIFF
--- a/functions/Get-DbaAgentAlertCategory.ps1
+++ b/functions/Get-DbaAgentAlertCategory.ps1
@@ -60,11 +60,11 @@ function Get-DbaAgentAlertCategory {
             }
 
             # get all the alert categories
-            $alertCategories = $server.JobServer.AlertCategories 
+            $alertCategories = $server.JobServer.AlertCategories
             if (Test-Bound -ParameterName Category) {
-                $alertCategories = $exportObjects | Where-Object { $Category -contains $_ }
+                $alertCategories = $alertCategories | Where-Object { $_.Name -in $Category }
             }
-              
+
             # Set the default output
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'ID', 'AlertCount'
 
@@ -79,7 +79,7 @@ function Get-DbaAgentAlertCategory {
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
                     Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name JobCount -Value $alertCount
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name AlertCount -Value $alertCount
 
                     # Show the result
                     Select-DefaultView -InputObject $cat -Property $defaults
@@ -94,7 +94,7 @@ function Get-DbaAgentAlertCategory {
 
     end {
         if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished retrieving job category." -Level Verbose
+        Write-Message -Message "Finished retrieving alert category." -Level Verbose
     }
 
 }

--- a/functions/Get-DbaAgentAlertCategory.ps1
+++ b/functions/Get-DbaAgentAlertCategory.ps1
@@ -1,0 +1,100 @@
+function Get-DbaAgentAlertCategory {
+    <#
+    .SYNOPSIS
+        Get-DbaAgentAlertCategory retrieves the alert categories.
+
+    .DESCRIPTION
+        Get-DbaAgentAlertCategory makes it possible to retrieve the alert categories.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Windows and SQL Authentication supported. Accepts credential objects (Get-Credential)
+
+    .PARAMETER Category
+        The name of the category to filter out. If no category is used all categories will be returned.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Agent, Alert, AlertCategory
+        Author: Patrick Flynn (@sqllensman)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaAgentAlertCategory
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentAlertCategory -SqlInstance sql1
+
+        Return all the agent alert categories.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentAlertCategory -SqlInstance sql1 -Category 'Severity Alert'
+
+        Return all the agent alert categories that have the name 'Severity Alert'.
+
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstance[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Category,
+        [switch]$EnableException
+    )
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            # get all the alert categories
+            $alertCategories = $server.JobServer.AlertCategories 
+            if (Test-Bound -ParameterName Category) {
+                $alertCategories = $exportObjects | Where-Object { $Category -contains $_ }
+            }
+              
+            # Set the default output
+            $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'ID', 'AlertCount'
+
+            # Loop through each of the categories
+            try {
+                foreach ($cat in $alertCategories) {
+
+                    # Get the alerts associated with the category
+                    $alertCount = ($server.JobServer.Alerts | Where-Object {$_.CategoryName -eq $cat.Name}).Count
+
+                    # Add new properties to the category object
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
+                    Add-Member -Force -InputObject $cat -MemberType NoteProperty -Name JobCount -Value $alertCount
+
+                    # Show the result
+                    Select-DefaultView -InputObject $cat -Property $defaults
+                }
+            } catch {
+                Stop-Function -ErrorRecord $_ -Target $instance -Message "Failure. Collection may have been modified" -Continue
+            }
+
+        } # for each instance
+
+    } # end process
+
+    end {
+        if (Test-FunctionInterrupt) { return }
+        Write-Message -Message "Finished retrieving job category." -Level Verbose
+    }
+
+}

--- a/functions/New-DbaAgentAlertCategory.ps1
+++ b/functions/New-DbaAgentAlertCategory.ps1
@@ -52,7 +52,6 @@ function New-DbaAgentAlertCategory {
         Creates a new alert category with the name 'Category 2'.
 
     #>
-
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
@@ -72,7 +71,6 @@ function New-DbaAgentAlertCategory {
     process {
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
@@ -80,7 +78,6 @@ function New-DbaAgentAlertCategory {
             }
 
             foreach ($cat in $Category) {
-                # Check if the category already exists
                 if ($cat -in $server.JobServer.AlertCategories.Name) {
                     Stop-Function -Message "Alert category $cat already exists on $instance" -Target $instance -Continue
                 } else {
@@ -94,22 +91,10 @@ function New-DbaAgentAlertCategory {
                         } catch {
                             Stop-Function -Message "Something went wrong creating the alert category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
                         }
-
-                    } # if should process
-
-                } # end else category exists
-
-                # Return the alert category
+                    }
+                }
                 Get-DbaAgentAlertCategory -SqlInstance $server -Category $cat
-
-            } # for each category
-
-        } # for each instance
+            }
+        }
     }
-
-    end {
-        if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished creating alert category." -Level Verbose
-    }
-
 }

--- a/functions/New-DbaAgentAlertCategory.ps1
+++ b/functions/New-DbaAgentAlertCategory.ps1
@@ -1,10 +1,10 @@
-function New-DbaAgentJobCategory {
+function New-DbaAgentAlertCategory {
     <#
     .SYNOPSIS
-        New-DbaAgentJobCategory creates a new job category.
+        New-DbaAgentAlertCategory creates a new job category.
 
     .DESCRIPTION
-        New-DbaAgentJobCategory makes it possible to create a job category that can be used with jobs.
+        New-DbaAgentAlertCategory makes it possible to create a job category that can be used with jobs.
         It returns an array of the job categories created .
 
     .PARAMETER SqlInstance
@@ -43,15 +43,15 @@ function New-DbaAgentJobCategory {
         License: MIT https://opensource.org/licenses/MIT
 
     .LINK
-        https://dbatools.io/New-DbaAgentJobCategory
+        https://dbatools.io/New-DbaAgentAlertCategory
 
     .EXAMPLE
-        PS C:\> New-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 1'
+        PS C:\> New-DbaAgentAlertCategory -SqlInstance sql1 -Category 'Category 1'
 
         Creates a new job category with the name 'Category 1'.
 
     .EXAMPLE
-        PS C:\> New-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 2' -CategoryType MultiServerJob
+        PS C:\> New-DbaAgentAlertCategory -SqlInstance sql1 -Category 'Category 2' -CategoryType MultiServerJob
 
         Creates a new job category with the name 'Category 2' and assign the category type for a multi server job.
 

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -84,7 +84,7 @@ function New-DbaAgentJobCategory {
 
     process {
 
-        foreach ($instance in $sqlinstance) {
+        foreach ($instance in $SqlInstance) {
             # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
@@ -99,10 +99,10 @@ function New-DbaAgentJobCategory {
                 } else {
                     if ($PSCmdlet.ShouldProcess($instance, "Adding the job category $cat")) {
                         try {
-                            $jobcategory = New-Object Microsoft.SqlServer.Management.Smo.Agent.JobCategory($server.JobServer, $cat)
-                            $jobcategory.CategoryType = $CategoryType
+                            $jobCategory = New-Object Microsoft.SqlServer.Management.Smo.Agent.JobCategory($server.JobServer, $cat)
+                            $jobCategory.CategoryType = $CategoryType
 
-                            $jobcategory.Create()
+                            $jobCategory.Create()
 
                             $server.JobServer.Refresh()
                         } catch {

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -56,7 +56,6 @@ function New-DbaAgentJobCategory {
         Creates a new job category with the name 'Category 2' and assign the category type for a multi server job.
 
     #>
-
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
@@ -74,9 +73,7 @@ function New-DbaAgentJobCategory {
     begin {
         if ($Force) {$ConfirmPreference = 'none'}
 
-        # Check the category type
         if (-not $CategoryType) {
-            # Setting category type to default
             Write-Message -Message "Setting the category type to 'LocalJob'" -Level Verbose
             $CategoryType = "LocalJob"
         }
@@ -85,7 +82,6 @@ function New-DbaAgentJobCategory {
     process {
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
@@ -93,7 +89,6 @@ function New-DbaAgentJobCategory {
             }
 
             foreach ($cat in $Category) {
-                # Check if the category already exists
                 if ($cat -in $server.JobServer.JobCategories.Name) {
                     Stop-Function -Message "Job category $cat already exists on $instance" -Target $instance -Continue
                 } else {
@@ -108,22 +103,10 @@ function New-DbaAgentJobCategory {
                         } catch {
                             Stop-Function -Message "Something went wrong creating the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
                         }
-
-                    } # if should process
-
-                } # end else category exists
-
-                # Return the job category
+                    }
+                }
                 Get-DbaAgentJobCategory -SqlInstance $server -Category $cat
-
-            } # for each category
-
-        } # for each instance
+            }
+        }
     }
-
-    end {
-        if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished creating job category." -Level Verbose
-    }
-
 }

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -1,11 +1,11 @@
 function Remove-DbaAgentAlertCategory {
     <#
     .SYNOPSIS
-        Remove-DbaAgentAlertCategory removes a job category.
+        Remove-DbaAgentAlertCategory removes an alert category.
 
     .DESCRIPTION
-        Remove-DbaAgentAlertCategory makes it possible to remove a job category.
-        Be assured that the category you want to remove is not used with other jobs. If another job uses this category it will be get the category [Uncategorized (Local)].
+        Remove-DbaAgentAlertCategory makes it possible to remove an alert category.
+        Insure that the category you want to remove is not used with any alerts. If an alert uses this category it will be get the category [Uncategorized].
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -31,8 +31,8 @@ function Remove-DbaAgentAlertCategory {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Agent, Job, JobCategory
-        Author: Sander Stad (@sqlstad, sqlstad.nl)
+        Tags: Agent, Alert, AlertCategory
+        Author: Patrick Flynn (@sqllensman)
 
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT
@@ -44,17 +44,17 @@ function Remove-DbaAgentAlertCategory {
     .EXAMPLE
         PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1 -Category 'Category 1'
 
-        Remove the job category Category 1 from the instance.
+        Remove the alert category Category 1 from the instance.
 
     .EXAMPLE
         PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1 -Category Category1, Category2, Category3
 
-        Remove multiple job categories from the instance.
+        Remove multiple alert categories from the instance.
 
     .EXAMPLE
         PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1, sql2, sql3 -Category Category1, Category2, Category3
 
-        Remove multiple job categories from the multiple instances.
+        Remove multiple alert categories from the multiple instances.
 
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
@@ -72,7 +72,7 @@ function Remove-DbaAgentAlertCategory {
     }
     process {
 
-        foreach ($instance in $sqlinstance) {
+        foreach ($instance in $SqlInstance) {
             # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
@@ -83,22 +83,22 @@ function Remove-DbaAgentAlertCategory {
             # Loop through each of the categories
             foreach ($cat in $Category) {
 
-                # Check if the job category exists
-                if ($cat -notin $server.JobServer.JobCategories.Name) {
-                    Stop-Function -Message "Job category $cat doesn't exist on $instance" -Target $instance -Continue
+                # Check if the alert category exists
+                if ($cat -notin $server.JobServer.AlertCategories.Name) {
+                    Stop-Function -Message "Alert category $cat doesn't exist on $instance" -Target $instance -Continue
                 }
 
                 # Remove the category
-                if ($PSCmdlet.ShouldProcess($instance, "Removing the job category $Category")) {
+                if ($PSCmdlet.ShouldProcess($instance, "Removing the alert category $Category")) {
                     try {
                         # Get the category
-                        $currentCategory = $server.JobServer.JobCategories[$cat]
+                        $currentCategory = $server.JobServer.AlertCategories[$cat]
 
-                        Write-Message -Message "Removing job category $cat" -Level Verbose
+                        Write-Message -Message "Removing alert category $cat" -Level Verbose
 
                         $currentCategory.Drop()
                     } catch {
-                        Stop-Function -Message "Something went wrong removing the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
+                        Stop-Function -Message "Something went wrong removing the alert category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
                     }
 
                 } #if should process
@@ -111,7 +111,7 @@ function Remove-DbaAgentAlertCategory {
 
     end {
         if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished removing job category." -Level Verbose
+        Write-Message -Message "Finished removing alert category." -Level Verbose
     }
 
 }

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -73,25 +73,19 @@ function Remove-DbaAgentAlertCategory {
     process {
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            # Loop through each of the categories
             foreach ($cat in $Category) {
-
-                # Check if the alert category exists
                 if ($cat -notin $server.JobServer.AlertCategories.Name) {
                     Stop-Function -Message "Alert category $cat doesn't exist on $instance" -Target $instance -Continue
                 }
 
-                # Remove the category
                 if ($PSCmdlet.ShouldProcess($instance, "Removing the alert category $Category")) {
                     try {
-                        # Get the category
                         $currentCategory = $server.JobServer.AlertCategories[$cat]
 
                         Write-Message -Message "Removing alert category $cat" -Level Verbose
@@ -100,18 +94,8 @@ function Remove-DbaAgentAlertCategory {
                     } catch {
                         Stop-Function -Message "Something went wrong removing the alert category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
                     }
-
-                } #if should process
-
-            } # for each category
-
-        } # for each instance
-
-    } # end process
-
-    end {
-        if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished removing alert category." -Level Verbose
+                }
+            }
+        }
     }
-
 }

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -1,10 +1,10 @@
-function Remove-DbaAgentJobCategory {
+function Remove-DbaAgentAlertCategory {
     <#
     .SYNOPSIS
-        Remove-DbaAgentJobCategory removes a job category.
+        Remove-DbaAgentAlertCategory removes a job category.
 
     .DESCRIPTION
-        Remove-DbaAgentJobCategory makes it possible to remove a job category.
+        Remove-DbaAgentAlertCategory makes it possible to remove a job category.
         Be assured that the category you want to remove is not used with other jobs. If another job uses this category it will be get the category [Uncategorized (Local)].
 
     .PARAMETER SqlInstance
@@ -39,20 +39,20 @@ function Remove-DbaAgentJobCategory {
         License: MIT https://opensource.org/licenses/MIT
 
     .LINK
-        https://dbatools.io/Remove-DbaAgentJobCategory
+        https://dbatools.io/Remove-DbaAgentAlertCategory
 
     .EXAMPLE
-        PS C:\> Remove-DbaAgentJobCategory -SqlInstance sql1 -Category 'Category 1'
+        PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1 -Category 'Category 1'
 
         Remove the job category Category 1 from the instance.
 
     .EXAMPLE
-        PS C:\> Remove-DbaAgentJobCategory -SqlInstance sql1 -Category Category1, Category2, Category3
+        PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1 -Category Category1, Category2, Category3
 
         Remove multiple job categories from the instance.
 
     .EXAMPLE
-        PS C:\> Remove-DbaAgentJobCategory -SqlInstance sql1, sql2, sql3 -Category Category1, Category2, Category3
+        PS C:\> Remove-DbaAgentAlertCategory -SqlInstance sql1, sql2, sql3 -Category Category1, Category2, Category3
 
         Remove multiple job categories from the multiple instances.
 

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -72,7 +72,7 @@ function Remove-DbaAgentJobCategory {
     }
     process {
 
-        foreach ($instance in $sqlinstance) {
+        foreach ($instance in $SqlInstance) {
             # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -73,25 +73,19 @@ function Remove-DbaAgentJobCategory {
     process {
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            # Loop through each of the categories
             foreach ($cat in $Category) {
-
-                # Check if the job category exists
                 if ($cat -notin $server.JobServer.JobCategories.Name) {
                     Stop-Function -Message "Job category $cat doesn't exist on $instance" -Target $instance -Continue
                 }
 
-                # Remove the category
                 if ($PSCmdlet.ShouldProcess($instance, "Removing the job category $Category")) {
                     try {
-                        # Get the category
                         $currentCategory = $server.JobServer.JobCategories[$cat]
 
                         Write-Message -Message "Removing job category $cat" -Level Verbose
@@ -100,18 +94,8 @@ function Remove-DbaAgentJobCategory {
                     } catch {
                         Stop-Function -Message "Something went wrong removing the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
                     }
-
-                } #if should process
-
-            } # for each category
-
-        } # for each instance
-
-    } # end process
-
-    end {
-        if (Test-FunctionInterrupt) { return }
-        Write-Message -Message "Finished removing job category." -Level Verbose
+                }
+            }
+        }
     }
-
 }

--- a/tests/Get-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Get-DbaAgentAlertCategory.Tests.ps1
@@ -1,0 +1,37 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    Context "Command gets alert categories" {
+        BeforeAll {
+            $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+        }
+        AfterAll {
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+        }
+        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
+        It "Should get at least 2 categories" {
+            $results.count | Should BeGreaterThan 1
+        }
+        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory | Where-Object {$_.Name -match "dbatoolsci"}
+        It "Should get the dbatoolsci_testcategory category" {
+            $results.count | Should Be 1
+        }
+        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -CategoryType LocalJob | Where-Object {$_.Name -match "dbatoolsci"}
+        It "Should get at least 1 LocalJob" {
+            $results.count | Should BeGreaterThan 1
+        }
+    }
+}

--- a/tests/Get-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Get-DbaAgentAlertCategory.Tests.ps1
@@ -16,22 +16,18 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Command gets alert categories" {
         BeforeAll {
-            $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+            $null = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         AfterAll {
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+            $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
-        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get at least 2 categories" {
             $results.count | Should BeGreaterThan 1
         }
-        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get the dbatoolsci_testcategory category" {
             $results.count | Should Be 1
-        }
-        $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -CategoryType LocalJob | Where-Object {$_.Name -match "dbatoolsci"}
-        It "Should get at least 1 LocalJob" {
-            $results.count | Should BeGreaterThan 1
         }
     }
 }

--- a/tests/New-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/New-DbaAgentAlertCategory.Tests.ps1
@@ -1,0 +1,47 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'CategoryType', 'Force', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "New Agent Job Category is added properly" {
+
+        It "Should have the right name and category type" {
+            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1
+            $results.Name | Should Be "CategoryTest1"
+            $results.CategoryType | Should Be "LocalJob"
+        }
+
+        It "Should have the right name and category type" {
+            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 -CategoryType MultiServerJob
+            $results.Name | Should Be "CategoryTest2"
+            $results.CategoryType | Should Be "MultiServerJob"
+        }
+
+        It "Should actually for sure exist" {
+            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
+            $newresults[0].Name | Should Be "CategoryTest1"
+            $newresults[0].CategoryType | Should Be "LocalJob"
+            $newresults[1].Name | Should Be "CategoryTest2"
+            $newresults[1].CategoryType | Should Be "MultiServerJob"
+        }
+
+        It "Should not write over existing job categories" {
+            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -WarningAction SilentlyContinue -WarningVariable warn
+            $warn -match "already exists" | Should Be $true
+        }
+
+        # Cleanup and ignore all output
+        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 *> $null
+    }
+}

--- a/tests/New-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/New-DbaAgentAlertCategory.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'CategoryType', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -14,34 +14,30 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    Context "New Agent Job Category is added properly" {
+    Context "New Agent Alert Category is added properly" {
 
         It "Should have the right name and category type" {
-            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1
+            $results = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1
             $results.Name | Should Be "CategoryTest1"
-            $results.CategoryType | Should Be "LocalJob"
         }
 
         It "Should have the right name and category type" {
-            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 -CategoryType MultiServerJob
+            $results = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest2
             $results.Name | Should Be "CategoryTest2"
-            $results.CategoryType | Should Be "MultiServerJob"
         }
 
         It "Should actually for sure exist" {
-            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
+            $newresults = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
             $newresults[0].Name | Should Be "CategoryTest1"
-            $newresults[0].CategoryType | Should Be "LocalJob"
             $newresults[1].Name | Should Be "CategoryTest2"
-            $newresults[1].CategoryType | Should Be "MultiServerJob"
         }
 
         It "Should not write over existing job categories" {
-            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1 -WarningAction SilentlyContinue -WarningVariable warn
+            $results = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1 -WarningAction SilentlyContinue -WarningVariable warn
             $warn -match "already exists" | Should Be $true
         }
 
         # Cleanup and ignore all output
-        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 *> $null
+        $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
     }
 }

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -1,0 +1,42 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'Force', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "New Agent Job Category is changed properly" {
+
+        It "Should have the right name and category type" {
+            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+            $results[0].Name | Should Be "CategoryTest1"
+            $results[0].CategoryType | Should Be "LocalJob"
+            $results[1].Name | Should Be "CategoryTest2"
+            $results[1].CategoryType | Should Be "LocalJob"
+            $results[2].Name | Should Be "CategoryTest3"
+            $results[2].CategoryType | Should Be "LocalJob"
+        }
+
+        It "Should actually for sure exist" {
+            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+            $newresults.Count | Should Be 3
+        }
+
+        It "Remove the job categories" {
+            Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3
+
+            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+
+            $newresults.Count | Should Be 0
+        }
+    }
+}

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -14,27 +14,24 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    Context "New Agent Job Category is changed properly" {
+    Context "New Agent Alert Category is changed properly" {
 
-        It "Should have the right name and category type" {
-            $results = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+        It "Should have the right name" {
+            $results = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
             $results[0].Name | Should Be "CategoryTest1"
-            $results[0].CategoryType | Should Be "LocalJob"
             $results[1].Name | Should Be "CategoryTest2"
-            $results[1].CategoryType | Should Be "LocalJob"
             $results[2].Name | Should Be "CategoryTest3"
-            $results[2].CategoryType | Should Be "LocalJob"
         }
 
         It "Should actually for sure exist" {
-            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+            $newresults = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
             $newresults.Count | Should Be 3
         }
 
-        It "Remove the job categories" {
-            Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3
+        It "Remove the alert categories" {
+            Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3
 
-            $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
+            $newresults = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
 
             $newresults.Count | Should Be 0
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5376)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
In order to fix one of issues of #5376, namely scripting out alert categories it is necessary to add the functions to Add, Remove or Retrieve Alert Categories in SQL Agent. (similar to Job Categories)

Also fixed minor formatting issues in the AgentJobCategory functions 

### Commands to test
Get-DbaAgentAlertCategory
New-DbaAgentAlertCategory
Remove-DbaAgentAlertCategory
New-DbaAgentJobCategory
Remove-DbaAgentAlertCategory


