### PR TITLE
Fix SizeOnDiskBytes value in Get-DbaIoLatency

### DIFF
--- a/functions/Get-DbaIoLatency.ps1
+++ b/functions/Get-DbaIoLatency.ps1
@@ -154,7 +154,7 @@ function Get-DbaIoLatency {
                     NumberOfBytesRead    = $row.num_of_bytes_read
                     NumberOfBytesWritten = $row.num_of_bytes_written
                     SampleMilliseconds   = $row.sample_ms
-                    SizeOnDiskBytes      = $row.num_of_bytes_written
+                    SizeOnDiskBytes      = $row.size_on_disk_bytes
                     FileHandle           = $row.file_handle
                     ReadLatency          = $row.ReadLatency
                     WriteLatency         = $row.WriteLatency


### PR DESCRIPTION
The SizeOnDiskBytes value in the return object is now set to reference
the correct column in the source query.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6062 )
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
This PR is to fix #6062 and update Get-DbaIoLatency to return the correct values for SizeOnDiskBytes

### Approach
This change updates the SizeOnDiskBytes property in the return object to reference the size_on_disk_bytes column in the function query

### Commands to test
Get-DbaIoLatency

