### PR TITLE
Get-DbaDbView & Get-DbaDbStoredProcedure - fix issue #6172 with piping

### DIFF
--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -74,21 +74,21 @@ function Get-DbaDbStoredProcedure {
     #>
     [CmdletBinding()]
     param (
+        [Parameter(ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemSp,
-        [parameter(ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
 
     process {
-        foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        if (Test-Bound SqlInstance) {
+            $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
-
 
         foreach ($db in $InputObject) {
             if (!$db.IsAccessible) {

--- a/functions/Get-DbaDbStoredProcedure.ps1
+++ b/functions/Get-DbaDbStoredProcedure.ps1
@@ -25,6 +25,9 @@ function Get-DbaDbStoredProcedure {
     .PARAMETER ExcludeSystemSp
         This switch removes all system objects from the Stored Procedure collection
 
+    .PARAMETER InputObject
+        Enables piping from Get-DbaDatabase
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -63,59 +66,53 @@ function Get-DbaDbStoredProcedure {
 
         Gets the Stored Procedures for the databases on Sql1 and Sql2/sqlexpress
 
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance Server1 -ExcludeSystem | Get-DbaDbStoredProcedure
+
+        Pipe the databases from Get-DbaDatabase into Get-DbaDbStoredProcedure
+
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemSp,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
 
     process {
         foreach ($instance in $SqlInstance) {
-            try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        }
+
+
+        foreach ($db in $InputObject) {
+            if (!$db.IsAccessible) {
+                Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
+                continue
+            }
+            if ($db.StoredProcedures.Count -eq 0) {
+                Write-Message -Message "No Stored Procedures exist in the $db database on $instance" -Target $db -Level Output
+                continue
             }
 
-            $databases = $server.Databases | Where-Object IsAccessible
-
-            if ($Database) {
-                $databases = $databases | Where-Object Name -In $Database
-            }
-            if ($ExcludeDatabase) {
-                $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
-            }
-
-            foreach ($db in $databases) {
-                if (!$db.IsAccessible) {
-                    Write-Message -Level Warning -Message "Database $db is not accessible. Skipping."
-                    continue
-                }
-                if ($db.StoredProcedures.Count -eq 0) {
-                    Write-Message -Message "No Stored Procedures exist in the $db database on $instance" -Target $db -Level Output
+            foreach ($proc in $db.StoredProcedures) {
+                if ( (Test-Bound -ParameterName ExcludeSystemSp) -and $proc.IsSystemObject ) {
                     continue
                 }
 
-                foreach ($proc in $db.StoredProcedures) {
-                    if ( (Test-Bound -ParameterName ExcludeSystemSp) -and $proc.IsSystemObject ) {
-                        continue
-                    }
+                Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $proc.Parent.ComputerName
+                Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name InstanceName -value $proc.Parent.InstanceName
+                Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $proc.Parent.SqlInstance
+                Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name
 
-                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
-                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-                    Add-Member -Force -InputObject $proc -MemberType NoteProperty -Name Database -value $db.Name
-
-                    $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ID as ObjectId', 'CreateDate',
-                    'DateLastModified', 'Name', 'ImplementationType', 'Startup'
-                    Select-DefaultView -InputObject $proc -Property $defaults
-                }
+                $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'ID as ObjectId', 'CreateDate',
+                'DateLastModified', 'Name', 'ImplementationType', 'Startup'
+                Select-DefaultView -InputObject $proc -Property $defaults
             }
         }
     }

--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -25,6 +25,9 @@ function Get-DbaDbView {
     .PARAMETER ExcludeSystemView
         This switch removes all system objects from the view collection.
 
+    .PARAMETER InputObject
+        Enables piping from Get-DbaDatabase
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -63,55 +66,48 @@ function Get-DbaDbView {
 
         Gets the views for the databases on Sql1 and Sql2/sqlexpress
 
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance Server1 -ExcludeSystem | Get-DbaDbView
+
+        Pipe the databases from Get-DbaDatabase into Get-DbaDbView
+
     #>
     [CmdletBinding()]
     param (
-        [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$ExcludeSystemView,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [switch]$EnableException
     )
 
     process {
         foreach ($instance in $SqlInstance) {
-            try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        }
+
+        foreach ($db in $InputObject) {
+            $views = $db.views
+
+            if (!$views) {
+                Write-Message -Message "No views exist in the $db database on $instance" -Target $db -Level Verbose
+                continue
+            }
+            if (Test-Bound -ParameterName ExcludeSystemView) {
+                $views = $views | Where-Object { $_.IsSystemObject -eq $false }
             }
 
-            $databases = $server.Databases | Where-Object IsAccessible
+            $views | ForEach-Object {
 
-            if ($Database) {
-                $databases = $databases | Where-Object Name -In $Database
-            }
-            if ($ExcludeDatabase) {
-                $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
-            }
+                Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $_.Parent.ComputerName
+                Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $_.Parent.Instancename
+                Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $_.Parent.SqlInstance
+                Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name
 
-            foreach ($db in $databases) {
-                $views = $db.views
-
-                if (!$views) {
-                    Write-Message -Message "No views exist in the $db database on $instance" -Target $db -Level Verbose
-                    continue
-                }
-                if (Test-Bound -ParameterName ExcludeSystemView) {
-                    $views = $views | Where-Object { $_.IsSystemObject -eq $false }
-                }
-
-                $views | ForEach-Object {
-
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name ComputerName -value $server.ComputerName
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name InstanceName -value $server.ServiceName
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name SqlInstance -value $server.DomainInstanceName
-                    Add-Member -Force -InputObject $_ -MemberType NoteProperty -Name Database -value $db.Name
-
-                    Select-DefaultView -InputObject $_ -Property ComputerName, InstanceName, SqlInstance, Database, Schema, CreateDate, DateLastModified, Name
-                }
+                Select-DefaultView -InputObject $_ -Property ComputerName, InstanceName, SqlInstance, Database, Schema, CreateDate, DateLastModified, Name
             }
         }
     }

--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -91,8 +91,12 @@ function Get-DbaDbView {
 
         foreach ($db in $InputObject) {
             $views = $db.views
+            if (-not $db.IsAccessible) {
+                Write-Message -Level Warning -Message "Database $db is not accessible. Skipping"
+                continue
+            }
 
-            if (!$views) {
+            if (-not $views) {
                 Write-Message -Message "No views exist in the $db database on $instance" -Target $db -Level Verbose
                 continue
             }
@@ -102,9 +106,10 @@ function Get-DbaDbView {
 
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'CreateDate', 'DateLastModified', 'Name'
             foreach ($view in $views) {
-                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name ComputerName -value $_.Parent.ComputerName
-                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name InstanceName -value $_.Parent.InstanceName
-                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name SqlInstance -value $_.Parent.SqlInstance
+
+                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name ComputerName -value $view.Parent.ComputerName
+                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name InstanceName -value $view.Parent.InstanceName
+                Add-Member -Force -InputObject $view -MemberType NoteProperty -Name SqlInstance -value $view.Parent.SqlInstance
                 Add-Member -Force -InputObject $view -MemberType NoteProperty -Name Database -value $db.Name
 
                 Select-DefaultView -InputObject $view -Property $defaults

--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -101,7 +101,7 @@ function Get-DbaDbView {
                 continue
             }
             if (Test-Bound -ParameterName ExcludeSystemView) {
-                $views = $views | Where-Object -Not IsSystemObject
+                $views = $views | Where-Object { -not $_.IsSystemObject }
             }
 
             $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Schema', 'CreateDate', 'DateLastModified', 'Name'

--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -85,8 +85,8 @@ function Get-DbaDbView {
         [switch]$EnableException
     )
     process {
-        foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        if (Test-Bound SqlInstance) {
+            $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }
 
         foreach ($db in $InputObject) {

--- a/tests/Get-DbaDbObjectTrigger.Tests.ps1
+++ b/tests/Get-DbaDbObjectTrigger.Tests.ps1
@@ -52,82 +52,82 @@ CREATE TRIGGER $triggerviewname
         $server.Query("CREATE VIEW $viewname AS SELECT * FROM $tablename;", $dbname)
         $server.Query("$triggerview", $dbname)
 
-        $systemDbs = get-dbadatabase -SqlInstance $script:instance2 -ExcludeUser
+        $systemDbs = Get-DbaDatabase -SqlInstance $script:instance2 -ExcludeUser
     }
     AfterAll {
         $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
     }
 
     Context "Gets Table Trigger" {
-        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -ExcludeDatabase $systemDbs.Name | Where-Object {$_.name -eq "dbatoolsci_triggerontable"}
+        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -ExcludeDatabase $systemDbs.Name | Where-Object { $_.name -eq "dbatoolsci_triggerontable" }
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_trigger table*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_trigger table*'
         }
     }
     Context "Gets Table Trigger when using -Database" {
-        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname | Where-Object {$_.name -eq "dbatoolsci_triggerontable"}
+        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname | Where-Object { $_.name -eq "dbatoolsci_triggerontable" }
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_trigger table*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_trigger table*'
         }
     }
     Context "Gets Table Trigger passing table object using pipeline" {
         $results = Get-DbaDbTable -SqlInstance $script:instance2 -Database $dbname -Table "dbatoolsci_trigger" | Get-DbaDbObjectTrigger
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_trigger table*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_trigger table*'
         }
     }
     Context "Gets View Trigger" {
-        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -ExcludeDatabase $systemDbs.Name | Where-Object {$_.name -eq "dbatoolsci_triggeronview"}
+        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -ExcludeDatabase $systemDbs.Name | Where-Object { $_.name -eq "dbatoolsci_triggeronview" }
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_view view*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_view view*'
         }
     }
     Context "Gets View Trigger when using -Database" {
-        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname | Where-Object {$_.name -eq "dbatoolsci_triggeronview"}
+        $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname | Where-Object { $_.name -eq "dbatoolsci_triggeronview" }
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_view view*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_view view*'
         }
     }
     Context "Gets View Trigger passing table object using pipeline" {
         $results = Get-DbaDbView -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemView | Get-DbaDbObjectTrigger
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.isenabled | Should Be $true
+            $results.isenabled | Should -Be $true
         }
         It "Should have text of Trigger" {
-            $results.TextBody | Should BeLike '*dbatoolsci_view view*'
+            $results.TextBody | Should -BeLike '*dbatoolsci_view view*'
         }
     }
     Context "Gets Table and View Trigger passing both objects using pipeline" {
@@ -135,43 +135,43 @@ CREATE TRIGGER $triggerviewname
         $viewResults = Get-DbaDbView -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemView
         $results = $tableResults, $viewResults | Get-DbaDbObjectTrigger
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be enabled" {
-            $results.Count | Should Be 2
+            $results.Count | Should -Be 2
         }
     }
     Context "Gets All types Trigger when using -Type" {
         $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname -Type All
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be only one" {
-            $results.Count | Should Be 2
+            $results.Count | Should -Be 2
         }
     }
     Context "Gets only Table Trigger when using -Type" {
         $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname -Type Table
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be only one" {
-            $results.Count | Should Be 1
+            $results.Count | Should -Be 1
         }
         It "Should have text of Trigger" {
-            $results.Parent.GetType().Name | Should Be "Table"
+            $results.Parent.GetType().Name | Should -Be "Table"
         }
     }
     Context "Gets only View Trigger when using -Type" {
         $results = Get-DbaDbObjectTrigger -SqlInstance $script:instance2 -Database $dbname -Type View
         It "Gets results" {
-            $results | Should Not Be $null
+            $results | Should -Not -Be $null
         }
         It "Should be only one" {
-            $results.Count | Should Be 1
+            $results.Count | Should -Be 1
         }
         It "Should have text of Trigger" {
-            $results.Parent.GetType().Name | Should Be "View"
+            $results.Parent.GetType().Name | Should -Be "View"
         }
     }
 }

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -10,7 +10,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 #>
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemSp', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
@@ -22,29 +22,46 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
-        $random = Get-Random
-        $procName = "dbatools_getdbsp"
-        $dbname = "dbatoolsci_getdbsp$random"
-        $server.Query("CREATE DATABASE $dbname")
-        $server.Query("CREATE PROCEDURE $procName AS SELECT 1", $dbname)
+        $procName = ("dbatools_{0}" -f $(Get-Random))
+        $server.Query("CREATE PROCEDURE $procName AS SELECT 1", 'tempdb')
     }
-
     AfterAll {
-        $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
+        $null = $server.Query("DROP PROCEDURE $procName", 'tempdb')
     }
 
     Context "Command actually works" {
-        $results = Get-DbaDbStoredProcedure -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemSp
-        it "Should have standard properties" {
+        $results = Get-DbaDbStoredProcedure -SqlInstance $script:instance2 -Database tempdb
+        It "Should have standard properties" {
             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance'.Split(',')
             ($results[0].PsObject.Properties.Name | Where-Object { $_ -in $ExpectedProps } | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
         }
+        It "Should get test procedure: $procName" {
+            ($results | Where-Object Name -eq $procName).Name | Should -Be $true
+        }
+        It "Should include system procedures" {
+            ($results | Where-Object Name -eq 'sp_columns') | Should -Be $true
+        }
+    }
 
-        It "Should include test procedure: $procName" {
-            ($results | Where-Object Name -eq $procName).Name | Should Be $procName
+    Context "Exclusions work correctly" {
+        It "Should contain no procs from master database" {
+            $results = Get-DbaDbStoredProcedure -SqlInstance $script:instance2 -ExcludeDatabase master
+            $results.Database | Should -Not -Contain 'master'
         }
         It "Should exclude system procedures" {
-            ($results | Where-Object Name -eq 'sp_helpdb') | Should Be $null
+            $results = Get-DbaDbStoredProcedure -SqlInstance $script:instance2 -Database tempdb -ExcludeSystemSp
+            $results | Where-Object Name -eq 'sp_helpdb' | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Piping works" {
+        It "Should allow piping from string" {
+            $results = $script:instance2 | Get-DbaDbStoredProcedure -Database tempdb
+            ($results | Where-Object Name -eq $procName).Name | Should -Not -BeNullOrEmpty
+        }
+        It "Should allow piping from Get-DbaDatabase" {
+            $results = Get-DbaDatabase -SqlInstance $script:instance2 -Database tempdb | Get-DbaDbStoredProcedure
+            ($results | Where-Object Name -eq $procName).Name | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/tests/Get-DbaDbStoredProcedure.Tests.ps1
+++ b/tests/Get-DbaDbStoredProcedure.Tests.ps1
@@ -10,11 +10,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 #>
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemSp', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemSp', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -37,7 +37,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $results = Get-DbaDbStoredProcedure -SqlInstance $script:instance2 -Database $dbname -ExcludeSystemSp
         it "Should have standard properties" {
             $ExpectedProps = 'ComputerName,InstanceName,SqlInstance'.Split(',')
-            ($results[0].PsObject.Properties.Name | Where-Object {$_ -in $ExpectedProps} | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+            ($results[0].PsObject.Properties.Name | Where-Object { $_ -in $ExpectedProps } | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
         }
 
         It "Should include test procedure: $procName" {

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -24,7 +24,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "Command actually works" {
-        $results = Get-DbaDbView -SqlInstance $script:instance2 -Database tempdb | Select-Object Name, IsSystemObject
+        $results = Get-DbaDbView -SqlInstance $script:instance2 -Database tempdb
+        It "Should have standard properties" {
+            $ExpectedProps = 'ComputerName,InstanceName,SqlInstance'.Split(',')
+            ($results[0].PsObject.Properties.Name | Where-Object { $_ -in $ExpectedProps } | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+        }
         It "Should get test view: $viewName" {
             ($results | Where-Object Name -eq $viewName).Name | Should Be $true
         }
@@ -46,11 +50,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
     Context "Piping workings" {
         It "Should allow piping from string" {
-            $results = $script:instance2 | Get-DbaDbView -Database tempdb -ExcludeSystemView | Select-Object Name, IsSystemObject
+            $results = $script:instance2 | Get-DbaDbView -Database tempdb
             ($results | Where-Object Name -eq $viewName).Name | Should -Be $true
         }
         It "Should allow piping from Get-DbaDatabase" {
-            $results = Get-DbaDatabase -SqlInstance $script:instance2 -Database tempdb | Get-DbaDbView -ExcludeSystemView
+            $results = Get-DbaDatabase -SqlInstance $script:instance2 -Database tempdb | Get-DbaDbView
             ($results | Where-Object Name -eq $viewName).Name | Should -Be $true
         }
     }

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemView', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'ExcludeSystemView', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -44,7 +44,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         It "Should exclude system views" {
             $results = Get-DbaDbView -SqlInstance $script:instance2 -ExcludeSystemView
-            $results.IsSystemObject | Should Not Contain $true
+            ($results | Where-Object IsSystemObject -eq $true).Count | Should -Be 0
         }
     }
 

--- a/tests/Get-DbaDbView.Tests.ps1
+++ b/tests/Get-DbaDbView.Tests.ps1
@@ -39,8 +39,19 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.Database | Should Not Contain 'master'
         }
         It "Should exclude system views" {
-            $results = Get-DbaDbView -SqlInstance $script:instance2 -ExcludeSystemView | Select-Object Name, IsSystemObject
+            $results = Get-DbaDbView -SqlInstance $script:instance2 -ExcludeSystemView
             $results.IsSystemObject | Should Not Contain $true
+        }
+    }
+
+    Context "Piping workings" {
+        It "Should allow piping from string" {
+            $results = $script:instance2 | Get-DbaDbView -Database tempdb -ExcludeSystemView | Select-Object Name, IsSystemObject
+            ($results | Where-Object Name -eq $viewName).Name | Should -Be $true
+        }
+        It "Should allow piping from Get-DbaDatabase" {
+            $results = Get-DbaDatabase -SqlInstance $script:instance2 -Database tempdb | Get-DbaDbView -ExcludeSystemView
+            ($results | Where-Object Name -eq $viewName).Name | Should -Be $true
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6172 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Issue #6172 - errors piping from Get-DbaDatabase into Get-DbaDbView & Get-DbaDbStoredProcedure

### Approach
Implement use of $InputObject for both, copying functionality from Get-DbaDbTable

### Commands to test
```
Get-DbaDatabase -SqlInstance server -ExcludeSystem | Get-DbaDbView
Get-DbaDatabase -SqlInstance server -ExcludeSystem | Get-DbaDbStoredProcedure
```
