### PR TITLE
Update Invoke-DbaAdvancedUpdate

### DIFF
--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -159,10 +159,10 @@ Function Invoke-DbaAdvancedUpdate {
                 $instanceClause = '/allinstances'
             }
             if ($currentAction.Build -like "10.0.*") {
-				$argumentList = @('/quiet', $instanceClause)
-			} else {
-				$argumentList = @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms')
-			}
+                $argumentList = @('/quiet', $instanceClause)
+            } else {
+                $argumentList = @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms')
+            }
             Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Now installing update SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel) from $spExtractPath"
             Write-Message -Level Verbose -Message "Starting installation from $spExtractPath"
             $updateResult = Invoke-Program @execParams -Path "$spExtractPath\setup.exe" -ArgumentList $argumentList -WorkingDirectory $spExtractPath -Fallback

--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -158,9 +158,14 @@ Function Invoke-DbaAdvancedUpdate {
             } else {
                 $instanceClause = '/allinstances'
             }
+            if ($currentAction.Build -like "10.0.*") {
+				$argumentList = @('/quiet', $instanceClause)
+			} else {
+				$argumentList = @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms')
+			}
             Write-ProgressHelper -ExcludePercent -Activity $activity -Message "Now installing update SQL$($currentAction.MajorVersion)$($currentAction.TargetLevel) from $spExtractPath"
             Write-Message -Level Verbose -Message "Starting installation from $spExtractPath"
-            $updateResult = Invoke-Program @execParams -Path "$spExtractPath\setup.exe" -ArgumentList @('/quiet', $instanceClause, '/IAcceptSQLServerLicenseTerms') -WorkingDirectory $spExtractPath -Fallback
+            $updateResult = Invoke-Program @execParams -Path "$spExtractPath\setup.exe" -ArgumentList $argumentList -WorkingDirectory $spExtractPath -Fallback
             $output.ExitCode = $updateResult.ExitCode
             if ($updateResult.Successful) {
                 $output.Successful = $true


### PR DESCRIPTION
SQL Server 2008 Updates setup.exe does not have the /IAcceptSQLServerLicenseTerms switch.
Invoke-DbaAdvancedUpdate fails to install these updates.
The change checks if the update is for version 10.0.* and then runs setup.exe without the /IAcceptSQLServerLicenseTerms  switch.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ *] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Failed attempt:
[C:\Temp\dbatools_KB4057114_Extract_cfd589c2a3ab4f259358fd4669c8c7f2\setup.exe] with arguments [/quiet /allinstances
/IAcceptSQLServerLicenseTerms] on * through Credssp protocol
WARNING: [15:50:50][Invoke-DbaAdvancedUpdate] Update failed with exit code -2068578301
ComputerName : *
MajorVersion : 2008
TargetLevel  : SP4
KB           : 4057114
Successful   : False
Restarted    : False
InstanceName :
Installer    : *\SQL2008\sqlserver2008-kb4057114-x64_9ce0b7c5909d8fcc5b9a12d17f29b7864a9df33a.exe
Notes        : {Update failed with exit code -2068578301}


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
