### PR TITLE
Fixing New-DbaAzAccessToken to compile on core

### DIFF
--- a/functions/New-DbaAzAccessToken.ps1
+++ b/functions/New-DbaAzAccessToken.ps1
@@ -114,7 +114,7 @@ function New-DbaAzAccessToken {
         }
 
         if ($Type -eq "RenewableServicePrincipal") {
-            $source = @"
+                        $source = @"
             using System;
             using Microsoft.SqlServer.Management.Common;
             using System.Management.Automation;
@@ -162,7 +162,10 @@ function New-DbaAzAccessToken {
                 public string ClientSecret { get; set; }
             }
 "@
-            Add-Type -TypeDefinition $source -ReferencedAssemblies ([Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly)
+            Add-Type -TypeDefinition $source -ReferencedAssemblies ([Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly, 
+                [PowerShell].Assembly, 
+                [Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly.GetReferencedAssemblies()[0])
+
         }
 
         switch ($Subtype) {

--- a/functions/New-DbaAzAccessToken.ps1
+++ b/functions/New-DbaAzAccessToken.ps1
@@ -114,7 +114,7 @@ function New-DbaAzAccessToken {
         }
 
         if ($Type -eq "RenewableServicePrincipal") {
-                        $source = @"
+            $source = @"
             using System;
             using Microsoft.SqlServer.Management.Common;
             using System.Management.Automation;
@@ -162,8 +162,8 @@ function New-DbaAzAccessToken {
                 public string ClientSecret { get; set; }
             }
 "@
-            Add-Type -TypeDefinition $source -ReferencedAssemblies ([Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly, 
-                [PowerShell].Assembly, 
+            Add-Type -TypeDefinition $source -ReferencedAssemblies ([Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly,
+                [PowerShell].Assembly,
                 [Microsoft.SqlServer.Management.Common.IRenewableToken].Assembly.GetReferencedAssemblies()[0])
 
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Fixing New-DbaAzAccessToken to compile on core

### Approach
Resolved assembly issues. 
### Commands to test
New-DbaAzAccessToken

### Learning
The bug report indicated that the issue was a failure to compile.
Add-Type does not automatically reference the assembly containing [PowerShell] on core.  Also, [DateTimeOffset] is effectively contained in two assemblies on core, and we must reference the same one as [IRenewableToken] does 