### PR TITLE
Resubmit: Update-Dbatools - Cross Platform Support Added

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -740,6 +740,7 @@ $script:xplat = @(
     'Export-DbaServerRole',
     'Get-DbaBuildReference',
     'Install-DbaWhoIsActive',
+    'Update-Dbatools',
     'Add-DbaServerRoleMember'
 )
 
@@ -780,7 +781,6 @@ $script:windowsonly = @(
     'Export-DbaXESessionTemplate',
     'Import-DbaSpConfigure',
     'Export-DbaSpConfigure',
-    'Update-Dbatools',
     'Install-DbaFirstResponderKit',
     'Read-DbaXEFile',
     'Watch-DbaXESession',


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<enter issue number>)
 - [X] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Update `install.ps1` so that it supports installation of Dbatools on Linux and Mac.
While I assume most people use PSGallery to install the module and update. The cmdlet `Update-DbaTools` relies upon this script. If the module is installed via gallery then this script is already cross plat, but if for some reason `-Dev` switch then it would fail. 
Resubmitted per #6144 

Don't think this is a breaking change, but do think @potatoqualitee should be aware since it is an entry point to the module for some users. 

### Approach
<!-- How does this change solve that purpose -->
Replace explicit paths with `Join-Path`
Add checks for code not supported on Unix
Add dynamic check for user home path in PSModulePath

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Update-Dbatools -Verbose -Dev`
or on a system with Dbatools not installed from the gallery (but running in memory)
`Update-Dbatools -Verbose` 

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Install on Windows
![image](https://user-images.githubusercontent.com/13426972/67149914-2f4f3800-f27f-11e9-9df0-838f1bbd1ba2.png)

Install on Linux Container
![image](https://user-images.githubusercontent.com/13426972/67149969-cae0a880-f27f-11e9-9f84-cc5ea4775f9d.png)


