### PR TITLE
Adding two renames for Invoke-DbatoolsRenameHelper to use.

### DIFF
--- a/functions/Invoke-DbatoolsRenameHelper.ps1
+++ b/functions/Invoke-DbatoolsRenameHelper.ps1
@@ -84,6 +84,7 @@ function Invoke-DbatoolsRenameHelper {
             UseLastBackups     = 'UseLastBackup'
             PasswordExpiration = 'PasswordExpirationEnabled'
             PasswordPolicy     = 'PasswordPolicyEnforced'
+            ServerInstance     = 'SqlInstance'
         }
 
         $commandrenames = @{
@@ -257,6 +258,7 @@ function Invoke-DbatoolsRenameHelper {
             'Test-DbaDatabaseCollation'         = 'Test-DbaDbCollation'
             'Test-DbaDatabaseCompatibility'     = 'Test-DbaDbCompatibility'
             'Test-DbaDatabaseOwner'             = 'Test-DbaDbOwner'
+            'Test-DbaDbVirtualLogFile'          = 'Measure-DbaDbVirtualLogFile'
             'Test-DbaFullRecoveryModel'         = 'Test-DbaDbRecoveryModel'
             'Test-DbaJobOwner'                  = 'Test-DbaAgentJobOwner'
             'Test-DbaLogShippingStatus'         = 'Test-DbaDbLogShipStatus'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5849
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Renames `Test-DbaDbVirtualLogFile` to `Measure-DbaDbVirtualLogFile`
- Renames `ServerInstance` to `SqlInstance`
  - This is for Invoke-DbaQuery - **It could break Invoke-SqlCmd(2)** if that is being used as the parameter for that actually is `ServerInstance`. Not sure if that means it shouldn't be added or not. Can remove if needed.

### Approach
Added to list in psm1 file.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/61295699-a66bc080-a7a6-11e9-890d-b24bf63561c0.png)