### PR TITLE
Update Install-DbaInstance.ps1

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -615,7 +615,7 @@ function Install-DbaInstance {
                 if ($cores -gt 8) {
                     $cores = 8
                 }
-                if ($cores) {
+                if ($cores -and $configNode.ACTION -ne "AddNode") {
                     $configNode.SQLTEMPDBFILECOUNT = $cores
                 }
             }


### PR DESCRIPTION
Avoid to add SQLTEMPDBFILECOUNT parameter if action = 'AddNode'. 

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X ] Bug fix (non-breaking change, fixes #6479 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
The SQLTEMPDBFILECOUNT parameter  was initially added while working with SQL2016+, despite the content of the configuration file passed by the user. It causes issues during the setup of an additional cluster node.

### Approach
Added a check on the value of ACTION parameter. If "AddNode", doesn't add SQLTEMPDBFILECOUNT parameter

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
