### PR TITLE
fixing 6069 - Backup-DbaDatabase verify output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ before_test:
 
   # Setting up the local SQL Server environments
   - ps: .\Tests\appveyor.sqlserver.ps1
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 test_script:
    # Test with native PS version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ before_test:
 
   # Setting up the local SQL Server environments
   - ps: .\Tests\appveyor.sqlserver.ps1
-  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 test_script:
    # Test with native PS version

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -603,8 +603,7 @@ function Backup-DbaDatabase {
                                     LastLsn              = $HeaderInfo.LastLsn
                                     BackupSetId          = $HeaderInfo.BackupSetId
                                     LastRecoveryForkGUID = $HeaderInfo.LastRecoveryForkGUID
-                                }
-                                $verifiedResult | Restore-DbaDatabase -SqlInstance $server -DatabaseName DbaVerifyOnly -VerifyOnly -TrustDbBackupHistory -DestinationFilePrefix DbaVerifyOnly
+                                } | Restore-DbaDatabase -SqlInstance $server -DatabaseName DbaVerifyOnly -VerifyOnly -TrustDbBackupHistory -DestinationFilePrefix DbaVerifyOnly
                                 if ($verifiedResult[0] -eq "Verify successful") {
                                     $failures += $verifiedResult[0]
                                     $Verified = $true

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -604,7 +604,7 @@ function Backup-DbaDatabase {
                                     BackupSetId          = $HeaderInfo.BackupSetId
                                     LastRecoveryForkGUID = $HeaderInfo.LastRecoveryForkGUID
                                 }
-                                $verifiedresult | Restore-DbaDatabase -SqlInstance $server -DatabaseName DbaVerifyOnly -VerifyOnly -TrustDbBackupHistory -DestinationFilePrefix DbaVerifyOnly
+                                $verifiedResult | Restore-DbaDatabase -SqlInstance $server -DatabaseName DbaVerifyOnly -VerifyOnly -TrustDbBackupHistory -DestinationFilePrefix DbaVerifyOnly
                                 if ($verifiedResult[0] -eq "Verify successful") {
                                     $failures += $verifiedResult[0]
                                     $Verified = $true

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -193,10 +193,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "Test backup  verification" {
-        $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database master -Query "CREATE DATABASE [backuptest]"
-        $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database master -Query "ALTER DATABASE [backuptest] SET RECOVERY FULL WITH NO_WAIT"
         It "Should perform a full backup and verify it" {
-            $b = Backup-DbaDatabase -SqlInstance $script:instance1 -Database backuptest -Type full -Verify
+            $b = Backup-DbaDatabase -SqlInstance $script:instance1 -Database master -Type full -Verify
             $b.BackupComplete | Should -Be $True
             $b.Verified | Should -Be $True
             $b.count | Should -Be 1
@@ -211,7 +209,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $b.BackupComplete | Should -Be $True
             $b.Verified | Should -Be $True
         }
-        $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database master -Query "DROP DATABASE [backuptest]"
     }
 
     Context "Backup can pipe to restore" {

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -195,10 +195,11 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Test backup  verification" {
         $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database master -Query "CREATE DATABASE [backuptest]"
         $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database master -Query "ALTER DATABASE [backuptest] SET RECOVERY FULL WITH NO_WAIT"
-        It -Skip "Should perform a full backup and verify it" {
+        It "Should perform a full backup and verify it" {
             $b = Backup-DbaDatabase -SqlInstance $script:instance1 -Database backuptest -Type full -Verify
             $b.BackupComplete | Should -Be $True
             $b.Verified | Should -Be $True
+            $b.count | Should -Be 1
         }
         It -Skip "Should perform a diff backup and verify it" {
             $b = Backup-DbaDatabase -SqlInstance $script:instance1 -Database backuptest -Type diff -Verify


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6069)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixing a small error that appears to have been introduced in #6034 

With -Verify Backup-DbaDatabase is returning an array rather than an object as the output from Restore-DbaDatabase is being put into the output stream rather than the variable.

### Approach
revert to the original code for that section.

Fixed verify tests. Issue there was model being locked so the create database statement was failing. Using master for the full backup test, and doing a count to make sure we don't get an array again/

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
