### PR TITLE
Fixes #6274 - Enables filtering on Find-DbaAgentJob for JobName or StepName when other filters used.

### DIFF
--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -183,26 +183,26 @@ function Find-DbaAgentJob {
                 $DaysBack = $LastUsed * -1
                 $SinceDate = (Get-Date).AddDays($DaysBack)
                 Write-Message -Level Verbose -Message "Finding job/s not ran in last $LastUsed days"
-                $output += $jobs | Where-Object { $_.LastRunDate -le $SinceDate }
+                $output = $jobs | Where-Object { $_.LastRunDate -le $SinceDate }
             }
 
             if ($IsDisabled) {
                 Write-Message -Level Verbose -Message "Finding job/s that are disabled"
-                $output += $jobs | Where-Object IsEnabled -eq $false
+                $output = $jobs | Where-Object IsEnabled -eq $false
             }
 
             if ($IsNotScheduled) {
                 Write-Message -Level Verbose -Message "Finding job/s that have no schedule defined"
-                $output += $jobs | Where-Object HasSchedule -eq $false
+                $output = $jobs | Where-Object HasSchedule -eq $false
             }
             if ($IsNoEmailNotification) {
                 Write-Message -Level Verbose -Message "Finding job/s that have no email operator defined"
-                $output += $jobs | Where-Object { [string]::IsNullOrEmpty($_.OperatorToEmail) -eq $true }
+                $output = $jobs | Where-Object { [string]::IsNullOrEmpty($_.OperatorToEmail) -eq $true }
             }
 
             if ($Category) {
                 Write-Message -Level Verbose -Message "Finding job/s that have the specified category defined"
-                $output += $jobs | Where-Object { $Category -contains $_.Category }
+                $output = $jobs | Where-Object { $Category -contains $_.Category }
             }
 
             if ($Owner) {
@@ -210,10 +210,10 @@ function Find-DbaAgentJob {
                 if ($Owner -match "-") {
                     $OwnerMatch = $Owner -replace "-", ""
                     Write-Message -Level Verbose -Message "Checking for jobs that NOT owned by: $OwnerMatch"
-                    $output += $server.JobServer.jobs | Where-Object { $OwnerMatch -notcontains $_.OwnerLoginName }
+                    $output = $jobs | Where-Object { $OwnerMatch -notcontains $_.OwnerLoginName }
                 } else {
                     Write-Message -Level Verbose -Message "Checking for jobs that are owned by: $owner"
-                    $output += $server.JobServer.jobs | Where-Object { $Owner -contains $_.OwnerLoginName }
+                    $output = $jobs | Where-Object { $Owner -contains $_.OwnerLoginName }
                 }
             }
 

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -158,7 +158,8 @@ function Find-DbaAgentJob {
 
             if ($JobName) {
                 Write-Message -Level Verbose -Message "Retrieving jobs by their name."
-                $output += Get-JobList -SqlInstance $server -JobFilter $JobName
+                $jobs = Get-JobList -SqlInstance $server -JobFilter $JobName
+                $output = $jobs
             }
 
             if ($StepName) {

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -154,7 +154,6 @@ function Find-DbaAgentJob {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $jobs = $server.JobServer.jobs
             $output = @()
 
             if ($JobName) {

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -112,6 +112,11 @@ function Find-DbaAgentJob {
 
         Queries CMS server to return all SQL instances in the Production folder and then list out all agent jobs that have either been disabled or have no schedule.
 
+    .EXAMPLE
+        $Instances = 'SQL2017N5','SQL2019N5','SQL2019N20','SQL2019N21','SQL2019N22'
+        Find-DbaAgentJob -SqlInstance $Instances -JobName *backup* -IsNotScheduled
+
+        Returns all agent job(s) wiht backup in the name, that don't have a schedule on 'SQL2017N5','SQL2019N5','SQL2019N20','SQL2019N21','SQL2019N22'
     #>
     [CmdletBinding()]
     param (
@@ -174,6 +179,11 @@ function Find-DbaAgentJob {
                 $output = $jobs
             }
 
+            if ($Category) {
+                Write-Message -Level Verbose -Message "Finding job/s that have the specified category defined"
+                $output = $jobs | Where-Object { $Category -contains $_.Category }
+            }
+
             if ($IsFailed) {
                 Write-Message -Level Verbose -Message "Checking for failed jobs."
                 $output = $jobs | Where-Object LastRunOutcome -eq "Failed"
@@ -188,21 +198,16 @@ function Find-DbaAgentJob {
 
             if ($IsDisabled) {
                 Write-Message -Level Verbose -Message "Finding job/s that are disabled"
-                $output = $jobs | Where-Object IsEnabled -eq $false
+                $output += $jobs | Where-Object IsEnabled -eq $false
             }
 
             if ($IsNotScheduled) {
                 Write-Message -Level Verbose -Message "Finding job/s that have no schedule defined"
-                $output = $jobs | Where-Object HasSchedule -eq $false
+                $output += $jobs | Where-Object HasSchedule -eq $false
             }
             if ($IsNoEmailNotification) {
                 Write-Message -Level Verbose -Message "Finding job/s that have no email operator defined"
-                $output = $jobs | Where-Object { [string]::IsNullOrEmpty($_.OperatorToEmail) -eq $true }
-            }
-
-            if ($Category) {
-                Write-Message -Level Verbose -Message "Finding job/s that have the specified category defined"
-                $output = $jobs | Where-Object { $Category -contains $_.Category }
+                $output += $jobs | Where-Object { [string]::IsNullOrEmpty($_.OperatorToEmail) -eq $true }
             }
 
             if ($Owner) {

--- a/functions/Find-DbaAgentJob.ps1
+++ b/functions/Find-DbaAgentJob.ps1
@@ -157,11 +157,6 @@ function Find-DbaAgentJob {
             $jobs = $server.JobServer.jobs
             $output = @()
 
-            if ($IsFailed) {
-                Write-Message -Level Verbose -Message "Checking for failed jobs."
-                $output += $jobs | Where-Object LastRunOutcome -eq "Failed"
-            }
-
             if ($JobName) {
                 Write-Message -Level Verbose -Message "Retrieving jobs by their name."
                 $output += Get-JobList -SqlInstance $server -JobFilter $JobName
@@ -169,7 +164,19 @@ function Find-DbaAgentJob {
 
             if ($StepName) {
                 Write-Message -Level Verbose -Message "Retrieving jobs by their step names."
-                $output += Get-JobList -SqlInstance $server -StepFilter $StepName
+                $jobs = Get-JobList -SqlInstance $server -StepFilter $StepName
+                $output = $jobs
+            }
+
+            if ( -not ($JobName -or $StepName)) {
+                Write-Message -Level Verbose -Message "Retrieving all jobs"
+                $jobs = Get-JobList -SqlInstance $server
+                $output = $jobs
+            }
+
+            if ($IsFailed) {
+                Write-Message -Level Verbose -Message "Checking for failed jobs."
+                $output = $jobs | Where-Object LastRunOutcome -eq "Failed"
             }
 
             if ($LastUsed) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #6274  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
So that filters accept JobName or StepName when used together with another filter
Also reduces calls back to instance
### Approach
Gets the Jobs by JobName or StepName and then adds remaining filter
Only one call to Agent

### Commands to test
$Instances = 'SQL2017N5','SQL2019N5','SQL2019N20','SQL2019N21','SQL2019N22'
Find-DbaAgentJob -SqlInstance $Instances[0] -JobName *backup* -IsNotScheduled -Verbose |Format-Table

### Screenshots
Used to do

![image](https://user-images.githubusercontent.com/6729780/71720772-bcd00c00-2e1a-11ea-8c11-fdf354d1324a.png)

now does

![image](https://user-images.githubusercontent.com/6729780/71720788-cd808200-2e1a-11ea-981d-57bbd3a8630f.png)


