### PR TITLE
Update cleanup.ps1 to fix #6455

### DIFF
--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -16,7 +16,7 @@ if ($ise) {
     return "PowerShell ISE found in use. Please close this program before using this script."
 }
 
-$installedVersion = Get-InstalledModule $module -AllVersions | Select-Object Version,InstalledLocation
+$installedVersion = Get-InstalledModule $module -AllVersions | Select-Object Version, InstalledLocation
 Write-Output "The currently installed version(s) of $module is/are: "
 $installedVersion.Version
 
@@ -36,7 +36,7 @@ foreach ($v in $installedVersion) {
 $newestVersion = Find-Module $module | Select-Object Version
 Write-Output "`nThe latest version of $module in the PSGallery is: $($newestVersion.Version)"
 if ($installedVersion.Count -gt 1) {
-    $olderVersions = $installedVersion | Where-Object [version]Version -lt [version]$newestVersion.Version
+    $olderVersions = @($installedVersion | Where-Object { [version]$_.Version -lt [version]$newestVersion.Version })
 }
 
 if ( ($olderVersions.Count -gt 0) -and $newestVersion.Version -in $installedVersion.Version ) {


### PR DESCRIPTION
Changes the Where-Object to use the script block syntax, wrapped inside a collection.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6455  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix #6455, which was 
**a**) deleting all versions including the newest, when the newest version and others are installed and **b**) not removing all the old one version when exactly one old version exists.

### Approach
1) Line 39: Changed the Where-Object syntax from "Comparison statement" to "Script block". This fixes the installedVersion... -lt newestVersion comparison issue.

2) Line 39: Wrapped the whole piece to the right of the "$olderVersions =" in a collection. In testing the first issue, I found that with exactly one older version, the $olderVersions variable is a single object and the .Count test on Line 42 doesn't work as expected. With only one old version, the .Count is empty/null/non-existent.

3) Line 19: minor cosmetic update, from the PS formatter in vscode

### Commands to test
```powershell
Install-Module -Name dbatools -RequiredVersion 1.0.101
Install-Module -Name dbatools -RequiredVersion 1.0.104
& "$((Get-InstalledModule dbatools).InstalledLocation)\cleanup.ps1"
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/6507651/78713562-7b06a400-78e8-11ea-9c2e-76effb96cb8e.png)


### Learning
Did a bunch of reading here but I can't find a definitive statement as to why the inline casting fails on a "Comparison statement". My guess... Perhaps it's because Where-Object expects <string> name of the Property but a cast here on this side does nothing to affect the value type.
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object

Here is some example code that shows the same problem exists with [int] and this is not specific to [version]
```powershell
$nums = @()
$nums += [PSCustomObject]@{num = '1'}
$nums += [PSCustomObject]@{num = '2'}
$newestNum = '2'
Write-Output "Comparison statement output: "
$nums | Where-Object [int]num -lt [int]$newestNum
Write-Output " "
Write-Output "Script block output: "
$nums | Where-Object {[int]$_.num -lt [int]$newestNum}
```
Output:
```
Comparison statement output: 

num
---
1  
2  
 
Script block output: 
1
```