### PR TITLE
Change Download Path for sp_whoisactive

### DIFF
--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -146,7 +146,7 @@ function Install-DbaWhoIsActive {
                 }
                 Remove-Item -Path $zipfile
             }
-            $sqlfile = (Get-ChildItem "$temp\who*active*.sql" -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+            $sqlfile = (Get-ChildItem "$temp\who*active*.sql" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
         } else {
             $sqlfile = $LocalFile
         }

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -93,8 +93,8 @@ function Install-DbaWhoIsActive {
         $zipfile = "$temp\spwhoisactive.zip"
 
         if ($LocalFile -eq $null -or $LocalFile.Length -eq 0) {
-            $baseUrl = "http://whoisactive.com/downloads"
-            $latest = ((Invoke-TlsWebRequest -UseBasicParsing -uri http://whoisactive.com/downloads).Links | where-object { $PSItem.href -match "who_is_active" } | Select-Object href -First 1).href
+            $baseUrl = "https://github.com/amachanic/sp_whoisactive/archive"
+            $latest = (((Invoke-TlsWebRequest -UseBasicParsing -uri https://github.com/amachanic/sp_whoisactive/releases/latest).Links | where-object { $PSItem.href -match "zip" } | Select-Object href -First 1).href -split '/')[-1]
             $LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath $latest;
 
             if ((Test-Path -Path $LocalCachedCopy -PathType Leaf) -and (-not $Force)) {

--- a/tests/Install-DbaWhoIsActive.Tests.ps1
+++ b/tests/Install-DbaWhoIsActive.Tests.ps1
@@ -5307,9 +5307,9 @@ GO
         #Offline webresponse for Internalcmdlet
         Mock -CommandName Invoke-TlsWebRequest -MockWith {
             [PSCustomObject]@{
-                outerHTML = "<a href='who_is_active_v11_32.zip' onclick='ga('send', 'event', 'download', 'sp_whoisactive', '11.32');'>Version 11...."
+                outerHTML = "<a href='/amachanic/sp_whoisactive/archive/v11.33.zip' rel='nofollow' class='d-flex flex-items-center'>..."
             }
-        } -ParameterFilter { [string]$args -eq '-UseBasicParsing -uri http://whoisactive.com/downloads' }
+        } -ParameterFilter { [string]$args -eq '-UseBasicParsing -uri https://github.com/amachanic/sp_whoisactive/releases/latest' }
 
         Mock -CommandName Invoke-WebRequest { }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5993)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Change the download location of sp_whoisactive to the GitHub page rather than from adam's web page. I thought this had already been done (or at least we talked about it, and noticed the issue).

### Approach
<!-- How does this change solve that purpose -->
Change URL for downloading to use GitHub, Fix tests to reflect the change.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
After clearing out temp and local Dbatools data directory run.
`Install-DbaWhoIsActive -SqlInstance Localhost'
