### PR TITLE
Install-DbaFirstReponderKit - Exclude procedures for Version 2005

### DIFF
--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -118,17 +118,6 @@ function Install-DbaFirstResponderKit {
         $zipFolder = Join-Path -Path $temp -ChildPath "SQL-Server-First-Responder-Kit-$Branch"
         $LocalCachedCopy = Join-Path -Path $DbatoolsData -ChildPath "SQL-Server-First-Responder-Kit-$Branch"
 
-        if ($LocalFile) {
-            if ($PSCmdlet.ShouldProcess($LocalFile, "File does not exists, returning to prompt")) {
-                Stop-Function -Message "$LocalFile doesn't exist"
-                return
-            }
-            if ($PSCmdlet.ShouldProcess($LocalFile, "File is not a zip file, returning to prompt")) {
-                Stop-Function -Message "$LocalFile should be a zip file"
-                return
-            }
-        }
-
         if ($Force -or -not(Test-Path -Path $LocalCachedCopy -PathType Container) -or $LocalFile) {
             # Force was passed, or we don't have a local copy, or $LocalFile was passed
             if (Test-Path $zipFile) {
@@ -138,13 +127,25 @@ function Install-DbaFirstResponderKit {
             }
 
             if ($LocalFile) {
+                if (-not (Test-Path $LocalFile)) {
+                    if ($PSCmdlet.ShouldProcess($LocalFile, "File does not exists, returning to prompt")) {
+                        Stop-Function -Message "$LocalFile doesn't exist"
+                        return
+                    }
+                }
+                if (Test-Path $LocalFile -PathType Container) {
+                    if ($PSCmdlet.ShouldProcess($LocalFile, "File is not a zip file, returning to prompt")) {
+                        Stop-Function -Message "$LocalFile should be a zip file"
+                        return
+                    }
+                }
                 if (Test-Windows -NoWarn) {
                     if ($PSCmdlet.ShouldProcess($LocalFile, "Checking if Windows system, unblocking file")) {
                         Unblock-File $LocalFile -ErrorAction SilentlyContinue
                     }
                 }
                 if ($PSCmdlet.ShouldProcess($LocalFile, "Extracting archive to $temp path")) {
-                    Expand-Archive -Path $LocalFile -DestinationPath $zipFolder -Force
+                    Expand-Archive -Path $LocalFile -DestinationPath $temp -Force
                 }
             } else {
                 Write-Message -Level Verbose -Message "Downloading and unzipping the First Responder Kit zip file."

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -196,7 +196,7 @@ function Install-DbaFirstResponderKit {
             $allprocedures_query = "select name from sys.procedures where is_ms_shipped = 0"
             $allprocedures = ($server.Query($allprocedures_query, $Database)).Name
             # Install/Update each FRK stored procedure
-            foreach ($script in (Get-ChildItem $LocalCachedCopy -Recurse -Filter "sp_*.sql")) {
+            foreach ($script in (Get-ChildItem $LocalCachedCopy -Recurse -Filter "sp_*.sql" -Exclude '*SQL_Server_2005.sql')) {
                 $scriptname = $script.Name
                 $scriptError = $false
                 if ($scriptname -ne "sp_BlitzRS.sql") {

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -4,40 +4,94 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'Force', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+            (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params).Count | Should Be 0
         }
     }
 }
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    Context "Testing First Responder Kit installer" {
+    Context "Testing First Responder Kit installer with download" {
         BeforeAll {
             $database = "dbatoolsci_frk_$(Get-Random)"
             $server = Connect-DbaInstance -SqlInstance $script:instance2
             $server.Query("CREATE DATABASE $database")
+
+            $resultsDownload = Install-DbaFirstResponderKit -SqlInstance $script:instance2 -Database $database -Branch main -Force -Verbose:$false
         }
         AfterAll {
             Remove-DbaDatabase -SqlInstance $script:instance2 -Database $database -Confirm:$false
         }
 
-        $results = Install-DbaFirstResponderKit -SqlInstance $script:instance2 -Database $database -Branch main -Force
-
         It "Installs to specified database: $database" {
-            $results[0].Database -eq $database | Should Be $true
+            $resultsDownload[0].Database -eq $database | Should Be $true
         }
         It "Shows status of Installed" {
-            $results[0].Status -eq "Installed" | Should Be $true
+            $resultsDownload[0].Status -eq "Installed" | Should Be $true
         }
         It "At least installed sp_Blitz and sp_BlitzIndex" {
-            'sp_Blitz', 'sp_BlitzIndex' | Should BeIn $results.Name
+            'sp_Blitz', 'sp_BlitzIndex' | Should BeIn $resultsDownload.Name
         }
         It "has the correct properties" {
-            $result = $results[0]
+            $result = $resultsDownload[0]
             $ExpectedProps = 'SqlInstance,InstanceName,ComputerName,Name,Status,Database'.Split(',')
             ($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+        }
+        It "Shows status of Updated" {
+            $resultsDownload = Install-DbaFirstResponderKit -SqlInstance $script:instance2 -Database $database -Verbose:$false
+            $resultsDownload[0].Status -eq 'Updated' | Should -Be $true
+        }
+        It "Shows status of Error" {
+            $folder = Join-Path (Get-DbatoolsConfigValue -FullName Path.DbatoolsData) -Child "SQL-Server-First-Responder-Kit-main"
+            $sqlScript = (Get-ChildItem $folder | Select-Object -First 1).FullName
+            Add-Content $sqlScript (New-Guid).ToString()
+            $result = Install-DbaFirstResponderKit -SqlInstance $script:instance2 -Database $database -Verbose:$false
+            $result[0].Status -eq "Error" | Should -Be $true
+        }
+    }
+    Context "Testing First Responder Kit installer with LocalFile" {
+        BeforeAll {
+            $database = "dbatoolsci_frk_$(Get-Random)"
+            $server = Connect-DbaInstance -SqlInstance $script:instance3
+            $server.Query("CREATE DATABASE $database")
+
+            $outfile = "SQL-Server-First-Responder-Kit-main.zip"
+            Invoke-WebRequest -Uri "https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit/archive/main.zip" -OutFile $outfile
+            if (Test-Path $outfile) {
+                $fullOutfile = (Get-ChildItem $outfile).FullName
+            }
+            $resultsLocalFile = Install-DbaFirstResponderKit -SqlInstance $script:instance3 -Database $database -Branch main -LocalFile $fullOutfile  -Force
+        }
+        AfterAll {
+            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $database -Confirm:$false
+        }
+
+        It "Installs to specified database: $database" {
+            $resultsLocalFile[0].Database -eq $database | Should -Be $true
+        }
+        It "Shows status of Installed" {
+            $resultsLocalFile[0].Status -eq "Installed" | Should -Be $true
+        }
+        It "At least installed sp_Blitz and sp_BlitzIndex" {
+            'sp_Blitz', 'sp_BlitzIndex' | Should BeIn $resultsLocalFile.Name
+        }
+        It "Has the correct properties" {
+            $result = $resultsLocalFile[0]
+            $ExpectedProps = 'SqlInstance,InstanceName,ComputerName,Name,Status,Database'.Split(',')
+            ($result.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedProps | Sort-Object)
+        }
+        It "Shows status of Updated" {
+            $resultsLocalFile = Install-DbaFirstResponderKit -SqlInstance $script:instance3 -Database $database
+            $resultsLocalFile[0].Status -eq 'Updated' | Should -Be $true
+        }
+        It "Shows status of Error" {
+            $folder = Join-Path (Get-DbatoolsConfigValue -FullName Path.DbatoolsData) -Child "SQL-Server-First-Responder-Kit-main"
+            $sqlScript = (Get-ChildItem $folder | Select-Object -First 1).FullName
+            Add-Content $sqlScript (New-Guid).ToString()
+            $result = Install-DbaFirstResponderKit -SqlInstance $script:instance3 -Database $database
+            $result[0].Status -eq "Error" | Should -Be $true
         }
     }
 }

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -8,7 +8,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'Force', 'EnableException'
 
         It "Should only contain our specific parameters" {
-            (Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params).Count | Should Be 0
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -4,15 +4,14 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Testing First Responder Kit installer" {
         BeforeAll {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6531 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

Because all procedures in the folder Deprecated are named *_SQL_Server_2005.sql it is easy to skip them so that the don't overwrite the new versions from the main folder.

I think this is the smallest possible change to fix the bug and get thing going again.
