### PR TITLE
Update Restore-DbaDatabase Help Text

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -233,8 +233,7 @@ function Restore-DbaDatabase {
         PS C:\> $result = Restore-DbaDatabase -SqlInstance server1\instance1 -Path \\server2\backups -DestinationDataDirectory c:\restores -OutputScriptOnly
         PS C:\> $result | Out-File -Filepath c:\scripts\restore.sql
 
-        Scans all the backup files in \\server2\backups, filters them and generate the T-SQL Scripts to restore 
-        the database to the latest point in time, and then stores the output in a file for later retrieval
+        Scans all the backup files in \\server2\backups, filters them and generate the T-SQL Scripts to restore the database to the latest point in time, and then stores the output in a file for later retrieval
 
     .EXAMPLE
         PS C:\> Restore-DbaDatabase -SqlInstance server1\instance1 -Path c:\backups -DestinationDataDirectory c:\DataFiles -DestinationLogDirectory c:\LogFile

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -231,11 +231,10 @@ function Restore-DbaDatabase {
 
     .EXAMPLE
         PS C:\> $result = Restore-DbaDatabase -SqlInstance server1\instance1 -Path \\server2\backups -DestinationDataDirectory c:\restores -OutputScriptOnly
-        PS C:\> $result | Select-Object -ExpandProperty Tsql | Out-File -Filepath c:\scripts\restore.sql
+        PS C:\> $result | Out-File -Filepath c:\scripts\restore.sql
 
-        Scans all the backup files in \\server2\backups stored in an Ola Hallengren style folder structure,
-        filters them and generate the T-SQL Scripts to restore the database to the latest point in time,
-        and then stores the output in a file for later retrieval
+        Scans all the backup files in \\server2\backups, filters them and generate the T-SQL Scripts to restore 
+        the database to the latest point in time, and then stores the output in a file for later retrieval
 
     .EXAMPLE
         PS C:\> Restore-DbaDatabase -SqlInstance server1\instance1 -Path c:\backups -DestinationDataDirectory c:\DataFiles -DestinationLogDirectory c:\LogFile


### PR DESCRIPTION
Removed `Select-Object` command from Example 5 as it was not necessary for output of the .sql file.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Update Example 5 comment based help. This example demonstrates `-OutputScriptOnly` parameter. Prior example included syntax which was unnecessary and prevented the cmdlet from functioning as desired. Additionally, remove reference to Ola Hallengren folder structure in description text as the `-MaintenanceSolutionBackup` parameter is not used in this example.
### Approach
<!-- How does this change solve that purpose -->
Remove `Select-Object -ExpandProperty tsql | ` from Example 5
Remove reference to Ola Hallengren folder structure in Example 5
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Follow Example 5 in help text. 