### PR TITLE
Add-DbaAgDatabase - fix for SQL Server 2014

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -153,10 +153,6 @@ function Add-DbaAgDatabase {
                 Stop-Function -Message "Automatic seeding mode only supported in SQL Server 2016 and above" -Continue
             }
 
-            if ($SeedingMode -eq 'Manual' -and -not $UseLastBackup -and -not $SharedPath) {
-                Stop-Function -Message "You must specify a SharedPath or UseLastBackup when adding databases to a manually seeded availability group" -Continue
-            }
-
             if (-not $Secondary) {
                 try {
                     $secondarynames = ($ag.AvailabilityReplicas | Where-Object Role -eq Secondary).Name

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -153,11 +153,9 @@ function Add-DbaAgDatabase {
                 Stop-Function -Message "Automatic seeding mode only supported in SQL Server 2016 and above" -Continue
             }
 
-            # disabled, we first have to discuss the need for this test and the consequences of this test
-            # was not active in previous version due to wrong placement
-            #            if (-not $UseLastBackup -and -not $SharedPath -and $SeedingMode -ne 'Automatic') {
-            #                Stop-Function -Message "You must specify a SharedPath when adding databases to a manually seeded availability group" -Continue
-            #            }
+            if ($SeedingMode -eq 'Manual' -and -not $UseLastBackup -and -not $SharedPath) {
+                Stop-Function -Message "You must specify a SharedPath or UseLastBackup when adding databases to a manually seeded availability group" -Continue
+            }
 
             if (-not $Secondary) {
                 try {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -153,9 +153,11 @@ function Add-DbaAgDatabase {
                 Stop-Function -Message "Automatic seeding mode only supported in SQL Server 2016 and above" -Continue
             }
 
-            if (-not $UseLastBackup -and -not $SharedPath -and $SeedingMode -ne 'Automatic') {
-                Stop-Function -Message "You must specify a SharedPath when adding databases to a manually seeded availability group" -Continue
-            }
+            # disabled, we first have to discuss the need for this test and the consequences of this test
+            # was not active in previous version due to wrong placement
+            #            if (-not $UseLastBackup -and -not $SharedPath -and $SeedingMode -ne 'Automatic') {
+            #                Stop-Function -Message "You must specify a SharedPath when adding databases to a manually seeded availability group" -Continue
+            #            }
 
             if (-not $Secondary) {
                 try {

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -111,7 +111,7 @@ function Add-DbaAgDatabase {
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
         [ValidateSet('Automatic', 'Manual')]
-        [string]$SeedingMode,
+        [string]$SeedingMode = 'Manual',
         [string]$SharedPath,
         [switch]$UseLastBackup,
         [switch]$EnableException

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -137,12 +137,12 @@ function Add-DbaAgDatabase {
             $allbackups = @{
             }
 
-            $Primary = $db.Parent
+            $primary = $db.Parent
             # check primary, should be run against primary
-            $ag = Get-DbaAvailabilityGroup -SqlInstance $db.Parent -AvailabilityGroup $AvailabilityGroup
+            $ag = Get-DbaAvailabilityGroup -SqlInstance $primary -AvailabilityGroup $AvailabilityGroup
 
             if (-not $ag.Parent) {
-                Stop-Function -Message "Availability Group $AvailabilityGroup not found on $($db.Parent.Name)" -Continue
+                Stop-Function -Message "Availability Group $AvailabilityGroup not found on $($primary.Name)" -Continue
             }
 
             if ($ag.AvailabilityDatabases.Name -contains $db.Name) {
@@ -170,12 +170,12 @@ function Add-DbaAgDatabase {
 
             if ($SeedingMode -eq "Automatic") {
                 # first check
-                if ($Pscmdlet.ShouldProcess($Primary, "Backing up $db to NUL")) {
-                    $null = Backup-DbaDatabase -BackupFileName NUL -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db.Name
+                if ($Pscmdlet.ShouldProcess($primary, "Backing up $db to NUL")) {
+                    $null = Backup-DbaDatabase -BackupFileName NUL -SqlInstance $primary -SqlCredential $SqlCredential -Database $db.Name
                 }
             }
 
-            if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Adding availability group $db to $($db.Parent.Name)")) {
+            if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Adding availability group $db to $($primary.Name)")) {
                 try {
                     $agdb = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityDatabase($ag, $db.Name)
                     # something is up with .net create(), force a stop
@@ -198,10 +198,10 @@ function Add-DbaAgDatabase {
                     $secondaryInstanceReplicaName = $secondaryInstanceReplicaName, $secondaryInstance.InstanceName -join "\"
                 }
 
-                $agreplica = Get-DbaAgReplica -SqlInstance $Primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $secondaryInstanceReplicaName
+                $agreplica = Get-DbaAgReplica -SqlInstance $primary -SqlCredential $SqlCredential -AvailabilityGroup $ag.name -Replica $secondaryInstanceReplicaName
 
                 if (-not $agreplica) {
-                    Stop-Function -Continue -Message "Secondary replica $($secondaryInstanceReplicaName) for availability group $($ag.name) not found on $($Primary.Name)"
+                    Stop-Function -Continue -Message "Secondary replica $($secondaryInstanceReplicaName) for availability group $($ag.name) not found on $($primary.Name)"
                 }
 
                 if ($SeedingMode -eq "Automatic" -and $secondaryInstance.VersionMajor -le 12) {
@@ -220,7 +220,7 @@ function Add-DbaAgDatabase {
                 $agreplica.Refresh()
                 $SeedingModeReplica = $agreplica.SeedingMode
 
-                $primarydb = Get-DbaDatabase -SqlInstance $Primary -SqlCredential $SqlCredential -Database $db.name
+                $primarydb = Get-DbaDatabase -SqlInstance $primary -SqlCredential $SqlCredential -Database $db.name
 
                 if ($SeedingModeReplica -ne 'Automatic') {
                     try {
@@ -234,7 +234,7 @@ function Add-DbaAgDatabase {
                             }
                             Write-Message -Level Verbose -Message "Backups still exist on $SharedPath"
                         }
-                        if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $Primary")) {
+                        if ($Pscmdlet.ShouldProcess("$Secondary", "restoring full and log backups of $primarydb from $primary")) {
                             # keep going to ensure output is shown even if dbs aren't added well.
                             $null = $allbackups[$db] | Restore-DbaDatabase -SqlInstance $secondaryInstance -WithReplace -NoRecovery -TrustDbBackupHistory -EnableException
                         }

--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -213,7 +213,7 @@ function Add-DbaAgDatabase {
                 }
 
 
-                if ($SeedingMode) {
+                if ($SeedingMode -and $secondaryInstance.VersionMajor -gt 12) {
                     $agreplica.SeedingMode = $SeedingMode
                     $agreplica.Alter()
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6608 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
I split up the changes in three commits to be able to see three diffs.
First change is the bugfix: Only set the property in versions that support this property.
Second change is just to make things nice: Having variables start with lowercase and using using variable that was set.
Third change is to align tests with similar tests in New-DbaAvailabilityGroup, to correct order of tests (tests had wrong nesting) and to test before creating the smo object.