### PR TITLE
Fix Repair-DbaOrphanUser skipping contained databases

### DIFF
--- a/functions/Get-DbaDbOrphanUser.ps1
+++ b/functions/Get-DbaDbOrphanUser.ps1
@@ -85,13 +85,6 @@ function Get-DbaDbOrphanUser {
             if ($DatabaseCollection.Count -gt 0) {
                 foreach ($db in $DatabaseCollection) {
                     try {
-                        #if SQL 2012 or higher only validate databases with ContainmentType = NONE
-                        if ($server.versionMajor -gt 10) {
-                            if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None) {
-                                Write-Message -Level Warning -Message "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
-                                Continue
-                            }
-                        }
                         Write-Message -Level Verbose -Message "Validating users on database '$db'."
                         $UsersToWork = $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
 

--- a/functions/Remove-DbaDbOrphanUser.ps1
+++ b/functions/Remove-DbaDbOrphanUser.ps1
@@ -102,7 +102,7 @@ function Remove-DbaDbOrphanUser {
         [switch]$EnableException
     )
     begin {
-        if ($Force) {$ConfirmPreference = 'none'}
+        if ($Force) { $ConfirmPreference = 'none' }
     }
     process {
         foreach ($Instance in $SqlInstance) {
@@ -133,13 +133,6 @@ function Remove-DbaDbOrphanUser {
             if ($DatabaseCollection) {
                 foreach ($db in $DatabaseCollection) {
                     try {
-                        #if SQL 2012 or higher only validate databases with ContainmentType = NONE
-                        if ($server.versionMajor -gt 10) {
-                            if ($db.ContainmentType -ne [Microsoft.SqlServer.Management.Smo.ContainmentType]::None) {
-                                Write-Message -Level Warning -Message "Database '$db' is a contained database. Contained databases can't have orphaned users. Skipping validation."
-                                Continue
-                            }
-                        }
 
                         if ($StackSource -eq "Repair-DbaDbOrphanUser") {
                             Write-Message -Level Verbose -Message "Call origin: Repair-DbaDbOrphanUser."
@@ -173,141 +166,141 @@ function Remove-DbaDbOrphanUser {
                                         $_.IsLocked -eq $False -and
                                         $_.Name -eq $dbuser.Name
                                     }
-                                }
+                            }
 
-                                #Schemas only appears on SQL Server 2005 (v9.0)
-                                if ($server.versionMajor -gt 8) {
+                            #Schemas only appears on SQL Server 2005 (v9.0)
+                            if ($server.versionMajor -gt 8) {
 
-                                    #reset variables
-                                    $AlterSchemaOwner = ""
-                                    $DropSchema = ""
+                                #reset variables
+                                $AlterSchemaOwner = ""
+                                $DropSchema = ""
 
-                                    #Validate if user owns any schema
-                                    $Schemas = @()
-                                    $Schemas = $db.Schemas | Where-Object Owner -eq $dbuser.Name
+                                #Validate if user owns any schema
+                                $Schemas = @()
+                                $Schemas = $db.Schemas | Where-Object Owner -eq $dbuser.Name
 
-                                    if (@($Schemas).Count -gt 0) {
-                                        Write-Message -Level Verbose -Message "User $dbuser owns one or more schemas."
+                                if (@($Schemas).Count -gt 0) {
+                                    Write-Message -Level Verbose -Message "User $dbuser owns one or more schemas."
 
-                                        foreach ($sch in $Schemas) {
-                                            <#
+                                    foreach ($sch in $Schemas) {
+                                        <#
                                                 On sql server 2008 or lower the EnumObjects method does not accept empty parameter.
                                                 0x1FFFFFFF is the way we can say we want everything known by those versions
 
                                                 When it is a higher version we can use empty to get all
                                             #>
-                                            if ($server.versionMajor -lt 11) {
-                                                $NumberObjects = ($db.EnumObjects(0x1FFFFFFF) | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
-                                            } else {
-                                                $NumberObjects = ($db.EnumObjects() | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
-                                            }
-
-                                            if ($NumberObjects -gt 0) {
-                                                if ($Force) {
-                                                    Write-Message -Level Verbose -Message "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
-
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used.")) {
-                                                        $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
-
-                                                        [pscustomobject]@{
-                                                            ComputerName      = $server.ComputerName
-                                                            InstanceName      = $server.ServiceName
-                                                            SqlInstance       = $server.DomainInstanceName
-                                                            DatabaseName      = $db.Name
-                                                            SchemaName        = $sch.Name
-                                                            Action            = "ALTER OWNER"
-                                                            SchemaOwnerBefore = $sch.Owner
-                                                            SchemaOwnerAfter  = "dbo"
-                                                        }
-                                                    }
-                                                } else {
-                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' owned by user $($dbuser.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$dbuser'."
-                                                    $SkipUser = $true
-                                                    break
-                                                }
-                                            } else {
-                                                if ($sch.Name -eq $dbuser.Name) {
-                                                    Write-Message -Level Verbose -Message "The schema '$($sch.Name)' have the same name as user $dbuser. Schema will be dropped."
-
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'.")) {
-                                                        $DropSchema += "DROP SCHEMA [$($sch.Name)]"
-
-                                                        [pscustomobject]@{
-                                                            ComputerName      = $server.ComputerName
-                                                            InstanceName      = $server.ServiceName
-                                                            SqlInstance       = $server.DomainInstanceName
-                                                            DatabaseName      = $db.Name
-                                                            SchemaName        = $sch.Name
-                                                            Action            = "DROP"
-                                                            SchemaOwnerBefore = $sch.Owner
-                                                            SchemaOwnerAfter  = "N/A"
-                                                        }
-                                                    }
-                                                } else {
-                                                    Write-Message -Level Warning -Message "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
-
-                                                    if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'.")) {
-                                                        $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
-
-                                                        [pscustomobject]@{
-                                                            ComputerName      = $server.ComputerName
-                                                            InstanceName      = $server.ServiceName
-                                                            SqlInstance       = $server.DomainInstanceName
-                                                            DatabaseName      = $db.Name
-                                                            SchemaName        = $sch.Name
-                                                            Action            = "ALTER OWNER"
-                                                            SchemaOwnerBefore = $sch.Owner
-                                                            SchemaOwnerAfter  = "dbo"
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                        if ($server.versionMajor -lt 11) {
+                                            $NumberObjects = ($db.EnumObjects(0x1FFFFFFF) | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
+                                        } else {
+                                            $NumberObjects = ($db.EnumObjects() | Where-Object { $_.Schema -eq $sch.Name } | Measure-Object).Count
                                         }
 
-                                    } else {
-                                        Write-Message -Level Verbose -Message "User $dbuser does not own any schema. Will be dropped."
-                                    }
+                                        if ($NumberObjects -gt 0) {
+                                            if ($Force) {
+                                                Write-Message -Level Verbose -Message "Parameter -Force was used! The schema '$($sch.Name)' have $NumberObjects underlying objects. We will change schema owner to 'dbo' and drop the user."
 
-                                    $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbuser
+                                                if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'. -Force used.")) {
+                                                    $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
 
-                                    Write-Message -Level Debug -Message $query
-                                } else {
-                                    $query = "EXEC master.dbo.sp_droplogin @loginame = N'$($dbuser.name)'"
-                                }
-
-                                if ($ExistLogin) {
-                                    if (-not $SkipUser) {
-                                        if ($Force) {
-                                            if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser using -Force")) {
-                                                $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-                                                Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name). -Force parameter was used!"
+                                                    [pscustomobject]@{
+                                                        ComputerName      = $server.ComputerName
+                                                        InstanceName      = $server.ServiceName
+                                                        SqlInstance       = $server.DomainInstanceName
+                                                        DatabaseName      = $db.Name
+                                                        SchemaName        = $sch.Name
+                                                        Action            = "ALTER OWNER"
+                                                        SchemaOwnerBefore = $sch.Owner
+                                                        SchemaOwnerAfter  = "dbo"
+                                                    }
+                                                }
+                                            } else {
+                                                Write-Message -Level Warning -Message "Schema '$($sch.Name)' owned by user $($dbuser.Name) have $NumberObjects underlying objects. If you want to change the schemas' owner to 'dbo' and drop the user anyway, use -Force parameter. Skipping user '$dbuser'."
+                                                $SkipUser = $true
+                                                break
                                             }
                                         } else {
-                                            Write-Message -Level Warning -Message "Orphan user $($dbuser.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
-                                            Continue
+                                            if ($sch.Name -eq $dbuser.Name) {
+                                                Write-Message -Level Verbose -Message "The schema '$($sch.Name)' have the same name as user $dbuser. Schema will be dropped."
+
+                                                if ($Pscmdlet.ShouldProcess($db.Name, "Dropping schema '$($sch.Name)'.")) {
+                                                    $DropSchema += "DROP SCHEMA [$($sch.Name)]"
+
+                                                    [pscustomobject]@{
+                                                        ComputerName      = $server.ComputerName
+                                                        InstanceName      = $server.ServiceName
+                                                        SqlInstance       = $server.DomainInstanceName
+                                                        DatabaseName      = $db.Name
+                                                        SchemaName        = $sch.Name
+                                                        Action            = "DROP"
+                                                        SchemaOwnerBefore = $sch.Owner
+                                                        SchemaOwnerAfter  = "N/A"
+                                                    }
+                                                }
+                                            } else {
+                                                Write-Message -Level Warning -Message "Schema '$($sch.Name)' does not have any underlying object. Ownership will be changed to 'dbo' so the user can be dropped. Remember to re-check permissions on this schema!"
+
+                                                if ($Pscmdlet.ShouldProcess($db.Name, "Changing schema '$($sch.Name)' owner to 'dbo'.")) {
+                                                    $AlterSchemaOwner += "ALTER AUTHORIZATION ON SCHEMA::[$($sch.Name)] TO [dbo]`r`n"
+
+                                                    [pscustomobject]@{
+                                                        ComputerName      = $server.ComputerName
+                                                        InstanceName      = $server.ServiceName
+                                                        SqlInstance       = $server.DomainInstanceName
+                                                        DatabaseName      = $db.Name
+                                                        SchemaName        = $sch.Name
+                                                        Action            = "ALTER OWNER"
+                                                        SchemaOwnerBefore = $sch.Owner
+                                                        SchemaOwnerAfter  = "dbo"
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
+
                                 } else {
-                                    if (-not $SkipUser) {
-                                        if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
+                                    Write-Message -Level Verbose -Message "User $dbuser does not own any schema. Will be dropped."
+                                }
+
+                                $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbuser
+
+                                Write-Message -Level Debug -Message $query
+                            } else {
+                                $query = "EXEC master.dbo.sp_droplogin @loginame = N'$($dbuser.name)'"
+                            }
+
+                            if ($ExistLogin) {
+                                if (-not $SkipUser) {
+                                    if ($Force) {
+                                        if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser using -Force")) {
                                             $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-                                            Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
+                                            Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name). -Force parameter was used!"
                                         }
+                                    } else {
+                                        Write-Message -Level Warning -Message "Orphan user $($dbuser.Name) has a matching login. The user will not be dropped. If you want to drop anyway, use -Force parameter."
+                                        Continue
+                                    }
+                                }
+                            } else {
+                                if (-not $SkipUser) {
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
+                                        $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                        Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
                                     }
                                 }
                             }
-                        } else {
-                            Write-Message -Level Verbose -Message "No orphan users found on database $db."
                         }
-                        #reset collection
-                        $users = $null
-                    } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $db -Continue
+                    } else {
+                        Write-Message -Level Verbose -Message "No orphan users found on database $db."
                     }
+                    #reset collection
+                    $users = $null
+                } catch {
+                    Stop-Function -Message "Failure" -ErrorRecord $_ -Target $db -Continue
                 }
-            } else {
-                Write-Message -Level Verbose -Message "There are no databases to analyse."
             }
+        } else {
+            Write-Message -Level Verbose -Message "There are no databases to analyse."
         }
     }
+}
 }

--- a/functions/Repair-DbaDbOrphanUser.ps1
+++ b/functions/Repair-DbaDbOrphanUser.ps1
@@ -149,70 +149,70 @@ function Repair-DbaDbOrphanUser {
                                     $_.Name -eq $User.Name
                                 }
 
-                            if ($ExistLogin) {
-                                if ($server.versionMajor -gt 8) {
-                                    $query = "ALTER USER " + $User + " WITH LOGIN = " + $User
-                                } else {
-                                    $query = "exec sp_change_users_login 'update_one', '$User'"
-                                }
-
-                                if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
-                                    $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-                                    Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
-
-                                    [PSCustomObject]@{
-                                        ComputerName = $server.ComputerName
-                                        InstanceName = $server.ServiceName
-                                        SqlInstance  = $server.DomainInstanceName
-                                        DatabaseName = $db.Name
-                                        User         = $User.Name
-                                        Status       = "Success"
+                                if ($ExistLogin) {
+                                    if ($server.versionMajor -gt 8) {
+                                        $query = "ALTER USER " + $User + " WITH LOGIN = " + $User
+                                    } else {
+                                        $query = "exec sp_change_users_login 'update_one', '$User'"
                                     }
-                                }
-                            } else {
-                                if ($RemoveNotExisting) {
-                                    #add user to collection
-                                    $UsersToRemove += $User
+
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
+                                        $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                        Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
+
+                                        [PSCustomObject]@{
+                                            ComputerName = $server.ComputerName
+                                            InstanceName = $server.ServiceName
+                                            SqlInstance  = $server.DomainInstanceName
+                                            DatabaseName = $db.Name
+                                            User         = $User.Name
+                                            Status       = "Success"
+                                        }
+                                    }
                                 } else {
-                                    Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
-                                    [PSCustomObject]@{
-                                        ComputerName = $server.ComputerName
-                                        InstanceName = $server.ServiceName
-                                        SqlInstance  = $server.DomainInstanceName
-                                        DatabaseName = $db.Name
-                                        User         = $User.Name
-                                        Status       = "No matching login"
+                                    if ($RemoveNotExisting) {
+                                        #add user to collection
+                                        $UsersToRemove += $User
+                                    } else {
+                                        Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
+                                        [PSCustomObject]@{
+                                            ComputerName = $server.ComputerName
+                                            InstanceName = $server.ServiceName
+                                            SqlInstance  = $server.DomainInstanceName
+                                            DatabaseName = $db.Name
+                                            User         = $User.Name
+                                            Status       = "No matching login"
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        #With the collection complete invoke remove.
-                        if ($RemoveNotExisting) {
-                            if ($Force) {
-                                if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
-                                    Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser' with -Force."
-                                    Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove -Force
-                                }
-                            } else {
-                                if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
-                                    Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser'."
-                                    Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove
+                            #With the collection complete invoke remove.
+                            if ($RemoveNotExisting) {
+                                if ($Force) {
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
+                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser' with -Force."
+                                        Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove -Force
+                                    }
+                                } else {
+                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
+                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser'."
+                                        Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove
+                                    }
                                 }
                             }
+                        } else {
+                            Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
                         }
-                    } else {
-                        Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
+                        #reset collection
+                        $UsersToWork = $null
+                    } catch {
+                        Stop-Function -Message $_ -Continue
                     }
-                    #reset collection
-                    $UsersToWork = $null
-                } catch {
-                    Stop-Function -Message $_ -Continue
                 }
+            } else {
+                Write-Message -Level Verbose -Message "There are no databases to analyse."
             }
-        } else {
-            Write-Message -Level Verbose -Message "There are no databases to analyse."
         }
     }
-}
 }

--- a/functions/Repair-DbaDbOrphanUser.ps1
+++ b/functions/Repair-DbaDbOrphanUser.ps1
@@ -149,70 +149,70 @@ function Repair-DbaDbOrphanUser {
                                     $_.Name -eq $User.Name
                                 }
 
-                                if ($ExistLogin) {
-                                    if ($server.versionMajor -gt 8) {
-                                        $query = "ALTER USER " + $User + " WITH LOGIN = " + $User
-                                    } else {
-                                        $query = "exec sp_change_users_login 'update_one', '$User'"
-                                    }
-
-                                    if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
-                                        $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
-                                        Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
-
-                                        [PSCustomObject]@{
-                                            ComputerName = $server.ComputerName
-                                            InstanceName = $server.ServiceName
-                                            SqlInstance  = $server.DomainInstanceName
-                                            DatabaseName = $db.Name
-                                            User         = $User.Name
-                                            Status       = "Success"
-                                        }
-                                    }
+                            if ($ExistLogin) {
+                                if ($server.versionMajor -gt 8) {
+                                    $query = "ALTER USER " + $User + " WITH LOGIN = " + $User
                                 } else {
-                                    if ($RemoveNotExisting) {
-                                        #add user to collection
-                                        $UsersToRemove += $User
-                                    } else {
-                                        Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
-                                        [PSCustomObject]@{
-                                            ComputerName = $server.ComputerName
-                                            InstanceName = $server.ServiceName
-                                            SqlInstance  = $server.DomainInstanceName
-                                            DatabaseName = $db.Name
-                                            User         = $User.Name
-                                            Status       = "No matching login"
-                                        }
+                                    $query = "exec sp_change_users_login 'update_one', '$User'"
+                                }
+
+                                if ($Pscmdlet.ShouldProcess($db.Name, "Mapping user '$($User.Name)'")) {
+                                    $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
+                                    Write-Message -Level Verbose -Message "User '$($User.Name)' mapped with their login."
+
+                                    [PSCustomObject]@{
+                                        ComputerName = $server.ComputerName
+                                        InstanceName = $server.ServiceName
+                                        SqlInstance  = $server.DomainInstanceName
+                                        DatabaseName = $db.Name
+                                        User         = $User.Name
+                                        Status       = "Success"
+                                    }
+                                }
+                            } else {
+                                if ($RemoveNotExisting) {
+                                    #add user to collection
+                                    $UsersToRemove += $User
+                                } else {
+                                    Write-Message -Level Verbose -Message "Orphan user $($User.Name) does not have matching login."
+                                    [PSCustomObject]@{
+                                        ComputerName = $server.ComputerName
+                                        InstanceName = $server.ServiceName
+                                        SqlInstance  = $server.DomainInstanceName
+                                        DatabaseName = $db.Name
+                                        User         = $User.Name
+                                        Status       = "No matching login"
                                     }
                                 }
                             }
-
-                            #With the collection complete invoke remove.
-                            if ($RemoveNotExisting) {
-                                if ($Force) {
-                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
-                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser' with -Force."
-                                        Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove -Force
-                                    }
-                                } else {
-                                    if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
-                                        Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser'."
-                                        Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove
-                                    }
-                                }
-                            }
-                        } else {
-                            Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
                         }
-                        #reset collection
-                        $UsersToWork = $null
-                    } catch {
-                        Stop-Function -Message $_ -Continue
+
+                        #With the collection complete invoke remove.
+                        if ($RemoveNotExisting) {
+                            if ($Force) {
+                                if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
+                                    Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser' with -Force."
+                                    Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove -Force
+                                }
+                            } else {
+                                if ($Pscmdlet.ShouldProcess($db.Name, "Remove-DbaDbOrphanUser")) {
+                                    Write-Message -Level Verbose -Message "Calling 'Remove-DbaDbOrphanUser'."
+                                    Remove-DbaDbOrphanUser -SqlInstance $server -Database $db.Name -User $UsersToRemove
+                                }
+                            }
+                        }
+                    } else {
+                        Write-Message -Level Verbose -Message "No orphan users found on database '$db'."
                     }
+                    #reset collection
+                    $UsersToWork = $null
+                } catch {
+                    Stop-Function -Message $_ -Continue
                 }
-            } else {
-                Write-Message -Level Verbose -Message "There are no databases to analyse."
             }
+        } else {
+            Write-Message -Level Verbose -Message "There are no databases to analyse."
         }
     }
+}
 }


### PR DESCRIPTION
Fix Repair-DbaOrphanUser skipping contained databases

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix for issue #5887  so that contained databases are not ignored when attempting to fix orphaned users. 
### Approach
<!-- How does this change solve that purpose -->
Eliminates the code that looks to see if the database is contained. The existing db level checks cover handling contained users correctly (see SQL below for DB creation on testing this).

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Create database, logins, users, contained users, orphaned users using SQL code at https://gist.github.com/sirsql/760c0c052fbd3d7ef6be5c0f9db09887
Then run `repair-dbadborphanuser -sqlinstance localhost
`
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
