### PR TITLE
fix BuildReference test

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2019-08-02T00:00:00",
+    "LastUpdated": "2019-09-18T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -34,7 +34,7 @@ Describe "$CommandName Unit Test" -Tags Unittest {
         }
         It "LastUpdated is updated regularly (keeps everybody on their toes)" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated
-            $lastupdate | Should BeGreaterThan (Get-Date).AddDays(-90)
+            $lastupdate | Should BeGreaterThan (Get-Date).AddDays(-45)
         }
         It "LastUpdated is not in the future" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Have the CI check matching the staleness check on the function itself.
To keep us checking the buildreference it's 45 days, users get a stale warning if their local copy is 45 days old.
In the meantime the CI test - now - fails if the buildreference in dev (which should match the one online) is 45 days old at most too.

tl;dr: 
- users will know if their index is stale.
- core devs need to bump the date of the local and online one every 45 days, if not, CI will remind with a failed test.

Thanks Aaron for the report, alevyinroc for upping and wsmelton for pointing the insanity of the incorrect check ^_^
