### PR TITLE
Updates to Get-DbaService and Restart-DbaService to fix #6458

### DIFF
--- a/functions/Get-DbaService.ps1
+++ b/functions/Get-DbaService.ps1
@@ -19,7 +19,7 @@ function Get-DbaService {
 
     .PARAMETER Type
         Use -Type to collect only services of the desired SqlServiceType.
-        Can be one of the following: "Agent","Browser","Engine","FullText","SSAS","SSIS","SSRS", "PolyBase"
+        Can be one of the following: "Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS", "PolyBase", "Launchpad"
 
     .PARAMETER ServiceName
         Can be used to specify service names explicitly, without looking for service types/instances.
@@ -99,7 +99,7 @@ function Get-DbaService {
         [string[]]$InstanceName,
         [PSCredential]$Credential,
         [Parameter(ParameterSetName = "Search")]
-        [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS", "PolyBase")]
+        [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS", "PolyBase", "Launchpad")]
         [string[]]$Type,
         [Parameter(ParameterSetName = "ServiceName")]
         [string[]]$ServiceName,
@@ -118,6 +118,7 @@ function Get-DbaService {
             @{ Name = "SSRS"; Id = 6 },
             @{ Name = "Browser"; Id = 7 },
             @{ Name = "PolyBase"; Id = 10, 11 },
+            @{ Name = "Launchpad"; Id = 12 },
             @{ Name = "Unknown"; Id = 8 }
         )
         if ($PsCmdlet.ParameterSetName -match 'Search') {
@@ -190,10 +191,10 @@ function Get-DbaService {
                     Add-Member -Force -InputObject $service -MemberType NoteProperty -Name State -Value $(switch ($service.State) { 1 { 'Stopped' } 2 { 'Start Pending' }  3 { 'Stop Pending' } 4 { 'Running' } })
                     Add-Member -Force -InputObject $service -MemberType NoteProperty -Name StartMode -Value $(switch ($service.StartMode) { 1 { 'Unknown' } 2 { 'Automatic' }  3 { 'Manual' } 4 { 'Disabled' } })
 
-                    if ($service.ServiceName -in ("MSSQLSERVER", "SQLSERVERAGENT", "ReportServer", "MSSQLServerOLAPService")) {
+                    if ($service.ServiceName -in ("MSSQLSERVER", "SQLSERVERAGENT", "ReportServer", "MSSQLServerOLAPService", "MSSQLFDLauncher", "SQLPBDMS", "SQLPBENGINE", "MSSQLLAUNCHPAD")) {
                         $instance = "MSSQLSERVER"
                     } else {
-                        if ($service.ServiceType -in @("Agent", "Engine", "SSRS", "SSAS")) {
+                        if ($service.ServiceType -in @("Agent", "Engine", "SSRS", "SSAS", "FullText", "PolyBase", "Launchpad")) {
                             if ($service.ServiceName.indexof('$') -ge 0) {
                                 $instance = $service.ServiceName.split('$')[1]
                             } else {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6458  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix the restart bug in #6458 and a couple other issues discovered in the process

### Approach
**Changes in Get-DbaService**

- Added Launchpad to list of values for parameter Type

- Got Launchpad's service type enum ID from
$mc = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer
$mc.Services | Where-Object DisplayName -like "*Launchpad*"
![image](https://user-images.githubusercontent.com/6507651/79279729-ac4d1a00-7e7c-11ea-9d36-b50af9dad746.png)


- Added Launchpad to the section that handles instance name for per-instance type services
In doing this, also added PolyBase and FullText which are instance scoped, this will fix calls to Get-DbaService with -Instance provided (bugs uncovered as part of this effort)


**Changes in Restart-DbaService**
- Added Launchpad and PolyBase to list of values for parameter Type. This allows them to be 
Found that calls to Get-DbaService using the "Silent" parameter changed this to EnableException, as the Silent alias was removed awhile back
-In the section that adds SQL Agent to the restart collection when Engine is detected, I added the PolyBase and Launchpad types as well. Essentially the same code for Agent was kept but now that logic is done for each of "Agent", "PolyBase", "Launchpad" types

- The call into Get-DbaService was also changed to use -WarningAction SilentlyContinue. This is because otherwise Get-DbaService will produce a warning for each Launchpad / PolyBase that it searches for and doesn't find. This wasn't needed before because Agent is always there with Engine.
This is only in the section where dependent services are added. If someone does Restart-DbaService - Type Launchpad explicitly on a machine without it, they'll get the service not found warning as expected.


**Testing**
I manually tested this on:
SQL 2016 with R & PolyBase
SQL 2017 with R, Python, PolyBase
SQL 2019 with R, Python, PolyBase (both options included)
SQL 2014, just for sanity
used a mix of named instances and a default instance
used a variety of commands, including piping such as Get-DbaService -Type Launchpad | Restart-DbaService
ran manual.pester on *DbaService.Tests.ps1


### Commands to test
Prerequisites:
Have PolyBase or in-database R/Python services installed in SQL 2016 and above
Then Run:
```powershell
Restart-DbaService -Type Engine -Force
```

### Screenshots
![image](https://user-images.githubusercontent.com/6507651/79280252-ecf96300-7e7d-11ea-8669-7fcfadb3d98f.png)
