### PR TITLE
Find-DbaCommand - fix command and ignore in appeyor tests

### DIFF
--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -97,15 +97,6 @@ function Find-DbaCommand {
             return $Text.Trim() -replace '(\r\n){2,}', "`n"
         }
 
-        # no idea why this is required
-        try {
-            Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Replication.dll" -ErrorAction Stop
-            Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Rmo.dll" -ErrorAction Stop
-        } catch {
-            Stop-Function -Message "Could not load replication libraries" -ErrorRecord $_
-            return
-        }
-
         $tagsRex = ([regex]'(?m)^[\s]{0,15}Tags:(.*)$')
         $authorRex = ([regex]'(?m)^[\s]{0,15}Author:(.*)$')
         $minverRex = ([regex]'(?m)^[\s]{0,15}MinimumVersion:(.*)$')

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -63,6 +63,7 @@ $TestsRunGroups = @{
         'New-DbaDbUser',
         # doesn't work on appveyor but so works locally D:
         'Read-DbaXeFile'
+        'Find-DbaCommand'
     )
     # do not run everywhere
     "disabled"          = @()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
`Find-DbaCommand` was failing on 1.0.17 with the following:

```
WARNING: [13:47:42][Find-DbaCommand] Could not load replication libraries | Could not load file or assembly
'Microsoft.SqlServer.Replication.dll' or one of its dependencies. The specified module could not be found.
Get-DbaIndex : The term 'Get-DbaIndex' is not recognized as the name of a cmdlet, function, script file, or operable
program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Github\dbatools\functions\Find-DbaCommand.ps1:209 char:13
+             Get-DbaIndex
+             ~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Get-DbaIndex:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

Get-Content : Cannot find path 'C:\bin\dbatools-index.json' because it does not exist.
At C:\Github\dbatools\functions\Find-DbaCommand.ps1:212 char:25
+         $consolidated = Get-Content -Raw $idxFile | ConvertFrom-Json
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\bin\dbatools-index.json:String) [Get-Content], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
```

### Approach
<!-- How does this change solve that purpose -->
Remove section added yesterday:
```
# no idea why this is required
  try {
    Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Replication.dll" -ErrorAction Stop
    Add-Type -Path "$script:PSModuleRoot\bin\smo\Microsoft.SqlServer.Rmo.dll" -ErrorAction Stop
  } catch {
    Stop-Function -Message "Could not load replication libraries" -ErrorRecord $_
    return
  }
```

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Find-DbaCommand *test*`

