### PR TITLE
Return TraceFlags as a collection rather than CSV

### DIFF
--- a/functions/Get-DbaStartupParameter.ps1
+++ b/functions/Get-DbaStartupParameter.ps1
@@ -94,7 +94,7 @@ function Get-DbaStartupParameter {
                     if ($traceflags.length -eq 0) {
                         $traceflags = "None"
                     } else {
-                        $traceflags = $traceflags.substring(2)
+                        [int[]]$traceflags = $traceflags.substring(2)
                     }
 
                     if ($Simple -eq $true) {
@@ -105,7 +105,7 @@ function Get-DbaStartupParameter {
                             MasterData      = $masterdata.TrimStart('-d')
                             MasterLog       = $masterlog.TrimStart('-l')
                             ErrorLog        = $errorlog.TrimStart('-e')
-                            TraceFlags      = $traceflags -join ','
+                            TraceFlags      = $traceflags
                             ParameterString = $wmisvc.StartupParameters
                         }
                     } else {
@@ -158,7 +158,7 @@ function Get-DbaStartupParameter {
                             MasterData           = $masterdata -replace '^-[dD]', ''
                             MasterLog            = $masterlog -replace '^-[lL]', ''
                             ErrorLog             = $errorlog -replace '^-[eE]', ''
-                            TraceFlags           = $traceflags -join ','
+                            TraceFlags           = $traceflags
                             CommandPromptStart   = $commandprompt
                             MinimalStart         = $minimalstart
                             MemoryToReserve      = $memorytoreserve


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Change the type of the TraceFlags member in the object returned from `Get-DbaStartupParameter` from a CSV (i.e. `string`) to `int[]`. This will allow for enhanced functionality for things like `TraceFlags.Contains(1118)`.

### Approach
Once all of the parsing is done, apply a type cast.

### Commands to test
Just the examples from the docs should be fine.


