### PR TITLE
Added DATA_PURITY, NO_INFOMSGS, ALL_ERRORMSGS

### DIFF
--- a/internal/functions/Start-DbccCheck.ps1
+++ b/internal/functions/Start-DbccCheck.ps1
@@ -18,7 +18,7 @@ function Start-DbccCheck {
                 $null = $server.databases[$dbname].CheckTables('None')
                 Write-Verbose "Dbcc CheckTables finished successfully for $dbname on $servername"
             } else {
-                $null = $server.Query("DBCC CHECKDB ([$dbname])")
+                $null = $server.Query("DBCC CHECKDB ([$dbname]) WITH DATA_PURITY, NO_INFOMSGS, ALL_ERRORMSGS")
                 Write-Verbose "Dbcc CHECKDB finished successfully for $dbname on $servername"
             }
             return "Success"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Assuming there are no extendible parameters, or a "public" variation of this function available which would give us more flexibility when running CHECKDB, we need to think what's the best "default" method to run it.

### Approach
<!-- How does this change solve that purpose -->

`DATA_PURITY` - Column-value integrity checks are enabled by default and do not require the DATA_PURITY option. For databases upgraded from earlier versions of SQL Server, column-value checks are not enabled by default until DBCC CHECKDB WITH DATA_PURITY has been run error free on the database. After this, DBCC CHECKDB checks column-value integrity by default. In other words: There's no reason not to do this.

`NO_INFOMSGS` - Enabling this option would reduce the "noise" we get from CHECKDB executions, when what really interests us are the high severity errors.

`ALL_ERRORMSGS` - By default, error messages are sorted by object ID. Enabling the `ALL_ERRORMSGS` option causes the command to display all reported errors per object.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

`Test-DbaLastBackup`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
