### PR TITLE
Add support to deploy Queue and QueueDatabase tables to Install-DbaMaintenanceSolution #6700

### DIFF
--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -297,8 +297,8 @@ function Install-DbaMaintenanceSolution {
             }
 
             if ((Test-Bound -ParameterName ReplaceExisting -Not)) {
-                $procs = Get-DbaModule -SqlInstance $server -Database $Database | Where-Object Name -in 'CommandExecute', 'DatabaseBackup', 'DatabaseIntegrityCheck', 'IndexOptimize'
-                $table = Get-DbaDbTable -SqlInstance $server -Database $Database -Table @('CommandLog', 'Queue', 'QueueDatabase') -IncludeSystemDBs | Where-Object Database -eq $Database
+                $procs = Get-DbaModule -SqlInstance $server -Database $Database | Where-Object Name -In 'CommandExecute', 'DatabaseBackup', 'DatabaseIntegrityCheck', 'IndexOptimize'
+                $table = Get-DbaDbTable -SqlInstance $server -Database $Database -Table @('CommandLog', 'Queue', 'QueueDatabase') -IncludeSystemDBs | Where-Object Database -EQ $Database
 
                 if ($null -ne $procs -or $null -ne $table) {
                     Stop-Function -Message "The Maintenance Solution already exists in $Database on $instance. Use -ReplaceExisting to automatically drop and recreate."
@@ -369,7 +369,7 @@ function Install-DbaMaintenanceSolution {
                 # Remove Ola's Jobs
                 if ($InstallJobs -and $ReplaceExisting) {
                     Write-ProgressHelper -ExcludePercent -Message "Removing existing SQL Agent Jobs created by Ola's Maintenance Solution"
-                    $jobs = Get-DbaAgentJob -SqlInstance $server | Where-Object Description -match "hallengren"
+                    $jobs = Get-DbaAgentJob -SqlInstance $server | Where-Object Description -Match "hallengren"
                     if ($jobs) {
                         $jobs | ForEach-Object {
                             if ($Pscmdlet.ShouldProcess($instance, "Dropping job $_.name")) {

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -232,7 +232,7 @@ function Install-DbaMaintenanceSolution {
 
         function Get-DbaOlaWithParameters($listOfFiles) {
 
-            [hashtable]$fileContents = [ordered]@{ }
+            $fileContents = [ordered] @{}
             foreach ($file in $listOfFiles) {
                 $fileContents[$file] = Get-Content -Path $file -Raw
             }

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -232,7 +232,7 @@ function Install-DbaMaintenanceSolution {
 
         function Get-DbaOlaWithParameters($listOfFiles) {
 
-            $fileContents = [ordered] @{}
+            $fileContents = [ordered]@{ }
             foreach ($file in $listOfFiles) {
                 $fileContents[$file] = Get-Content -Path $file -Raw
             }
@@ -345,21 +345,21 @@ function Install-DbaMaintenanceSolution {
             $CleanupQuery = $null
             if ($ReplaceExisting) {
                 [string]$CleanupQuery = $("
-                            IF OBJECT_ID('[dbo].[CommandLog]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[CommandLog];
-                            IF OBJECT_ID('[dbo].[QueueDatabase]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[QueueDatabase];
-                            IF OBJECT_ID('[dbo].[Queue]', 'U') IS NOT NULL
-                                DROP TABLE [dbo].[Queue];
-                            IF OBJECT_ID('[dbo].[CommandExecute]', 'P') IS NOT NULL
-                                DROP PROCEDURE [dbo].[CommandExecute];
-                            IF OBJECT_ID('[dbo].[DatabaseBackup]', 'P') IS NOT NULL
-                                DROP PROCEDURE [dbo].[DatabaseBackup];
-                            IF OBJECT_ID('[dbo].[DatabaseIntegrityCheck]', 'P') IS NOT NULL
-                                DROP PROCEDURE [dbo].[DatabaseIntegrityCheck];
-                            IF OBJECT_ID('[dbo].[IndexOptimize]', 'P') IS NOT NULL
-                                DROP PROCEDURE [dbo].[IndexOptimize];
-                            ")
+                    IF OBJECT_ID('[dbo].[CommandLog]', 'U') IS NOT NULL
+                        DROP TABLE [dbo].[CommandLog];
+                    IF OBJECT_ID('[dbo].[QueueDatabase]', 'U') IS NOT NULL
+                        DROP TABLE [dbo].[QueueDatabase];
+                    IF OBJECT_ID('[dbo].[Queue]', 'U') IS NOT NULL
+                        DROP TABLE [dbo].[Queue];
+                    IF OBJECT_ID('[dbo].[CommandExecute]', 'P') IS NOT NULL
+                        DROP PROCEDURE [dbo].[CommandExecute];
+                    IF OBJECT_ID('[dbo].[DatabaseBackup]', 'P') IS NOT NULL
+                        DROP PROCEDURE [dbo].[DatabaseBackup];
+                    IF OBJECT_ID('[dbo].[DatabaseIntegrityCheck]', 'P') IS NOT NULL
+                        DROP PROCEDURE [dbo].[DatabaseIntegrityCheck];
+                    IF OBJECT_ID('[dbo].[IndexOptimize]', 'P') IS NOT NULL
+                        DROP PROCEDURE [dbo].[IndexOptimize];
+                    ")
 
                 if ($Pscmdlet.ShouldProcess($instance, "Dropping all objects created by Ola's Maintenance Solution")) {
                     Write-ProgressHelper -ExcludePercent -Message "Dropping objects created by Ola's Maintenance Solution"

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -232,7 +232,7 @@ function Install-DbaMaintenanceSolution {
 
         function Get-DbaOlaWithParameters($listOfFiles) {
 
-            $fileContents = @{ }
+            [hashtable]$fileContents = [ordered]@{ }
             foreach ($file in $listOfFiles) {
                 $fileContents[$file] = Get-Content -Path $file -Raw
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (effects multiple commands or functionality, fixes #6700  )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add support to deploy Queue and QueueDatabase tables to Install-DbaMaintenanceSolution.

### Approach
Added necessary references to the Queue.sql and QueueDatabase.sql files already contained within the zip file downloaded.  By the same token, made the installation of the CommandLog table required as well.  It does not make sense to conditionally install a table that is used by the core of the components.

### Commands to test
Install-DbaMaintenanceSolution