### PR TITLE
Remove-DbaAgentSchedule - New feature ScheduleUid

### DIFF
--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -57,6 +57,11 @@ function Get-DbaAgentSchedule {
         Returns the SQL Agent Shared Schedules with the Id of 3
 
     .EXAMPLE
+        PS C:\> Get-DbaAgentSchedule -SqlInstance localhost, sql2016 -ScheduleUid 'bf57fa7e-7720-4936-85a0-87d279db7eb7'
+
+        Returns the SQL Agent Shared Schedules with the UID
+
+    .EXAMPLE
         PS C:\> Get-DbaAgentSchedule -SqlInstance sql2016 -Schedule "Maintenance10min","Maintenance60min"
 
         Returns the "Maintenance10min" & "Maintenance60min" schedules from the sql2016 SQL Server instance
@@ -256,7 +261,7 @@ function Get-DbaAgentSchedule {
             $scheduleCollection = @()
 
             if ($Schedule -or $ScheduleUid -or $Id) {
-                if ($ScheduleUid) {
+                if ($Schedule) {
                     $scheduleCollection += $server.JobServer.SharedSchedules | Where-Object { $_.Name -in $Schedule }
                 }
 

--- a/functions/Get-DbaAgentSchedule.ps1
+++ b/functions/Get-DbaAgentSchedule.ps1
@@ -270,7 +270,7 @@ function Get-DbaAgentSchedule {
                 }
 
                 if ($Id) {
-                    $scheduleCollection += $scheduleCollection | Where-Object { $_.Id -in $Id }
+                    $scheduleCollection += $server.JobServer.SharedSchedules | Where-Object { $_.Id -in $Id }
                 }
             } else {
                 $scheduleCollection = $server.JobServer.SharedSchedules

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -19,6 +19,9 @@ function Remove-DbaAgentSchedule {
     .PARAMETER Schedule
         The name of the job schedule.
 
+    .PARAMETER ScheduleUid
+        The unique identifier of the schedule
+
     .PARAMETER InputObject
         A collection of schedule (such as returned by Get-DbaAgentSchedule), to be removed.
 

--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -76,24 +76,33 @@ function Remove-DbaAgentSchedule {
 
         Remove the schedules using a pipeline
 
+    .EXAMPLE
+        Remove-DbaAgentSchedule -SqlInstance sql1, sql2, sql3 -ScheduleUid 'bf57fa7e-7720-4936-85a0-87d279db7eb7'
+
+        Remove the schedules usingthe schdule uid
+
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param (
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "instance")]
         [DbaInstanceParameter[]]$SqlInstance,
         [System.Management.Automation.PSCredential]$SqlCredential,
-        [Parameter(Mandatory, ParameterSetName = "instance")]
+        [Parameter(ParameterSetName = "instance")]
         [ValidateNotNullOrEmpty()]
-        [Alias("Schedules")]
-        [object[]]$Schedule,
+        [Alias("Schedules", "Name")]
+        [string[]]$Schedule,
+        [Alias("Uid")]
+        [string[]]$ScheduleUid,
         [Parameter(ValueFromPipeline, Mandatory, ParameterSetName = "schedules")]
         [Microsoft.SqlServer.Management.Smo.Agent.ScheduleBase[]]$InputObject,
         [switch]$EnableException,
         [switch]$Force
     )
+
     begin {
         if ($Force) { $ConfirmPreference = 'none' }
     }
+
     process {
 
         foreach ($instance in $SqlInstance) {
@@ -104,10 +113,18 @@ function Remove-DbaAgentSchedule {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            if (-not $InputObject -and (-not $Schedule -or $ScheduleUid)) {
+                Stop-Function -Message "Please enter the schedule or schedule uid"
+            }
+
             $InputObject += $server.JobServer.SharedSchedules
 
             if ($Schedule) {
                 $InputObject = $InputObject | Where-Object Name -in $Schedule
+            }
+
+            if ($ScheduleUid) {
+                $InputObject = $InputObject | Where-Object ScheduleUid -in $ScheduleUid
             }
 
         } # foreach object instance

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'Id', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'ScheduleUid', 'Id', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Remove-DbaAgentSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentSchedule.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'InputObject', 'EnableException', 'Force'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'ScheduleUid', 'InputObject', 'EnableException', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -35,7 +35,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     Context "Should remove schedules" {
         $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-            Where-Object {$_.name -like 'dbatools*'}
+        Where-Object { $_.name -like 'dbatools*' }
         It "Should find all created schedule" {
             $results | Should Not BeNullOrEmpty
         }
@@ -47,8 +47,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
 
         $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-            Where-Object {$_.name -like 'dbatools*'} |
-            Remove-DbaAgentSchedule -Confirm:$false -Force
+        Where-Object { $_.name -like 'dbatools*' } |
+        Remove-DbaAgentSchedule -Confirm:$false -Force
         It "Should not find any created schedule" {
             $results | Should BeNullOrEmpty
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #5353)
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The command can only remove schedules based on their name. Theoretically it's possible to have multiple schedules with the same name which makes it hard to remove the schedule.

### Approach
The command now has the ability to assign the `ScheduleUid`.

### Commands to test
Get-DbaAgentSchedule
Remove-DbaAgentSchedule

### Screenshots
Changes to Get-DbaAgentSchedule
![nf_remove-dbaagentschedule_getdbaagentschedule](https://user-images.githubusercontent.com/6154981/85996597-bbb61b00-ba08-11ea-806c-7504d2f60f9b.png)

Removing the schedules based on the UID
![nf_remove-dbaagentschedule_removedbaagentschedule](https://user-images.githubusercontent.com/6154981/85996587-b789fd80-ba08-11ea-962d-3618da55d34a.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
