### PR TITLE
Fix -StepSize datatype parameter to int64

### DIFF
--- a/functions/Invoke-DbaDbShrink.ps1
+++ b/functions/Invoke-DbaDbShrink.ps1
@@ -135,7 +135,7 @@ function Invoke-DbaDbShrink {
         [string]$ShrinkMethod = "Default",
         [ValidateSet('All', 'Data', 'Log')]
         [string]$FileType = "All",
-        [int]$StepSize,
+        [int64]$StepSize,
         [int]$StatementTimeout = 0,
         [switch]$ExcludeIndexStats,
         [switch]$ExcludeUpdateUsage,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes: #5958

### Approach
<!-- How does this change solve that purpose -->
Change `-StepSize` parameter datatype from `[int]` to `[int64]`

### Commands to test
<!-- if these are the examples in the help just note it as such -->
``` powershell
Invoke-DbaDbShrink -SqlInstance sql2016 -Database test -StepSize 2GB
```
Note: Before, with 2GB gives the error reported.