### PR TITLE
Set-DbaMaxDop - Correct support for piping from Test-DbaMaxDop

### DIFF
--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -85,6 +85,7 @@ function Set-DbaMaxDop {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param (
+        [Parameter(ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
@@ -104,12 +105,12 @@ function Set-DbaMaxDop {
 
     process {
         if ((Test-Bound -Parameter Database) -and (Test-Bound -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
-            Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one. Quitting."
+            Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one."
             return
         }
 
         if ((Test-Bound -not -Parameter SqlInstance) -and (Test-Bound -not -Parameter InputObject)) {
-            Stop-Function -Category InvalidArgument -Message "Please provide either the SqlInstance or an Input object. Quitting."
+            Stop-Function -Category InvalidArgument -Message "Please provide either the SqlInstance or an Input object."
             return
         }
 

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -44,7 +44,7 @@ function Set-DbaMaxDop {
         Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
     .PARAMETER Confirm
-        Prompts you for confirmation before running the cmdlet.
+        Prompts you for conf    irmation before running the cmdlet.
 
     .NOTES
         Tags: MaxDop, SpConfigure
@@ -85,7 +85,6 @@ function Set-DbaMaxDop {
     #>
     [CmdletBinding(SupportsShouldProcess)]
     param (
-        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
@@ -101,6 +100,11 @@ function Set-DbaMaxDop {
     process {
         if ((Test-Bound -Parameter Database) -and (Test-Bound -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
             Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one. Quitting."
+            return
+        }
+
+        if ((Test-Bound -Parameter SqlInstance) -or (Test-Bound -Parameter InputObject)) {
+            Stop-Function -Category InvalidArgument -Message "Please provide either the SqlInstance or an Input object. Quitting."
             return
         }
 

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -104,19 +104,19 @@ function Set-DbaMaxDop {
     }
 
     process {
-        if ((Test-Bound -Parameter Database) -and (Test-Bound -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
+        if (Test-Bound -ParameterName Database, AllDatabases, ExcludeDatabase) {
             Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one."
             return
         }
 
-        if ((Test-Bound -not -Parameter SqlInstance) -and (Test-Bound -not -Parameter InputObject)) {
-            Stop-Function -Category InvalidArgument -Message "Please provide either the SqlInstance or an Input object."
+        if ((Test-Bound -ParameterName SqlInstance, InputObject -not)) {
+            Stop-Function -Category InvalidArgument -Message "Please provide either the SqlInstance or InputObject."
             return
         }
 
         $dbscopedconfiguration = $false
 
-        if ((Test-Bound -Not -Parameter InputObject)) {
+        if ((Test-Bound -Not -ParameterName InputObject)) {
             $InputObject = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
         } elseif ($null -eq $InputObject.SqlInstance) {
             $InputObject = Test-DbaMaxDop -SqlInstance $sqlinstance -SqlCredential $SqlCredential -Verbose:$false
@@ -144,18 +144,18 @@ function Set-DbaMaxDop {
             if ($server.versionMajor -ge 13) {
                 Write-Message -Level Verbose -Message "Server '$servername' supports Max DOP configuration per database."
 
-                if ((Test-Bound -Not -Parameter Database) -and (Test-Bound -Not -Parameter ExcludeDatabase)) {
+                if ((Test-Bound -ParameterName Database, ExcludeDatabase -not)) {
                     #Set at instance level
                     $InputObject = $InputObject | Where-Object { $_.DatabaseMaxDop -eq "N/A" }
                 } else {
                     $dbscopedconfiguration = $true
 
-                    if ((Test-Bound -Not -Parameter AllDatabases) -and (Test-Bound -Parameter Database)) {
+                    if ((Test-Bound -Not -ParameterName AllDatabases) -and (Test-Bound -ParameterName Database)) {
                         $InputObject = $InputObject | Where-Object { $_.Database -in $Database }
-                    } elseif ((Test-Bound -Not -Parameter AllDatabases) -and (Test-Bound -Parameter ExcludeDatabase)) {
+                    } elseif ((Test-Bound -Not -ParameterName AllDatabases) -and (Test-Bound -ParameterName ExcludeDatabase)) {
                         $InputObject = $InputObject | Where-Object { $_.Database -notin $ExcludeDatabase }
                     } else {
-                        if (Test-Bound -Parameter AllDatabases) {
+                        if (Test-Bound -ParameterName AllDatabases) {
                             $InputObject = $InputObject | Where-Object { $_.DatabaseMaxDop -ne "N/A" }
                         } else {
                             $InputObject = $InputObject | Where-Object { $_.DatabaseMaxDop -eq "N/A" }
@@ -164,7 +164,7 @@ function Set-DbaMaxDop {
                     }
                 }
             } else {
-                if ((Test-Bound -Parameter database) -or (Test-Bound -Parameter AllDatabases)) {
+                if ((Test-Bound -ParameterName database) -or (Test-Bound -ParameterName AllDatabases)) {
                     Write-Message -Level Warning -Message "Server '$servername' (v$($server.versionMajor)) does not support Max DOP configuration at the database level. Remember that this option is only available from SQL Server 2016 (v13). Run the command again without using database related parameters. Skipping."
                     Continue
                 }

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -81,7 +81,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.CurrentInstanceMaxDop | Should Not BeNullOrEmpty
             $results.CurrentInstanceMaxDop | Should Be 4
         }
-        It 'Maxdop should not match expected' {
+        It 'Maxdop should match expected' {
             $server.Configuration.MaxDegreeOfParallelism.ConfigValue | Should Be 4
         }
     }

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -74,7 +74,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         }
     }
 
-    Context "Piping works" {
+    Context "Piping from Test-DbaMaxDop works" {
         $results = Test-DbaMaxDop -SqlInstance $script:instance2 | Set-DbaMaxDop -MaxDop 4
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         It 'Command returns output' {
@@ -83,6 +83,18 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         }
         It 'Maxdop should match expected' {
             $server.Configuration.MaxDegreeOfParallelism.ConfigValue | Should Be 4
+        }
+    }
+
+    Context "Piping SqlInstance name works" {
+        $results = $script:instance2 | Set-DbaMaxDop -MaxDop 2
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        It 'Command returns output' {
+            $results.CurrentInstanceMaxDop | Should Not BeNullOrEmpty
+            $results.CurrentInstanceMaxDop | Should Be 2
+        }
+        It 'Maxdop should match expected' {
+            $server.Configuration.MaxDegreeOfParallelism.ConfigValue | Should Be 2
         }
     }
 }

--- a/tests/Set-DbaMaxDop.Tests.ps1
+++ b/tests/Set-DbaMaxDop.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$commandname Unit Tests" -Tag "UnitTests", Set-DbaMaxDop {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'MaxDop', 'InputObject', 'AllDatabases', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 
@@ -71,6 +71,18 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             It 'Returns 8 for each database' {
                 $result.DatabaseMaxDop | Should Be 8
             }
+        }
+    }
+
+    Context "Piping works" {
+        $results = Test-DbaMaxDop -SqlInstance $script:instance2 | Set-DbaMaxDop -MaxDop 4
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        It 'Command returns output' {
+            $results.CurrentInstanceMaxDop | Should Not BeNullOrEmpty
+            $results.CurrentInstanceMaxDop | Should Be 4
+        }
+        It 'Maxdop should not match expected' {
+            $server.Configuration.MaxDegreeOfParallelism.ConfigValue | Should Be 4
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6057
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- fixes #6057 
- adds test to Set-DbaMaxDop to ensure piping is working
- added properties to output to include ComputerName and SqlInstance
- added ConfirmImpact = 'Medium'

### Commands to test
`Test-DbaMaxDop -SqlInstance sql2008 | Set-DbaMaxDop`
