### PR TITLE
Improve Export-Dba* output

### DIFF
--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -442,7 +442,11 @@ function Export-DbaUser {
                     if ($ExcludeGoBatchSeparator) {
                         $sql = "$useDatabase $outsql"
                     } else {
-                        $sql = "$useDatabase`r`nGO`r`n" + ($outsql -join "`r`nGO`r`n")
+                        if ($useDatabase) {
+                            $sql = "$useDatabase`r`nGO`r`n" + ($outsql -join "`r`nGO`r`n")
+                        } else {
+                            $sql = $outsql -join "`r`nGO`r`n"
+                        }
                         #add the final GO
                         $sql += "`r`nGO"
                     }
@@ -454,18 +458,20 @@ function Export-DbaUser {
                         if (-not [string]::IsNullOrEmpty($sql)) {
                             $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
                             Get-ChildItem -Path $FilePath
-                            $outsql = @()
-                            $sql = ""
                         }
+                    } else {
+                        $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
                     }
+                    # Clear variables for next user
+                    $outsql = @()
+                    $sql = ""
                 } else {
                     $sql
                 }
             }
         }
-        # Just a single file, will be output here.
+        # Just a single file, output path once here
         if (-Not $GenerateFilePerUser) {
-            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
             Get-ChildItem -Path $FilePath
         }
     }

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -236,7 +236,7 @@ function Export-DbaUser {
 
                 #setting database
                 if (((Test-Bound ScriptingOptionsObject) -and $ScriptingOptionsObject.IncludeDatabaseContext) -or - (Test-Bound ScriptingOptionsObject -Not)) {
-                    $outsql += "USE [" + $db.Name + "]"
+                    $useDatabase = "USE [" + $db.Name + "]"
                 }
 
                 try {
@@ -433,13 +433,16 @@ function Export-DbaUser {
                     Stop-Function -Message "This user may be using functionality from $($versionName[$db.CompatibilityLevel.ToString()]) that does not exist on the destination version ($versionNameDesc)." -Continue -InnerErrorRecord $_ -Target $db
                 }
 
-                if ($ExcludeGoBatchSeparator) {
-                    $sql = $outsql
-                } else {
-                    $sql = $outsql -join "`r`nGO`r`n"
-                    #add the final GO
-                    $sql += "`r`nGO"
+                if ($perms.Count -gt 0) {
+                    if ($ExcludeGoBatchSeparator) {
+                        $sql = "$useDatabase $outsql"
+                    } else {
+                        $sql = "$useDatabase`r`nGO`r`n" + ($outsql -join "`r`nGO`r`n")
+                        #add the final GO
+                        $sql += "`r`nGO"
+                    }
                 }
+
                 if (-not $Passthru) {
                     # If generate a file per user, clean the collection to populate with next one
                     if ($GenerateFilePerUser) {

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -433,7 +433,7 @@ function Export-DbaUser {
                     Stop-Function -Message "This user may be using functionality from $($versionName[$db.CompatibilityLevel.ToString()]) that does not exist on the destination version ($versionNameDesc)." -Continue -InnerErrorRecord $_ -Target $db
                 }
 
-                if ($perms.Count -gt 0) {
+                if (@($perms.Count) -gt 0) {
                     if ($ExcludeGoBatchSeparator) {
                         $sql = "$useDatabase $outsql"
                     } else {
@@ -446,9 +446,12 @@ function Export-DbaUser {
                 if (-not $Passthru) {
                     # If generate a file per user, clean the collection to populate with next one
                     if ($GenerateFilePerUser) {
-                        $outsql = @()
-                        $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
-                        Get-ChildItem -Path $FilePath
+                        if (-not [string]::IsNullOrEmpty($sql)) {
+                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
+                            Get-ChildItem -Path $FilePath
+                            $outsql = @()
+                            $sql = ""
+                        }
                     }
                 } else {
                     $sql

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -76,27 +76,27 @@ function Export-DbaUser {
         https://dbatools.io/Export-DbaUser
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sql2005 -Path C:\temp\sql2005-users.sql
+        PS C:\> Export-DbaUser -SqlInstance sql2005 -FilePath C:\temp\sql2005-users.sql
 
         Exports SQL for the users in server "sql2005" and writes them to the file "C:\temp\sql2005-users.sql"
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2014a $scred -Path C:\temp\users.sql -Append
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2014a $scred -FilePath C:\temp\users.sql -Append
 
         Authenticates to sqlserver2014a using SQL Authentication. Exports all users to C:\temp\users.sql, and appends to the file if it exists. If not, the file will be created.
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2014a -User User1, User2 -Path C:\temp\users.sql
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2014a -User User1, User2 -FilePath C:\temp\users.sql
 
         Exports ONLY users User1 and User2 from sqlserver2014a to the file  C:\temp\users.sql
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -User User1 -Path C:\temp\users.sql -DestinationVersion SQLServer2016
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -User User1 -FilePath C:\temp\users.sql -DestinationVersion SQLServer2016
 
         Exports user User1 from sqlserver2008 to the file C:\temp\users.sql with syntax to run on SQL Server 2016
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -Path C:\temp\users.sql
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -FilePath C:\temp\users.sql
 
         Exports ONLY users from db1 and db2 database on sqlserver2008 server, to the C:\temp\users.sql file.
 
@@ -104,13 +104,13 @@ function Export-DbaUser {
         PS C:\> $options = New-DbaScriptingOption
         PS C:\> $options.ScriptDrops = $false
         PS C:\> $options.WithDependencies = $true
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -Path C:\temp\users.sql -ScriptingOptionsObject $options
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -FilePath C:\temp\users.sql -ScriptingOptionsObject $options
 
         Exports ONLY users from db1 and db2 database on sqlserver2008 server, to the C:\temp\users.sql file.
         It will not script drops but will script dependencies.
 
     .EXAMPLE
-        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -Path C:\temp\users.sql -ExcludeGoBatchSeparator
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -Database db1,db2 -FilePath C:\temp\users.sql -ExcludeGoBatchSeparator
 
         Exports ONLY users from db1 and db2 database on sqlserver2008 server, to the C:\temp\users.sql file without the 'GO' batch separator.
 

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -88,7 +88,12 @@ function Export-DbaUser {
     .EXAMPLE
         PS C:\> Export-DbaUser -SqlInstance sqlserver2014a -User User1, User2 -FilePath C:\temp\users.sql
 
-        Exports ONLY users User1 and User2 from sqlserver2014a to the file  C:\temp\users.sql
+        Exports ONLY users User1 and User2 from sqlserver2014a to the file C:\temp\users.sql
+
+    .EXAMPLE
+        PS C:\> Export-DbaUser -SqlInstance sqlserver2014a -User User1, User2 -Path C:\temp
+
+        Exports ONLY users User1 and User2 from sqlserver2014a to the folder C:\temp. One file per user will be generated
 
     .EXAMPLE
         PS C:\> Export-DbaUser -SqlInstance sqlserver2008 -User User1 -FilePath C:\temp\users.sql -DestinationVersion SQLServer2016

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -55,25 +55,22 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It 'Excludes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $false
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
+            $null = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
+            $results = Get-Content -Path $outputFile2 -Raw
             $results | Should Not BeLike ('*USE `[' + $dbname + '`]*')
             (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $true
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
+            $null = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
+            $results = Get-Content -Path $outputFile2 -Raw
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
             (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }
         It 'Defaults to include database context' {
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -FilePath $outputFile2 -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
-            $allfiles += $file.FullName
+            $null = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -FilePath $outputFile2 -WarningAction SilentlyContinue
+            $results = Get-Content -Path $outputFile2 -Raw
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
             (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -22,6 +22,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $dbname = "dbatoolsci_exportdbauser"
             $login = "dbatoolsci_exportdbauser_login"
             $user = "dbatoolsci_exportdbauser_user"
+            $table = "dbatoolsci_exportdbauser_table"
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $null = $server.Query("CREATE DATABASE [$dbname]")
 
@@ -30,6 +31,9 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
             $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
             $null = $db.Query("CREATE USER [$user] FOR LOGIN [$login]")
+
+            $null = $db.Query("CREATE TABLE $table (C1 INT);")
+            $null = $db.Query("GRANT SELECT ON OBJECT::$table TO [$user];")
         } catch { } # No idea why appveyor can't handle this
     }
     AfterAll {

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -16,31 +16,39 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $AltExportPath = "$env:USERPROFILE\Documents"
+        $outputPath = "$AltExportPath\Dbatoolsci_user_CustomFolder"
         $outputFile = "$AltExportPath\Dbatoolsci_user_CustomFile.sql"
         $outputFile2 = "$AltExportPath\Dbatoolsci_user_CustomFile2.sql"
         try {
             $dbname = "dbatoolsci_exportdbauser"
             $login = "dbatoolsci_exportdbauser_login"
+            $login2 = "dbatoolsci_exportdbauser_login2"
             $user = "dbatoolsci_exportdbauser_user"
+            $user2 = "dbatoolsci_exportdbauser_user2"
             $table = "dbatoolsci_exportdbauser_table"
             $server = Connect-DbaInstance -SqlInstance $script:instance1
             $null = $server.Query("CREATE DATABASE [$dbname]")
 
             $securePassword = $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force)
             $null = New-DbaLogin -SqlInstance $script:instance1 -Login $login -Password $securePassword
+            $null = New-DbaLogin -SqlInstance $script:instance1 -Login $login2 -Password $securePassword
 
             $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
             $null = $db.Query("CREATE USER [$user] FOR LOGIN [$login]")
+            $null = $db.Query("CREATE USER [$user2] FOR LOGIN [$login2]")
 
             $null = $db.Query("CREATE TABLE $table (C1 INT);")
             $null = $db.Query("GRANT SELECT ON OBJECT::$table TO [$user];")
+            $null = $db.Query("GRANT SELECT ON OBJECT::$table TO [$user2];")
         } catch { } # No idea why appveyor can't handle this
     }
     AfterAll {
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
         Remove-DbaLogin -SqlInstance $script:instance1 -Login $login -Confirm:$false
+        Remove-DbaLogin -SqlInstance $script:instance1 -Login $login2 -Confirm:$false
         (Get-ChildItem $outputFile -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
+        Remove-Item -Path $outputPath -Recurse -ErrorAction SilentlyContinue -Confirm:$false
     }
 
     Context "Check if output file was created" {
@@ -77,6 +85,19 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results = Get-Content -Path $outputFile2 -Raw
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
             (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context "Check if one output file per user was created" {
+        $null = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -Path $outputPath
+        It "Exports two files to the path" {
+            (Get-ChildItem $outputPath).Count | Should Be 2
+        }
+        It "Exported file name contains username '$user'" {
+            Get-ChildItem $outputPath | Where-Object Name -like ('*' + $User + '*') | Should BeTrue
+        }
+        It "Exported file name contains username '$user2'" {
+            Get-ChildItem $outputPath | Where-Object Name -like ('*' + $User2 + '*') | Should BeTrue
         }
     }
 }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -54,7 +54,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $false
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
+            $results = Get-Content -FilePath $file -Raw
             $allfiles += $file.FullName
             $results | Should Not BeLike ('*USE `[' + $dbname + '`]*')
         }
@@ -62,13 +62,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $true
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
+            $results = Get-Content -FilePath $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }
         It 'Defaults to include database context' {
             $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
-            $results = Get-Content -Path $file -Raw
+            $results = Get-Content -FilePath $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -53,22 +53,22 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It 'Excludes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $false
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -FilePath $file -Raw
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Not BeLike ('*USE `[' + $dbname + '`]*')
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $true
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -WarningAction SilentlyContinue
-            $results = Get-Content -FilePath $file -Raw
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }
         It 'Defaults to include database context' {
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -WarningAction SilentlyContinue
-            $results = Get-Content -FilePath $file -Raw
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -FilePath $outputFile -WarningAction SilentlyContinue
+            $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
         }

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -17,6 +17,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $AltExportPath = "$env:USERPROFILE\Documents"
         $outputFile = "$AltExportPath\Dbatoolsci_user_CustomFile.sql"
+        $outputFile2 = "$AltExportPath\Dbatoolsci_user_CustomFile2.sql"
         try {
             $dbname = "dbatoolsci_exportdbauser"
             $login = "dbatoolsci_exportdbauser_login"
@@ -35,6 +36,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
         Remove-DbaLogin -SqlInstance $script:instance1 -Login $login -Confirm:$false
         (Get-ChildItem $outputFile -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
+        (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
     }
 
     Context "Check if output file was created" {
@@ -53,24 +55,27 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It 'Excludes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $false
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Not BeLike ('*USE `[' + $dbname + '`]*')
+            (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }
         It 'Includes database context' {
             $scriptingOptions = New-DbaScriptingOption
             $scriptingOptions.IncludeDatabaseContext = $true
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -ScriptingOptionsObject $scriptingOptions -FilePath $outputFile2 -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
+            (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }
         It 'Defaults to include database context' {
-            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -FilePath $outputFile -WarningAction SilentlyContinue
+            $file = Export-DbaUser -SqlInstance $script:instance1 -Database $dbname -FilePath $outputFile2 -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should BeLike ('*USE `[' + $dbname + '`]*')
+            (Get-ChildItem $outputFile2 -ErrorAction SilentlyContinue) | Remove-Item -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6090 #6163)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- Improve documentation.  
  - In this case, the examples to match correct behaviour. Examples showed `-FilePath` but a folder with that name was being created (#6090). Also, no examples of `-Path`. 

- Normalize outputs depending on used parameters
  - File names will have `<instance>-<user>-<timestamp>
  - Examples:
    - When `-Path` is used one file per user will be created on that path. If the path does not exists will be created.
    - When `-FilePath` is used, all permissions will be written to the same file. the one specified

### Approach

1. Have a variable `$GenerateFilePerUser` that will be `true` when `-FilePath` is not used.
2. Use a hashtable to save the file names generated so they can be used and not generate a new one where only timestamp part will be different.
3. Only write the file if there are any permissions. This prevents having files with just `USE <dbname>` syntax. 

### Commands to test
`Export-DbaUser` with `-Path` or `-FilePath`. With none specific user or with multiple.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Notes
If we agree on this approach I will be doing the same for others `Export-Dba*` commands