### PR TITLE
Get-DbaPermission: GrantStatement handling of WITH_GRANT_OPTION

### DIFF
--- a/functions/Get-DbaPermission.ps1
+++ b/functions/Get-DbaPermission.ps1
@@ -158,6 +158,7 @@ function Get-DbaPermission {
                     , [GranteeType] = pr.type_desc
                     , [RevokeStatement] = 'REVOKE ' + permission_name + ' ON ' + isnull(schema_name(o.object_id) COLLATE DATABASE_DEFAULT+'.','')+OBJECT_NAME(major_id)+ ' FROM [' + USER_NAME(grantee_principal_id) +']'
                     , [GrantStatement] = 'GRANT ' + permission_name + ' ON ' + isnull(schema_name(o.object_id) COLLATE DATABASE_DEFAULT+'.','')+OBJECT_NAME(major_id)+ ' TO [' + USER_NAME(grantee_principal_id) + ']'
+                        + CASE WHEN dp.state_desc = 'GRANT_WITH_GRANT_OPTION' THEN ' WITH GRANT OPTION' ELSE '' END
                     FROM sys.database_permissions dp
                     JOIN sys.database_principals pr ON pr.principal_id = dp.grantee_principal_id
                     LEFT OUTER JOIN sys.all_objects o ON o.object_id = dp.major_id


### PR DESCRIPTION
Adds a case so that if the permission has WITH GRANT OPTION specified
it will be carried into the grant statement.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (not reported)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
I wanted to make the grant statement match what is there if it is used to restore the permissions, whether that grant option is really a good idea or not. 

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
create database grant_test
go
use grant_test
go
create user test_user1 for login test_user1
create user test_user2 for login test_user2
create table test_table1 (id int)
go
grant select on test_table1 to [test_user1]
grant select on test_table1 to [test_user2] with grant option
```
```
# should show test_user2 with the extra grant option
PS> Get-DbaPermission -SqlInstance $sqlinstance -Database grant_test | Where-Object {$_.Securable -eq "dbo.test_table1"} | Select-Object GrantStatement
```
```
--cleanup
USE [master]
GO
drop database grant_test
GO
drop login test_user1
drop login test_user2
GO
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
original:
![image](https://user-images.githubusercontent.com/30151317/84546108-2a377100-acc6-11ea-9c4e-5ca20c48a1aa.png)
new:
![image](https://user-images.githubusercontent.com/30151317/84545172-5e119700-acc4-11ea-813b-0bce075f722b.png)

