### PR TITLE
fixing import error on SMO already available

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -196,7 +196,15 @@ if (($PSVersionTable.PSVersion.Major -le 5) -or $script:isWindows) {
 
 $script:DllRoot = (Resolve-Path -Path "$script:PSModuleRoot\bin\").ProviderPath
 
-if (-not ('Microsoft.SqlServer.Management.Smo.Server' -as [type])) {
+<#
+If dbatools has not been imported yet, it also hasn't done libraries yet. Fix that.
+Previously checked for SMO being available, but that would break import with SqlServer loaded
+Some people also use the dbatools library for other things without the module, so also check,
+whether the modulebase has been set (first thing it does after loading library through dbatools import)
+Theoretically, there's a minor cuncurrency collision risk with that, but since the cost is only
+a little import time loss if that happens ...
+#>
+if ((-not ('Sqlcollaborative.Dbatools.dbaSystem.DebugHost' -as [type])) -or (-not [Sqlcollaborative.Dbatools.dbaSystem.SystemHost]::ModuleBase)) {
     . $script:psScriptRoot\internal\scripts\libraryimport.ps1
     Write-ImportTime -Text "Starting import SMO libraries"
 }


### PR DESCRIPTION
# Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Changes

Changed the decision, when dbatools will import the SQL libraries during import.
Previously checked for SMO being loaded, colliding with SqlSever and other script samples out there.
The new check may under rare circumstances try loading the libraries when there should be no need, merely costing a little import times.

It should be the lesser risk and have the lesser impact