### PR TITLE
add filtering to Get-DbaDbAssembly

### DIFF
--- a/functions/Get-DbaDbAssembly.ps1
+++ b/functions/Get-DbaDbAssembly.ps1
@@ -78,9 +78,10 @@ function Get-DbaDbAssembly {
             }
             foreach ($db in $databases) {
                 try {
-                    $assemblies = $db.assemblies
                     if (Test-Bound 'Name') {
                         $assemblies = $assemblies | Where-Object Name -in  $Name
+                    } else {
+                        $assemblies = $db.assemblies
                     }
                     foreach ($assembly in $assemblies) {
 

--- a/functions/Get-DbaDbAssembly.ps1
+++ b/functions/Get-DbaDbAssembly.ps1
@@ -20,7 +20,7 @@ function Get-DbaDbAssembly {
     .PARAMETER Database
         Specify a Database to be checked for assembly. If not specified, all databases in the specified Instance(s) will be checked
 
-    .PARAMETER AssemblyName
+    .PARAMETER Name
         Specify an Assembly to be fetched. If not specified all Assemblys will be returned
 
     .PARAMETER EnableException

--- a/functions/Get-DbaDbAssembly.ps1
+++ b/functions/Get-DbaDbAssembly.ps1
@@ -17,6 +17,12 @@ function Get-DbaDbAssembly {
 
         For MFA support, please use Connect-DbaInstance.
 
+    .PARAMETER Database
+        Specify a Database to be checked for assembly. If not specified, all databases in the specified Instance(s) will be checked
+
+    .PARAMETER AssemblyName
+        Specify an Assembly to be fetched. If not specified all Assemblys will be returned
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -43,12 +49,19 @@ function Get-DbaDbAssembly {
 
         Returns all Database Assembly for the local and sql2016 SQL Server instances
 
+    .EXAMPLE
+        PS C:\> Get-DbaDbAssemly -SqlInstance Server1 -Database MyDb -Name MyTechCo.Houids.SQLCLR
+
+        Will fetch details for the MyTechCo.Houids.SQLCLR assemlby in the MyDb Database on the Server1 instance
+
     #>
     [CmdletBinding()]
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [Object[]]$Database,
+        [string[]]$Name,
         [switch]$EnableException
     )
 
@@ -59,16 +72,24 @@ function Get-DbaDbAssembly {
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-
-            foreach ($database in ($server.Databases | Where-Object IsAccessible)) {
+            $databases = $server.Databases | Where-Object IsAccessible
+            if (Test-Bound 'Database') {
+                $databases = $databases | Where-Object Name -in $Database
+            }
+            foreach ($db in $databases) {
                 try {
-                    foreach ($assembly in $database.assemblies) {
+                    $assemblies = $db.assemblies
+                    if (Test-Bound 'Name') {
+                        $assemblies = $assemblies | Where-Object Name -in  $Name
+                    }
+                    foreach ($assembly in $assemblies) {
 
                         Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name ComputerName -value $assembly.Parent.Parent.ComputerName
                         Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name InstanceName -value $assembly.Parent.Parent.ServiceName
                         Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name SqlInstance -value $assembly.Parent.Parent.DomainInstanceName
+                        Add-Member -Force -InputObject $assembly -MemberType NoteProperty -Name Database -value $db.name
 
-                        Select-DefaultView -InputObject $assembly -Property ComputerName, InstanceName, SqlInstance, ID, Name, Owner, 'AssemblySecurityLevel as SecurityLevel', CreateDate, IsSystemObject, Version
+                        Select-DefaultView -InputObject $assembly -Property ComputerName, InstanceName, SqlInstance, Database, ID, Name, Owner, 'AssemblySecurityLevel as SecurityLevel', CreateDate, IsSystemObject, Version
                     }
                 } catch {
                     Stop-Function -Message "Issue pulling assembly information" -Target $assembly -ErrorRecord $_ -Continue

--- a/tests/Get-DbaDbAssembly.Tests.ps1
+++ b/tests/Get-DbaDbAssembly.Tests.ps1
@@ -4,18 +4,18 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'EnableException', 'Name', 'Database'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Gets the Db Assembly" {
-        $results = Get-DbaDbAssembly -SqlInstance $script:instance2 | Where-Object {$_.parent.name -eq 'master'}
+        $results = Get-DbaDbAssembly -SqlInstance $script:instance2 | Where-Object { $_.parent.name -eq 'master' }
         It "Gets results" {
             $results | Should Not Be $Null
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adding encryption support to Backups
So need to add support for managing asymmetric keys
So need to add support for creating keys from assemblies
So need to check for a specific assembly in a specific db

So I made a change :)

No impact to anyone using the older parameter list

The others will follow along later to save a huge change

### Approach
Added the traditional dbatools filtering

### Commands to test
Example in code

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
always add filtering to a command as at some point someone will want it to return a single object
