### PR TITLE
New-DbaDbTable Added Decimal Precision and Scale

### DIFF
--- a/functions/New-DbaDbTable.ps1
+++ b/functions/New-DbaDbTable.ps1
@@ -43,6 +43,19 @@ function New-DbaDbTable {
             Type      = 'int'
             Nullable  = $false
         }
+        $cols += @{
+            Name      = 'test3'
+            Type      = 'decimal'
+            MaxLength = 9
+            Nullable  = $true
+        }
+        $cols += @{
+            Name      = 'test4'
+            Type      = 'decimal'
+            Precision = 8
+            Scale = 2
+            Nullable  = $false
+        }
 
     .PARAMETER ColumnObject
         If you want to get fancy, you can build your own column objects and pass them in
@@ -341,6 +354,15 @@ function New-DbaDbTable {
                         if ($sqlDbType -eq 'VarBinary' -or $sqlDbType -eq 'VarChar') {
                             if ($column.MaxLength -gt 0) {
                                 $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType, $column.MaxLength
+                            } else {
+                                $sqlDbType = [Microsoft.SqlServer.Management.Smo.SqlDataType]"$(Get-SqlType $column.DataType.Name)Max"
+                                $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType
+                            }
+                        } elseif ($sqlDbType -eq 'Decimal') {
+                            if ($column.MaxLength -gt 0) {
+                                $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType, $column.MaxLength
+                            } elseif ($column.Precision -gt 0) {
+                                $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType, $column.Precision, $column.Scale
                             } else {
                                 $sqlDbType = [Microsoft.SqlServer.Management.Smo.SqlDataType]"$(Get-SqlType $column.DataType.Name)Max"
                                 $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType


### PR DESCRIPTION
Added support for defining the Decimal data type's Precision and Scale in a ColumMap.  Users can use "Precision" and "Scale" properties in the hash table to define the column.  MaxLength is also supported for setting Precision (without a Scale), to align with additional MS constructor.

<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ X ] New feature (non-breaking change, adds functionality, fixes #6151 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system