### PR TITLE
Test-DbaLinkedServerConnection - Fix for issue #6036

### DIFF
--- a/functions/Test-DbaLinkedServerConnection.ps1
+++ b/functions/Test-DbaLinkedServerConnection.ps1
@@ -55,6 +55,7 @@ function Test-DbaLinkedServerConnection {
         Test all Linked Servers for the SQL Server instances sql2016, sql2014 and sql2012 using SQL login credentials
 
     .EXAMPLE
+        PS C:\> $servers = "sql2016","sql2014","sql2012"
         PS C:\> $servers | Get-DbaLinkedServer | Test-DbaLinkedServerConnection
 
         Test all Linked Servers for the SQL Server instances sql2016, sql2014 and sql2012
@@ -78,9 +79,8 @@ function Test-DbaLinkedServerConnection {
                 } catch {
                     Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
+                $linkedServerCollection = $server.LinkedServers
             }
-
-            $linkedServerCollection = $server.LinkedServers
 
             foreach ($ls in $linkedServerCollection) {
                 Write-Message -Level Verbose -Message "Testing linked server $($ls.name) on server $($ls.parent.name)"

--- a/tests/Test-DbaLinkedServerConnection.Tests.ps1
+++ b/tests/Test-DbaLinkedServerConnection.Tests.ps1
@@ -24,10 +24,29 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $server = Connect-DbaInstance -SqlInstance $script:instance1 -Database master
         $server.Query("EXEC master.dbo.sp_dropserver @server=N'localhost', @droplogins='droplogins'")
     }
+    Context "Function works" {
+        $results = Test-DbaLinkedServerConnection -SqlInstance $script:instance1 | Where-Object LinkedServerName -eq 'localhost'
+        It "function returns results" {
+            $results | Should Not BeNullOrEmpty
+        }
+        It "linked server name is localhost" {
+            $results.LinkedServerName | Should Be 'localhost'
+        }
+        It "connectivity is true" {
+            $results.Connectivity | Should BeTrue
+        }
+    }
 
-    $results = Test-DbaLinkedServerConnection -SqlInstance $script:instance1 | Where-Object LinkedServerName -eq 'localhost'
-    It "can connect to linked server 'localhost'" {
-        $results.LinkedServerName -eq 'localhost'
-        $results.Connectivity -eq $true
+    Context "Piping to function works" {
+        $pipeResults =  Get-DbaLinkedServer -SqlInstance $script:instance1 | Test-DbaLinkedServerConnection
+        It "piping from Get-DbaLinkedServerConnection returns results" {
+            $pipeResults | Should Not BeNullOrEmpty
+        }
+        It "linked server name is localhost" {
+            $pipeResults.LinkedServerName | Should Be 'localhost'
+        }
+        It "connectivity is true" {
+            $pipeResults.Connectivity | Should BeTrue
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6036)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Fixes issue with piping from `Get-DbaLinkedServerConnection` to `Test-DbaLinkedServerConnection`.
- Added a test for pipe

### Approach
If piped to the `$LinkedServerCollection` was at the `$instance.LinkedServer`, which was correctly defined. However then it was overwritten by `$server.LinkedServer` which is only needed when not piping.

### Commands to test
`$servers | Get-DbaLinkedServer | Test-DbaLinkedServerConnection`