### PR TITLE
Test-DbaConnection address passing Credential parameter properly

### DIFF
--- a/functions/Get-DbaTcpPort.ps1
+++ b/functions/Get-DbaTcpPort.ps1
@@ -18,6 +18,9 @@ function Get-DbaTcpPort {
 
         $scred = Get-Credential, then pass $scred object to the -SqlCredential parameter.
 
+    .PARAMETER Credential
+        Credential object used to connect to the Computer as a different user
+
     .PARAMETER All
         If this switch is enabled, an object with server name, IPAddress (ipv4 and ipv6), port and static ($true/$false) for one or more SQL Servers is returned.
 
@@ -68,6 +71,7 @@ function Get-DbaTcpPort {
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [PSCredential]$Credential,
         [switch]$All,
         [Alias("Ipv4")]
         [switch]$ExcludeIpv6,

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -66,7 +66,7 @@ function Test-DbaConnection {
     [CmdletBinding()]
     param (
         [parameter(ValueFromPipeline)]
-        [DbaInstance[]]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$Credential,
         [PSCredential]$SqlCredential,
         [switch]$EnableException
@@ -78,9 +78,9 @@ function Test-DbaConnection {
             $localInfo = [pscustomobject]@{
                 Windows    = [environment]::OSVersion.Version.ToString()
                 Edition    = $PSVersionTable.PSEdition
-                PowerShell = $PSVersionTable.PSversion.ToString()
+                PowerShell = $PSVersionTable.PSVersion.ToString()
                 CLR        = [string]$PSVersionTable.CLRVersion
-                SMO        = ((([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.Fullname -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]).TrimStart("Version=")
+                SMO        = ((([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName -like "Microsoft.SqlServer.SMO,*" }).FullName -Split ", ")[1]).TrimStart("Version=")
                 DomainUser = $env:computername -ne $env:USERDOMAIN
                 RunAsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
             }
@@ -88,23 +88,23 @@ function Test-DbaConnection {
             try {
                 <# gather following properties #>
                 <#
-                        InputName        :
-                        ComputerName     :
-                        IPAddress        :
-                        DNSHostName      :
-                        DNSDomain        :
-                        Domain           :
-                        DNSHostEntry     :
-                        FQDN             :
-                        FullComputerName :
-                     #>
+                    InputName        :
+                    ComputerName     :
+                    IPAddress        :
+                    DNSHostName      :
+                    DNSDomain        :
+                    Domain           :
+                    DNSHostEntry     :
+                    FQDN             :
+                    FullComputerName :
+                #>
                 $resolved = Resolve-DbaNetworkName -ComputerName $instance.ComputerName -Credential $Credential -EnableException
             } catch {
                 Stop-Function -Message "Unable to resolve server information" -Category ConnectionError -Target $instance -ErrorRecord $_ -Continue
             }
 
-            # Test for WinRM #Test-WinRM neh
-            Write-Message -Level Verbose -Message "Checking remote acccess"
+            # Test for WinRM #Test-WinRM
+            Write-Message -Level Verbose -Message "Checking remote access"
             try {
                 $null = Invoke-Command2 -ComputerName $instance.ComputerName -Credential $Credential -ScriptBlock { Get-ChildItem } -ErrorAction Stop
                 $remoting = $true
@@ -112,7 +112,7 @@ function Test-DbaConnection {
                 $remoting = $_
             }
 
-            # Test Connection first using Ping class which requires ICMP access then failback to tcp if pings are blocked
+            # Test Connection first using Ping class which requires ICMP access then fail back to tcp if pings are blocked
             Write-Message -Level Verbose -Message "Testing ping to $($instance.ComputerName)"
             $ping = New-Object System.Net.NetworkInformation.Ping
             $timeout = 1000 #milliseconds
@@ -146,7 +146,7 @@ function Test-DbaConnection {
 
             # TCP Port
             try {
-                $tcpport = (Get-DbaTcpPort -SqlInstance $server -EnableException).Port
+                $tcpport = (Get-DbaTcpPort -SqlInstance $server -Credential $Credential -EnableException).Port
             } catch {
                 $tcpport = $_
             }

--- a/tests/Get-DbaTcpPort.Tests.ps1
+++ b/tests/Get-DbaTcpPort.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'All', 'ExcludeIpv6', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Credential', 'All', 'ExcludeIpv6', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5929 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
This command included a call to `Invoke-ManagedComputerCommand` but was passing a `$Credential` variable that the command never accepted as a parameter. So I updated the command to now accept that object.

In turn this fixes an issue `Test-DbaConnection` has because we were not passing in the actual Credential to `Get-DbaTcpPort`. I updated that call to now pass the `Credential` properly.