### PR TITLE
Add Resolve-Path to Find-DbaCommand

### DIFF
--- a/functions/Find-DbaCommand.ps1
+++ b/functions/Find-DbaCommand.ps1
@@ -184,7 +184,7 @@ function Find-DbaCommand {
                     $helpcoll.Add($x)
                 }
                 # $dest = Get-DbatoolsConfigValue -Name 'Path.TagCache' -Fallback "$(Resolve-Path $PSScriptRoot\..)\dbatools-index.json"
-                $dest = "$moduleDirectory\bin\dbatools-index.json"
+                $dest = Resolve-Path "$moduleDirectory\bin\dbatools-index.json"
                 $helpcoll | ConvertTo-Json -Depth 4 | Out-File $dest -Encoding UTF8
             }
         }
@@ -193,7 +193,7 @@ function Find-DbaCommand {
     }
     process {
         $Pattern = $Pattern.TrimEnd("s")
-        $idxFile = "$moduleDirectory\bin\dbatools-index.json"
+        $idxFile = Resolve-Path "$moduleDirectory\bin\dbatools-index.json"
         if (!(Test-Path $idxFile) -or $Rebuild) {
             Write-Message -Level Verbose -Message "Rebuilding index into $idxFile"
             $swRebuild = [system.diagnostics.stopwatch]::StartNew()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes # core issues)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Include `Resolve-Path` for cmdlets that are cross platform except for file paths. Noticed that the cmdlet was still mostly working, but had some odd behavior when showing the synopsis. 

### Approach
<!-- How does this change solve that purpose -->
Added `Resolve-Path` to two path variables.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

![image](https://user-images.githubusercontent.com/13426972/63824149-25b2ef00-c924-11e9-9d69-e68fde928d6f.png)

