### PR TITLE
Update Get-DbaRegServer.ps1 to use environment for APPDATA\Roaming path

### DIFF
--- a/functions/Get-DbaRegServer.ps1
+++ b/functions/Get-DbaRegServer.ps1
@@ -115,7 +115,7 @@ function Get-DbaRegServer {
     }
     process {
         if (-not $PSBoundParameters.SqlInstance -and -not ($IsLinux -or $IsMacOs)) {
-            $null = Get-ChildItem -Recurse "$home\AppData\Roaming\Microsoft\*sql*" -Filter RegSrvr.xml | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            $null = Get-ChildItem -Recurse "$env:APPDATA\Microsoft\*sql*" -Filter RegSrvr.xml | Sort-Object LastWriteTime -Descending | Select-Object -First 1
         }
 
         $servers = @()


### PR DESCRIPTION
## Type of Change
 - [x ] Bug fix (non-breaking change, fixes #5891)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The prior method for specifying the APPDATA\Roaming path assumes that APPDATA\Roaming is located beneath $Home, which is not the case in some folder redirection scenarios. Running Get-DbaRegServer without parameters in these scenarios results in a System.Management.Automation.ItemNotFoundException.

### Approach
Use $env:APPDATA to locate APPDATA\Roaming.
