### PR TITLE
Added AsymmetricKey support (New, Get and Remove)

### DIFF
--- a/functions/Get-DbaDbAsymmetricKey.ps1
+++ b/functions/Get-DbaDbAsymmetricKey.ps1
@@ -64,6 +64,8 @@ function Get-DbaDbAsymmetricKey {
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
         [string[]]$Name,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
     process {
@@ -85,7 +87,7 @@ function Get-DbaDbAsymmetricKey {
             }
 
             if ($Name) {
-                $akeys = $akeys| Where-Object Name -in $Name
+                $akeys = $akeys | Where-Object Name -in $Name
             }
 
             foreach ($akey in $akeys) {

--- a/functions/Get-DbaDbAsymmetricKey.ps1
+++ b/functions/Get-DbaDbAsymmetricKey.ps1
@@ -34,8 +34,8 @@ function Get-DbaDbAsymmetricKey {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Certificate
-        Author: Chrissy LeMaire (@cl), netnerds.net
+        Tags: AsymmetricKey
+        Author: Stuart Moore (@napalmgram), stuart-moore.com
 
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT

--- a/functions/Get-DbaDbAsymmetricKey.ps1
+++ b/functions/Get-DbaDbAsymmetricKey.ps1
@@ -25,7 +25,7 @@ function Get-DbaDbAsymmetricKey {
     .PARAMETER InputObject
         Enables piping from Get-DbaDatabase
 
-    .PARAMETER KeyName
+    .PARAMETER Name
         Get specific Asymmetric Key by name
 
     .PARAMETER EnableException
@@ -52,7 +52,7 @@ function Get-DbaDbAsymmetricKey {
         Gets the Asymmetric Keys for the db1 database
 
     .EXAMPLE
-        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance Server1 -Database db1 -KeyName key1
+        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance Server1 -Database db1 -Name key1
 
         Gets the key1 Asymmetric Key within the db1 database
 
@@ -63,7 +63,7 @@ function Get-DbaDbAsymmetricKey {
         [PSCredential]$SqlCredential,
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
-        [string[]]$KeyName,
+        [string[]]$Name,
         [switch]$EnableException
     )
     process {
@@ -84,8 +84,8 @@ function Get-DbaDbAsymmetricKey {
                 continue
             }
 
-            if ($KeyName) {
-                $akeys = $akeys| Where-Object Name -in $KeyName
+            if ($Name) {
+                $akeys = $akeys| Where-Object Name -in $Name
             }
 
             foreach ($akey in $akeys) {

--- a/functions/Get-DbaDbAsymmetricKey.ps1
+++ b/functions/Get-DbaDbAsymmetricKey.ps1
@@ -1,0 +1,101 @@
+function Get-DbaDbAsymmetricKey {
+    <#
+    .SYNOPSIS
+        Gets database Asymmetric Key
+
+    .DESCRIPTION
+        Gets database Asymmetric Key
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        Get Asymmetric Keys from specific database
+
+    .PARAMETER ExcludeDatabase
+        Database(s) to ignore when retrieving Asymmetric Keys
+
+    .PARAMETER InputObject
+        Enables piping from Get-DbaDatabase
+
+    .PARAMETER KeyName
+        Get specific Asymmetric Key by name
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Certificate
+        Author: Chrissy LeMaire (@cl), netnerds.net
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance sql2016
+
+        Gets all Asymmetric Keys
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance Server1 -Database db1
+
+        Gets the Asymmetric Keys for the db1 database
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance Server1 -Database db1 -KeyName key1
+
+        Gets the key1 Asymmetric Key within the db1 database
+
+    #>
+    [CmdletBinding()]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
+        [string[]]$KeyName,
+        [switch]$EnableException
+    )
+    process {
+        if ($SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        }
+
+        foreach ($db in $InputObject) {
+            if (!$db.IsAccessible) {
+                Write-Message -Level Warning -Message "$db is not accessible, skipping"
+                continue
+            }
+
+            $akeys = $db.AsymmetricKeys
+
+            if ($null -eq $akeys) {
+                Write-Message -Message "No Asymmetic Keys exists in the $db database on $instance" -Target $db -Level Verbose
+                continue
+            }
+
+            if ($KeyName) {
+                $akeys = $akeys| Where-Object Name -in $KeyName
+            }
+
+            foreach ($akey in $akeys) {
+                Add-Member -Force -InputObject $akey -MemberType NoteProperty -Name ComputerName -value $db.ComputerName
+                Add-Member -Force -InputObject $akey -MemberType NoteProperty -Name InstanceName -value $db.InstanceName
+                Add-Member -Force -InputObject $akey -MemberType NoteProperty -Name SqlInstance -value $db.SqlInstance
+                Add-Member -Force -InputObject $akey -MemberType NoteProperty -Name Database -value $db.Name
+
+                Select-DefaultView -InputObject $akey -Property ComputerName, InstanceName, SqlInstance, Database, Name, Owner, KeyEncryptionAlgorithm, KeyLength, PrivateKeyEncryptionType, Thumbprint
+            }
+        }
+    }
+}

--- a/functions/New-DbaDbAsymmetricKey.ps1
+++ b/functions/New-DbaDbAsymmetricKey.ps1
@@ -29,13 +29,21 @@ function New-DbaDbAsymmetricKey {
         Enables piping from Get-DbaDatabase
 
     .PARAMETER KeySourceType
+        The source of external keys loaded in, can be one of Executable, File or Assemnly
+        We do not currently support Provider
 
     .PARAMETER KeySource
+        The path to the Executable, File or Assembly to be passed in.
+        The path is parsed by the SQL Server instance, so needs to visiable to the instance
 
     .PARAMETER Algorithm
+        The algorithm used to generate the key. Can be one of RSA512, RSA1024, RSA1024, RSA2048, RSA3072 or RSA4096. If not specified RSA2048 is the default
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Owner
+        User within the database who will own the key. Defaults to the user creating the key if not specified. User must exist withing the database already
 
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
@@ -63,6 +71,10 @@ function New-DbaDbAsymmetricKey {
 
         Suppresses all prompts to install but prompts to securely enter your password and creates an asymmetric key in the 'db1' database
 
+    .EXAMPLE
+        PS C:\> New-DbaDbAsymmetrickKey -SqlInstance Server1 -Database enctest -KeySourceType File -KeySource c:\keys\NewKey.snk -Name BackupKey -Owner KeyOwner
+
+        Installs the key pair held in NewKey.snk into the enctest database creating an AsymmetricKey called BackupKey, which will be owned by KeyOwner
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (

--- a/functions/New-DbaDbAsymmetricKey.ps1
+++ b/functions/New-DbaDbAsymmetricKey.ps1
@@ -1,0 +1,123 @@
+function New-DbaDbAsymmetricKey {
+    <#
+    .SYNOPSIS
+        Creates a new database asymmetric key
+
+    .DESCRIPTION
+        Creates a new database asymmetric key. If no database is specified, the asymmetric key will be created in master.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The database where the asymmetric key will be created. Defaults to master.
+
+    .PARAMETER Name
+        Optional name to create the asymmetric key. Defaults to database name.
+
+    .PARAMETER SecurePassword
+        Optional password - if no password is supplied, the password will be protected by the master key
+
+    .PARAMETER InputObject
+        Enables piping from Get-DbaDatabase
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: asymmetrickey
+        Author: Stuart Moore (@napalmgram), stuart-moore.com
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .EXAMPLE
+        PS C:\> New-DbaDbAsymmetricKey -SqlInstance Server1
+
+        You will be prompted to securely enter your password, then an asymmetric key will be created in the master database on server1 if it does not exist.
+
+    .EXAMPLE
+        PS C:\> New-DbaDbAsymmetricKey -SqlInstance Server1 -Database db1 -Confirm:$false
+
+        Suppresses all prompts to install but prompts to securely enter your password and creates an asymmetric key in the 'db1' database
+
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Name,
+        [string[]]$Database = "master",
+        [Alias("Password")]
+        [Security.SecureString]$SecurePassword,
+        [String]$Owner,
+        [String]$FilePath,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [ValidateSet('Rsa4096', 'Rsa3072', 'Rsa2048', 'Rsa1024', 'Rsa512')]
+        [string]$Algorithm = 'Rsa2048',
+        [switch]$EnableException
+    )
+    process {
+        if ($SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+            if ((Test-Bound -Not -ParameterName Name)) {
+                Write-Message -Level Verbose -Message "Name of asymmetric key not specified, setting it to '$db'"
+                $Name = $db.Name
+            }
+
+            foreach ($askey in $Name) {
+                if ($null -ne $db.AsymmetricKeys[$askey]) {
+                    Stop-Function -Message "Asymmetric Key '$askey' already exists in $($db.Name) on $($db.Parent.Name)" -Target $db -Continue
+                }
+
+                if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Creating asymmetric key for database '$($db.Name)'")) {
+
+                    # something is up with .net, force a stop
+                    $eap = $ErrorActionPreference
+                    $ErrorActionPreference = 'Stop'
+                    try {
+                        $smokey = New-Object -TypeName Microsoft.SqlServer.Management.Smo.AsymmetricKey $db, $askey
+                        $smokey = $Name
+
+                        if ($SecurePassword) {
+                            $smokey.Create([Microsoft.SqlServer.Management.Smo.AsymmetricKeyEncryptionAlgorithm]::$Algorithm, ([System.Runtime.InteropServices.marshal]::PtrToStringAuto([System.Runtime.InteropServices.marshal]::SecureStringToBSTR($SecurePassword))))
+                        } else {
+                            $smokey.Create([Microsoft.SqlServer.Management.Smo.AsymmetricKeyEncryptionAlgorithm]::$Algorithm)
+                        }
+
+                        Add-Member -Force -InputObject $smokey -MemberType NoteProperty -Name ComputerName -value $db.Parent.ComputerName
+                        Add-Member -Force -InputObject $smokey -MemberType NoteProperty -Name InstanceName -value $db.Parent.ServiceName
+                        Add-Member -Force -InputObject $smokey -MemberType NoteProperty -Name SqlInstance -value $db.Parent.DomainInstanceName
+                        Add-Member -Force -InputObject $smokey -MemberType NoteProperty -Name Database -value $db.Name
+                        Add-Member -Force -InputObject $smokey -MemberType NoteProperty -Name Credential -value $Credential
+                        Select-DefaultView -InputObject $smokey -Property ComputerName, InstanceName, SqlInstance, Database, Name, Subject, StartDate, ActiveForServiceBrokerDialog, ExpirationDate, Issuer, LastBackupDate, Owner, PrivateKeyEncryptionType, Serial
+                    } catch {
+                        $ErrorActionPreference = $eap
+                        Stop-Function -Message "Failed to create asymmetric key in $($db.Name) on $($db.Parent.Name)" -Target $smocert -ErrorRecord $_ -Continue
+                    }
+                    $ErrorActionPreference = $eap
+                }
+            }
+        }
+    }
+}

--- a/functions/Remove-DbaDbAsymmetricKey.ps1
+++ b/functions/Remove-DbaDbAsymmetricKey.ps1
@@ -81,7 +81,7 @@ function Remove-DbaDbAsymmetricKey {
                         InstanceName = $server.ServiceName
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.Name
-                        Name  = $askey.Name
+                        Name         = $askey.Name
                         Status       = "Success"
                     }
                 } catch {

--- a/functions/Remove-DbaDbAsymmetricKey.ps1
+++ b/functions/Remove-DbaDbAsymmetricKey.ps1
@@ -28,6 +28,9 @@ function Remove-DbaDbAsymmetricKey {
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
+    .PARAMETER InputObject
+        Allows passing in of AsymmetricKey objects from Get-DbaDbAsymmetricKey
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Remove-DbaDbAsymmetricKey.ps1
+++ b/functions/Remove-DbaDbAsymmetricKey.ps1
@@ -1,0 +1,93 @@
+function Remove-DbaDbAsymmetricKey {
+    <#
+    .SYNOPSIS
+        Deletes specified asymmetric key
+
+    .DESCRIPTION
+        Deletes specified asymmetric key
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The database from which the asymmetric key will be deleted.
+
+    .PARAMETER Name
+        Name of the asymmetric key to be removed
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: asymmetrickey
+        Author: Stuart Moore (@napalmgram), stuart-moore.com
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .EXAMPLE
+        PS C:\> Remove-DbaDbAsymmetricKey -SqlInstance Server1 -Database Enctest -Name AsCert1
+
+        The Asymmetric Key AsCert1 will be removed from the Enctest database on Instance Server1
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbAsymmetricKey -SqlInstance Server1 -Database Enctest  | Remove-DbaDbAsymmetricKey
+
+        Will remove all the asymmetric keys found in the Enctrst databae on the Server1 instance
+
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Name,
+        [string[]]$Database = "master",
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.AsymmetricKey[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+        if ($SqlInstance) {
+            $InputObject += Get-DbaDbAsymmetricKey -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Name $Name -Database $Database
+        }
+        foreach ($askey in $InputObject) {
+            $db = $askey.Parent
+            $server = $db.Parent
+
+            if ($Pscmdlet.ShouldProcess($server.Name, "Dropping the Asymmetric key named $Name for database $db")) {
+                try {
+                    # erroractionprefs are not invoked for .net methods suddenly (??), so use Invoke-DbaQuery
+                    # Avoids modifying the collection
+                    Invoke-DbaQuery -SqlInstance $server -Database $db.Name -Query "DROP ASYMMETRIC KEY $($askey.Name)" -EnableException
+                    Write-Message -Level Verbose -Message "Successfully removed asymmetric key named $Name from the $db database on $server"
+                    [pscustomobject]@{
+                        ComputerName = $server.ComputerName
+                        InstanceName = $server.ServiceName
+                        SqlInstance  = $server.DomainInstanceName
+                        Database     = $db.Name
+                        Name  = $askey.Name
+                        Status       = "Success"
+                    }
+                } catch {
+                    Stop-Function -Message "Failed to drop asymmetric key named $($askey.Name) from $($db.Name) on $($server.Name)." -Target $askey -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','InputObject','EnableException','ExcludeDatabase'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Database', 'InputObject', 'EnableException', 'ExcludeDatabase'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -16,39 +16,41 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Gets a certificate" {
         $keyname = 'test4'
-        $keyname2  = 'test5'
+        $keyname2 = 'test5'
         $algorithm = 'Rsa4096'
         $dbuser = 'keyowner'
         $database = 'GetAsKey'
-        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDatabase -SqlInstance $script:instance2 -Name $database
+        $tPassword = ConvertTo-SecureString "ThisIsThePassword1" -AsPlainText -Force
+        New-DbaDbMasterKey -SqlInstance $script:instance2 -Database $database -SecurePassword $tPassword -confirm:$false
         New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It "Should Create new key in master called $keyname"{
-            ($warnvar -eq $null) | Should -Be $True
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        It "Should Create new key in $database called $keyname" {
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be $database
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
             $results.Owner | Should -Be $dbuser
             $results | Should -HaveCount 1
         }
-        $pipeResults = Get-DbaDbDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
+        $pipeResults = Get-DbaDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
         It "Should work with a piped database" {
             $pipeResults.database | Should -Be $database
             $pipeResults.name | Should -Be $keyname
-            $pipeResults.KeyEncryptionAlgorithm | Should -Be $algorithm
             $pipeResults.Owner | Should -Be $dbuser
             $pipeResults | Should -HaveCount 1
         }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
-        }
+
         $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname2 -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
-        $multiResults = = Get-DbaDbDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
+        $multiResults = Get-DbaDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
         It "Should return 2 keys" {
-            $multiResults | Should -HaveCounte 2
+            $multiResults | Should -HaveCount 2
             $multiresults.name | Should -Contain $keyname
             $multiresults.name | Should -Contain $keyname2
+        }
+        $drop = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $database -confirm:$false
+        It "Should drop database" {
+            $drop.Status | Should -Be 'Dropped'
         }
     }
 }

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -1,0 +1,54 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','InputObject','EnableException','ExcludeDatabase'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    Context "Gets a certificate" {
+        $keyname = 'test4'
+        $keyname2  = 'test5'
+        $algorithm = 'Rsa4096'
+        $dbuser = 'keyowner'
+        $database = 'GetAsKey'
+        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It "Should Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be $database
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.Owner | Should -Be $dbuser
+            $results | Should -HaveCount 1
+        }
+        $pipeResults = Get-DbaDbDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
+        It "Should work with a piped database" {
+            $pipeResults.database | Should -Be $database
+            $pipeResults.name | Should -Be $keyname
+            $pipeResults.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $pipeResults.Owner | Should -Be $dbuser
+            $pipeResults | Should -HaveCount 1
+        }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        }
+        $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname2 -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
+        $multiResults = = Get-DbaDbDatabase -SqlInstance $script:instance2 -Database $database | Get-DbaDbAsymmetricKey
+        It "Should return 2 keys" {
+            $multiResults | Should -HaveCounte 2
+            $multiresults.name | Should -Contain $keyname
+            $multiresults.name | Should -Contain $keyname2
+        }
+    }
+}

--- a/tests/Get-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Get-DbaDbAsymmetricKey.Tests.ps1
@@ -20,7 +20,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $algorithm = 'Rsa4096'
         $dbuser = 'keyowner'
         $database = 'GetAsKey'
-        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
         New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master

--- a/tests/New-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/New-DbaDbAsymmetricKey.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
         It  "Should create new key in master called $keyname" {
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
@@ -43,7 +43,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Algorithm $algorithm -WarningVariable warnvar
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         It "Should Create new key in master called $keyname"{
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm
@@ -61,7 +61,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         It "Should Create new key in master called $keyname"{
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm
@@ -77,12 +77,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $algorithm = 'Rsa4096'
         $dbuser = 'keyowner'
         $database = 'enctest'
-        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
         New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         It "Should Create new key in master called $keyname"{
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be $database
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm
@@ -99,12 +99,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $dbuser = 'keyowner'
         $database = 'enctest'
         $path = "$($script:appveyorlabrepo)\keytest\keypair.snk"
-        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
         New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar -KeySourceType File -KeySource $path
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         It "Should Create new key in master called $keyname"{
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be $database
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm

--- a/tests/New-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/New-DbaDbAsymmetricKey.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $keyname = 'test1'
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
-        It Should "Create new key in master called $keyname"{
+        It  "Should create new key in master called $keyname" {
             ($warnvar -eq $null) | Should -Be $True
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
@@ -29,21 +29,27 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Handles pre-existing key" {
         $keyname = 'test1'
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name test1 -Database master -WarningVariable -warnvar
-        It Should "Warn that they key already exists" {
+        It "Should Warn that they key already exists" {
             $Warnvar | Should -BeLike "*asymmetric key with name '$keyname' already exists*"
+        }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         }
     }
 
     Context "Handles Algorithm changes" {
         $keyname = 'test2'
         $algorithm = 'Rsa4096'
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -Algorithm $algorithm -WarningVariable warnvar
-        It Should "Create new key in master called $keyname"{
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It "Should Create new key in master called $keyname"{
             ($warnvar -eq $null) | Should -Be $True
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+        }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         }
     }
 
@@ -52,18 +58,60 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $algorithm = 'Rsa4096'
         $dbuser = 'keyowner'
         New-DbaDbUser -SqlInstance $script:instance2 -Database Master -UserName $dbuser
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -Algorithm $algorithm -WarningVariable warnvar
-        It Should "Create new key in master called $keyname"{
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It "Should Create new key in master called $keyname"{
             ($warnvar -eq $null) | Should -Be $True
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be $algorithm
             $results.Owner | Should -Be $dbuser
         }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        }
     }
 
-    # Context "Non master database" {    }
+     Context "Non master database" {
+        $keyname = 'test4'
+        $algorithm = 'Rsa4096'
+        $dbuser = 'keyowner'
+        $database = 'enctest'
+        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It "Should Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be $database
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.Owner | Should -Be $dbuser
+        }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        }
+    }
 
-    # Context "Loaded from a keyfile" {}
+    Context "Loaded from a keyfile" {
+        $keyname = 'test5'
+        $algorithm = 'Rsa4096'
+        $dbuser = 'keyowner'
+        $database = 'enctest'
+        $path = "$($script:appveyorlabrepo)\keytest\keypair.snk"
+        New-DbaDbDatabase -SqlInstance $sciprt:instance2 -Name $database
+        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar -KeySourceType File -KeySource $path
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It "Should Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be $database
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.Owner | Should -Be $dbuser
+        }
+        It "Should Cleanup after itself" {
+            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        }
+    }
 }

--- a/tests/New-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/New-DbaDbAsymmetricKey.Tests.ps1
@@ -4,17 +4,21 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','SecurePassword','Owner','KeySource','KeySourceType','InputObject','Algorithm','EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Database', 'SecurePassword', 'Owner', 'KeySource', 'KeySourceType', 'InputObject', 'Algorithm', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
+        $tPassword = ConvertTo-SecureString "ThisIsThePassword1" -AsPlainText -Force
+        if (!(Get-DbaDbMasterKey -SqlInstance $script:instance2 -Database master )) {
+            New-DbaDbMasterKey -SqlInstance $script:instance2 -Database master -SecurePassword $tpassword -confirm:$false
+        }
         $keyname = 'test1'
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
@@ -22,18 +26,16 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
+            $results.KeyLength | Should -Be '2048'
         }
     }
 
     Context "Handles pre-existing key" {
         $keyname = 'test1'
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name test1 -Database master -WarningVariable -warnvar
-        It "Should Warn that they key already exists" {
-            $Warnvar | Should -BeLike "*asymmetric key with name '$keyname' already exists*"
-        }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
+        $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
+        It "Should Warn that they key $keyname already exists" {
+            $Warnvar | Should -BeLike '*already exists in master on*'
         }
     }
 
@@ -42,55 +44,54 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $algorithm = 'Rsa4096'
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Algorithm $algorithm -WarningVariable warnvar
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It "Should Create new key in master called $keyname"{
+        It "Should Create new key in master called $keyname" {
             $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.KeyLength | Should -Be 4096
         }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
+
+    }
+
+    Context "Non master database" {
+        $keyname = 'test4'
+        $algorithm = 'Rsa4096'
+        $dbuser = 'keyowner'
+        $database = 'enctest'
+        New-DbaDatabase -SqlInstance $script:instance2 -Name $database
+        $tPassword = ConvertTo-SecureString "ThisIsThePassword1" -AsPlainText -Force
+        New-DbaDbMasterKey -SqlInstance $script:instance2 -Database $database -SecurePassword $tpassword -Confirm:$false
+        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        It "Should Create new key in master called $keyname" {
+            $warnvar | Should -BeNullOrEmpty
+            $results.database | Should -Be $database
+            $results.name | Should -Be $keyname
+            $results.KeyLength | Should -Be 4096
+            $results.Owner | Should -Be $dbuser
         }
+        $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -confirm:$false
+
     }
 
     Context "Sets owner correctly" {
         $keyname = 'test3'
         $algorithm = 'Rsa4096'
         $dbuser = 'keyowner'
-        New-DbaDbUser -SqlInstance $script:instance2 -Database Master -UserName $dbuser
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It "Should Create new key in master called $keyname"{
-            $warnvar | Should -BeNullOrEmpty
-            $results.database | Should -Be 'master'
-            $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
-            $results.Owner | Should -Be $dbuser
-        }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        }
-    }
-
-     Context "Non master database" {
-        $keyname = 'test4'
-        $algorithm = 'Rsa4096'
-        $dbuser = 'keyowner'
         $database = 'enctest'
-        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
-        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It "Should Create new key in master called $keyname"{
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner -Database $database -Algorithm $algorithm -WarningVariable warnvar
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+
+        It "Should Create new key in master called $keyname" {
             $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be $database
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.KeyLength | Should -Be 4096
             $results.Owner | Should -Be $dbuser
         }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
-        }
+        $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -confirm:$false
     }
 
     Context "Loaded from a keyfile" {
@@ -99,19 +100,16 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $dbuser = 'keyowner'
         $database = 'enctest'
         $path = "$($script:appveyorlabrepo)\keytest\keypair.snk"
-        New-DbaDatabase -SqlInstance $sciprt:instance2 -Name $database
-        New-DbaDbUser -SqlInstance $script:instance2 -Database $database -UserName $dbuser
         $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -Name $keyname -Owner keyowner -Algorithm $algorithm -WarningVariable warnvar -KeySourceType File -KeySource $path
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It "Should Create new key in master called $keyname"{
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        It "Should Create new key in master called $keyname" {
             $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be $database
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.KeyLength | Should -Be '4096'
             $results.Owner | Should -Be $dbuser
         }
-        It "Should Cleanup after itself" {
-            $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
-        }
+        $null = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -confirm:$false
+
     }
 }

--- a/tests/New-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/New-DbaDbAsymmetricKey.Tests.ps1
@@ -1,0 +1,69 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','SecurePassword','Owner','KeySource','KeySourceType','InputObject','Algorithm','EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    Context "commands work as expected" {
+        $keyname = 'test1'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
+        It Should "Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be 'master'
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
+        }
+    }
+
+    Context "Handles pre-existing key" {
+        $keyname = 'test1'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name test1 -Database master -WarningVariable -warnvar
+        It Should "Warn that they key already exists" {
+            $Warnvar | Should -BeLike "*asymmetric key with name '$keyname' already exists*"
+        }
+    }
+
+    Context "Handles Algorithm changes" {
+        $keyname = 'test2'
+        $algorithm = 'Rsa4096'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -Algorithm $algorithm -WarningVariable warnvar
+        It Should "Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be 'master'
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+        }
+    }
+
+    Context "Sets owner correctly" {
+        $keyname = 'test3'
+        $algorithm = 'Rsa4096'
+        $dbuser = 'keyowner'
+        New-DbaDbUser -SqlInstance $script:instance2 -Database Master -UserName $dbuser
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Owner keyowner
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -Algorithm $algorithm -WarningVariable warnvar
+        It Should "Create new key in master called $keyname"{
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be 'master'
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be $algorithm
+            $results.Owner | Should -Be $dbuser
+        }
+    }
+
+    # Context "Non master database" {    }
+
+    # Context "Loaded from a keyfile" {}
+}

--- a/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
@@ -1,0 +1,53 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','InputObject','EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    Context "Remove a certificate" {
+        $keyname = 'test1'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
+        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
+        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It  "Should create new key in master called $keyname" {
+            ($warnvar -eq $null) | Should -Be $True
+            $results.database | Should -Be 'master'
+            $results.name | Should -Be $keyname
+            $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
+        }
+        It "Should Remove a certificate" {
+            $getResults | Should -HaveCount 0
+            $removeResults.Status | Should -Be 'Success'
+        }
+    }
+    Context "Remove a specific certificate" {
+        $keyname = 'test1'
+        $keyname2 = 'test2'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
+        $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname2
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
+        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
+        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
+        It  "Should new keys in master " {
+            ($warnvar -eq $null) | Should -Be $True
+            $results | Should -HaveCount 2
+        }
+        It "Should Remove a specific certificate" {
+            $getResults | Should -HaveCount 1
+            $getResults[0].Name | Should -Be $keyname2
+            $removeResults.Status | Should -Be 'Success'
+            $removeResults.Name | Should -Be $keyname
+        }
+    }
+}

--- a/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance','SqlCredential','Name','Database','InputObject','EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Database', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -16,16 +16,22 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Remove a certificate" {
         $keyname = 'test1'
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
-        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
-        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It  "Should create new key in master called $keyname" {
+        $database = 'RemAsy'
+        New-DbaDatabase -SqlInstance $script:instance2 -Name $database
+        $tPassword = ConvertTo-SecureString "ThisIsThePassword1" -AsPlainText -Force
+        New-DbaDbMasterKey -SqlInstance $script:instance2 -Database $database -SecurePassword $tPassword -confirm:$false
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -database $database
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -WarningVariable warnvar
+
+        It  "Should create new key in $database called $keyname" {
             $warnvar | Should -BeNullOrEmpty
-            $results.database | Should -Be 'master'
+            $results.database | Should -Be $database
             $results.name | Should -Be $keyname
-            $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
+            $results.KeyLength | Should -Be '2048'
         }
+
+        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -confirm:$false
+        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
         It "Should Remove a certificate" {
             $getResults | Should -HaveCount 0
             $removeResults.Status | Should -Be 'Success'
@@ -34,20 +40,23 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Remove a specific certificate" {
         $keyname = 'test1'
         $keyname2 = 'test2'
-        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname
-        $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname2
-        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
-        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
-        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database master
-        It  "Should creatd new keys in master " {
+        $database = 'RemAsy'
+        $key = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database
+        $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname2 -Database $database
+        $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database -WarningVariable warnvar
+
+        It  "Should created new keys in $database " {
             $warnvar | Should -BeNullOrEmpty
             $results | Should -HaveCount 2
         }
+        $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database $database -confirm:$false
+        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database $database
         It "Should Remove a specific certificate" {
             $getResults | Should -HaveCount 1
             $getResults[0].Name | Should -Be $keyname2
             $removeResults.Status | Should -Be 'Success'
             $removeResults.Name | Should -Be $keyname
         }
+        Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname2 -Database $database -confirm:$false
     }
 }

--- a/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
+++ b/tests/Remove-DbaDbAsymmetricKey.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
         $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
         It  "Should create new key in master called $keyname" {
-            ($warnvar -eq $null) | Should -Be $True
+            $warnvar | Should -BeNullOrEmpty
             $results.database | Should -Be 'master'
             $results.name | Should -Be $keyname
             $results.KeyEncryptionAlgorithm | Should -Be 'Rsa2048'
@@ -38,9 +38,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $key2 = New-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname2
         $results = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -WarningVariable warnvar
         $removeResults = Remove-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master -confirm:$false
-        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Name $keyname -Database master
-        It  "Should new keys in master " {
-            ($warnvar -eq $null) | Should -Be $True
+        $getResults = Get-DbaDbAsymmetricKey -SqlInstance $script:instance2 -Database master
+        It  "Should creatd new keys in master " {
+            $warnvar | Should -BeNullOrEmpty
             $results | Should -HaveCount 2
         }
         It "Should Remove a specific certificate" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [x] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
To make sure we're fully supporting backup encryption we need to have some means of handling Asymmetric keys. So we needed these command:
Get-DbaDbAsymmetricKey
New-DbaDbAsymmetricKey
Remove-DbaAsymmetricKey

### Approach
Added the commands. All follow standard dbatools style (ie; I've used copy and paste liberally)

No EKM (Provider) support yet as I don't have anything to test against. But, should be moving to Azure Key Vault soonish, so will add it then

### Commands to test
Examples in the help

### Screenshots
<!-- pictures say a thousand words without typing any of it -->


