### PR TITLE
Added filter of system files added in SQL 2019 install

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -168,7 +168,7 @@ function Find-DbaOrphanedFile {
         }
 
         $FileType += "mdf", "ldf", "ndf"
-        $systemfiles = "distmdl.ldf", "distmdl.mdf", "mssqlsystemresource.ldf", "mssqlsystemresource.mdf"
+        $systemfiles = "distmdl.ldf", "distmdl.mdf", "mssqlsystemresource.ldf", "mssqlsystemresource.mdf", "model_msdbdata.mdf", "model_msdblog.ldf", "model_replicatedmaster.mdf", "model_replicatedmaster.ldf"
 
         $FileTypeComparison = $FileType | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { $_ } | Sort-Object | Get-Unique
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
With the SQL 2019 installation the following four files are now being dropped in the DATA folder by default.

model_msdbdata.mdf
model_msdblog.ldf
model_replicatedmaster.ldf
model_replicatedmaster.mdf

The current version of the function identifies these as orphaned because they are not hosted by SQL Server, but I believe they are there for AG replication of system files or for some other SQL related feature.  I would not recommend displaying these as orphaned as deleting them might break the SQL 2019 instance.

### Approach
<!-- How does this change solve that purpose -->
Added them as system files which then removes them from the output of the function.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
run Find-DbaOrphanedFiles against a SQL 2019 instance 

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Before: (ver 0.1.100)
![image](https://user-images.githubusercontent.com/169602/75713693-eb8a2780-5c8f-11ea-9b46-04750f31e148.png)

After fix from PR:
![image](https://user-images.githubusercontent.com/169602/75713728-ffce2480-5c8f-11ea-8d9b-b2c62ac878ed.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
