### PR TITLE
Get-DbaAgentJob unexcepted behavior if JobSteps.DatabaseName is array

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
 	"[powershell]": {
 		"editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?"
     },
-    "powershell.scriptAnalysis.settingsPath": "bin\\PSScriptAnalyzerRules.psd1"
+    "powershell.scriptAnalysis.settingsPath": "bin\\PSScriptAnalyzerRules.psd1",
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true
 }

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -79,10 +79,16 @@ function Get-DbaAgentJob {
         PS C:\> $servers | Get-DbaAgentJob | Out-GridView -PassThru | Start-DbaAgentJob -WhatIf
 
         Find all of your Jobs from SQL Server instances in the $servers collection, select the jobs you want to start then see jobs would start if you ran Start-DbaAgentJob
+
     .EXAMPLE
-       PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a | Where-Object Category -eq "Report Server" | Export-DbaScript -Path "C:\temp\sqlserver2014a_SSRSJobs.sql"
+        PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a | Where-Object Category -eq "Report Server" | Export-DbaScript -Path "C:\temp\sqlserver2014a_SSRSJobs.sql"
 
         Exports all SSRS jobs from SQL instance sqlserver2014a to a file.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJob -SqlInstance sqlserver2014a -Database msdb
+
+        Finds all jobs on sqlserver2014a that T-SQL job steps associated with msdb database
     #>
     [CmdletBinding()]
     param (
@@ -119,9 +125,7 @@ function Get-DbaAgentJob {
                 $jobs = $Jobs | Where-Object IsEnabled -eq $true
             }
             if ($Database) {
-                $jobs = $jobs | Where-Object {
-                    $_.JobSteps.DatabaseName | Where-Object { [string]$_ -in $Database }
-                }
+                $jobs = $jobs | Where-Object { $_.JobSteps.DatabaseName -contains $Database }
             }
             if ($Category) {
                 $jobs = $jobs | Where-Object Category -in $Category

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -125,7 +125,7 @@ function Get-DbaAgentJob {
                 $jobs = $Jobs | Where-Object IsEnabled -eq $true
             }
             if ($Database) {
-                $jobs = $jobs | Where-Object { $_.JobSteps.DatabaseName -contains $Database }
+                $jobs = $jobs | Where-Object { $_.JobSteps | Where-Object DatabaseName -in $Database }
             }
             if ($Category) {
                 $jobs = $jobs | Where-Object Category -in $Category

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -120,7 +120,7 @@ function Get-DbaAgentJob {
             }
             if ($Database) {
                 $jobs = $jobs | Where-Object {
-                    $_.JobSteps.DatabaseName -in $Database
+                    $_.JobSteps.DatabaseName | Where-Object { [string]$_ -in $Database }
                 }
             }
             if ($Category) {

--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -75,40 +75,37 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results.name -contains "dbatoolsci_testjob_cat2" | Should Be $False
         }
     }
-    Context "Command gets jobs with specified database" {
+    Context "Command gets jobs when databases are specified" {
         BeforeAll {
-            $jobName = "dbatoolsci_dbfilter_(Get-Random)"
-            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName -Disabled
-            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
-            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-y" -Subsystem TransactSql -Database "tempdb"
-            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
+            $jobName1 = "dbatoolsci_dbfilter_$(Get-Random)"
+            $jobName2 = "dbatoolsci_dbfilter_$(Get-Random)"
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName1 -Disabled
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName1 -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName1 -StepName "TSQL-y" -Subsystem TransactSql -Database "tempdb"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName1 -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
+
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName2 -Disabled
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName2 -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName2 -StepName "TSQL-y" -Subsystem TransactSql -Database "model"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName2 -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
         }
         AfterAll {
-            $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName
+            $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName1, $jobName2
         }
-        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb
-        It "Returns results" {
-            $results.Count | Should -BeGreaterOrEqual 1
+        $resultSingleDatabase = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb
+        It "Returns result with single database" {
+            $resultSingleDatabase.Count | Should -BeGreaterOrEqual 1
         }
-        It "Should return job for Database: tempdb" {
-            $results.name -contains $jobName | Should -BeTrue
+        It "Returns job result for Database: tempdb" {
+            $resultSingleDatabase.name -contains $jobName1 | Should -BeTrue
+        }
+
+        $resultMultipleDatabases = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb, model
+        It "Returns both jobs with double database" {
+            $resultMultipleDatabases.Count | Should -BeGreaterOrEqual 2
+        }
+        It "Includes job result for Database: model" {
+            $resultMultipleDatabases.name -contains $jobName2 | Should -BeTrue
         }
     }
-}            $jobName = "dbatoolsci_dbfilter_(Get-Random)"
-$null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName -Disabled
-$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
-$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-y" -Subsystem TransactSql -Database "tempdb"
-$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
-}
-AfterAll {
-    $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName
-}
-$results = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb
-It "Returns results" {
-    $results.Count | Should -BeGreaterOrEqual 1
-}
-It "Should return job for Database: tempdb" {
-    $results.name -contains $jobName | Should -BeTrue
-}
-}
 }

--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -4,11 +4,10 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'Database', 'Category', 'ExcludeDisabledJobs', 'EnableException', 'ExcludeCategory'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
     }
 }
