### PR TITLE
New Feature - Data Masking Export Dictionary

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -652,9 +652,22 @@ function Invoke-DbaDbDataMasking {
 
                 # Export the dictionary when needed
                 if ($DictionaryExportPath) {
-                    $dictionaryFileName = "$($server.ComputerName)_$($server.DbaInstanceName)_$($db.Name)_Dictionary.csv"
+                    Write-Message -Message "Writing dictionary for $($db.Name)" -Level Verbose
+                    try {
+                        $filenamepart = $server.Name.Replace('\', '$').Replace('TCP:', '').Replace(',', '.')
+                        $dictionaryFileName = "$Path\$($filenamepart).$($db.Name)._Dictionary.csv"
 
-                    $dictionary.GetEnumerator() | Select-Object Key, Value, @{Name = "Type"; Expression = { $_.Value.GetType().Name } } | Export-Csv -Path $dictionaryFileName -NoTypeInformation
+                        if (-not $script:isWindows) {
+                            $temppath = $temppath.Replace("\", "/")
+                        }
+
+                        $dictionary.GetEnumerator() | Select-Object Key, Value, @{Name = "Type"; Expression = { $_.Value.GetType().Name } } | Export-Csv -Path $dictionaryFileName -NoTypeInformation
+                        Get-ChildItem -Path $dictionaryFileName
+                    } catch {
+                        Stop-Function -Message "Something went wrong writing the dictionary to the $DictionaryExportPath" -Target $DictionaryExportPath -Continue -ErrorRecord $_
+                    }
+
+
                 }
             }
         }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -658,7 +658,7 @@ function Invoke-DbaDbDataMasking {
                         $dictionaryFileName = "$Path\$($filenamepart).$($db.Name)._Dictionary.csv"
 
                         if (-not $script:isWindows) {
-                            $temppath = $temppath.Replace("\", "/")
+                            $dictionaryFileName = $dictionaryFileName.Replace("\", "/")
                         }
 
                         $dictionary.GetEnumerator() | Select-Object Key, Value, @{Name = "Type"; Expression = { $_.Value.GetType().Name } } | Export-Csv -Path $dictionaryFileName -NoTypeInformation

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -77,6 +77,8 @@ function Invoke-DbaDbDataMasking {
     .PARAMETER DictionaryExportPath
         Export the dictionary to the given path. Naming convention will be [instance]_[database]_Dictionary.csv
 
+        Be carefull with this feature, this export is the key to get the original values which is a security risk!
+
     .PARAMETER Force
         Forcefully execute commands when needed
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -75,7 +75,7 @@ function Invoke-DbaDbDataMasking {
         Import the dictionary to be used in in the database masking
 
     .PARAMETER DictionaryExportPath
-        Export the dictionary to the given path. Naming convention will be [instance]_[database]_Dictionary.csv
+        Export the dictionary to the given path. Naming convention will be [computername]_[instancename]_[database]_Dictionary.csv
 
         Be carefull with this feature, this export is the key to get the original values which is a security risk!
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -146,7 +146,7 @@ function Invoke-DbaDbDataMasking {
         [switch]$ExactLength,
         [int]$ConnectionTimeout = 0,
         [int]$CommandTimeout = 300,
-        [string]$DictionaryFilePath,
+        [string[]]$DictionaryFilePath,
         [string]$DictionaryExportPath,
         [switch]$EnableException
     )

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -71,6 +71,12 @@ function Invoke-DbaDbDataMasking {
     .PARAMETER CommandTimeout
         Timeout for the database connection in seconds. Default is 300.
 
+    .PARAMETER DictionaryFilePath
+        Import the dictionary to be used in in the database masking
+
+    .PARAMETER DictionaryExportPath
+        Export the dictionary to the given path. Naming convention will be [instance]_[database]_Dictionary.csv
+
     .PARAMETER Force
         Forcefully execute commands when needed
 
@@ -138,6 +144,8 @@ function Invoke-DbaDbDataMasking {
         [switch]$ExactLength,
         [int]$ConnectionTimeout = 0,
         [int]$CommandTimeout = 300,
+        [string]$DictionaryFilePath,
+        [string]$DictionaryExportPath,
         [switch]$EnableException
     )
     begin {

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -703,9 +703,8 @@ function Invoke-DbaDbDataMasking {
                         }
 
                         $dictionary.GetEnumerator() | Sort-Object Key | Select-Object Key, Value, @{Name = "Type"; Expression = { $_.Value.GetType().Name } } | Export-Csv -Path $dictionaryFileName -NoTypeInformation
-                        $file = Get-ChildItem -Path $dictionaryFileName
 
-                        $file.FullName
+                        Get-ChildItem -Path $dictionaryFileName
                     } catch {
                         Stop-Function -Message "Something went wrong writing the dictionary to the $DictionaryExportPath" -Target $DictionaryExportPath -Continue -ErrorRecord $_
                     }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -166,6 +166,7 @@ function Invoke-DbaDbDataMasking {
             $dictionary = @{ }
 
             foreach ($file in $DictionaryFilePath) {
+                Write-Message -Level Verbose -Message "Importing dictionary file '$file'"
                 if (Test-Path -Path $file) {
                     try {
                         # Import the keys and values
@@ -174,13 +175,15 @@ function Invoke-DbaDbDataMasking {
                         # Loop through the items and define the types
                         foreach ($item in $items) {
                             if ($item.Type) {
-                                $type = [type]"$($_.type)"
+                                $type = [type]"$($item.type)"
                             } else {
                                 $type = [type]"string"
                             }
 
                             # Add the items to the hash array
-                            $dictionary.Add($_.Key, ($($_.Value) -as $type))
+                            if ($dictionary.Keys -notcontains $item.Key) {
+                                $dictionary.Add($item.Key, ($($item.Value) -as $type))
+                            }
                         }
                     } catch {
                         Stop-Function -Message "Could not import csv data from file '$file'" -ErrorRecord $_ -Target $file
@@ -189,6 +192,10 @@ function Invoke-DbaDbDataMasking {
                     Stop-Function -Message "Could not import dictionary file '$file'" -ErrorRecord $_ -Target $file
                 }
             }
+
+            $dictionary
+
+            return
         }
     }
 

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -180,7 +180,7 @@ function Invoke-DbaDbDataMasking {
                                 $type = [type]"string"
                             }
 
-                            # Add the items to the hash array
+                            # Add the item to the hash array
                             if ($dictionary.Keys -notcontains $item.Key) {
                                 $dictionary.Add($item.Key, ($($item.Value) -as $type))
                             }
@@ -192,10 +192,6 @@ function Invoke-DbaDbDataMasking {
                     Stop-Function -Message "Could not import dictionary file '$file'" -ErrorRecord $_ -Target $file
                 }
             }
-
-            $dictionary
-
-            return
         }
     }
 
@@ -228,6 +224,7 @@ function Invoke-DbaDbDataMasking {
             if ($Table -and $tabletest.Name -notin $Table) {
                 continue
             }
+
             foreach ($columntest in $tabletest.Columns) {
                 if ($columntest.ColumnType -in 'hierarchyid', 'geography', 'xml', 'geometry' -and $columntest.Name -notin $Column) {
                     Stop-Function -Message "$($columntest.ColumnType) is not supported, please remove the column $($columntest.Name) from the $($tabletest.Name) table" -Target $tables -Continue

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -188,8 +188,6 @@ function Invoke-DbaDbDataMasking {
             }
         }
 
-        $dictionary = @{ }
-
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential -MinimumVersion 9
@@ -202,6 +200,8 @@ function Invoke-DbaDbDataMasking {
             }
 
             foreach ($dbname in $Database) {
+                $dictionary = @{ }
+
                 if ($server.VersionMajor -lt 9) {
                     Stop-Function -Message "SQL Server version must be 2005 or greater" -Continue
                 }

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -642,11 +642,19 @@ function Invoke-DbaDbDataMasking {
                     $uniqueValues = $null
                 }
 
+                # Commit the transaction and close it
                 try {
                     $null = $transaction.Commit()
                     $sqlconn.Close()
                 } catch {
                     Stop-Function -Message "Failure" -Continue -ErrorRecord $_
+                }
+
+                # Export the dictionary when needed
+                if ($DictionaryExportPath) {
+                    $dictionaryFileName = "$($server.ComputerName)_$($server.DbaInstanceName)_$($db.Name)_Dictionary.csv"
+
+                    $dictionary.GetEnumerator() | Select-Object Key, Value, @{Name = "Type"; Expression = { $_.Value.GetType().Name } } | Export-Csv -Path $dictionaryFileName -NoTypeInformation
                 }
             }
         }

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'Query', 'MaxValue', 'ModulusFactor', 'ExactLength', 'ConnectionTimeout', 'CommandTimeout', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'Query', 'MaxValue', 'ModulusFactor', 'ExactLength', 'ConnectionTimeout', 'CommandTimeout', 'DictionaryFilePath', 'DictionaryExportPath', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
In some cases, especially running testing, you want the data to be masked consistently between masking actions. Before you would get different values for the masked columns every time.

### Approach
It's now possible to export and import dictionaries to make the masking consistent.

The command will export all the values and keys to a CSV file.

### Commands to test
```
Invoke-DbaDbDataMasking -SqlInstance [instance]-Database [database] -FilePath [pathtomaskingfile] -DictionaryExportPath [exportdirectory]
```
```
Invoke-DbaDbDataMasking -SqlInstance [instance]-Database [database] -FilePath [pathtomaskingfile] -DictionaryFilePath [pathtodictionary]
```
### Screenshots
**Export the dictionary**
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/6154981/64518134-ec9a5780-d2f1-11e9-8357-ecd5aa7026a1.png)

**The result of the export**
![image](https://user-images.githubusercontent.com/6154981/64518188-0471db80-d2f2-11e9-9ce7-2e19eacd514c.png)

**The result of the masking**
![image](https://user-images.githubusercontent.com/6154981/64518224-12276100-d2f2-11e9-8a26-12829cf3c73f.png)

**Look up a specific value**
![image](https://user-images.githubusercontent.com/6154981/64518258-20757d00-d2f2-11e9-8c71-bdefce62e54e.png)

**Run the masking with importing the dictionary file**
![image](https://user-images.githubusercontent.com/6154981/64518296-32572000-d2f2-11e9-9bf2-97c29cbde55b.png)

**The result after using the dictionary**
![image](https://user-images.githubusercontent.com/6154981/64518327-3edb7880-d2f2-11e9-81a2-fa73ed025572.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
