### PR TITLE
Fix selection of last log in Select-DbaBackupInformation Issue #6467

### DIFF
--- a/functions/Select-DbaBackupInformation.ps1
+++ b/functions/Select-DbaBackupInformation.ps1
@@ -227,7 +227,7 @@ function Select-DbaBackupInformation {
                 }
                 # Get Last T-log
 
-                $lastLog = $DatabaseHistory | Where-Object { $_.Type -in ('Log', 'Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -eq $Full.CheckpointLSN } | Sort-Object -Property LastLsn, FirstLsn | Select-Object -First 1
+                $lastLog = $DatabaseHistory | Where-Object { $_.Type -in ('Log', 'Transaction Log') -and $_.End -ge $RestoreTime -and $_.DatabaseBackupLSN -ge $Full.CheckpointLSN } | Sort-Object -Property LastLsn, FirstLsn | Select-Object -First 1
                 if ($null -ne $lastlog) {
                     $lastLog.FullName = ($DatabaseHistory | Where-Object { $_.BackupSetID -eq $lastLog.BackupSetID }).Fullname
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6467  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
To fix grabbing the last log backup while doing a restore. 
### Approach
<!-- How does this change solve that purpose -->
See the detailed explanation on the issue comments. #6467
### Commands to test
Test restore
<!-- if these are the examples in the help just note it as such -->
```powershell
Restore-DbaDatabase -SqlInstance localhost\instance-DatabaseName testdb -WithReplace -path 'C:\Path\to\backups\testdb\' -RestoreTime "2020-05-09 18:01:00" -MaintenanceSolutionBackup -OutputScriptOnly
```
Test selection of backup information 
```powershell
$BackupHistory = Get-DbaBackupInformation -SqlInstance localhost\instance  -Path 'C:\Path\to\backups\testdb\'  -MaintenanceSolution
Select-DbaBackupInformation -BackupHistory $BackupHistory -RestoreTime "2020-05-09 18:01:00"
```

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