@@ -22,7 +21,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         AfterAll {
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob, dbatoolsci_testjob_disabled
         }
-        $results = Get-DbaAgentJob -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentJob -SqlInstance $script:instance2 | Where-Object { $_.Name -match "dbatoolsci" }
         It "Should get 2 dbatoolsci jobs" {
             $results.count | Should Be 2
         }
@@ -40,7 +39,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         AfterAll {
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob, dbatoolsci_testjob_disabled
         }
-        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeDisabledJobs | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeDisabledJobs | Where-Object { $_.Name -match "dbatoolsci" }
         It "Should return only enabled jobs" {
             $results.enabled -contains $False | Should Be $False
         }
@@ -53,7 +52,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         AfterAll {
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob, dbatoolsci_testjob_disabled
         }
-        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeJob dbatoolsci_testjob  | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeJob dbatoolsci_testjob | Where-Object { $_.Name -match "dbatoolsci" }
         It "Should not return excluded job" {
             $results.name -contains "dbatoolsci_testjob" | Should Be $False
         }
@@ -71,9 +70,45 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob_cat1, dbatoolsci_testjob_cat2
         }
-        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeCategory 'Cat2'  | Where-Object {$_.Name -match "dbatoolsci"}
+        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -ExcludeCategory 'Cat2' | Where-Object { $_.Name -match "dbatoolsci" }
         It "Should not return excluded job" {
             $results.name -contains "dbatoolsci_testjob_cat2" | Should Be $False
         }
     }
+    Context "Command gets jobs with specified database" {
+        BeforeAll {
+            $jobName = "dbatoolsci_dbfilter_(Get-Random)"
+            $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName -Disabled
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-y" -Subsystem TransactSql -Database "tempdb"
+            $null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
+        }
+        AfterAll {
+            $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName
+        }
+        $results = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb
+        It "Returns results" {
+            $results.Count | Should -BeGreaterOrEqual 1
+        }
+        It "Should return job for Database: tempdb" {
+            $results.name -contains $jobName | Should -BeTrue
+        }
+    }
+}            $jobName = "dbatoolsci_dbfilter_(Get-Random)"
+$null = New-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName -Disabled
+$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-x" -Subsystem TransactSql -Database "msdb"
+$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-y" -Subsystem TransactSql -Database "tempdb"
+$null = New-DbaAgentJobStep -SqlInstance $script:instance2 -Job $jobName -StepName "TSQL-z" -Subsystem TransactSql -Database "master"
+}
+AfterAll {
+    $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job $jobName
+}
+$results = Get-DbaAgentJob -SqlInstance $script:instance2 -Database tempdb
+It "Returns results" {
+    $results.Count | Should -BeGreaterOrEqual 1
+}
+It "Should return job for Database: tempdb" {
+    $results.name -contains $jobName | Should -BeTrue
+}
+}
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6699 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
https://github.com/sqlcollaborative/dbatools/issues/6699
### Approach
<!-- How does this change solve that purpose -->
Fix unexcepted behavior with JobSteps.DatabaseName which can be array of object if a job has 2 or more steps.
### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
