### PR TITLE
Issue with Get-DbaRegServer for ADS servers

### DIFF
--- a/functions/Get-DbaRegServer.ps1
+++ b/functions/Get-DbaRegServer.ps1
@@ -171,7 +171,7 @@ function Get-DbaRegServer {
                             if (-not $connname) {
                                 $connname = $server.Options['server']
                             }
-                            $adsconn = $adsconnection | Where-Object server -eq $server.Options['server']
+                            $adsconn = $adsconnection | Where-Object {$_.server -eq $server.Options['server'] -and !$_.database}
 
                             $tempserver = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer $tempgroup, $connname
                             $tempserver.Description = $server.Options['Description']


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6292 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
`Get-ADSConnection` is returning multiple connection strings for a single ADS registered server so filter to only include the main connection string (not one for the database)

### Approach
<!-- How does this change solve that purpose -->
Adds a filter for where the database isn't set on ADS connections
```
$adsconn = $adsconnection | Where-Object {$_.server -eq $server.Options['server'] -and !$_.database}
```

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
Get-DbaRegisteredServer | select name, connectionstring
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Current:
![image](https://user-images.githubusercontent.com/981370/77888400-1c945280-7264-11ea-928e-3928dee9729b.png)

After:
![image](https://user-images.githubusercontent.com/981370/77888349-04bcce80-7264-11ea-89c7-cb4edbd28928.png)
