### PR TITLE
Grant-DbaAgPermission - Fix usage of $server to enable creation of login

### DIFF
--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -121,30 +121,28 @@ function Grant-DbaAgPermission {
         }
 
         foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
+            } catch {
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
             if ($perm -contains "CreateAnyDatabase") {
-                try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
-                } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-                }
-
                 foreach ($ag in $AvailabilityGroup) {
                     try {
                         $server.Query("ALTER AVAILABILITY GROUP $ag GRANT CREATE ANY DATABASE")
                     } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
-                        return
+                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
                     }
                 }
-            } elseif ($Login) {
-                $InputObject += Get-DbaLogin -SqlInstance $instance -SqlCredential $SqlCredential -Login $Login
+            }
+            if ($Login) {
+                $InputObject += Get-DbaLogin -SqlInstance $server -SqlCredential $SqlCredential -Login $Login
                 foreach ($account in $Login) {
                     if ($account -notin $InputObject.Name) {
                         try {
                             $InputObject += New-DbaLogin -SqlInstance $server -Login $account -EnableException
                         } catch {
-                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
-                            return
+                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
                         }
                     }
                 }
@@ -186,7 +184,7 @@ function Grant-DbaAgPermission {
             }
 
             if ($Type -contains "AvailabilityGroup") {
-                $ags = Get-DbaAvailabilityGroup -SqlInstance $account.Parent -AvailabilityGroup $AvailabilityGroup
+                $ags = Get-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $AvailabilityGroup
                 foreach ($ag in $ags) {
                     foreach ($perm in $Permission) {
                         if ($perm -notin 'Alter', 'Control', 'TakeOwnership', 'ViewDefinition') {

--- a/functions/Grant-DbaAgPermission.ps1
+++ b/functions/Grant-DbaAgPermission.ps1
@@ -131,7 +131,8 @@ function Grant-DbaAgPermission {
                     try {
                         $server.Query("ALTER AVAILABILITY GROUP $ag GRANT CREATE ANY DATABASE")
                     } catch {
-                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
+                        return
                     }
                 }
             }
@@ -142,7 +143,8 @@ function Grant-DbaAgPermission {
                         try {
                             $InputObject += New-DbaLogin -SqlInstance $server -Login $account -EnableException
                         } catch {
-                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
+                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance
+                            return
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6613 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
I brought the call to Connect-SqlInstance one level up
to serve all following parts with the variable $server.

I changed "elseif" to "if" to create missing logins even
if permissions contain CreateAnyDatabase.

I changed the Stop-Function to continue after error
to harmonize these calls within the commandlet.
