### PR TITLE
Restore-DbaDatabase. Set initial catalog to master

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -381,7 +381,7 @@ function Restore-DbaDatabase {
 
         #region Validation
         try {
-            $RestoreInstance = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database Master
+            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database master
         } catch {
             Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             return

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -381,7 +381,7 @@ function Restore-DbaDatabase {
 
         #region Validation
         try {
-            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $RestoreInstance = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database Master
         } catch {
             Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             return

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -61,6 +61,7 @@ function Connect-SqlInstance {
         [PSCredential]$SqlCredential,
         [int]$StatementTimeout,
         [int]$MinimumVersion,
+        [string]$Database,
         [switch]$AzureUnsupported,
         [switch]$NonPooled
     )

--- a/tests/Connect-SqlInstance.Tests.ps1
+++ b/tests/Connect-SqlInstance.Tests.ps1
@@ -6,7 +6,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tags "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'StatementTimeout', 'MinimumVersion', 'AzureUnsupported', 'NonPooled'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'StatementTimeout', 'MinimumVersion', 'AzureUnsupported', 'NonPooled'
 
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {


### PR DESCRIPTION
$RestoreInstance is now set using Connect-DbaInstance instead of
Connect-Sqlinstance. This change means that instead of connecting
to the inital catalogue based on your SQL login, you will always
connect to master before restoring the database. This is needed
in case your default connection puts you in the context of the
database you are trying to restore.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ Yes ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

So that if restoring a database which is the same as the one you are automatically connected to, the restore will no longer fail. It's not a common scenario but it happened to me today where my initial catalog was the same as the DB I wanted to restore.

### Approach
<!-- How does this change solve that purpose -->

It sets the database context to master for all connections.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

Get-ChildItem '\\BACKUPS\DBName1\' | Restore-DbaDatabase -SqlInstance 'DEVSQL1' -DatabaseName 'DBName1' -UseDestinationDefaultDirectories -WithReplace

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
