### PR TITLE
Fix Pipeline Input for Invoke-DbaAgFailover

### DIFF
--- a/functions/Invoke-DbaAgFailover.ps1
+++ b/functions/Invoke-DbaAgFailover.ps1
@@ -63,11 +63,11 @@ function Invoke-DbaAgFailover {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
-        [parameter(Mandatory)]
+        [parameter(ParameterSetName = "NoPipe", Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$AvailabilityGroup,
-        [parameter(ValueFromPipeline)]
+        [parameter(ParameterSetName = "Pipe", ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.AvailabilityGroup[]]$InputObject,
         [switch]$Force,
         [switch]$EnableException


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Piping AGs to the `Invoke-DbaAgFailover` command complains about a missing `SqlInstance` parameter:

```powershell
Get-DbaAvailabilityGroup SERVER | Invoke-DbaAgFailover

cmdlet Invoke-DbaAgFailover at command pipeline position 2
Supply values for the following parameters:
SqlInstance[0]:
```

### Approach
<!-- How does this change solve that purpose -->
Add `ParameterSetName` attributes to the `SqlInstance` and `InputObject` parameters to allow both to work as expected.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
The examples in the help work:
```powershell
# Pipeline
Get-DbaAvailabilityGroup SERVER | Invoke-DbaAgFailover

# No pipeline
Invoke-DbaAgFailover -SqlInstance SERVER -AvailabilityGroup TestAG
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
