### PR TITLE
Set-DbaSpConfigure - Fix wrong output

### DIFF
--- a/functions/Set-DbaSpConfigure.ps1
+++ b/functions/Set-DbaSpConfigure.ps1
@@ -89,7 +89,7 @@ function Set-DbaSpConfigure {
         }
 
         foreach ($configobject in $InputObject) {
-            $server = $InputObject.Parent
+            $server = $configobject.Parent
             $currentRunValue = $configobject.RunningValue
             $currentConfigValue = $configobject.ConfiguredValue
             $minValue = $configobject.MinValue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Sorry I had to fix my fix...
Getting $server from $InputObject instead of $configobject resulted in wrong output

Input:
```
Set-DbaSpConfigure -SqlInstance SRV1, SRV2 -Name CostThresholdForParallelism -Value 50 | Format-Table
```

Wrong output (old):
```
ComputerName InstanceName               SqlInstance  ConfigName                  PreviousValue NewValue
------------ ------------               -----------  ----------                  ------------- --------
{SRV1, SRV2} {MSSQLSERVER, MSSQLSERVER} {SRV1, SRV2} CostThresholdForParallelism             5       50
{SRV1, SRV2} {MSSQLSERVER, MSSQLSERVER} {SRV1, SRV2} CostThresholdForParallelism             5       50
```

Correct output (new):
```
ComputerName InstanceName SqlInstance ConfigName                  PreviousValue NewValue
------------ ------------ ----------- ----------                  ------------- --------
SRV1         MSSQLSERVER  SRV1        CostThresholdForParallelism             5       50
SRV2         MSSQLSERVER  SRV2        CostThresholdForParallelism             5       50
```
