### PR TITLE
refactor bulk rows count to not use c#

### DIFF
--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -204,44 +204,6 @@ function Copy-DbaDbTableData {
     )
 
     begin {
-        # Getting the total rows copied is a challenge. Use SqlBulkCopyExtension.
-        # http://stackoverflow.com/questions/1188384/sqlbulkcopy-row-count-when-complete
-
-        $sourcecode = 'namespace System.Data.SqlClient {
-            using Reflection;
-
-            public static class SqlBulkCopyExtension
-            {
-                const String _rowsCopiedFieldName = "_rowsCopied";
-                static FieldInfo _rowsCopiedField = null;
-
-                public static int RowsCopiedCount(this SqlBulkCopy bulkCopy)
-                {
-                    if (_rowsCopiedField == null) _rowsCopiedField = typeof(SqlBulkCopy).GetField(_rowsCopiedFieldName, BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-                    return (int)_rowsCopiedField.GetValue(bulkCopy);
-                }
-            }
-        }'
-
-        try {
-            if ($script:core) {
-                #.NET Core has moved most of the System.Data.SqlClient namespace to a separate assembly
-                $SqlClientPath = "$script:PSModuleRoot\bin\smo\coreclr\System.Data.SqlClient.dll"
-                if (Test-Path $SqlClientPath) {
-                    #Powershell 6 appears to include a version of System.Data.SqlClient.dll
-                    #that often precedes the following statement, but this enures that a version of
-                    #the assemble gets loaded before loading our custom class.
-                    Add-Type -Path $SqlClientPath
-                }
-                Add-Type -ReferencedAssemblies System.Data.SqlClient.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            } else {
-                Add-Type -ReferencedAssemblies System.Data.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            }
-            Write-Message -Level Verbose -Message "SqlBulkCopyExtension loaded."
-        } catch {
-            Stop-Function -Message 'Could not load a usable version of SqlBulkCopy.' -ErrorRecord $_
-            return
-        }
 
         $bulkCopyOptions = 0
         $options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default"
@@ -423,7 +385,7 @@ function Copy-DbaDbTableData {
                     if ($Pscmdlet.ShouldProcess($destServer, "Writing rows to $fqtndest")) {
                         $reader = $cmd.ExecuteReader()
                         $bulkCopy.WriteToServer($reader)
-                        $RowsTotal = [System.Data.SqlClient.SqlBulkCopyExtension]::RowsCopiedCount($bulkCopy)
+                        $RowsTotal = Get-BulkRowsCopiedCount $bulkCopy
                         $TotalTime = [math]::Round($elapsed.Elapsed.TotalSeconds, 1)
                         Write-Message -Level Verbose -Message "$RowsTotal rows inserted in $TotalTime sec"
                         if ($rowCount -is [int]) {

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -200,44 +200,6 @@ function Copy-DbaDbViewData {
     )
 
     begin {
-        # Getting the total rows copied is a challenge. Use SqlBulkCopyExtension.
-        # http://stackoverflow.com/questions/1188384/sqlbulkcopy-row-count-when-complete
-
-        $sourcecode = 'namespace System.Data.SqlClient {
-            using Reflection;
-
-            public static class SqlBulkCopyExtension
-            {
-                const String _rowsCopiedFieldName = "_rowsCopied";
-                static FieldInfo _rowsCopiedField = null;
-
-                public static int RowsCopiedCount(this SqlBulkCopy bulkCopy)
-                {
-                    if (_rowsCopiedField == null) _rowsCopiedField = typeof(SqlBulkCopy).GetField(_rowsCopiedFieldName, BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-                    return (int)_rowsCopiedField.GetValue(bulkCopy);
-                }
-            }
-        }'
-
-        try {
-            if ($script:core) {
-                #.NET Core has moved most of the System.Data.SqlClient namespace to a separate assembly
-                $SqlClientPath = "$script:PSModuleRoot\bin\smo\coreclr\System.Data.SqlClient.dll"
-                if (Test-Path $SqlClientPath) {
-                    #Powershell 6 appears to include a version of System.Data.SqlClient.dll
-                    #that often precedes the following statement, but this enures that a version of
-                    #the assemble gets loaded before loading our custom class.
-                    Add-Type -Path $SqlClientPath
-                }
-                Add-Type -ReferencedAssemblies System.Data.SqlClient.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            } else {
-                Add-Type -ReferencedAssemblies System.Data.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            }
-            Write-Message -Level Verbose -Message "SqlBulkCopyExtension loaded."
-        } catch {
-            Stop-Function -Message 'Could not load a usable version of SqlBulkCopy.' -ErrorRecord $_
-            return
-        }
 
         $bulkCopyOptions = 0
         $options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default"
@@ -427,7 +389,7 @@ function Copy-DbaDbViewData {
                     if ($Pscmdlet.ShouldProcess($destServer, "Writing rows to $fqtndest")) {
                         $reader = $cmd.ExecuteReader()
                         $bulkCopy.WriteToServer($reader)
-                        $RowsTotal = [System.Data.SqlClient.SqlBulkCopyExtension]::RowsCopiedCount($bulkCopy)
+                        $RowsTotal = Get-BulkRowsCopiedCount $bulkCopy
                         $TotalTime = [math]::Round($elapsed.Elapsed.TotalSeconds, 1)
                         Write-Message -Level Verbose -Message "$RowsTotal rows inserted in $TotalTime sec"
                         if ($rowCount -is [int]) {

--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -346,44 +346,6 @@ function Write-DbaDbTableData {
         #region Prepare type for bulk copy
         if (-not $Truncate) { $ConfirmPreference = "None" }
 
-        # Getting the total rows copied is a challenge. Use SqlBulkCopyExtension.
-        # http://stackoverflow.com/questions/1188384/sqlbulkcopy-row-count-when-complete
-
-        $sourcecode = 'namespace System.Data.SqlClient {
-            using Reflection;
-
-            public static class SqlBulkCopyExtension
-            {
-                const String _rowsCopiedFieldName = "_rowsCopied";
-                static FieldInfo _rowsCopiedField = null;
-
-                public static int RowsCopiedCount(this SqlBulkCopy bulkCopy)
-                {
-                    if (_rowsCopiedField == null) _rowsCopiedField = typeof(SqlBulkCopy).GetField(_rowsCopiedFieldName, BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-                    return (int)_rowsCopiedField.GetValue(bulkCopy);
-                }
-            }
-        }'
-
-        try {
-            if ($script:core) {
-                #.NET Core has moved most of the System.Data.SqlClient namespace to a separate assembly
-                $SqlClientPath = "$script:PSModuleRoot\bin\smo\coreclr\System.Data.SqlClient.dll"
-                if (Test-Path $SqlClientPath) {
-                    #Powershell 6 appears to include a version of System.Data.SqlClient.dll
-                    #that often precedes the following statement, but this enures that a version of
-                    #the assemble gets loaded before loading our custom class.
-                    Add-Type -Path $SqlClientPath
-                }
-                Add-Type -ReferencedAssemblies System.Data.SqlClient.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            } else {
-                Add-Type -ReferencedAssemblies System.Data.dll -TypeDefinition $sourcecode -ErrorAction Stop
-            }
-            Write-Message -Level Verbose -Message "SqlBulkCopyExtension loaded."
-        } catch {
-            Stop-Function -Message 'Could not load a usable version of SqlBulkCopy.' -ErrorRecord $_
-            return
-        }
         #endregion Prepare type for bulk copy
 
         #region Resolve Full Qualified Table Name

--- a/internal/functions/Get-BulkRowsCopiedCount.ps1
+++ b/internal/functions/Get-BulkRowsCopiedCount.ps1
@@ -1,0 +1,41 @@
+function Get-BulkRowsCopiedCount {
+    <#
+        .SYNOPSIS
+            Gets the number of rows returned by a sql bulk copy
+
+        .DESCRIPTION
+            Uses reflection to return the _rowsCopied private field value from a SqlBulkCopy object
+            see http://stackoverflow.com/questions/1188384/sqlbulkcopy-row-count-when-complete
+
+        .PARAMETER BulkCopy
+            The Bulk copy object to retrieve the rows copied field from
+
+            This is internal function is used by
+            - Copy-DbaDbTableData
+            - Copy-DbaDbViewData
+            - Import-DbaCsv
+
+        .EXAMPLE
+            Get-BulkRowsCopied $bulkObject
+
+            Returns a integer containing the number of rows copied by SqlBulkCopy
+
+        .NOTES
+        Author: Jason Chester (@jasonchester)
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2020 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+    #>
+    [OutputType([int])]
+    param (
+        [System.Data.SqlClient.SqlBulkCopy] $BulkCopy
+    )
+    $BindingFlags = [Reflection.BindingFlags] "NonPublic,GetField,Instance"
+    $rowsCopiedField = [System.Data.SqlClient.SqlBulkCopy].GetField("_rowsCopied", $BindingFlags)
+    try {
+        return [int]$rowsCopiedField.GetValue($BulkCopy)
+    } catch {
+        return -1;
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Simplify and standardize how bulk copy operations get the private rows count field. This is to resolve issues raised in discussion on https://github.com/sqlcollaborative/dbatools/pull/6435

### Approach
<!-- How does this change solve that purpose -->
Rewrite C# extension method as pure powershell

### Commands to test
<!-- if these are the examples in the help just note it as such -->
functions/Copy-DbaDbTableData.ps1
functions/Copy-DbaDbViewData.ps1
functions/Import-DbaCsv.ps1
functions/Write-DbaDbTableData.ps1

### Learning
<!-- Optional -->
- https://blog.netspi.com/using-powershell-and-reflection-api-to-invoke-methods-from-net-assemblies/
- https://github.com/sqlcollaborative/dbatools/pull/6435