### PR TITLE
Fixes #6070 - Get-DbaRegisteredServer Does Not Exclude Sub-Groups

### DIFF
--- a/functions/Get-DbaRegServer.ps1
+++ b/functions/Get-DbaRegServer.ps1
@@ -206,12 +206,6 @@ function Get-DbaRegServer {
             $servers = $servers | Where-Object Id -in $Id
         }
 
-        if ($ExcludeGroup) {
-            $excluded = Get-DbaRegServer -SqlInstance $serverstore.ParentServer -Group $ExcludeGroup
-            Write-Message -Level Verbose -Message "Excluding $ExcludeGroup"
-            $servers = $servers | Where-Object { $_.Urn.Value -notin $excluded.Urn.Value }
-        }
-
         foreach ($server in $servers) {
             $az = $azureids | Where-Object Id -in $server.Id
             if ($az) {
@@ -232,6 +226,9 @@ function Get-DbaRegServer {
                 $groupname = $null
             }
 
+            if ($ExcludeGroup -and ($groupname -in $ExcludeGroup)) {
+                continue
+            }
 
             if ($server.ConnectionStringWithEncryptedPassword) {
                 $encodedconnstring = $connstring = $server.ConnectionStringWithEncryptedPassword

--- a/tests/Get-DbaRegServer.Tests.ps1
+++ b/tests/Get-DbaRegServer.Tests.ps1
@@ -77,6 +77,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results = Get-DbaRegServer -SqlInstance $script:instance1 -ExcludeGroup "$group\$group2"
             @($results | Where-Object Name -eq $srvName3).Count | Should -Be 1
         }
+        It "Should filter subgroups" {
+            $results = Get-DbaRegServer -SqlInstance $script:instance1 -Group $group -ExcludeGroup "$group\$group2"
+            $results.Count | Should Be 1
+            $results.Group | Should Be $group
+        }
 
         # Property Comparisons will come later when we have the commands
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6070)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Allow -ExcludeGroup to filter nested groups.

### Approach
<!-- How does this change solve that purpose -->
Moved ExcludeGroup logic to filter groups when objects were returned. The object being returned had a nice `$groupname` variable that could be used to easily filter out ones that should be filtered.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Get-DbaRegServer -SqlInstance mySqlInstance -Group 'Dev' -ExcludeGroup 'Dev\Nested'
