### PR TITLE
More PsRemoting coverage (-UseSSL & -IncludePortInSPN)

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -198,6 +198,7 @@ function Invoke-DbaAdvancedInstall {
     $connectionParams = @{
         ComputerName = $ComputerName
         ErrorAction  = "Stop"
+        UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
     }
     if ($Credential) { $connectionParams.Credential = $Credential }
     # need to figure out where to store the config file

--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -222,7 +222,12 @@ function Reset-DbaAdmin {
             # Setup remote session if server is not local
             if (-not $instance.IsLocalHost) {
                 try {
-                    $session = New-PSSession -ComputerName $hostname -ErrorAction Stop
+                    $connectionParams = @{
+                        ComputerName = $hostname
+                        ErrorAction  = "Stop"
+                        UseSSL       = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
+                    }
+                    $session = New-PSSession @connectionParams
                 } catch {
                     Stop-Function -Continue -ErrorRecord $_ -Message "Can't access $hostname using PSSession. Check your firewall settings and ensure Remoting is enabled or run the script locally."
                 }

--- a/internal/configurations/settings/remoting.ps1
+++ b/internal/configurations/settings/remoting.ps1
@@ -3,3 +3,9 @@ Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.ExpirationTimeout' -Value (New
 
 # Disables session caching
 Set-DbatoolsConfig -FullName 'PSRemoting.Sessions.Enable' -Value $true -Initialize -Validation bool -Handler { [Sqlcollaborative.Dbatools.Connection.ConnectionHost]::PSSessionCacheEnabled = $args[0] } -Description 'Globally enables session caching for PowerShell remoting'
+
+# New-PSSessionOption
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Value $false -Initialize -Validation bool -Description 'Changes the value of -IncludePortInSPN parameter used by New-PsSessionOption which is used for dbatools internally when working with PSRemoting.'
+
+# New-PSSession
+Set-DbatoolsConfig -FullName 'PSRemoting.PsSession.UseSSL' -Value $false -Initialize -Validation bool -Description 'Changes the value of -UseSSL parameter used by New-PsSession which is used for dbatools internally when working with PSRemoting.'

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -95,7 +95,7 @@ function Invoke-Command2 {
                     IdleTimeout      = (New-TimeSpan -Minutes 10).TotalMilliSeconds
                     IncludePortInSPN = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Fallback $false)
                 }
-                $sessionOption = New-PSSessionOption $psSessionOptionsSplat
+                $sessionOption = New-PSSessionOption @psSessionOptionsSplat
                 $psSessionSplat += @{ SessionOption = $sessionOption }
             }
             if ($Credential) {

--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -88,10 +88,15 @@ function Invoke-Command2 {
                 Authentication = $Authentication
                 Name           = $sessionName
                 ErrorAction    = 'Stop'
+                UseSSL         = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
             }
             if (Test-Windows -NoWarn) {
-                $timeout = New-PSSessionOption -IdleTimeout (New-TimeSpan -Minutes 10).TotalMilliSeconds
-                $psSessionSplat += @{ SessionOption = $timeout }
+                $psSessionOptionsSplat = @{
+                    IdleTimeout      = (New-TimeSpan -Minutes 10).TotalMilliSeconds
+                    IncludePortInSPN = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSessionOption.IncludePortInSPN' -Fallback $false)
+                }
+                $sessionOption = New-PSSessionOption $psSessionOptionsSplat
+                $psSessionSplat += @{ SessionOption = $sessionOption }
             }
             if ($Credential) {
                 $psSessionSplat += @{ Credential = $Credential }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Due to different environment configurations, In my work I need to use `-UseSSL` and `-IncludePortInSPN` when running PowerShell remote stuff (which make use of `Invoke-Command2`).
Example: `Get-DbaComputerCertificate`

### Approach
<!-- How does this change solve that purpose -->
Make configurable these two values by using Get/Set-DbatoolsConfig

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Any that uses internal `Invoke-Command2` function.

Use the following commands to change the values of the configurations:
``` powershell
Set-DbaToolsConfig -Name 'psremoting.pssession.usessl' -Value $true
Set-DbaToolsConfig -Name 'psremoting.pssessionoption.includeportinspn' -Value $true
```
Note: Default values are `$false` which are also defaults values of the `New-PsSessionOption` and `New-PsSession` commands

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
Two blog posts will be published after these improvements are available. On on dbatools blog, related with what these configs are, how to get current values, set new, etc.
The 2nd one will be on my blog and is on the detail why I need it and how I have made the implementation.

Note: This code is currently running without problems on my dbatools installation within the company.
Note2: There is no easy way to test these changes. (AFAIK, our test environment don't have settings for SSL and SPNs needed).