### PR TITLE
New-DbaDbUser only working on first database #6052

### DIFF
--- a/functions/New-DbaDbUser.ps1
+++ b/functions/New-DbaDbUser.ps1
@@ -198,7 +198,6 @@ function New-DbaDbUser {
                             Write-Message -Level Verbose -Message "Using LoginName: $Name"
                         }
 
-                        $Login = $smoLogin
                         $UserType = [Microsoft.SqlServer.Management.Smo.UserType]::SqlLogin
                     }
 

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -12,7 +12,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
     Context "Should error out if the database does not exist" {
-        Mock -CommandName Connect-DbaInstance {
+        Mock -CommandName Connect-SqlInstance {
             [PSCustomObject]@{
                 Databases    = [String]::Empty
                 IsAccessible = $false

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -33,12 +33,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         $password = 'MyV3ry$ecur3P@ssw0rd'
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
-        $null = New-DbaLogin -SqlInstance $script:instance3 -Login $userName -Password $securePassword
+        $null = New-DbaLogin -SqlInstance $script:instance3 -Login $userName -Password $securePassword -Force
         $null = New-DbaDatabase -SqlInstance $script:instance3 -Name $dbname
     }
     AfterAll {
-        $null = Remove-DbaDbUser -SqlInstance $script:instance3 -Database $dbname -User $userNameWithoutLogin -Confirm:$false
-        $null = Remove-DbaDbUser -SqlInstance $script:instance3 -Database $dbname -User $userName -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbname -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $script:instance3 -Login $userName -Confirm:$false
     }
@@ -49,11 +47,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
     }
     Context "Should create the user without login" {
-        It -Skip "Creates the user and get it. Login property is empty" {
+        It "Creates the user and get it. Login property is empty" {
             New-DbaDbUser -SqlInstance $script:instance3 -Database $dbname[0] -User $userNameWithoutLogin
             $results = Get-DbaDbUser -SqlInstance $script:instance3 -Database $dbname[0] | Where-Object Name -eq $userNameWithoutLogin
             $results.Name | Should Be $userNameWithoutLogin
-            $results.Login | Should Be ""
+            $results.Login | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -12,7 +12,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
     Context "Should error out if the database does not exist" {
-        Mock -CommandName Connect-SqlInstance {
+        Mock -CommandName Connect-DbaInstance {
             [PSCustomObject]@{
                 Databases    = [String]::Empty
                 IsAccessible = $false


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6052)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixes reported bug New-DbaDbUser only working on first database #6052 
### Approach
<!-- How does this change solve that purpose -->
The parameter for login was getting set incorrectly at the end of the foreach loop causing only the first database to work. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
New-DbaLogin -SqlInstance localhost -Login $login -SqlCredential $cred
New-DbaDbUser -SqlInstance localhost -Login $login -Confirm -Force -EnableException -Verbose -Debug -SqlCredential $cred

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
