### PR TITLE
Adding aliases for two common commands in module

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -291,6 +291,16 @@ Write-ImportTime -Text "Script: Asynchronous TEPP Cache"
 Write-ImportTime -Text "Script: Maintenance"
 
 #region Aliases
+
+# New 3-char aliases
+$shortcuts = @{
+    'ivq' = 'Invoke-DbaQuery'
+    'cdi' = 'Connect-DbaInstance'
+}
+foreach ($_ in $shortcuts.GetEnumerator()) {
+    New-Alias -Name $_.Key -Value $_.Value
+}
+
 # Leave forever
 $forever = @{
     'Get-DbaRegisteredServer' = 'Get-DbaRegServer'
@@ -906,7 +916,7 @@ $script:windowsonly = @(
 )
 
 # If a developer or appveyor calls the psm1 directly, they want all functions
-# So do not explicity export because everything else is then implicity excluded
+# So do not explicitly export because everything else is then implicitly excluded
 if (-not $script:multiFileImport) {
     $exports =
     @(if (($PSVersionTable.Platform)) {
@@ -929,6 +939,9 @@ if (-not $script:multiFileImport) {
         }
         foreach ($k in $script:Forever.Keys) {
             $k
+        }
+        foreach ($c in $script:shortcuts.Keys) {
+            $c
         }
     )
 

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -11,6 +11,11 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
+    Context "Validate alias" {
+        It "Should contain the alias: cdi" {
+            (Get-Alias cdi) | Should -Not -BeNullOrEmpty
+        }
+    }
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -4,11 +4,16 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Query', 'QueryTimeout', 'File', 'SqlObject', 'As', 'SqlParameters', 'AppendServerInstance', 'MessagesToOutput', 'InputObject', 'ReadOnly', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+    Context "Validate alias" {
+        It "Should contain the alias: ivq" {
+            (Get-Alias ivq) | Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
Just for convenience (and bit of fun) adding two aliases for our most commonly used commands, for those that do a lot of interactive console work:

`ivq` for `Invoke-DbaQuery`
`cdi` for `Connect-DbaInstance`

I also added unit test to each of the associated commands to ensure the aliases are present.