### PR TITLE
Copy-DbaLogin add more complex LoginRenameHashtable example issue #6188

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -113,7 +113,7 @@ function Copy-DbaLogin {
         Copies ONLY Logins netnerds and realcajun. If Login realcajun or netnerds exists on Destination, the existing Login(s) will be dropped and recreated.
 
     .EXAMPLE
-        PS C:\> Copy-DbaLogin -LoginRenameHashtable @{ "PreviousUser" = "newlogin" } -Source $Sql01 -Destination Localhost -SourceSqlCredential $sqlcred
+        PS C:\> Copy-DbaLogin -LoginRenameHashtable @{ "PreviousUser" = "newlogin" } -Source $Sql01 -Destination Localhost -SourceSqlCredential $sqlcred -Login PreviousUser
 
         Copies PreviousUser and then renames it to newlogin.
 
@@ -121,6 +121,22 @@ function Copy-DbaLogin {
         PS C:\> Get-DbaLogin -SqlInstance sql2016 | Out-GridView -Passthru | Copy-DbaLogin -Destination sql2017
 
         Displays all available logins on sql2016 in a grid view, then copies all selected logins to sql2017.
+
+    .EXAMPLE
+        PS C:\> $loginSplat = @{
+                    Source               = $Sql01
+                    Destination          = "Localhost"
+                    SourceSqlCredential  = $sqlcred
+                    Login                = 'ReadUserP', 'ReadWriteUserP', 'AdminP'
+                    LoginRenameHashtable = @{
+                        "ReadUserP"      = "ReadUserT"
+                        "ReadWriteUserP" = "ReadWriteUserT"
+                        "AdminP"         = "AdminT"
+                    }
+                }
+        PS C:\> Copy-DbaLogin @loginSplat
+
+       Copies the three specified logins to 'localhost' and renames them according to the LoginRenameHashTable.
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "Medium")]

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -124,19 +124,19 @@ function Copy-DbaLogin {
 
     .EXAMPLE
         PS C:\> $loginSplat = @{
-                    Source               = $Sql01
-                    Destination          = "Localhost"
-                    SourceSqlCredential  = $sqlcred
-                    Login                = 'ReadUserP', 'ReadWriteUserP', 'AdminP'
-                    LoginRenameHashtable = @{
-                        "ReadUserP"      = "ReadUserT"
-                        "ReadWriteUserP" = "ReadWriteUserT"
-                        "AdminP"         = "AdminT"
-                    }
-                }
+        >> Source = $Sql01
+        >> Destination = "Localhost"
+        >> SourceSqlCredential = $sqlcred
+        >> Login = 'ReadUserP', 'ReadWriteUserP', 'AdminP'
+        >> LoginRenameHashtable = @{
+        >> "ReadUserP" = "ReadUserT"
+        >> "ReadWriteUserP" = "ReadWriteUserT"
+        >> "AdminP"         = "AdminT"
+        >> }
+        >> }
         PS C:\> Copy-DbaLogin @loginSplat
 
-       Copies the three specified logins to 'localhost' and renames them according to the LoginRenameHashTable.
+        Copies the three specified logins to 'localhost' and renames them according to the LoginRenameHashTable.
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "Medium")]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6188
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Highlight the use of LoginRenameHashTable

### Commands to test
```
$loginSplat = @{
                    Source               = $Sql01
                    Destination          = "Localhost"
                    SourceSqlCredential  = $sqlcred
                    Login                = 'ReadUserP', 'ReadWriteUserP', 'AdminP'
                    LoginRenameHashtable = @{
                        "ReadUserP"      = "ReadUserT"
                        "ReadWriteUserP" = "ReadWriteUserT"
                        "AdminP"         = "AdminT"
                    }
                }
Copy-DbaLogin @loginSplat
```
