### PR TITLE
Test-DbaLastBackup - Add support for MaxTransferSize and BufferCount

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -89,11 +89,6 @@ function Test-DbaLastBackup {
     .PARAMETER Confirm
         If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
-    .PARAMETER EnableException
-        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
-        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
-        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-
     .PARAMETER MaxTransferSize
         Parameter to set the unit of transfer. Values must be a multiple of 64kb and a max of 4GB
         Parameter is used as passtrough for Restore-DbaDatabase.
@@ -102,6 +97,11 @@ function Test-DbaLastBackup {
         Number of I/O buffers to use to perform the operation.
         Refer to https://msdn.microsoft.com/en-us/library/ms178615.aspx for more detail
         Parameter is used as passtrough for Restore-DbaDatabase.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
         Tags: DisasterRecovery, Backup, Restore
@@ -184,9 +184,9 @@ function Test-DbaLastBackup {
         [string]$AzureCredential,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
-        [switch]$EnableException,
         [int]$MaxTransferSize,
-        [int]$BufferCount
+        [int]$BufferCount,
+        [switch]$EnableException
     )
     process {
         if ($SqlInstance) {

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -95,7 +95,7 @@ function Test-DbaLastBackup {
 
     .PARAMETER BufferCount
         Number of I/O buffers to use to perform the operation.
-        Refer to https://msdn.microsoft.com/en-us/library/ms178615.aspx for more detail
+        Refererence: https://msdn.microsoft.com/en-us/library/ms178615.aspx#data-transfer-options
         Parameter is used as passtrough for Restore-DbaDatabase.
 
     .PARAMETER EnableException
@@ -159,6 +159,15 @@ function Test-DbaLastBackup {
 
         Copies the backup files for sql2014 databases to sql2016 default backup locations and then attempts restore from there.
 
+    .EXAMPLE
+        PS C:\> Test-DbaLastBackup -SqlInstance sql2016 -NoCheck -MaxTransferSize 4194302 -BufferCount 24
+
+        Determines the last full backup for ALL databases, attempts to restore all databases (with a different name and file structure).
+        The Restore will use more memory for reading the backup files. Do not set these values to high or you can get an Out of Memory error!!!
+        When running the restore with these additional parameters and there is other server activity it could affect server OLTP performance. Please use with causion.
+        Prior to running, you should check memory and server resources before configure it to run automatically.
+        More information:
+        https://www.mssqltips.com/sqlservertip/4935/optimize-sql-server-database-restore-performance/
     #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "", Justification = "For Parameters DestinationCredential and AzureCredential")]

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -393,7 +393,7 @@ function Test-DbaLastBackup {
                 $ogdbname = $dbName
                 $restorelist = Read-DbaBackupHeader -SqlInstance $destserver -Path $lastbackup[0].Path -AzureCredential $AzureCredential
 
-                $totalsize = ($restorelist.BackupSize.Megabyte | Measure-Object -sum ).Sum
+                $totalsize = ($restorelist.BackupSize.Megabyte | Measure-Object -Sum ).Sum
 
                 if ($MaxSize -and $MaxSize -lt $totalsize) {
                     $success = "The backup size for $dbName ($totalsize MB) exceeds the specified maximum size ($MaxSize MB)."
@@ -413,21 +413,21 @@ function Test-DbaLastBackup {
                         $startRestore = Get-Date
                         try {
                             $restoreSplat = @{
-                                SqlInstance = $destserver
+                                SqlInstance                = $destserver
                                 RestoredDatabaseNamePrefix = $prefix
-                                DestinationFilePrefix = $Prefix
-                                DestinationDataDirectory = $datadirectory
-                                DestinationLogDirectory = $logdirectory
-                                IgnoreLogBackup = $IgnoreLogBackup
-                                AzureCredential = $AzureCredential
-                                TrustDbBackupHistory = $true
-                                EnableException = $true
+                                DestinationFilePrefix      = $Prefix
+                                DestinationDataDirectory   = $datadirectory
+                                DestinationLogDirectory    = $logdirectory
+                                IgnoreLogBackup            = $IgnoreLogBackup
+                                AzureCredential            = $AzureCredential
+                                TrustDbBackupHistory       = $true
+                                EnableException            = $true
                             }
 
-                            if(Test-Bound "MaxTransferSize"){
+                            if (Test-Bound "MaxTransferSize") {
                                 $restoreSplat.Add('MaxTransferSize', $MaxTransferSize)
                             }
-                            if(Test-Bound "BufferCount"){
+                            if (Test-Bound "BufferCount") {
                                 $restoreSplat.Add('BufferCount', $BufferCount)
                             }
 

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -403,7 +403,7 @@ function Test-DbaLastBackup {
                         Write-Message -Level Verbose -Message "Performing restore."
                         $startRestore = Get-Date
                         try {
-                            $RestoreSplat = @{
+                            $restoreSplat = @{
                                 SqlInstance = $destserver
                                 RestoredDatabaseNamePrefix = $prefix
                                 DestinationFilePrefix = $Prefix
@@ -423,9 +423,9 @@ function Test-DbaLastBackup {
                             }
 
                             if ($verifyonly) {
-                                $restoreresult = $lastbackup | Restore-DbaDatabase @RestoreSplat -VerifyOnly:$VerifyOnly
+                                $restoreresult = $lastbackup | Restore-DbaDatabase @restoreSplat -VerifyOnly:$VerifyOnly
                             } else {
-                                $restoreresult = $lastbackup | Restore-DbaDatabase @RestoreSplat
+                                $restoreresult = $lastbackup | Restore-DbaDatabase @restoreSplat
                                 Write-Message -Level Verbose -Message " Restore-DbaDatabase -SqlInstance $destserver -RestoredDatabaseNamePrefix $prefix -DestinationFilePrefix $Prefix -DestinationDataDirectory $datadirectory -DestinationLogDirectory $logdirectory -IgnoreLogBackup:$IgnoreLogBackup -AzureCredential $AzureCredential -TrustDbBackupHistory"
                             }
                         } catch {

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -416,10 +416,10 @@ function Test-DbaLastBackup {
                             }
 
                             if(Test-Bound "MaxTransferSize"){
-                                $RestoreSplat.Add('MaxTransferSize', $MaxTransferSize)
+                                $restoreSplat.Add('MaxTransferSize', $MaxTransferSize)
                             }
                             if(Test-Bound "BufferCount"){
-                                $RestoreSplat.Add('BufferCount', $BufferCount)
+                                $restoreSplat.Add('BufferCount', $BufferCount)
                             }
 
                             if ($verifyonly) {

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType', 'MaxTransferSize', 'BufferCount'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
… can give 50% speed improvement on restores

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ X] New feature (non-breaking change, adds functionality, fixes #6694)
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Give a possible speedup for people using Test-DbaLastBackup.

### Approach
<!-- How does this change solve that purpose -->
Test-DbaLastBackup uses Restore-DbaDatabase to do a restore of a database.
Restore-DbaDatabase has two parameters that when used use more memory to restore a database.
Test-DbaLastBackup did not use those parameters. 
I have added those two parameters in a passthrough way in Test-DbaLastBackup.

by adding -MaxTransferSize 4128768 -BufferCount = 100 as parameters to Test-DbaLastBackup i get a 50% higher throughput in my restores ( differs from system to system )

because the parameters are passthrough, i did not add a sanitize section. sanitizing is the job of Restore-DbaDatabase. 

Also did a small section of code cleanup by adding a splat variable.

### Learning
[https://www.mssqltips.com/sqlservertip/4935/optimize-sql-server-database-restore-performance/](url)
