### PR TITLE
Backup-DbaDatabase - Issue with URL backups and error message

### DIFF
--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -105,7 +105,7 @@ function New-DbaCredential {
     )
 
     begin {
-        if ($Force) {$ConfirmPreference = 'none'}
+        if ($Force) { $ConfirmPreference = 'none' }
 
         $mappedClass = switch ($MappedClassType) {
             "CryptographicProvider" { 1 }
@@ -131,7 +131,11 @@ function New-DbaCredential {
                 if ($currentCred) {
                     if ($force) {
                         Write-Message -Level Verbose -Message "Dropping credential $Name"
-                        $currentCred.Drop()
+                        try {
+                            $currentCred.Drop()
+                        } catch {
+                            Stop-Function -Message "Error dropping credential $Name" -Target $name -Continue
+                        }
                     } else {
                         Stop-Function -Message "Credential exists and Force was not specified" -Target $Name -Continue
                     }
@@ -151,7 +155,7 @@ function New-DbaCredential {
 
                         Select-DefaultView -InputObject $credential -Property ComputerName, InstanceName, SqlInstance, Name, Identity, CreateDate, MappedClassType, ProviderName
                     } catch {
-                        Stop-Function -Message "Failed to create credential in $cred on $instance. Exception: $($_.Exception.InnerException)" -Target $credential -InnerErrorRecord $_ -Continue
+                        Stop-Function -Message "Failed to create credential in $cred on $instance" -Target $credential -InnerErrorRecord $_ -Continue
                     }
                 }
             }

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -75,10 +75,16 @@ function New-DbaCredential {
         Creates a credential, "AzureBackupBlobStore", on Server1 using the Access Keys for Backup To URL. Identity must be the full URI for the blob container that will be the backup target. The SecurePassword supplied is one of the two Access Keys for the Azure Storage Account.
 
     .EXAMPLE
-        PS C:\> New-DbaCredential -SqlInstance Server1 -Name 'https://<Azure Storage Account Name>.blob.core.windows.net/<Blob Store Container Name>' -Identity 'SHARED ACCESS SIGNATURE' -SecurePassword (ConvertTo-SecureString '<Shared Access Token>' -AsPlainText -Force)
+        PS C:\> $sasParams = @{
+        >>SqlInstance = "server1"
+        >>Name = "https://<azure storage account name>.blob.core.windows.net/<blob container>"
+        >>Identity = "SHARED ACCESS SIGNATURE"
+        >>SecurePassword = (ConvertTo-SecureString '<Shared Access Token>' -AsPlainText -Force)
+        >>}
+        PS C:\> New-DbaCredential @sasParams
 
-        Create a credential on Server1 using a SAS token for Backup To URL. Name has to be the full URI for the blob store container that will be the backup target. The SecurePassword will be the Share Access Token (SAS) and passed in as a SecureString.
-
+        Create a credential on Server1 using a SAS token for Backup To URL. The Name is the full URI for the blob container that will be the backup target.
+        The SecurePassword will be the Shared Access Token (SAS), as a SecureString.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
     param (


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6019 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

I found we had to adjust logic for a few different things. If someone passing in a base URL with a folder name included we are taking that as-is to validate the SAS token credential. I had to include splitting that base url out so we can only get to the container path (<base URL>/<container>) as that is what the credential name will be on SAS tokens.

In addition there was logic that was populating the `$Path` variable if it was not provided with the default backup path. This is directly related to the error received in #6019 and has been fixed with these changes.

In doing the above I'm also adjusting the error output for `New-DbaCredential` as it was outputting the whole error stack for some reason. So instead of this output:

```
[5] > New-DbaCredential @sasParams
WARNING: [01:48:07][New-DbaCredential] Failed to create credential in SHARED ACCESS TOKEN on localhost,1411. Exception: Microsoft.SqlServer.Management.Smo.FailedOperationException: Create failed for Credential 'https://sqlbackup6019.blob.core.windows.net/backups'.  ---> Microsoft.SqlServer.Management.Common.ExecutionFailureException: An exception occurred while executing a Transact-SQL statement or batch. ---> System.Data.SqlClient.SqlEx   at Microsoft.SqlServer.Management.Common.ConnectionManager.ExecuteTSql(ExecuteTSqlAction action, Object execObject, DataSet fillDataSet, Boolean catchException)
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(String sqlCommand, ExecutionTypes executionType, Boolean retry)       
   --- End of inner exception stack trace ---
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(String sqlCommand, ExecutionTypes executionType, Boolean retry)       
   at Microsoft.SqlServer.Management.Common.ServerConnection.ExecuteNonQuery(StringCollection sqlCommands, ExecutionTypes executionType, Boolean retry)
   at Microsoft.SqlServer.Management.Smo.ExecutionManager.ExecuteNonQuery(StringCollection queries, Boolean retry)
   at Microsoft.SqlServer.Management.Smo.ExecutionManager.ExecuteNonQuery(StringCollection queries)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.ExecuteNonQuery(StringCollection queries, Boolean includeDbContext, Boolean executeForAlter) 
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.CreateImplFinish(StringCollection createQuery, ScriptingPreferences sp)
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.CreateImpl()
   --- End of inner exception stack trace ---
   at Microsoft.SqlServer.Management.Smo.SqlSmoObject.CreateImpl()
   at Microsoft.SqlServer.Management.Smo.Credential.Create()
   at Microsoft.SqlServer.Management.Smo.Credential.Create(String identity, SecureString secret)
   at CallSite.Target(Closure , CallSite , Object , String[] , SecureString )
```
You get this now:
```
[8] > New-DbaCredential @sasParams       
WARNING: [02:07:15][New-DbaCredential] Failed to create credential in SHARED ACCESS TOKEN on localhost,1411 | An error occurred during Service Master Key decryption
```