### PR TITLE
Only return instances with at least the minimum confidence

### DIFF
--- a/functions/Find-DbaInstance.ps1
+++ b/functions/Find-DbaInstance.ps1
@@ -542,7 +542,7 @@ function Find-DbaInstance {
                         }
                     }
 
-                    $masterList
+                    $masterList | Where-Object { $_.Confidence -ge $MinimumConfidence }
                 }
             }
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6247 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Find-DbaInstance wasn't honoring the MinimumConfidence parameter

### Approach
Before returning $masterlist from Test-SqlInstance pipe it to Where-Object and do a check on the confidence level.  If instances can be filtered out earlier that would speed things up but the SqlConnect scan, which can set confidence, happens right before this.

### Commands to test
Identify a server that returns a confidence lower than High then:
Find-DbaInstance -Computername <server> -MinimumConfidence High

You can also run the following and confirm None, Low, or Medium instances are returned then up the MinimumConfidence:
Find-DbaInstance -DiscoveryType DomainServer -MinimumConfidence None