### PR TITLE
Fixed incorrect variable causing duplicate output

### DIFF
--- a/functions/Get-DbaDbMailAccount.ps1
+++ b/functions/Get-DbaDbMailAccount.ps1
@@ -75,7 +75,7 @@ function Get-DbaDbMailAccount {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDbMail -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $InputObject += Get-DbaDbMail -SqlInstance $instance -SqlCredential $SqlCredential
         }
 
         if (-not $InputObject) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
While working with the command today I found that the wrong variable was being passed in causing multiple server output be duplicated for each pass through the foreach.
### Approach
<!-- How does this change solve that purpose -->
Changed variable from $SqlInsance to just $instance to allow one server be added to output list once instead of all servers each loop.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Get-DbaDbMailAccount -SqlInstance $servers -Account IT_DBA`
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
