### PR TITLE
Get-DbaLastGoodCheckDb - fixes issue #6226

### DIFF
--- a/functions/Get-DbaLastGoodCheckDb.ps1
+++ b/functions/Get-DbaLastGoodCheckDb.ps1
@@ -101,11 +101,6 @@ function Get-DbaLastGoodCheckDb {
             return
         }
 
-        #if ($SqlInstance) {
-        #    Write-Message -Level Verbose -Message "Processing via SQL Instance."
-        #    $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
-        #}
-
         if ($SqlInstance) {
             $InputObject = $SqlInstance
         }
@@ -115,7 +110,7 @@ function Get-DbaLastGoodCheckDb {
             switch ($inputType) {
                 'Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter' {
                     Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
-                    $databases = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+                    $databases = Get-DbaDatabase -SqlInstance $input -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
                 }
                 'Microsoft.SqlServer.Management.Smo.Server' {
                     Write-Message -Level Verbose -Message "Processing Server through InputObject"

--- a/tests/Get-DbaLastGoodCheckDb.Tests.ps1
+++ b/tests/Get-DbaLastGoodCheckDb.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -24,33 +24,43 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -confirm:$false
     }
+    Context "Command actually works" {
+        $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -Database master
+        It "LastGoodCheckDb is a valid date" {
+            $results.LastGoodCheckDb -ne $null | Should Be $true
+            $results.LastGoodCheckDb -is [datetime] | Should Be $true
+        }
 
-    $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -Database master
-    It "LastGoodCheckDb is a valid date" {
-        $results.LastGoodCheckDb -ne $null | Should Be $true
-        $results.LastGoodCheckDb -is [datetime] | Should Be $true
+        $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -WarningAction SilentlyContinue
+        It "returns more than 3 results" {
+            ($results).Count -gt 3 | Should Be $true
+        }
+
+        $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -Database $dbname
+        It "LastGoodCheckDb is a valid date for database with embedded ] characters" {
+            $results.LastGoodCheckDb -ne $null | Should Be $true
+            $results.LastGoodCheckDb -is [datetime] | Should Be $true
+        }
     }
 
-    $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -WarningAction SilentlyContinue
-    It "returns more than 3 results" {
-        ($results).Count -gt 3 | Should Be $true
+    Context "Piping works" {
+        $server = Connect-DbaInstance -SqlInstance $script:instance1
+        $results = $server | Get-DbaLastGoodCheckDb -Database $dbname, master
+        It "LastGoodCheckDb accepts piped input from Connect-DbaInstance" {
+            ($results).Count -eq 2 | Should Be $true
+        }
+
+        $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname, master
+        $results = $db | Get-DbaLastGoodCheckDb
+        It "LastGoodCheckDb accepts piped input from Get-DbaDatabase" {
+            ($results).Count -eq 2 | Should Be $true
+        }
     }
 
-    $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1 -Database $dbname
-    It "LastGoodCheckDb is a valid date for database with embedded ] characters" {
-        $results.LastGoodCheckDb -ne $null | Should Be $true
-        $results.LastGoodCheckDb -is [datetime] | Should Be $true
-    }
-
-    $server = Connect-DbaInstance -SqlInstance $script:instance1
-    $results = $server | Get-DbaLastGoodCheckDb -Database $dbname, master
-    It "LastGoodCheckDb accepts piped input from Connect-DbaInstance" {
-        ($results).Count -eq 2 | Should Be $true
-    }
-
-    $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname, master
-    $results = $db | Get-DbaLastGoodCheckDb
-    It "LastGoodCheckDb accepts piped input from Get-DbaDatabase" {
-        ($results).Count -eq 2 | Should Be $true
+    Context "Doesn't return duplicate results" {
+        $results = Get-DbaLastGoodCheckDb -SqlInstance $script:instance1, $script:instance2 -Database $dbname
+        It "LastGoodCheckDb doesn't return duplicates when multiple servers are passed in" {
+            ($results | Group-Object SqlInstance, Database | Where-Object Count -gt 1) | Should BeNullOrEmpty
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6226 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Resolve issue where passing in multiple instances gives you duplicate results

### Approach
Run the command once for all sql instances, instead of looping through and running it multiple times

### Commands to test
```
Get-DbaLastGoodCheckDb -SqlInstance mssql1,mssql2
'mssql1','mssql2' | Get-DbaLastGoodCheckDb
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/70232198-e0c00500-1729-11ea-9af7-fe22ad240bab.png)
