### PR TITLE
Invoke-DbaAgFailover: Remove the requirement to provide value for SqlInstance

### DIFF
--- a/functions/Invoke-DbaAgFailover.ps1
+++ b/functions/Invoke-DbaAgFailover.ps1
@@ -63,7 +63,6 @@ function Invoke-DbaAgFailover {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
-        [parameter(Mandatory)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$AvailabilityGroup,
@@ -76,6 +75,11 @@ function Invoke-DbaAgFailover {
         if ($Force) { $ConfirmPreference = 'none' }
     }
     process {
+        if (-not $SqlInstance -and -not $InputObject) {
+            Stop-Function -Message "You must either specify the SqlInstnace parameter or pass in at least one AvailabilityGroup object."
+            return
+        }
+
         if ($SqlInstance -and -not $AvailabilityGroup) {
             Stop-Function -Message "You must specify at least one availability group when using SqlInstance."
             return

--- a/functions/Invoke-DbaAgFailover.ps1
+++ b/functions/Invoke-DbaAgFailover.ps1
@@ -76,7 +76,7 @@ function Invoke-DbaAgFailover {
     }
     process {
         if (-not $SqlInstance -and -not $InputObject) {
-            Stop-Function -Message "You must either specify the SqlInstnace parameter or pass in at least one AvailabilityGroup object."
+            Stop-Function -Message "You must either specify the SqlInstance parameter or pass in at least one AvailabilityGroup object."
             return
         }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6141)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Make SqlInstance parameter not required in order to enable pipeline from Get-DbaAvailabilityGroup

### Approach
Remove the required tag from the SqlInstance parameter, and add handling to ensure either SqlInstance or the InputObject is specified

### Commands to test
Pipeline examples for Invoke-DbaAgFailover cmdlet.  Currently the pipeline from Get-DbaAvailabilityGroup to Invoke-DbaAgFailover does not function

### Screenshots
Screenshots below are of the updated cmdlet
![New_Invoke-DbaAgFailover](https://user-images.githubusercontent.com/52503242/67125600-3284ee00-f1c3-11e9-9792-55174c2d1289.png)
