### PR TITLE
Update Disable-DbaTraceFlag Examples

### DIFF
--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -44,7 +44,8 @@ function Enable-DbaTraceFlag {
         PS C:\> Enable-DbaTraceFlag -SqlInstance sql2016 -TraceFlag 1117, 1118
 
         Enable multiple trace flags on SQL Server instance sql2016
-        
+
+    .EXAMPLE
         PS C:\> Disable-DbaTraceFlag -SqlInstance sql2016_1, sql2016_2 -TraceFlag 6532,7314
 
         Disable more than 1 globally running trace flags on more than 1 SQL Server instances sql2016_1 and sql2016_2

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -44,7 +44,10 @@ function Enable-DbaTraceFlag {
         PS C:\> Enable-DbaTraceFlag -SqlInstance sql2016 -TraceFlag 1117, 1118
 
         Enable multiple trace flags on SQL Server instance sql2016
+        
+        PS C:\> Disable-DbaTraceFlag -SqlInstance sql2016_1, sql2016_2 -TraceFlag 6532,7314
 
+        Disable more than 1 globally running trace flags on more than 1 SQL Server instances sql2016_1 and sql2016_2
     #>
     [CmdletBinding()]
     param (


### PR DESCRIPTION
Hi,

I have updated the examples section of the function with new example to Disable the globally running more than 1 trace flag on more than 1 SQL Server instances sql2016_1 and sql2016_2

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Purpose of this PR to add more examples in examples 
### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

