### PR TITLE
*-DbaDiagnosticQuery - Cross Platform Support Added

### DIFF
--- a/functions/Invoke-DbaDiagnosticQuery.ps1
+++ b/functions/Invoke-DbaDiagnosticQuery.ps1
@@ -181,16 +181,16 @@ function Invoke-DbaDiagnosticQuery {
         Write-Message -Level Verbose -Message "Interpreting DMV Script Collections"
 
         if (!$Path) {
-            $Path = "$script:PSModuleRoot\bin\diagnosticquery"
+            $Path = Join-Path -Path "$script:PSModuleRoot" -ChildPath "bin\diagnosticquery"
         }
 
         $scriptversions = @()
-        $scriptfiles = Get-ChildItem "$Path\SQLServerDiagnosticQueries_*_*.sql"
+        $scriptfiles = Get-ChildItem -Path "$Path\SQLServerDiagnosticQueries_*_*.sql"
 
         if (!$scriptfiles) {
             Write-Message -Level Warning -Message "Diagnostic scripts not found in $Path. Using the ones within the module."
 
-            $Path = "$base\bin\diagnosticquery"
+            $Path = Join-Path -Path $base -ChildPath "\bin\diagnosticquery"
 
             $scriptfiles = Get-ChildItem "$base\bin\diagnosticquery\SQLServerDiagnosticQueries_*_*.sql"
             if (!$scriptfiles) {

--- a/functions/Save-DbaDiagnosticQueryScript.ps1
+++ b/functions/Save-DbaDiagnosticQueryScript.ps1
@@ -72,16 +72,17 @@ function Save-DbaDiagnosticQueryScript {
     $glenberrysql = @()
     $RssPostFilter = "SQL Server Diagnostic Information Queries for*"
     $DropboxLinkFilter = "*dropbox.com*"
-    $LinkTitleFilter = "*Diagnostic*"
+    $LinkTitleFilter = "*Diagnostic Information Queries*"
+    $ExcludeSpreadsheet = "*BlankResutsSpreadsheet*"
 
     foreach ($post in $Feed.item) {
         if ($post.title -like $RssPostFilter) {
             # We found the first post that matches it, lets go visit and scrape.
             $page = Get-WebData -uri $post.link
-            $glenberrysql += ($page.Links | Where-Object { $_.href -like $DropboxLinkFilter -and $_.innerText -like $LinkTitleFilter } | ForEach-Object {
+            $glenberrysql += ($page.Links | Where-Object { $_.href -like $DropboxLinkFilter -and $_.outerHTML -like $LinkTitleFilter -and $_.outerHTML -notlike $ExcludeSpreadsheet } | ForEach-Object {
                     [pscustomobject]@{
                         URL        = $_.href
-                        SQLVersion = $_.innerText -replace " Diagnostic Information Queries", "" -replace "SQL Server ", "" -replace ' ', ''
+                        SQLVersion = $_.outerHTML -replace "<.+`">", "" -replace "</a>", "" -replace " Diagnostic Information Queries", "" -replace "SQL Server ", "" -replace ' ', ''
                         FileYear   = ($post.title -split " ")[-1]
                         FileMonth  = "{0:00}" -f [int]([CultureInfo]::InvariantCulture.DateTimeFormat.MonthNames.IndexOf(($post.title -split " ")[-2]))
                     }
@@ -95,7 +96,7 @@ function Save-DbaDiagnosticQueryScript {
             $link = $doc.URL.ToString().Replace('dl=0', 'dl=1')
             Write-Message -Level Verbose -Message "Downloading $link)"
             Write-ProgressHelper -Activity "Downloading Glenn Berry's most recent DMVs" -ExcludePercent -Message "Downloading $link" -StepNumber 1
-            $filename = "{0}\SQLServerDiagnosticQueries_{1}_{2}.sql" -f $Path, $doc.SQLVersion, "$($doc.FileYear)$($doc.FileMonth)"
+            $filename = Join-Path -Path $Path  -ChildPath "SQLServerDiagnosticQueries_$($doc.SQLVersion)_$("$($doc.FileYear)$($doc.FileMonth)").sql"
             Invoke-TlsWebRequest -Uri $link -OutFile $filename -ErrorAction Stop
             Get-ChildItem -Path $filename
         } catch {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Provide the ability to `Save-` and `Invoke-` the scripts created by Glenn Barry on Linux.
Since `Invoke-TLSWebRequest` is really just a wrapper for `Invoke-WebRequest` (Which works differently on core regardless of OS), this PR addresses some of those differences.
This is another chip away at #4647 

### Approach
<!-- How does this change solve that purpose -->
Replace explicit paths with `Join-Path`
Replace use of `InnerText` with `OuterHTML` and some regex since `InnerText` isn't supported on core. (See https://github.com/PowerShell/PowerShell/issues/2867)

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Save-DbaDiagnosticQueryScript -Path /my/path/here`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
On Linux
![image](https://user-images.githubusercontent.com/13426972/67821603-f8a1ca80-fa93-11e9-990b-770ebb7818cc.png)

Same Code on Windows
![image](https://user-images.githubusercontent.com/13426972/67821977-410db800-fa95-11e9-95f9-cca03abab135.png)
![image](https://user-images.githubusercontent.com/13426972/67822008-597dd280-fa95-11e9-80b1-9b6ff1b197e7.png)
