### PR TITLE
Fixes issue with Repair-DbaDbOrpahnUser - #6459

### DIFF
--- a/functions/Remove-DbaDbOrphanUser.ps1
+++ b/functions/Remove-DbaDbOrphanUser.ps1
@@ -126,14 +126,6 @@ function Remove-DbaDbOrphanUser {
                 $DatabaseCollection = $DatabaseCollection | Where-Object Name -NotIn $ExcludeDatabase
             }
 
-            $CallStack = Get-PSCallStack | Select-Object -Property *
-            if ($CallStack.Count -eq 1) {
-                $StackSource = $CallStack[0].Command
-            } else {
-                #-2 because index base is 0 and we want the one before the last (the last is the actual command)
-                $StackSource = $CallStack[($CallStack.Count - 2)].Command
-            }
-
             if ($DatabaseCollection) {
                 foreach ($db in $DatabaseCollection) {
                     try {
@@ -145,24 +137,17 @@ function Remove-DbaDbOrphanUser {
                             }
                         }
 
-                        if ($StackSource -eq "Repair-DbaDbOrphanUser") {
-                            Write-Message -Level Verbose -Message "Call origin: Repair-DbaDbOrphanUser."
-                            #Will use collection from parameter ($User)
+                        Write-Message -Level Verbose -Message "Validating users on database $db."
+
+                        $users = @()
+                        if ($User.Count -eq 0) {
+                            #the third validation will remove from list sql users without login or mapped to certificate. The rule here is Sid with length higher than 16
+                            $users += $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
+                            $users += $db.Users | Where-Object { ($_.Name -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser) }
                         } else {
-                            Write-Message -Level Verbose -Message "Validating users on database $db."
-
-                            $users = @()
-                            if ($User.Count -eq 0) {
-                                #the third validation will remove from list sql users without login  or mapped to certificate. The rule here is Sid with length higher than 16
-                                $users += $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
-                                $users += $db.Users | Where-Object { ($_.Name -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser) }
-                            } else {
-
-                                Write-Message -Level Verbose -Message "Validating users on database $db."
-                                #the fourth validation will remove from list sql users without login or mapped to certificate. The rule here is Sid with length higher than 16
-                                $users += $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($User -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
-                                $users += $db.Users | Where-Object { ($_.Name -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($User -contains $_.Name) -and ($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser) }
-                            }
+                            #the fourth validation will remove from list sql users without login or mapped to certificate. The rule here is Sid with length higher than 16
+                            $users += $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and ($User.Name -contains $_.Name) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
+                            $users += $db.Users | Where-Object { ($_.Name -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($User.Name -contains $_.Name) -and ($_.Sid.Length -gt 16 -and $_.LoginType -eq [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser) }
                         }
 
                         if ($users.Count -gt 0) {
@@ -172,14 +157,11 @@ function Remove-DbaDbOrphanUser {
 
                                 $ExistLogin = $null
 
-                                if ($StackSource -ne "Repair-DbaDbOrphanUser") {
-                                    #Need to validate Existing Login because the call does not came from Repair-DbaDbOrphanUser
-                                    $ExistLogin = $server.logins | Where-Object {
-                                        $_.Isdisabled -eq $False -and
-                                        $_.IsSystemObject -eq $False -and
-                                        $_.IsLocked -eq $False -and
-                                        $_.Name -eq $dbuser.Name
-                                    }
+                                $ExistLogin = $server.logins | Where-Object {
+                                    $_.Isdisabled -eq $False -and
+                                    $_.IsSystemObject -eq $False -and
+                                    $_.IsLocked -eq $False -and
+                                    $_.Name -eq $dbuser.Name
                                 }
 
                                 #Schemas only appears on SQL Server 2005 (v9.0)

--- a/functions/Remove-DbaDbOrphanUser.ps1
+++ b/functions/Remove-DbaDbOrphanUser.ps1
@@ -294,6 +294,14 @@ function Remove-DbaDbOrphanUser {
                                         if ($Pscmdlet.ShouldProcess($db.Name, "Dropping user $dbuser")) {
                                             $server.Databases[$db.Name].ExecuteNonQuery($query) | Out-Null
                                             Write-Message -Level Verbose -Message "User $dbuser was dropped from $($db.Name)."
+                                            [pscustomobject]@{
+                                                ComputerName = $server.ComputerName
+                                                InstanceName = $server.ServiceName
+                                                SqlInstance  = $server.DomainInstanceName
+                                                DatabaseName = $db.Name
+                                                User         = $dbuser.name
+                                                Status       = "Success"
+                                            }
                                         }
                                     }
                                 }

--- a/tests/Repair-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Repair-DbaDbOrphanUser.Tests.ps1
@@ -24,7 +24,6 @@ CREATE DATABASE dbatoolsci_orphan;
 '@
         $server = Connect-DbaInstance -SqlInstance $script:instance1
         $null = Remove-DbaLogin -SqlInstance $server -Login dbatoolsci_orphan1, dbatoolsci_orphan2, dbatoolsci_orphan3 -Force -Confirm:$false
-        $null = Remove-DbaDatabase -SqlInstance $server -Database dbatoolsci_orphan -Confirm:$false
         $null = Invoke-DbaQuery -SqlInstance $server -Query $loginsq
         $usersq = @'
 CREATE USER [dbatoolsci_orphan1] FROM LOGIN [dbatoolsci_orphan1];
@@ -45,10 +44,11 @@ CREATE LOGIN [dbatoolsci_orphan2] WITH PASSWORD = N'password2', CHECK_EXPIRATION
         $null = Remove-DbaLogin -SqlInstance $server -Login dbatoolsci_orphan1, dbatoolsci_orphan2, dbatoolsci_orphan3 -Force -Confirm:$false
         $null = Remove-DbaDatabase -SqlInstance $server -Database dbatoolsci_orphan -Confirm:$false
     }
+
     It "shows time taken for preparation" {
         1 | Should -Be 1
     }
-    $results = Repair-DbaDbOrphanUser -SqlInstance $script:instance1 -Database dbatoolsci_orphan
+    $results = Repair-DbaDbOrphanUser -SqlInstance $script:instance1 -Database dbatoolsci_orphan -RemoveNotExisting
     It "Finds two orphans" {
         $results.Count | Should -Be 2
         foreach ($user in $Users) {
@@ -62,7 +62,8 @@ CREATE LOGIN [dbatoolsci_orphan2] WITH PASSWORD = N'password2', CHECK_EXPIRATION
         $ExpectedProps = 'ComputerName,InstanceName,SqlInstance,DatabaseName,User,Status'.Split(',')
         ($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
     }
-    $results = Repair-DbaDbOrphanUser -SqlInstance $script:instance1 -Database dbatoolsci_orphan
+
+    $results = Repair-DbaDbOrphanUser -SqlInstance $script:instance1 -Database dbatoolsci_orphan -RemoveNotExisting
     It "does not find any other orphan" {
         $results | Should -BeNullOrEmpty
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6459 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To fix issue #6459 when Repair-DbaDbOrphanUser passes through to Remove-DbaDbOrphanUser it handles the $User param differently and so wasn't removing the users.

### Approach
Changed the logic so whether $User is passed in from another function or a human it is handled the same way.

### Commands to test
```
# setup an orphan 
New-DbaLogin -SqlInstance mssql2 -Login Jessp -Password $securePassword 
New-DbaDbUser -SqlInstance mssql2 -Database DatabaseAdmin -Login JessP
Remove-DbaLogin -SqlInstance mssql2 -Login jessp -Confirm:$false

# remove the orphan
Repair-DbaDbOrphanUser -SqlInstance mssql2 -Database DatabaseAdmin -RemoveNotExisting -Verbose
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/981370/78814998-81b81880-79c7-11ea-9c89-0d1847baed1e.png)
