### PR TITLE
Ben thul/skip existing membership

### DIFF
--- a/functions/Add-DbaDbRoleMember.ps1
+++ b/functions/Add-DbaDbRoleMember.ps1
@@ -141,7 +141,7 @@ function Add-DbaDbRoleMember {
 
                 foreach ($username in $User) {
                     if ($db.Users.Name -contains $username) {
-                        if ($members.Name -notcontains $username) {
+                        if ($members -notcontains $username) {
                             if ($PSCmdlet.ShouldProcess($instance, "Adding User $username to role: $dbRole in database $db")) {
                                 Write-Message -Level 'Verbose' -Message "Adding User $username to role: $dbRole in database $db on $instance"
                                 $dbRole.AddMember($username)

--- a/tests/Add-DbaDbRoleMember.Tests.ps1
+++ b/tests/Add-DbaDbRoleMember.Tests.ps1
@@ -67,5 +67,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $roleDB.UserName -contains $user2 | Should Be $false
             $roleDBAfter.UserName -contains $user2 | Should Be $true
         }
+
+        It 'Skip adding user to role if already a member' {
+            $messages = Add-DbaDbRoleMember -SqlInstance $script:instance2 -Role $role -User $user1 -Database $dbname -confirm:$false -Verbose 4>&1
+            $messageCount = ($messages -match 'Adding user').Count
+
+            $messageCount | Should Be 0
+        }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

Existing `Add-DbaDbRoleMember` was not properly checking whether the passed in user already existed in the role. Now if the user is already in the role, the cmdlet skips trying to add it.

### Approach
<!-- How does this change solve that purpose -->

* Get existing role members (`$dbRole.EnumMembers()` - note: returns StringCollection)
* Test whether user was in role:
   * Before change: `$members.Name -notcontains $user`
   * After change: `$members -notcontains $user`

### Commands to test
<!-- if these are the examples in the help just note it as such -->

Repeated calls to Add-DbaDbRoleMember. The first call may perform an actual action (depending on whether the user was already in the role or not). 

* Without the change, subsequent calls would also say that they were adding the user to the role.
* With the change, the second and subsequent calls will now return with nothing to do.

### Learning
Had to look up how to test against the verbose message stream. That was pretty neat!
