### PR TITLE
Uses Query parameter instead of $query variable.

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -328,7 +328,7 @@ function Invoke-DbaDbDataMasking {
                             $columnString += ",[$($identityColumn)]"
                             $query = "SELECT $($columnString) FROM [$($tableobject.Schema)].[$($tableobject.Name)]"
                         }
-                        [array]$data = $db.Query($query)
+                        [array]$data = $db.Query($Query)
 
                     } catch {
                         Stop-Function -Message "Failure retrieving the data from table $($tableobject.Name)" -Target $Database -ErrorRecord $_ -Continue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
This is to fix the issue where Query parameter supplied to Invoke-DbaDbDataMasking function is ignored.

### Approach
The code incorrectly uses the local $query variable whereas should have been using $Query parameter.



