### PR TITLE
Adjusting help for Dac commands

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -16,9 +16,7 @@ function Export-DbaDacPackage {
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
 
-        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
-
-        For MFA support, please use Connect-DbaInstance.
+        Only SQL authentication is supported. When not specified, uses Trusted Authentication.
 
     .PARAMETER Path
         Specifies the directory where the file or files will be exported.

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -12,9 +12,7 @@ function Publish-DbaDacPackage {
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
 
-        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
-
-        For MFA support, please use Connect-DbaInstance.
+        Only SQL authentication is supported. When not specified, uses Trusted Authentication.
 
     .PARAMETER Path
         Specifies the filesystem path to the DACPAC


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6526 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To make documentation clear which credential usage is supported.

### Approach
Remove parts which say about supporting multiple authentication options. Since it's connection string-based, only SQL auth and Trusted auth are supported.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
