### PR TITLE
Fix for multiple sever patch operation via Update-DbaInstance

### DIFF
--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -325,7 +325,9 @@ function Update-DbaInstance {
                 Stop-Function -Message "$resolvedName is pending a reboot. Reboot the computer before proceeding." -Continue
             }
             $upgrades = @()
-            :actions foreach ($currentAction in $actions) {
+            :actions foreach ($actionItem in $actions) {
+                # Clone action to use as a splat
+                $currentAction = $actionItem.Clone()
                 # Attempt to configure CredSSP for the remote host when credentials are defined
                 if ($Credential -and -not ([DbaInstanceParameter]$resolvedName).IsLocalHost -and $Authentication -eq 'Credssp') {
                     Write-Message -Level Verbose -Message "Attempting to configure CredSSP for remote connections"

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -410,6 +410,10 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 }
             }
             $resolvedComputers += $resolvedComputer.FullComputerName
+            # Mock invoke-parallel to prevent runspace-based execution
+            Mock -CommandName Invoke-Parallel -ModuleName dbatools -MockWith {
+                $InputObject | ForEach-Object -Process $ScriptBlock
+            }
         }
         AfterAll {
             if (Test-Path $exeDir) {

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -358,6 +358,83 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract_*'
         }
     }
+    Context "Validate upgrades of a specific Major version" {
+        BeforeAll {
+            #this is our 'currently installed' versions
+            Mock -CommandName Get-SQLInstanceComponent -ModuleName dbatools -MockWith {
+                @(
+                    [pscustomobject]@{InstanceName = 'LAB'; Version = [pscustomobject]@{
+                            "SqlInstance" = $null
+                            "Build"       = "13.0.4435"
+                            "NameLevel"   = "2016"
+                            "SPLevel"     = "SP1"
+                            "CULevel"     = "CU3"
+                            "KBLevel"     = "4019916"
+                            "BuildLevel"  = [version]'13.0.4435'
+                            "MatchType"   = "Exact"
+                        }
+                    }
+                    [pscustomobject]@{InstanceName = 'LAB2'; Version = [pscustomobject]@{
+                            "SqlInstance" = $null
+                            "Build"       = "10.0.4279"
+                            "NameLevel"   = "2008"
+                            "SPLevel"     = "SP2"
+                            "CULevel"     = "CU3"
+                            "KBLevel"     = "2498535"
+                            "BuildLevel"  = [version]'10.0.4279'
+                            "MatchType"   = "Exact"
+                        }
+                    }
+                )
+            }
+            if (-Not(Test-Path $exeDir)) {
+                $null = New-Item -ItemType Directory -Path $exeDir
+            }
+            #Create dummy files for specific patch versions
+            $kbs = @(
+                'SQLServer2008SP3-KB2546951-x64-ENU.exe'
+                'SQLServer2008-KB2555408-x64-ENU.exe'
+                'SQLServer2008-KB2738350-x64-ENU.exe'
+                'SQLServer2016-KB4040714-x64.exe'
+                'SQLServer2016SP2-KB4052908-x64-ENU.exe'
+                'SQLServer2008-KB2738350-x64-ENU.exe'
+                'SQLServer2016-KB4024305-x64-ENU.exe'
+            )
+            foreach ($kb in $kbs) {
+                $null = New-Item -ItemType File -Path (Join-Path $exeDir $kb) -Force
+            }
+            # Mock computer names to test multiple computers
+            Mock -CommandName Resolve-DbaNetworkName -ParameterFilter { $ComputerName -in 'localhost', '127.0.0.1' } -ModuleName dbatools -MockWith {
+                [pscustomobject]@{
+                    FullComputerName = $ComputerName
+                }
+            }
+            $resolvedComputers += $resolvedComputer.FullComputerName
+        }
+        AfterAll {
+            if (Test-Path $exeDir) {
+                Remove-Item $exeDir -Force -Recurse
+            }
+        }
+        It "Should mock-upgrade two SQL2016 servers to SP2" {
+            $results = Update-DbaInstance -ComputerName 'localhost', '127.0.0.1' -Version SQL2016SP2 -Path $exeDir -Restart -EnableException -Confirm:$false
+            Assert-MockCalled -CommandName Get-SQLInstanceComponent -Exactly 2 -Scope It -ModuleName dbatools
+            Assert-MockCalled -CommandName Invoke-Program -Exactly 4 -Scope It -ModuleName dbatools
+            Assert-MockCalled -CommandName Restart-Computer -Exactly 2 -Scope It -ModuleName dbatools
+
+            foreach ($result in $results) {
+                $result | Should -Not -BeNullOrEmpty
+                $result.MajorVersion | Should -Be 2016
+                $result.TargetLevel | Should -Be SP2
+                $result.KB | Should -Be 4052908
+                $result.Successful | Should -Be $true
+                $result.Restarted | Should -Be $true
+                $result.Installer | Should -Be (Join-Path $exeDir 'SQLServer2016SP2-KB4052908-x64-ENU.exe')
+                $result.Notes | Should -BeNullOrEmpty
+                $result.ExtractPath | Should -BeLike '*\dbatools_KB*Extract_*'
+            }
+        }
+    }
     Context "Validate upgrade to the same version when installation failed" {
         BeforeAll {
             #this is our 'currently installed' versions


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6437  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Prevent the function from removing MajorVersion when executed against multiple computers

### Approach
Clone the object before modifying it

### Commands to test
Update-DbaInstance -ComputerName sql1, sql2 -Version SQL2016SP2CU12

### Learning
Turns out you can mock Invoke-Parallel to prevent creating new scopes.
