### PR TITLE
Adding -UpdateSourcePath parameter to Install-DbaInstance

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -86,6 +86,9 @@ function Install-DbaInstance {
     .PARAMETER BackupPath
         Path to the Backup folder.
 
+    .PARAMETER UpdateSourcePath
+        Path to the updates that you want to slipstream into the installation.
+
     .PARAMETER AdminAccount
         One or more members of the sysadmin group. Uses UserName from the -Credential parameter if specified, or current Windows user by default.
 
@@ -177,9 +180,10 @@ function Install-DbaInstance {
         Install a default named SQL Server instance on the remote machine, sql2017 and use the local configuration.ini
 
     .Example
-        C:\PS> Install-DbaInstance -Version 2017 -InstancePath G:\SQLServer
+        C:\PS> Install-DbaInstance -Version 2017 -InstancePath G:\SQLServer -UpdateSourcePath \\my\updates
 
         Run the installation locally with default settings apart from the application volume, this will be redirected to G:\SQLServer.
+        The installation procedure would search for SQL Server updates in \\my\updates and slipstream them into the installation.
 
     .Example
         C:\PS> $svcAcc = Get-Credential MyDomain\SvcSqlServer
@@ -230,6 +234,7 @@ function Install-DbaInstance {
         [string]$LogPath,
         [string]$TempPath,
         [string]$BackupPath,
+        [string]$UpdateSourcePath,
         [string[]]$AdminAccount,
         [int]$Port,
         [int]$Throttle = 50,
@@ -582,7 +587,7 @@ function Install-DbaInstance {
             if ($Configuration) {
                 foreach ($key in $Configuration.Keys) {
                     $configNode.$key = [string]$Configuration.$key
-                    if ($key -eq 'UpdateSource' -and $Configuration.Keys -notcontains 'UPDATEENABLED') {
+                    if ($key -eq 'UpdateSource' -and $configNode.$key -and $Configuration.Keys -notcontains 'UPDATEENABLED') {
                         #enable updates since now we have a source
                         $configNode.UPDATEENABLED = "True"
                     }
@@ -616,6 +621,10 @@ function Install-DbaInstance {
             }
             if (Test-Bound -ParameterName AdminAccount) {
                 $configNode.SQLSYSADMINACCOUNTS = $AdminAccount
+            }
+            if (Test-Bound -ParameterName UpdateSourcePath) {
+                $configNode.UPDATESOURCE = $UpdateSourcePath
+                $configNode.UPDATEENABLED = "True"
             }
             # PID
             if (Test-Bound -ParameterName ProductID) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6253  )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Minor update for the function, adding one more parameter that would allow people to slipstream updates without using the `-Configuration` parameter.

### Approach
One more parameter, that sets the path and enables the updates.