### PR TITLE
New Feature Data Masking - Empty or set value for entire column

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -727,7 +727,7 @@ function Invoke-DbaDbDataMasking {
                                     Message    = "Executing Batch $batchCounter/$totalBatches"
                                 }
 
-                                Write-ProgressHelper @progressParams
+                                #Write-ProgressHelper @progressParams
 
                                 try {
                                     Invoke-DbaQuery -SqlInstance $instance -SqlCredential $SqlCredential -Database $db.Name -Query $stringBuilder.ToString()

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -473,7 +473,17 @@ function Invoke-DbaDbDataMasking {
                                                 $query += "[$($columnObject.Name)] - $($columnAction.Value);"
                                             }
                                         }
+                                    } elseif ($columnAction.Category -eq 'Column') {
+                                        switch ($columnAction.Type) {
+                                            "Set" {
+                                                $query += "$($columnObject.Value)"
+                                            }
+                                            "Nullify" {
+                                                $query += "NULL"
+                                            }
+                                        }
                                     }
+
                                     # Add the query to the rest
                                     $null = $stringBuilder.AppendLine($query)
                                 }

--- a/functions/Test-DbaDbDataMaskingConfig.ps1
+++ b/functions/Test-DbaDbDataMaskingConfig.ps1
@@ -77,9 +77,9 @@ function Test-DbaDbDataMaskingConfig {
 
         $requiredColumnProperties = @('Action', 'CharacterString', 'ColumnType', 'Composite', 'Deterministic', 'Format', 'MaskingType', 'MaxValue', 'MinValue', 'Name', 'Nullable', 'KeepNull', 'SubType')
 
-        $allowedActionCategories = @('datetime', 'number')
+        $allowedActionCategories = @('datetime', 'number', 'column')
         $allowedActionSubCategories = @('year', 'quarter', 'month', 'dayofyear', 'day', 'week', 'weekday', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond')
-        $allowedActionTypes = @('Add', 'Divide', 'Multiply', 'Subtract')
+        $allowedActionTypes = @('Add', 'Divide', 'Multiply', 'Nullify', 'Set', 'Subtract')
 
         $allowedDateTimeTypes = @('date', 'datetime', 'datetime2', 'smalldatetime', 'time')
         $allowedNumberTypes = @('bigint', 'bit', 'int', 'money', 'smallint')
@@ -223,7 +223,7 @@ function Test-DbaDbDataMaskingConfig {
                         }
                     }
 
-                    if ($null -eq $column.Action.Value -and $column.Action.Type -in $allowedActionTypes) {
+                    if ($column.Action.Category -ne 'Column' -and $column.Action.Type -ne 'Nullify' -and $null -eq $column.Action.Value -and $column.Action.Type -in $allowedActionTypes) {
                         [PSCustomObject]@{
                             Table  = $table.Name
                             Column = $column.Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #6652 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The masking supports all sorts of masking based on rows and some things to combine columns, but it does not have a feature to empty or set an entire column. 

For performance, setting the value for an entire column is a lot better than setting it row by row.

### Approach
In the latest release a new feature was added called actions. It is now possible to use another action category called "Column".

This action category has two types:
- Set: Sets a certain value for the entire column
- Nullify: Empties the entire column when the column is nullable

**Example config for the AdventureWorks2017 database**

Set the column value
```json
{
    "Name": "AdventureWorks2017",
    "Type": "DataMaskingConfiguration",
    "Tables": [
        {
            "Name": "EmailAddress",
            "Schema": "Person",
            "Columns": [
                {
                    "Name": "EmailAddress",
                    "ColumnType": "nvarchar",
                    "CharacterString": null,
                    "MinValue": 25,
                    "MaxValue": 50,
                    "MaskingType": "Internet",
                    "SubType": "Email",
                    "Format": null,
                    "Deterministic": false,
                    "Nullable": true,
                    "KeepNull": true,
                    "Composite": null,
                    "Action": {
                        "Category": "Column",
                        "Type": "Set",
                        "Value": "justsomemail@bla.com"
                    }
                }
            ],
            "HasUniqueIndex": false
        }
    ]
}
```

Nullify the column
```json
{
    "Name": "AdventureWorks2017",
    "Type": "DataMaskingConfiguration",
    "Tables": [
        {
            "Name": "EmailAddress",
            "Schema": "Person",
            "Columns": [
                {
                    "Name": "EmailAddress",
                    "ColumnType": "nvarchar",
                    "CharacterString": null,
                    "MinValue": 25,
                    "MaxValue": 50,
                    "MaskingType": "Internet",
                    "SubType": "Email",
                    "Format": null,
                    "Deterministic": false,
                    "Nullable": true,
                    "KeepNull": true,
                    "Composite": null,
                    "Action": {
                        "Category": "Column",
                        "Type": "Nullify"
                    }
                }
            ],
            "HasUniqueIndex": false
        }
    ]
}
```

### Commands to test
Invoke-DbaDbDataMasking

### Screenshots

**Before the masking**
![image](https://user-images.githubusercontent.com/6154981/87307604-3196a800-c51a-11ea-9e23-c56a8895a10b.png)

**Result setting of a value for the column**
![image](https://user-images.githubusercontent.com/6154981/87307643-4410e180-c51a-11ea-9467-f56a59a3e1a1.png)

**Result nullifying the column**
![image](https://user-images.githubusercontent.com/6154981/87307651-48d59580-c51a-11ea-8992-dd6efdb6cbd3.png)



### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
