### PR TITLE
Get-DbaCmObject - Fixing error handling

### DIFF
--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -363,7 +363,7 @@ function Get-DbaCmObject {
                                 #region 20 = Namespace not empty
                                 20 { Stop-Function -Message "[$computer] The specified namespace $Namespace is not empty." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage }
                                 #endregion 20 = Namespace not empty
-								
+                                
                                 #region Default | 0 = Non-CIM Issue not covered by the framework
                                 default {
                                     # 0 & ExtendedStatus = Weird issue beyond the scope of the CIM standard. Often a server-side issue

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -263,7 +263,7 @@ function Get-DbaCmObject {
                                         continue sub
                                     }
                                 }
-								#endregion Default | 0 = Non-CIM Issue not covered by the framework
+                                #endregion Default | 0 = Non-CIM Issue not covered by the framework
                             }
                         }
                     }
@@ -364,7 +364,7 @@ function Get-DbaCmObject {
                                 20 { Stop-Function -Message "[$computer] The specified namespace $Namespace is not empty." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage }
                                 #endregion 20 = Namespace not empty
 								
-								#region Default | 0 = Non-CIM Issue not covered by the framework
+                                #region Default | 0 = Non-CIM Issue not covered by the framework
                                 default {
                                     # 0 & ExtendedStatus = Weird issue beyond the scope of the CIM standard. Often a server-side issue
                                     if ($errorItem.Exception.InnerException.ErrorData.original_error -like "__ExtendedStatus") {
@@ -375,7 +375,7 @@ function Get-DbaCmObject {
                                         continue sub
                                     }
                                 }
-								#endregion Default | 0 = Non-CIM Issue not covered by the framework
+                                #endregion Default | 0 = Non-CIM Issue not covered by the framework
                             }
                         }
                     }

--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -252,8 +252,8 @@ function Get-DbaCmObject {
                                 20 { Stop-Function -Message "[$computer] The specified namespace $Namespace is not empty." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage }
                                 #endregion 20 = Namespace not empty
 
-                                #region 0 = Non-CIM Issue not covered by the framework
-                                0 {
+                                #region Default | 0 = Non-CIM Issue not covered by the framework
+                                default {
                                     # 0 & ExtendedStatus = Weird issue beyond the scope of the CIM standard. Often a server-side issue
                                     if ($errorItem.Exception.InnerException.ErrorData.original_error -like "__ExtendedStatus") {
                                         Stop-Function -Message "[$computer] Something went wrong when looking for $ClassName, in $Namespace. This often indicates issues with the target system." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue
@@ -263,7 +263,7 @@ function Get-DbaCmObject {
                                         continue sub
                                     }
                                 }
-                                #endregion 0 = Non-CIM Issue not covered by the framework
+								#endregion Default | 0 = Non-CIM Issue not covered by the framework
                             }
                         }
                     }
@@ -363,9 +363,9 @@ function Get-DbaCmObject {
                                 #region 20 = Namespace not empty
                                 20 { Stop-Function -Message "[$computer] The specified namespace $Namespace is not empty." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue -OverrideExceptionMessage }
                                 #endregion 20 = Namespace not empty
-
-                                #region 0 = Non-CIM Issue not covered by the framework
-                                0 {
+								
+								#region Default | 0 = Non-CIM Issue not covered by the framework
+                                default {
                                     # 0 & ExtendedStatus = Weird issue beyond the scope of the CIM standard. Often a server-side issue
                                     if ($errorItem.Exception.InnerException.ErrorData.original_error -like "__ExtendedStatus") {
                                         Stop-Function -Message "[$computer] Something went wrong when looking for $ClassName, in $Namespace. This often indicates issues with the target system." -Target $computer -Continue -ContinueLabel "main" -ErrorRecord $errorItem -SilentlyContinue:$SilentlyContinue
@@ -375,7 +375,7 @@ function Get-DbaCmObject {
                                         continue sub
                                     }
                                 }
-                                #endregion 0 = Non-CIM Issue not covered by the framework
+								#endregion Default | 0 = Non-CIM Issue not covered by the framework
                             }
                         }
                     }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

Added a default error handling for Get-DbaCmObject, since not every error out there is guaranteed to have a CIM error code.
Resolves #5998 