### PR TITLE
Test-DbaMaxDop - Fixed link to calculator

### DIFF
--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -4,7 +4,7 @@ function Test-DbaMaxDop {
         Displays information relating to SQL Server Max Degree of Parallelism setting. Works on SQL Server 2005-2016.
 
     .DESCRIPTION
-        Inspired by Sakthivel Chidambaram's post about SQL Server MAXDOP Calculator (https://blogs.msdn.microsoft.com/sqlsakthi/p/maxdop-calculator-SqlInstance/),
+        Inspired by Sakthivel Chidambaram's post about SQL Server MAXDOP Calculator (https://blogs.msdn.microsoft.com/sqlsakthi/p/maxdop-calculator/),
         this script displays a SQL Server's: max dop configured, and the calculated recommendation.
 
         For SQL Server 2016 shows:


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The link to the calculator was broken, it had a `-SqlInstance` pasted on the end.

### Approach
Removed `-SqlInstance` and now the link works 😍
