### PR TITLE
Update cleanup.ps1 so it compares semantic (vs string) versions.

### DIFF
--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -36,7 +36,7 @@ foreach ($v in $installedVersion) {
 $newestVersion = Find-Module $module | Select-Object Version
 Write-Output "`nThe latest version of $module in the PSGallery is: $($newestVersion.Version)"
 if ($installedVersion.Count -gt 1) {
-    $olderVersions = $installedVersion | Where-Object Version -lt $newestVersion.Version
+    $olderVersions = $installedVersion | Where-Object [version]Version -lt [version]$newestVersion.Version
 }
 
 if ( ($olderVersions.Count -gt 0) -and $newestVersion.Version -in $installedVersion.Version ) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
With the patch section in the dbatools version number having just gotten over 100, the cleanup script is not removing versions prior to 100 since (for example) from a string perspective `100 -lt 90`.

### Approach
Casting both the current and previous versions as the `version` datatype allows the comparison to work as intended.

### Commands to test
cleanup.ps1