### PR TITLE
Added optional User parameter to Set-DbaPrivilege

### DIFF
--- a/functions/Set-DbaPrivilege.ps1
+++ b/functions/Set-DbaPrivilege.ps1
@@ -91,8 +91,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                         $SQLServiceAccounts = @();
                         if (Test-Bound 'User') {
                             $SQLServiceAccounts += $User;
-                        }
-                        else {
+                        } else {
                             Write-Message -Level Verbose -Message "Getting SQL Service Accounts on $computer"
                             $SQLServiceAccounts += (Get-DbaService -ComputerName $computer -Type Engine).StartName
                         }
@@ -103,7 +102,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                 param ($ResolveAccountToSID,
                                     $SQLServiceAccounts,
                                     $Type
-                                    )
+                                )
                                 . ([ScriptBlock]::Create($ResolveAccountToSID))
                                 $temp = ([System.IO.Path]::GetTempPath()).TrimEnd("");
                                 $tempfile = "$temp\secpolByDbatools.cfg"

--- a/functions/Set-DbaPrivilege.ps1
+++ b/functions/Set-DbaPrivilege.ps1
@@ -89,7 +89,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                         }
 
                         $SQLServiceAccounts = @();
-                        if ([string]::IsNullOrEmpty($User) -eq $false) {
+                        if (Test-Bound 'User') {
                             $SQLServiceAccounts += $User;
                         }
                         else {

--- a/functions/Set-DbaPrivilege.ps1
+++ b/functions/Set-DbaPrivilege.ps1
@@ -18,6 +18,9 @@ function Set-DbaPrivilege {
         Use this to choose the privilege(s) to which you want to add the SQL Service account.
         Accepts 'IFI', 'LPIM', 'BatchLogon', and/or 'SecAudit' for local privileges 'Instant File Initialization', 'Lock Pages in Memory', 'Logon as Batch', and 'Generate Security Audits'.
 
+    .PARAMETER User
+        If provided, will add requested permissions to this account instead of the the account under which the SQL service is running.
+
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
 

--- a/tests/Set-DbaPrivilege.Tests.ps1
+++ b/tests/Set-DbaPrivilege.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'Type', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'Type', 'EnableException', 'User'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
* In order to prepare for changing a service account, permissions should
be able to be set for the new account ahead of the change in order to
minimize service restarts. Adding an optional parameter for the user to
set allows for this possibility. If provided, it skips the remote
service enumeration and attempts to set the requested permissions for
the passed in user.

* Fixed what appeared to be a bug where... none of the permissions
were to be set.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Added optional User parameter to Set-DbaPrivilege

### Approach
Check if new parameter is provided. If so, populate the list of accounts to add permissions to with that user (rather than through service enumeration).

### Commands to test
Set-DbaPrivilege
