### PR TITLE
Get-DbaAgentHistory - Added parameter OutcomeType to filter the results on the server

### DIFF
--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -107,6 +107,11 @@ function Get-DbaAgentJobHistory {
 
         Gets all jobs with the name that match the regex pattern "backup" and then gets the job history from those. You can also use -Like *backup* in this example.
 
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJobHistory -SqlInstance sql2016 -OutcomeType Failed
+
+        Returns only the failed SQL Agent Job execution results for the sql2016 SQL Server instance.
+
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (

--- a/functions/Get-DbaAgentJobHistory.ps1
+++ b/functions/Get-DbaAgentJobHistory.ps1
@@ -32,6 +32,9 @@ function Get-DbaAgentJobHistory {
     .PARAMETER EndDate
         The DateTime before which the history is wanted. If unspecified, all available records will be processed.
 
+    .PARAMETER OutcomeType
+        The CompletionResult to filter the history for. Valid values are: Failed, Succeeded, Retry, Cancelled, InProgress, Unknown
+
     .PARAMETER ExcludeJobSteps
         Use this switch to discard all job steps, and return only the job totals
 
@@ -115,6 +118,8 @@ function Get-DbaAgentJobHistory {
         [object[]]$ExcludeJob,
         [DateTime]$StartDate = "1900-01-01",
         [DateTime]$EndDate = $(Get-Date),
+        [ValidateSet('Failed', 'Succeeded', 'Retry', 'Cancelled', 'InProgress', 'Unknown')]
+        [Microsoft.SqlServer.Management.Smo.Agent.CompletionResult]$OutcomeType,
         [switch]$ExcludeJobSteps,
         [switch]$WithOutputFile,
         [parameter(Mandatory, ValueFromPipeline, ParameterSetName = "Collection")]
@@ -127,6 +132,9 @@ function Get-DbaAgentJobHistory {
         $filter.StartRunDate = $StartDate
         $filter.EndRunDate = $EndDate
 
+        if (Test-Bound OutcomeType) {
+            $filter.OutcomeTypes = $OutcomeType
+        }
 
         if ($ExcludeJobSteps -and $WithOutputFile) {
             Stop-Function -Message "You can't use -ExcludeJobSteps and -WithOutputFile together"

--- a/tests/Get-DbaAgentJobHistory.Tests.ps1
+++ b/tests/Get-DbaAgentJobHistory.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'StartDate', 'EndDate', 'ExcludeJobSteps', 'WithOutputFile', 'JobCollection', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'StartDate', 'EndDate', 'OutcomeType', 'ExcludeJobSteps', 'WithOutputFile', 'JobCollection', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #6680 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Allow filtering by agent JobHistory Outcome type (Cancelled, Failed, InProgress, Retry, Succeeded or Unknown) on the server to reduce the amount of data transfered from server to client.

### Approach
Uses property OutcomeTypes of Microsoft.SqlServer.Management.Smo.Agent.JobHistoryFilter
