### PR TITLE
Address issue with Set-DbaLogin not handling multiple logins

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+SQLCollaborative Organization and the dbatools team is dedicated to providing a positive and harassment-free experience for everyone, regardless of age, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, ethnicity, race, religion, nationality, or level of experience. We do not tolerate harassment in any form, nor do we tolerate any behavior that would reasonably lead to someone being made to feel unsafe, insecure, or frightened for their physical or emotional well-being.
+
+This applies to all interactions here on GitHub, Slack, YouTube comments and YouTube chat. All communication should be appropriate for a professional audience including people of many different backgrounds.
+
+Examples of encouraged behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for everyone at the event
+- Showing empathy towards other participants
+
+Unacceptable behavior includes:
+
+- Offensive comments related to gender identity and expression, sexual orientation, race, ethnicity, language, neuro-type, size, ability, class, religion, culture, subculture, political opinion, age, skill level, occupation, or background
+- Trolling, insulting or derogatory comments, personal or political attacks
+- Deliberate intimidation
+- Harassment of any kind, even in a joking or ironic manner
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+- Sexually explicit or violent material
+- Or any other kinds of harassment
+- Be kind to others. Do not insult or put down others. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate.
+
+Use your best judgement. If it will possibly make others uncomfortable, do not post it.
+
+If you believe someone is violating the code of conduct, we ask that you report it by contacting [Chrissy LeMaire](https://twitter.com/cl) or [Shawn Melton](https://twitter.com/wsmelton).
+
+# Credit
+
+Portions of this Code of Conduct are based on the [example anti-harassment policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) from the Geek Feminism wiki, created by the Ada Initiative and other volunteers, under a Creative Commons Zero license.

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -223,7 +223,7 @@ function Set-DbaLogin {
                 Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $allLogins[$instance.ToString()] = Get-DbaLogin -SqlInstance $server
-            $InputObject += $allLogins[$instance.ToString()] | Where-Object { ($_.Name -eq $Login) -and ($_.IsSystemObject -eq $false) -and ($_.Name -notlike '##*') }
+            $InputObject += $allLogins[$instance.ToString()] | Where-Object { ($_.Name -in $Login) -and ($_.IsSystemObject -eq $false) -and ($_.Name -notlike '##*') }
         }
 
         # Loop through all the logins


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6080)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Updated test to validate multiple logins can be processed now.