### PR TITLE
Allow inserting steps with New-DbaAgentJobStep

### DIFF
--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -140,6 +140,12 @@ function New-DbaAgentJobStep {
 
         Create a step in "Job1" with the name Step1 where the database will the "msdb" for multiple servers using pipeline
 
+    .EXAMPLE
+        PS C:\> New-DbaAgentJobStep -SqlInstance sq1 -Job Job1 -StepName StepA -Datavase msdb -StepId 2 -Insert
+
+        Assuming Job1 already has steps Step1 and Step2, will create a new step Step A and set the step order as Step1, StepA, Step2
+        Internal StepIds will be updated, and any specific OnSuccess/OnFailure step references will also be updated
+
     #>
 
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -266,14 +266,14 @@ function New-DbaAgentJobStep {
                             $JobStep.ID = $StepId
                         } elseif (($Job.JobSteps.ID -contains $StepID) -and $Insert) {
                             Write-Message -Message "Inserting step as step $StepID" -Level Verbose
-                            foreach ($tStep in $Server.JobServer.Jobs[$j].JobSteps){
-                               if ($tStep.Id -ge $Stepid) {
-                                   $tStep.Id = ($tStep.ID)+1
-                               }
-                               if ($tStep.OnFailureStepID -ge $StepId -and $tStep.OnFailureStepId -ne 0) {
-                                $tStep.OnFailureStepID = ($tStep.OnFailureStepID)+1
-                               }
-                               $tStep.Alter()
+                            foreach ($tStep in $Server.JobServer.Jobs[$j].JobSteps) {
+                                if ($tStep.Id -ge $Stepid) {
+                                    $tStep.Id = ($tStep.ID) + 1
+                                }
+                                if ($tStep.OnFailureStepID -ge $StepId -and $tStep.OnFailureStepId -ne 0) {
+                                    $tStep.OnFailureStepID = ($tStep.OnFailureStepID) + 1
+                                }
+                                $tStep.Alter()
                             }
                             $JobStep.ID = $StepId
                         } elseif (($Job.JobSteps.ID -contains $StepId) -and $Force) {

--- a/tests/New-DbaAgentJobStep.Tests.ps1
+++ b/tests/New-DbaAgentJobStep.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'StepId', 'StepName', 'Subsystem', 'SubsystemServer', 'Command', 'CmdExecSuccessCode', 'OnSuccessAction', 'OnSuccessStepId', 'OnFailAction', 'OnFailStepId', 'Database', 'DatabaseUser', 'RetryAttempts', 'RetryInterval', 'OutputFileName', 'Flag', 'ProxyName', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'StepId', 'StepName', 'Subsystem', 'SubsystemServer', 'Command', 'CmdExecSuccessCode', 'OnSuccessAction', 'OnSuccessStepId', 'OnFailAction', 'OnFailStepId', 'Database', 'DatabaseUser', 'RetryAttempts', 'RetryInterval', 'OutputFileName', 'Insert', 'Flag', 'ProxyName', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/New-DbaAgentJobStep.Tests.ps1
+++ b/tests/New-DbaAgentJobStep.Tests.ps1
@@ -69,5 +69,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $newresults.JobSteps | Where-Object Id -eq 1 | Select-Object -ExpandProperty Name | Should -Be "New Step One"
             $newresults.JobSteps | Where-Object Id -eq 2 | Select-Object -ExpandProperty Name | Should -Be "Step One"
         }
+
+        It "Insert should insert jobstep between steps and update IDs" {
+            $results = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job "dbatoolsci Job One" -StepName "New Step Three" -StepId 2 -Insert
+            $results.Name | Should -Be "New Step Three"
+            $newresults = Get-DbaAgentJob -SqlInstance $script:instance2 -Job "dbatoolsci Job One"
+            $newresults.JobSteps | Where-Object Id -eq 1 | Select-Object -ExpandProperty Name | Should -Be "New Step One"
+            $newresults.JobSteps | Where-Object Id -eq 2 | Select-Object -ExpandProperty Name | Should -Be "New Step Three"
+            $newresults.JobSteps | Where-Object Id -eq 3 | Select-Object -ExpandProperty Name | Should -Be "Step One"
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Wanting to add a new step to a lot of agent jobs, and want it to be step 1 as it needs to run before all other steps.

### Approach
To avoid breaking current usage, requires an explicit `-Insert` switch to activate. If specified then:

Increment stepid of all steps above new step by 1
Increment Success/Failure target stepid by 1 if greater than the new step

### Commands to test
Example added to command

### Screenshots
<!-- pictures say a thousand words without typing any of it -->


