### PR TITLE
Database Owner does not reflect correct name after New Database creation

### DIFF
--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -363,6 +363,7 @@ function New-DbaDatabase {
                         Write-Message -Message "Setting database owner to $Owner" -Level Verbose
                         try {
                             $newdb.SetOwner($Owner)
+                            $newdb.Refresh()
                         } catch {
                             Stop-Function -Message "Error setting Database Owner to $Owner" -ErrorRecord $_ -Target $instance -Continue
                         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
I found that when running New-DbaDatabase and setting the -Owner 'sa' parameter, the new database is created and has the correct owner, but the output reflected by the function shows the original owner of the created database. 
### Approach
<!-- How does this change solve that purpose -->
 I put in a refresh to hopefully flush cache or whatever is holding that original owner value.  This approach worked in my test.

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Before:
![image](https://user-images.githubusercontent.com/169602/85327624-eba77080-b494-11ea-8145-55d383c25490.png)

After fix:
![image](https://user-images.githubusercontent.com/169602/85327690-01b53100-b495-11ea-993c-da12c99265d0.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
