### PR TITLE
Fix missing shuffling functionality in masking command

### DIFF
--- a/functions/Get-DbaRandomizedValue.ps1
+++ b/functions/Get-DbaRandomizedValue.ps1
@@ -38,6 +38,10 @@ function Get-DbaRandomizedValue {
     .PARAMETER Symbol
         Use a symbol in front of the value i.e. $100,12
 
+    .PARAMETER Value
+        This is the value that needs to be used for several possible transformations.
+        One example is the subtype "Shuffling" where the value will be shuffled.
+
     .PARAMETER Locale
         Set the local to enable certain settings in the masking. The default is 'en'
 

--- a/functions/Get-DbaRandomizedValue.ps1
+++ b/functions/Get-DbaRandomizedValue.ps1
@@ -100,6 +100,7 @@ function Get-DbaRandomizedValue {
         [string]$CharacterString = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
         [string]$Format,
         [string]$Symbol,
+        [string]$Value,
         [string]$Locale = 'en',
         [switch]$EnableException
     )
@@ -156,6 +157,10 @@ function Get-DbaRandomizedValue {
         if ($RandomizerSubType) {
             if ($RandomizerSubType -notin $script:uniquerandomizersubtype) {
                 Stop-Function -Message "Invalid randomizer sub type" -Continue -Target $RandomizerSubType
+            }
+
+            if ($RandomizerSubType.ToLowerInvariant() -eq 'shuffle' -and $null -eq $Value) {
+                Stop-Function -Message "Value cannot be empty when using sub type 'Shuffle'" -Continue -Target $RandomizerSubType
             }
         }
 
@@ -486,6 +491,8 @@ function Get-DbaRandomizedValue {
                         $script:faker.Random.Bytes($Max)
                     } elseif ($randSubType -in 'string', 'string2') {
                         $script:faker.Random.String2([int]$Min, [int]$Max, $CharacterString)
+                    } elseif ($randSubType -eq 'shuffle') {
+                        $script:faker.Random.Shuffle($Value)
                     } else {
                         $script:faker.Random.$RandomizerSubType()
                     }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -569,10 +569,7 @@ function Invoke-DbaDbDataMasking {
                                     }
                                 }
 
-                                $compositeItems = $compositeItems | ForEach-Object {
-                                    $_ = "ISNULL($($_), '')"
-                                    $_
-                                }
+                                $compositeItems = $compositeItems | ForEach-Object { $_ = "ISNULL($($_), '')"; $_ }
 
                                 $null = $stringbuilder.AppendLine("UPDATE [$($tableobject.Schema)].[$($tableobject.Name)] SET $($columnObject.Name) = $($compositeItems -join ' + ')")
                             }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -419,7 +419,9 @@ function Invoke-DbaDbDataMasking {
                                         if ($column.SubType.ToLowerInvariant() -eq 'shuffle') {
                                             if ($columnobject.ColumnType -like '*int') {
                                                 [int]$newValue = ((($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join '')
-                                            } else {
+                                            }
+
+                                            if ($columnobject.ColumnType -like '*char*') {
                                                 $newValue = (($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join ''
                                             }
                                         } elseif (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -517,6 +517,7 @@ function Invoke-DbaDbDataMasking {
                             $sqlcmd = New-Object System.Data.SqlClient.SqlCommand(($stringbuilder.ToString()), $sqlconn, $transaction)
                             $null = $sqlcmd.ExecuteNonQuery()
                         } catch {
+                            $stringbuilder.ToString()
                             Write-Message -Level VeryVerbose -Message "$updatequery"
                             $errormessage = $_.Exception.Message.ToString()
                             Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $errormessage.`n$updatequery" -Target $updatequery -Continue -ErrorRecord $_
@@ -534,7 +535,7 @@ function Invoke-DbaDbDataMasking {
                                 foreach ($columnComposite in $columnObject.Composite) {
                                     if ($columnComposite.Type -eq 'Column') {
                                         $compositeItems += $columnComposite.Value
-                                    } elseif ($columnComposite.Type -eq 'Random') {
+                                    } elseif ($columnComposite.Type -in $supportedFakerMaskingTypes) {
                                         try {
                                             $newValue = $null
 
@@ -580,6 +581,7 @@ function Invoke-DbaDbDataMasking {
                                 $sqlcmd = New-Object System.Data.SqlClient.SqlCommand(($stringbuilder.ToString()), $sqlconn, $transaction)
                                 $null = $sqlcmd.ExecuteNonQuery()
                             } catch {
+                                $stringbuilder.ToString()
                                 Write-Message -Level VeryVerbose -Message "$updatequery"
                                 $errormessage = $_.Exception.Message.ToString()
                                 Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $errormessage.`n$updatequery" -Target $updatequery -Continue -ErrorRecord $_

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -427,7 +427,6 @@ function Invoke-DbaDbDataMasking {
                                         } else {
                                             $newValue = Get-DbaRandomizedValue -RandomizerType $columnobject.MaskingType -RandomizerSubtype $columnobject.SubType -Min $min -Max $max -CharacterString $charstring -Format $columnobject.Format -Locale $Locale
                                         }
-
                                     } catch {
 
                                         Stop-Function -Message "Failure" -Target $columnobject -Continue -ErrorRecord $_

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -416,7 +416,13 @@ function Invoke-DbaDbDataMasking {
                                     try {
                                         $newValue = $null
 
-                                        if (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
+                                        if ($column.SubType.ToLowerInvariant() -eq 'shuffle') {
+                                            if ($columnobject.ColumnType -like '*int') {
+                                                [int]$newValue = ((($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join '')
+                                            } else {
+                                                $newValue = (($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join ''
+                                            }
+                                        } elseif (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
                                             $newValue = Get-DbaRandomizedValue -DataType $columnobject.ColumnType -Min $min -Max $max -CharacterString $charstring -Format $columnobject.Format -Locale $Locale
                                         } else {
                                             $newValue = Get-DbaRandomizedValue -RandomizerType $columnobject.MaskingType -RandomizerSubtype $columnobject.SubType -Min $min -Max $max -CharacterString $charstring -Format $columnobject.Format -Locale $Locale

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -513,7 +513,6 @@ function Invoke-DbaDbDataMasking {
                         }
 
                         try {
-                            $stringbuilder.ToString()
                             Write-ProgressHelper -ExcludePercent -Activity "Masking data" -Message "Updating $($data.Rows.Count) rows in $($tableobject.Schema).$($tableobject.Name) in $($dbName) on $instance"
                             $sqlcmd = New-Object System.Data.SqlClient.SqlCommand(($stringbuilder.ToString()), $sqlconn, $transaction)
                             $null = $sqlcmd.ExecuteNonQuery()
@@ -583,7 +582,6 @@ function Invoke-DbaDbDataMasking {
                             } catch {
                                 Write-Message -Level VeryVerbose -Message "$updatequery"
                                 $errormessage = $_.Exception.Message.ToString()
-                                $updatequery
                                 Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $errormessage.`n$updatequery" -Target $updatequery -Continue -ErrorRecord $_
                             }
                         }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -416,14 +416,11 @@ function Invoke-DbaDbDataMasking {
                                     try {
                                         $newValue = $null
 
-                                        if ($column.SubType.ToLowerInvariant() -eq 'shuffle') {
-                                            if ($columnobject.ColumnType -like '*int') {
-                                                [int]$newValue = ((($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join '')
-                                            }
+                                        if ($columnobject.SubType.ToLowerInvariant() -eq 'shuffle') {
+                                            $newValue = Get-DbaRandomizedValue -RandomizerType "Random" -RandomizerSubtype "SHuffle" -Value ($row.$($columnobject.Name)) -Locale $Locale
 
-                                            if ($columnobject.ColumnType -like '*char*') {
-                                                $newValue = (($row.$item).Tostring() -split '' | Sort-Object { Get-Random }) -join ''
-                                            }
+                                            $newValue = ($newValue -join '')
+
                                         } elseif (-not $columnobject.SubType -and $columnobject.ColumnType -in $supportedDataTypes) {
                                             $newValue = Get-DbaRandomizedValue -DataType $columnobject.ColumnType -Min $min -Max $max -CharacterString $charstring -Format $columnobject.Format -Locale $Locale
                                         } else {
@@ -516,6 +513,7 @@ function Invoke-DbaDbDataMasking {
                         }
 
                         try {
+                            $stringbuilder.ToString()
                             Write-ProgressHelper -ExcludePercent -Activity "Masking data" -Message "Updating $($data.Rows.Count) rows in $($tableobject.Schema).$($tableobject.Name) in $($dbName) on $instance"
                             $sqlcmd = New-Object System.Data.SqlClient.SqlCommand(($stringbuilder.ToString()), $sqlconn, $transaction)
                             $null = $sqlcmd.ExecuteNonQuery()

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -330,7 +330,7 @@ function New-DbaDbMaskingConfig {
                             $maxValue = $null
                         }
                         "decimal" {
-                            $min = 1.1
+                            $minValue = 1.1
                             $maxValue = $null
                         }
                         "float" {
@@ -370,12 +370,12 @@ function New-DbaDbMaskingConfig {
                             if ($columnLength -eq 1) {
                                 $maxValue = $columnLength
                             } else {
-                                $min = [int]($columnLength / 2)
+                                $minValue = [int]($columnLength / 2)
                                 $maxValue = $columnLength
                             }
                         }
                         default {
-                            $min = [int]($columnLength / 2)
+                            $minValue = [int]($columnLength / 2)
                             $maxValue = $columnLength
                         }
                     }
@@ -385,7 +385,7 @@ function New-DbaDbMaskingConfig {
                     } else {
 
                         if ($columnobject.InPrimaryKey -and $columnobject.DataType.SqlDataType.ToString().ToLowerInvariant() -notmatch 'date') {
-                            $min = 2
+                            $minValue = 2
                         }
 
                         if ($columnobject.DataType.Name -eq "geography") {

--- a/tests/Get-DbaRandomizedValue.Tests.ps1
+++ b/tests/Get-DbaRandomizedValue.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'DataType', 'RandomizerType', 'RandomizerSubType', 'Min', 'Max', 'Precision', 'CharacterString', 'Format', 'Symbol', 'Locale', 'EnableException'
+        [object[]]$knownParameters = 'DataType', 'RandomizerType', 'RandomizerSubType', 'Min', 'Max', 'Precision', 'CharacterString', 'Format', 'Symbol', 'Locale', 'Value', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Somewhere along the way the functionality for shuffling the data was lost.
The functionality is now added back in.

Another thing that was not possible was to use all the different masking types in composites.

### Approach
Added functionality in the command to shuffle text and numbers.
Added functionality to allow for masking types in composites

### Commands to test
Invoke-DbaDbDataMaskingConfig

### Screenshots
The column "Comment" has the original value "Just some comment"
![image](https://user-images.githubusercontent.com/6154981/64073102-a44bbb80-cc99-11e9-9fda-22a70cc27afd.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
