### PR TITLE
Export-DbaInstance & Export-DbaScript fixes

### DIFF
--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -247,8 +247,8 @@ function Export-DbaInstance {
                 $fileCounter++
                 Write-Message -Level Verbose -Message "Exporting Central Management Server"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting Central Management Server"
-                $null = Get-DbaRegServerGroup -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-regserver.sql" -Append:$Append -BatchSeparator 'GO'
-                $null = Get-DbaRegServer -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-regserver.sql" -Append:$Append -BatchSeparator 'GO'
+                $null = Get-DbaRegServerGroup -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-regserver.sql" -Append:$Append -BatchSeparator 'GO' -NoPrefix:$NoPrefix
+                $null = Get-DbaRegServer -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-regserver.sql" -Append:$Append -BatchSeparator 'GO' -NoPrefix:$NoPrefix
                 Get-ChildItem -ErrorAction Ignore -Path "$Path\$fileCounter-regserver.sql"
                 if (-not (Test-Path "$Path\$fileCounter-regserver.sql")) {
                     $fileCounter--
@@ -308,7 +308,7 @@ function Export-DbaInstance {
                 $fileCounter++
                 Write-Message -Level Verbose -Message "Exporting logins"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting logins"
-                Export-DbaLogin -SqlInstance $server -FilePath "$Path\$fileCounter-logins.sql" -Append:$Append -ExcludePassword:$ExcludePassword -WarningAction SilentlyContinue
+                Export-DbaLogin -SqlInstance $server -FilePath "$Path\$fileCounter-logins.sql" -Append:$Append -ExcludePassword:$ExcludePassword -NoPrefix:$NoPrefix -WarningAction SilentlyContinue
                 if (-not (Test-Path "$Path\$fileCounter-logins.sql")) {
                     $fileCounter--
                 }
@@ -351,9 +351,9 @@ function Export-DbaInstance {
                 $fileCounter++
                 Write-Message -Level Verbose -Message "Exporting Policy Management"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting Policy Management"
-                $null = Get-DbaPbmCondition -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator
-                $null = Get-DbaPbmObjectSet -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator
-                $null = Get-DbaPbmPolicy -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator
+                $null = Get-DbaPbmCondition -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator -NoPrefix:$NoPrefix
+                $null = Get-DbaPbmObjectSet -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator -NoPrefix:$NoPrefix
+                $null = Get-DbaPbmPolicy -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-policymanagement.sql" -Append:$Append -BatchSeparator $BatchSeparator -NoPrefix:$NoPrefix
                 Get-ChildItem -ErrorAction Ignore -Path "$Path\$fileCounter-policymanagement.sql"
                 if (-not (Test-Path "$Path\$fileCounter-policymanagement.sql")) {
                     $fileCounter--
@@ -379,7 +379,7 @@ function Export-DbaInstance {
                 $fileCounter++
                 Write-Message -Level Verbose -Message "Exporting Extended Events"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting Extended Events"
-                $null = Get-DbaXESession -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-extendedevents.sql" -Append:$Append -BatchSeparator 'GO'
+                $null = Get-DbaXESession -SqlInstance $server | Export-DbaScript -FilePath "$Path\$fileCounter-extendedevents.sql" -Append:$Append -BatchSeparator 'GO' -NoPrefix:$NoPrefix
                 Get-ChildItem -ErrorAction Ignore -Path "$Path\$fileCounter-extendedevents.sql"
                 if (-not (Test-Path "$Path\$fileCounter-extendedevents.sql")) {
                     $fileCounter--
@@ -429,7 +429,7 @@ function Export-DbaInstance {
                 $fileCounter++
                 Write-Message -Level Verbose -Message "Exporting availability group"
                 Write-ProgressHelper -StepNumber ($stepCounter++) -Message "Exporting availability groups"
-                $null = Get-DbaAvailabilityGroup -SqlInstance $server -WarningAction SilentlyContinue | Export-DbaScript -FilePath "$Path\$fileCounter-DbaAvailabilityGroups.sql" -Append:$Append -BatchSeparator $BatchSeparator #-ScriptingOptionsObject $ScriptingOption
+                $null = Get-DbaAvailabilityGroup -SqlInstance $server -WarningAction SilentlyContinue | Export-DbaScript -FilePath "$Path\$fileCounter-DbaAvailabilityGroups.sql" -Append:$Append -BatchSeparator $BatchSeparator -NoPrefix:$NoPrefix #-ScriptingOptionsObject $ScriptingOption
                 Get-ChildItem -ErrorAction Ignore -Path "$Path\$fileCounter-DbaAvailabilityGroups.sql"
                 if (-not (Test-Path "$Path\$fileCounter-DbaAvailabilityGroups.sql")) {
                     $fileCounter--

--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -174,19 +174,24 @@ function Export-DbaScript {
             $typename = $object.GetType().ToString()
 
             if ($typename.StartsWith('Microsoft.SqlServer.')) {
-                $shortype = $typename.Split(".")[-1]
+                $shorttype = $typename.Split(".")[-1]
             } else {
                 Stop-Function -Message "InputObject is of type $typename which is not a SQL Management Object. Only SMO objects are supported." -Category InvalidData -Target $object -Continue
             }
 
-            if ($shortype -in "LinkedServer", "Credential", "Login") {
-                Write-Message -Level Warning -Message "Support for $shortype is limited at this time. No passwords, hashed or otherwise, will be exported if they exist."
+            if ($shorttype -in "LinkedServer", "Credential", "Login") {
+                Write-Message -Level Warning -Message "Support for $shorttype is limited at this time. No passwords, hashed or otherwise, will be exported if they exist."
             }
 
             # Just gotta add the stuff that Nic Cain added to his script
 
-            if ($shortype -eq "Configuration") {
-                Write-Message -Level Warning -Message "Support for $shortype is limited at this time."
+            if ($shorttype -eq "Configuration") {
+                Write-Message -Level Warning -Message "Support for $shorttype is limited at this time."
+            }
+
+            if ($shorttype -eq "Session" -and $ScriptingOptionsObject) {
+                Write-Message -Level Warning -Message "$shorttype doesn't support Scripting Options at this time."
+                Remove-Variable ScriptingOptionsObject
             }
 
             # Find the server object to pass on to the function
@@ -265,7 +270,7 @@ function Export-DbaScript {
                                 } else {
                                     $scriptpart = "$scriptpart`r`n"
                                 }
-                                $scriptpart  | Out-String
+                                $scriptpart | Out-String
                             }
                         }
                     } else {
@@ -293,14 +298,19 @@ function Export-DbaScript {
                                 $ScriptingOptionsObject.FileName = $soFileName
                             }
                         } else {
-                            foreach ($scriptpart in $scripter.EnumScript($object)) {
-                                if ($BatchSeparator) {
-                                    $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
-                                } else {
-                                    $scriptpart = "$scriptpart`r`n"
-                                }
-                                $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
+
+                            if (Get-Member -Name ScriptCreate -InputObject $object) {
+                                $scriptpart = $object.ScriptCreate().GetScript()
+                            } else {
+                                $scriptpart = $object.Script()
                             }
+
+                            if ($BatchSeparator) {
+                                $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
+                            } else {
+                                $scriptpart = "$scriptpart`r`n"
+                            }
+                            $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                         }
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5930 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- missed some calls that should honour `-NoPrefix` in `Export-DbaInstance`
- fixes issue #5930 

### Approach
- added calls to `-NoPrefix` in `Export-DbaInstance`
- for issue #5930 
  - The Extended Events type `Microsoft.SqlServer.Management.XEvent.Session` doesn't support `$scripter.EnumScript($object)` so throws a warning and you get no output in the exported file.
  - This was changed in #5795 within the block that gets called if no scripting options are passed in so I'm not sure if there are other benefits to using `$scripter.EnumScript($object)` than the ability to use scripting options.
  - Also added a block at the top, if someone passes in an extended events object & scripting options there is a warning and the scripting options are removed.

### Commands to test
```
Get-DbaXESession -SqlInstance server | Export-DbaScript  -Path C:\Temp\export\

Get-DbaXESession -SqlInstance server | Export-DbaScript  -Path C:\Temp\export\ -ScriptingOptionsObject $options

Export-DbaInstance -SqlInstance server -Path C:\temp\export\
```