### PR TITLE
Export-DbaLogin Respect ScriptingOptionsObject.IncludeDatabaseContext

### DIFF
--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -210,7 +210,9 @@ function Export-DbaUser {
                 Write-ProgressHelper -TotalSteps $users.Count -Activity "Exporting from $($db.Name)" -StepNumber ($stepCounter++) -Message "Generating script for user $dbuser"
 
                 #setting database
-                $outsql += "USE [" + $db.Name + "]"
+                if (($PSBoundParameters.ContainsKey('ScriptingOptionsObject') -and $ScriptingOptionsObject.IncludeDatabaseContext) -or -not $PSBoundParameters.ContainsKey('ScriptingOptionsObject')) {
+                    $outsql += "USE [" + $db.Name + "]"
+                }
 
                 try {
                     #Fixed Roles #Dependency Issue. Create Role, before add to role.

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -210,7 +210,7 @@ function Export-DbaUser {
                 Write-ProgressHelper -TotalSteps $users.Count -Activity "Exporting from $($db.Name)" -StepNumber ($stepCounter++) -Message "Generating script for user $dbuser"
 
                 #setting database
-                if (($PSBoundParameters.ContainsKey('ScriptingOptionsObject') -and $ScriptingOptionsObject.IncludeDatabaseContext) -or -not $PSBoundParameters.ContainsKey('ScriptingOptionsObject')) {
+                if (((Test-Bound ScriptingOptionsObject) -and $ScriptingOptionsObject.IncludeDatabaseContext) -or - (Test-Bound ScriptingOptionsObject -Not)) {
                     $outsql += "USE [" + $db.Name + "]"
                 }
 

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -139,28 +139,4 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             { Export-DbaLogin -SqlInstance $script:instance2 -FilePath "$AltExportPath\Dbatoolsci_login_CustomFile.sql" -NoClobber -WarningAction SilentlyContinue } | Should Throw
         }
     }
-    Context "Respects options specified in the ScriptingOptionsObject parameter" {
-        It 'Excludes database context' {
-            $scriptingOptions = New-DbaScriptingOption
-            $scriptingOptions.IncludeDatabaseContext = $false
-            $file = Export-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Database $dbname1 -DefaultDatabase master -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
-            $results | Should Not Match "USE [$dbname1]"
-        }
-        It 'Includes database context' {
-            $scriptingOptions = New-DbaScriptingOption
-            $scriptingOptions.IncludeDatabaseContext = $true
-            $file = Export-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Database $dbname1 -DefaultDatabase master -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
-            $results | Should Match "USE [$dbname1]"
-        }
-        It 'Defaults to include database context' {
-            $file = Export-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Database $dbname1 -DefaultDatabase master -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
-            $results | Should Match "USE [$dbname1]"
-        }
-    }
 }

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -156,5 +156,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $allfiles += $file.FullName
             $results | Should Match "USE [$dbname1]"
         }
+        It 'Defaults to include database context' {
+            $file = Export-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Database $dbname1 -DefaultDatabase master -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
+            $allfiles += $file.FullName
+            $results | Should Match "USE [$dbname1]"
+        }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -53,7 +53,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It 'Excludes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $false
-            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Not Match "USE [$dbname]"
@@ -61,13 +61,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $true
-            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Match "USE [$dbname]"
         }
         It 'Defaults to include database context' {
-            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Match "USE [$dbname]"

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Not BeLike '*USE `[' + $dbname + '`]*'
+            $results | Should Not BeLike ('*USE `[' + $dbname + '`]*')
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
@@ -64,13 +64,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike '*USE `[' + $dbname + '`]*'
+            $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }
         It 'Defaults to include database context' {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike '*USE `[' + $dbname + '`]*'
+            $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Not BeLike "*USE [$dbname]*"
+            $results | Should Not BeLike "*USE `[$dbname`]*"
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
@@ -64,13 +64,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike "*USE [$dbname]*"
+            $results | Should BeLike "*USE `[$dbname`]*"
         }
         It 'Defaults to include database context' {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike "*USE [$dbname]*"
+            $results | Should BeLike "*USE `[$dbname`]*"
         }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'User', 'DestinationVersion', 'Path', 'FilePath', 'InputObject', 'NoClobber', 'Append', 'EnableException', 'ScriptingOptionsObject', 'ExcludeGoBatchSeparator', 'Passthru'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -46,6 +46,31 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             It "Exported file is bigger than 0" {
                 (Get-ChildItem $outputFile).Length | Should BeGreaterThan 0
             }
+        }
+    }
+
+    Context "Respects options specified in the ScriptingOptionsObject parameter" {
+        It 'Excludes database context' {
+            $scriptingOptions = New-DbaScriptingOption
+            $scriptingOptions.IncludeDatabaseContext = $false
+            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
+            $allfiles += $file.FullName
+            $results | Should Not Match "USE [$dbname]"
+        }
+        It 'Includes database context' {
+            $scriptingOptions = New-DbaScriptingOption
+            $scriptingOptions.IncludeDatabaseContext = $true
+            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
+            $allfiles += $file.FullName
+            $results | Should Match "USE [$dbname]"
+        }
+        It 'Defaults to include database context' {
+            $file = Export-DbaLogin -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
+            $allfiles += $file.FullName
+            $results | Should Match "USE [$dbname]"
         }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Not Match "USE [$dbname]"
+            $results | Should Not BeLike "*USE [$dbname]*"
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
@@ -64,13 +64,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Match "USE [$dbname]"
+            $results | Should BeLike "*USE [$dbname]*"
         }
         It 'Defaults to include database context' {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Match "USE [$dbname]"
+            $results | Should BeLike "*USE [$dbname]*"
         }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -56,7 +56,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Not BeLike "*USE `[$dbname`]*"
+            $results | Should Not BeLike '*USE `[' + $dbname + '`]*'
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
@@ -64,13 +64,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike "*USE `[$dbname`]*"
+            $results | Should BeLike '*USE `[' + $dbname + '`]*'
         }
         It 'Defaults to include database context' {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should BeLike "*USE `[$dbname`]*"
+            $results | Should BeLike '*USE `[' + $dbname + '`]*'
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6271 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Export-DbaLogin does not look at the value of IncludeDatabaseContext in the ScriptingOptionsObject before including a `USE [dbname]` statement in the output.

### Approach
<!-- How does this change solve that purpose -->
Look at what parameters were specified and if ScriptingOptionsObject is used, make sure to respect what was specified.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See Pester tests.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
