### PR TITLE
Get-DbaBuildReference - cross-platform support added

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -738,6 +738,7 @@ $script:xplat = @(
     'Get-DbaDbLogSpace',
     'Export-DbaDbRole',
     'Export-DbaServerRole',
+    'Get-DbaBuildReference',
     'Add-DbaServerRoleMember'
 )
 
@@ -773,12 +774,11 @@ $script:windowsonly = @(
     'Export-DbaScript',
     'Get-DbaAgentJobOutputFile',
     'Set-DbaAgentJobOutputFile',
-    'Get-DbaBuildReference',
-    'New-DbaDacProfile'
+    'New-DbaDacProfile',
     'Import-DbaXESessionTemplate',
     'Export-DbaXESessionTemplate',
     'Import-DbaSpConfigure',
-    'Export-DbaSpConfigure'
+    'Export-DbaSpConfigure',
     'Update-Dbatools',
     'Install-DbaWhoIsActive',
     'Install-DbaFirstResponderKit',

--- a/functions/Get-DbaBuildReference.ps1
+++ b/functions/Get-DbaBuildReference.ps1
@@ -126,7 +126,7 @@ function Get-DbaBuildReference {
                 $EnableException
             )
 
-            $orig_idxfile = "$Moduledirectory\bin\dbatools-buildref-index.json"
+            $orig_idxfile = Resolve-Path "$Moduledirectory\bin\dbatools-buildref-index.json"
             $DbatoolsData = Get-DbatoolsConfigValue -Name 'Path.DbatoolsData'
             $writable_idxfile = Join-Path $DbatoolsData "dbatools-buildref-index.json"
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Slowly working back through the cross plat issue and thought this would be an easy one to fix.

### Approach
<!-- How does this change solve that purpose -->
Added `Resolve-Path` to the one explicit file path cmdlet and tested in both Linux container and from windows. 
Also moved the file to the correct location in the dbatools.psm1

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Any of the examples (as this uses the referenced path)
`Get-DbaBuildReference -Build "12.00.4502" -Update`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Working on Linux Container!
![image](https://user-images.githubusercontent.com/13426972/67136278-0e8cd100-f1f2-11e9-939f-c8ef5c19e2b0.png)
