### PR TITLE
5853 Fix Import-DbaCsv not reading args

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -128,6 +128,8 @@ function Import-DbaCsv {
         You can also choose AdvanceToNextLine which basically ignores parse errors.
 
     .PARAMETER Encoding
+        By default, set to UTF-8.
+
         The encoding of the file.
 
     .PARAMETER NullValue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix for [[Bug] Import-DbaCsv Imports header row by default](https://github.com/sqlcollaborative/dbatools/issues/5853)

### Approach
The current system of forcing members of the CsvReader class seem to no longer work. 
Changed to use one of the constructors that takes all our args, but moved encoding to the StreamReader instantiation as for some reason the CsvReader constructors using that don't work!

### Commands to test
Import-DbaCsv using examples in help. Specific issues were test files with a header row always importing the header, and not being able to set a delimiter or string delimiter.
