### PR TITLE
Fixes Copy-DbaAgentProxy -EnableExceptions throws error on existing account

### DIFF
--- a/functions/Copy-DbaAgentProxy.ps1
+++ b/functions/Copy-DbaAgentProxy.ps1
@@ -166,7 +166,8 @@ function Copy-DbaAgentProxy {
                         $copyAgentProxyAccountStatus.Status = "Skipped"
                         $copyAgentProxyAccountStatus.Notes = "Already exists on destination"
                         $copyAgentProxyAccountStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
-                        Stop-Function -Message "Server proxy account $proxyName exists at destination. Use -Force to drop and migrate." -Continue
+                        Write-Message -Level Verbose -Message "Server proxy account $proxyName exists at destination. Use -Force to drop and migrate."
+                        Continue
                     } else {
                         if ($Pscmdlet.ShouldProcess($destinstance, "Dropping server proxy account $proxyName and recreating")) {
                             try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->

## Type of Change

<!-- What type of change does your code introduce -->

 - [x] Bug fix (non-breaking change, fixes #6499)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->

### Purpose

<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Fix issue #6499.

### Approach

<!-- How does this change solve that purpose -->

Replace Stop-Function with Write-Message.

### Commands to test

<!-- if these are the examples in the help just note it as such -->

Copy-DbaAgentProxy -Source SQL01 -Destination SQL02 -EnableException -WhatIf

### Screenshots

<!-- pictures say a thousand words without typing any of it -->

```
#### Output:

Type         Name          Status  Notes                        
----         ----          ------  -----                        
ProxyAccount Test Proxy    Skipped Already exists on destination
ProxyAccount Test Proxy2   Skipped Already exists on destination
```

### Learning

<!-- Optional -->
<!-- 
	Include:

  - blog post that may have assisted in writing the code
    - blog post that were initial source
     - special or unique approach made to solve the problem
       -->

I tried replacing the -Continue parameter on the Stop-Function call with -SilentlyContinue but this still threw an error.