### PR TITLE
Invoke-DbaQuery - Documentation update grammar and spelling

### DIFF
--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -30,7 +30,7 @@ function Invoke-DbaQuery {
         Specifies the path to one or several files to be used as the query input.
 
     .PARAMETER SqlObject
-        Specify on or multiple SQL objects. Those will be converted to script and their scripts run on the target system(s).
+        Specify one or more SQL objects. Those will be converted to script and their scripts run on the target system(s).
 
     .PARAMETER As
         Specifies output type. Valid options for this parameter are 'DataSet', 'DataTable', 'DataRow', 'PSObject', and 'SingleValue'


### PR DESCRIPTION
Typo in SqlObject parameter (on --> one). Change "multiple" to "more" for consistency with other parameters.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
