### PR TITLE
Copy-DbaLogin fix - needed to add ParameterSets so it was valid option

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -125,10 +125,12 @@ function Copy-DbaLogin {
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "Medium")]
     param (
+        [parameter(ParameterSetName = "File", Mandatory)]
         [parameter(ParameterSetName = "SqlInstance", Mandatory)]
         [DbaInstanceParameter]$Source,
         [PSCredential]$SourceSqlCredential,
-        [parameter(Mandatory)]
+        [parameter(ParameterSetName = "SqlInstance", Mandatory)]
+        [parameter(ParameterSetName = "InputObject")]
         [DbaInstanceParameter[]]$Destination,
         [PSCredential]$DestinationSqlCredential,
         [object[]]$Login,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6037 
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix issue using -OutFile parameter

### Approach
1. Previously the only parameter with the File ParameterSet was Outfile, so when you try and pass in Source and File it got upset.
```
        [parameter(ParameterSetName = "File", Mandatory)]
        [string]$OutFile,
```
2. Added File parameterset to Source... which fixed it, but broke piping.
```
        [parameter(ParameterSetName = "File", Mandatory)]
        [parameter(ParameterSetName = "SqlInstance", Mandatory)]
        [DbaInstanceParameter]$Source,
```
3. Added two ParameterSets to Destination. Now all the scenarios below work.
```
        [parameter(ParameterSetName = "SqlInstance", Mandatory)]
        [parameter(ParameterSetName = "InputObject")]
        [DbaInstanceParameter[]]$Destination,
```

I'm not sure if there is a cleaner approach?

### Commands to test
```
Copy-DbaLogin -source sourceServer -OutFile "test.txt"
Copy-DbaLogin -Source sourceServer -Login loginName -Destination destServer
Get-DbaLogin -SqlInstance sourceServer | Out-GridView -Passthru | Copy-DbaLogin -Destination destServer