### PR TITLE
Install-DbaWhoIsActive - Cross Platform Support Added

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -739,6 +739,7 @@ $script:xplat = @(
     'Export-DbaDbRole',
     'Export-DbaServerRole',
     'Get-DbaBuildReference',
+    'Install-DbaWhoIsActive',
     'Add-DbaServerRoleMember'
 )
 
@@ -780,7 +781,6 @@ $script:windowsonly = @(
     'Import-DbaSpConfigure',
     'Export-DbaSpConfigure',
     'Update-Dbatools',
-    'Install-DbaWhoIsActive',
     'Install-DbaFirstResponderKit',
     'Read-DbaXEFile',
     'Watch-DbaXESession',

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -136,7 +136,7 @@ function Install-DbaWhoIsActive {
             # Unpack
             # Unblock if there's a block
             if ($PSCmdlet.ShouldProcess($env:computername, "Unpacking zipfile")) {
-                if (Test-Windows) {
+                if (Test-Windows -NoWarn) {
                     Unblock-File $zipfile -ErrorAction SilentlyContinue
                 }
                 try {

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -89,8 +89,8 @@ function Install-DbaWhoIsActive {
         if ($Force) { $ConfirmPreference = 'none' }
 
         $DbatoolsData = Get-DbatoolsConfigValue -FullName "Path.DbatoolsData"
-        $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
-        $zipfile = "$temp\spwhoisactive.zip"
+        $temp = ([System.IO.Path]::GetTempPath())
+        $zipfile = Join-Path -Path $temp -ChildPath "spwhoisactive.zip"
 
         if ($LocalFile -eq $null -or $LocalFile.Length -eq 0) {
             $baseUrl = "https://github.com/amachanic/sp_whoisactive/archive"
@@ -136,8 +136,9 @@ function Install-DbaWhoIsActive {
             # Unpack
             # Unblock if there's a block
             if ($PSCmdlet.ShouldProcess($env:computername, "Unpacking zipfile")) {
-
-                Unblock-File $zipfile -ErrorAction SilentlyContinue
+                if ([Environment]::OSVersion.Platfrom -eq 'Win32NT') {
+                    Unblock-File $zipfile -ErrorAction SilentlyContinue
+                }
                 try {
                     Expand-Archive -Path $zipfile -DestinationPath $temp -Force
                 } catch {
@@ -146,7 +147,7 @@ function Install-DbaWhoIsActive {
                 }
                 Remove-Item -Path $zipfile
             }
-            $sqlfile = (Get-ChildItem "$temp\who*active*.sql" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+            $sqlfile = (Get-ChildItem "$($temp)who*active*.sql" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
         } else {
             $sqlfile = $LocalFile
         }
@@ -233,11 +234,6 @@ function Install-DbaWhoIsActive {
                 }
 
             }
-        }
-    }
-    end {
-        if ($PSCmdlet.ShouldProcess($env:computername, "Post-install cleanup")) {
-            Get-Item $sqlfile | Remove-Item
         }
     }
 }

--- a/functions/Install-DbaWhoIsActive.ps1
+++ b/functions/Install-DbaWhoIsActive.ps1
@@ -136,7 +136,7 @@ function Install-DbaWhoIsActive {
             # Unpack
             # Unblock if there's a block
             if ($PSCmdlet.ShouldProcess($env:computername, "Unpacking zipfile")) {
-                if ([Environment]::OSVersion.Platfrom -eq 'Win32NT') {
+                if (Test-Windows) {
                     Unblock-File $zipfile -ErrorAction SilentlyContinue
                 }
                 try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6126)
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add cross platform support for installing sp_WhoisActive from Linux or Mac.
Also remove logic for deleting the file after installing as requested in #6126 
After looking at other `Install-` cmdlets it looks like we delete the ZIP (which this is doing), but not the other files as a cache.

### Approach
<!-- How does this change solve that purpose -->
Replace explicit pathing with `Join-Path` and add a check for `Unblock-File` when ran on Windows.
Also moved the Function name to the xplat section of *.psm1

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Run any example from any system running PowerShell Core.
`Install-DbaWhoIsActive -SqlInstance sqlserver2014a -SqlCredential $cred`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
While the screen shot shows it working from a cached file, it also worked from downloading directly from GitHub.
![image](https://user-images.githubusercontent.com/13426972/67145965-3ad93980-f254-11e9-8b9b-f1831231976f.png)
