### PR TITLE
changed fileUserShared location to default to home local share folder

### DIFF
--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -79,8 +79,9 @@ if ($IsLinux -or $IsMacOs) {
 #region User Shared
 if ($IsLinux -or $IsMacOs) {
     # Defaults to the first value in $Env:XDG_CONFIG_DIRS on Linux or MacOS (or $HOME/.local/share/)
-    $fileUserShared = @($Env:XDG_CONFIG_DIRS -split ([IO.Path]::PathSeparator))[0]
-    if (-not $fileUserShared) { $fileUserShared = Join-Path $HOME .local/share/ }
+    # Defaults to $HOME .local/share/
+    # It previously was picking the first value in $Env:XDG_CONFIG_DIRS, but was causing and exception with ubuntu and xdg, saying that access to path /etc/xdg/xdg-ubuntu is denied.
+    $fileUserShared = Join-Path $HOME .local/share/
 
     $script:path_FileUserShared = Join-DbaPath $fileUserShared $psVersionName "dbatools/"
     $script:AppData = $fileUserShared


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ X] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
On ubuntu, when trying to do import-module, I was getting an exception 
![image](https://user-images.githubusercontent.com/6862119/79509638-ced56380-8033-11ea-90ae-02c53da2a12a.png)

### Approach
<!-- How does this change solve that purpose -->
After analyzing with @potatoqualitee and @FriedrichWeinmann , there was a suggestion to remove the line that was fetching the first XDG dir. After this change, the module was successfully imported.
### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
