### PR TITLE
Compression - Exclude sparse columns, no compression there! fixes #6016

### DIFF
--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -192,8 +192,8 @@ function Set-DbaDbCompression {
                     } else {
                         if ($Pscmdlet.ShouldProcess($db, "Applying $CompressionType compression")) {
                             Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
-                            foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object { !$_.IsMemoryOptimized }) {
-                                if ($MaxRunTime -ne 0 -and ($(Get-Date) - $starttime).TotalMinutes -ge $MaxRunTime) {
+                            foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object { !$_.IsMemoryOptimized -and !$_.HasSparseColumn }) {
+                                if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
                                     break
                                 }

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -193,7 +193,7 @@ function Set-DbaDbCompression {
                         if ($Pscmdlet.ShouldProcess($db, "Applying $CompressionType compression")) {
                             Write-Message -Level Verbose -Message "Applying $CompressionType compression to all objects in $($db.name)"
                             foreach ($obj in $server.Databases[$($db.name)].Tables | Where-Object { !$_.IsMemoryOptimized -and !$_.HasSparseColumn }) {
-                                if ($MaxRunTime -ne 0 -and ($(get-date) - $starttime).TotalMinutes -ge $MaxRunTime) {
+                                if ($MaxRunTime -ne 0 -and ($(Get-Date) - $starttime).TotalMinutes -ge $MaxRunTime) {
                                     Write-Message -Level Verbose -Message "Reached max run time of $MaxRunTime"
                                     break
                                 }

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -369,6 +369,15 @@ ORDER BY [TableName] ASC;
 
 $sqlRestrict
 
+BEGIN
+    -- remove any tables with sparse columns
+    DELETE tdc
+    FROM ##TestDbaCompression tdc
+    INNER JOIN sys.columns c
+        on tdc.ObjectId = c.object_id
+    WHERE c. is_sparse = 1
+END
+
 $sqlVersionRestrictions
 
 DECLARE @schema SYSNAME

--- a/tests/Test-DbaDbCompression.Tests.ps1
+++ b/tests/Test-DbaDbCompression.Tests.ps1
@@ -33,7 +33,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
     Context "Command gets suggestions" {
         $results = Test-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname
-        It "Should get results for $dbaname" {
+        It "Should get results for $dbname" {
             $results | Should Not Be $null
         }
         $results.foreach{
@@ -48,10 +48,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
     Context "Command makes right suggestions" {
         $results = Test-DbaDbCompression -SqlInstance $script:instance2 -Database $dbname
-        It "Should sugggest PAGE compression for a table with no updates or scans" {
+        It "Should suggest PAGE compression for a table with no updates or scans" {
             $($results | Where-Object { $_.TableName -eq "syscols" -and $_.IndexType -eq "HEAP"}).CompressionTypeRecommendation | Should Be "PAGE"
         }
-        It "Should sugggest ROW compression for table with more updates" {
+        It "Should suggest ROW compression for table with more updates" {
             $($results | Where-Object { $_.TableName -eq "sysallparams"}).CompressionTypeRecommendation | Should Be "ROW"
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6016
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Tables that have sparse columns can't be compressed (not even NC indexes on those tables that don't include the sparse column)

### Approach
- Test - Remove those affected tables from the temp table that contains all objects to test compression for
- Set - exclude tables where `HasSparseColumn` is true