### PR TITLE
Fix for Copy-DbaLogin to not overwrite files and include ObjectLevel permissions if specified

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -380,15 +380,13 @@ function Copy-DbaLogin {
         } else {
             $loginsCollection += Get-DbaLogin -SqlInstance $Source -SqlCredential $SourceSqlCredential -Login $Login -EnableException:$EnableException
         }
-        foreach ($loginObject in $loginsCollection) {
-            $sourceServer = $loginObject[0].Parent
-            $sourceLoginName = $loginObject.Name
-            $sourceVersionMajor = $sourceServer.VersionMajor
 
-            if ($OutFile) {
-                Export-DbaLogin -SqlInstance $sourceServer -FilePath $OutFile -Login $sourceLoginName -ExcludeLogin $ExcludeLogin
-                continue
-            }
+        if ($OutFile) {
+            return (Export-DbaLogin -SqlInstance $Source -SqlCredential $SourceSqlCredential -FilePath $OutFile -Login $loginsCollection -ObjectLevel:$ObjectLevel -ExcludeLogin $ExcludeLogin -EnableException:$EnableException)
+        }
+        foreach ($loginObject in $loginsCollection) {
+            $sourceServer = $loginObject.Parent
+            $sourceVersionMajor = $sourceServer.VersionMajor
 
             foreach ($destinstance in $Destination) {
                 try {

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -80,6 +80,9 @@ function Export-DbaLogin {
         -- UTF8: Encodes in UTF-8 format.
         -- Unknown: The encoding type is unknown or invalid. The data can be treated as binary.
 
+    .PARAMETER ObjectLevel
+        Include object-level permissions for each user associated with copied login.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -468,9 +468,20 @@ function Export-DbaLogin {
                             $scriptOptions.ContinueScriptingOnError = $false
                             $scriptOptions.IncludeDatabaseContext = $false
                             $scriptOptions.IncludeIfNotExists = $true
-                            # BatchSeparator
+
+                            $exportSplat = @{
+                                SqlInstance            = $server
+                                Database               = $dbName
+                                User                   = $dbUsername
+                                ScriptingOptionsObject = $scriptOptions
+                            }
+                            # remove batch separator if the $BatchSeparator string is empty
+                            if (-Not $BatchSeparator) {
+                                $scriptOptions.NoCommandTerminator = $true
+                                $exportSplat.ExcludeGoBatchSeparator = $true
+                            }
                             try {
-                                $userScript = Export-DbaUser -SqlInstance $server -Database $dbName -User $dbUsername -Passthru -ScriptingOptionsObject $scriptOptions -EnableException
+                                $userScript = Export-DbaUser @exportSplat -Passthru -EnableException
                                 $outsql += $userScript
                             } catch {
                                 Stop-Function -Message "Failed to extract permissions for user $dbUserName in database $dbName" -Continue -ErrorRecord $_

--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -470,11 +470,10 @@ function Export-DbaLogin {
                             $scriptOptions.IncludeIfNotExists = $true
                             # BatchSeparator
                             try {
-                                $userScript = Export-DbaUser -SqlInstance $server -Database $dbName -User $dbUsername -Passthru -ScriptingOptionsObject $scriptOptions -EnableException:$EnableException
-                                write-host $userScript
+                                $userScript = Export-DbaUser -SqlInstance $server -Database $dbName -User $dbUsername -Passthru -ScriptingOptionsObject $scriptOptions -EnableException
                                 $outsql += $userScript
                             } catch {
-                                Write-Message -Level Warning -Message "Failed to extract permissions for user $dbUserName"
+                                Stop-Function -Message "Failed to extract permissions for user $dbUserName in database $dbName" -Continue -ErrorRecord $_
                             }
                         } else {
                             try {

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -149,10 +149,16 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "Supports db object permissions" {
+        BeforeAll {
+            $tempExportFile = [System.IO.Path]::GetTempFileName()
+        }
         BeforeEach {
             'tester', 'tester_new' | ForEach-Object {
                 Initialize-TestLogin -Instance $script:instance2 -Login $_
             }
+        }
+        AfterAll {
+            Remove-Item -Path $tempExportFile -Force
         }
         It "clones the one tester login with sysadmin permissions" {
             $results = Copy-DbaLogin -Source $script:instance1 -Login tester -Destination $script:instance2 -LoginRenameHashtable @{ tester = 'tester_new' }
@@ -173,6 +179,16 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $login | Should -Not -BeNullOrEmpty
             $permissions = Export-DbaUser -SqlInstance $script:instance2 -Database tempdb -User tester_new -Passthru
             $permissions | Should -BeLike '*GRANT INSERT ON OBJECT::`[dbo`].`[tester_table`] TO `[tester_new`]*'
+        }
+        It "scripts out two tester login with object permissions" {
+            $results = Copy-DbaLogin -Source $script:instance1 -Login tester, port -OutFile $tempExportFile -ObjectLevel
+            $results | Should -Be $tempExportFile
+            $permissions = Get-Content $tempExportFile -Raw
+            $permissions | Should -BeLike '*CREATE LOGIN `[tester`]*'
+            $permissions | Should -BeLike '*ALTER SERVER ROLE `[sysadmin`] ADD MEMBER `[tester`]*'
+            $permissions | Should -BeLike '*GRANT INSERT ON OBJECT::`[dbo`].`[tester_table`] TO `[tester`]*'
+            $permissions | Should -BeLike '*CREATE LOGIN `[port`]*'
+            $permissions | Should -BeLike '*GRANT CONNECT SQL TO `[port`]*'
         }
     }
 }

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -185,7 +185,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results | Should -Be $tempExportFile
             $permissions = Get-Content $tempExportFile -Raw
             $permissions | Should -BeLike '*CREATE LOGIN `[tester`]*'
-            $permissions | Should -BeLike '*ALTER SERVER ROLE `[sysadmin`] ADD MEMBER `[tester`]*'
+            $permissions | Should -Match "(ALTER SERVER ROLE \[sysadmin\] ADD MEMBER \[tester\]|EXEC sys.sp_addsrvrolemember @rolename=N'sysadmin', @loginame=N'tester')"
             $permissions | Should -BeLike '*GRANT INSERT ON OBJECT::`[dbo`].`[tester_table`] TO `[tester`]*'
             $permissions | Should -BeLike '*CREATE LOGIN `[port`]*'
             $permissions | Should -BeLike '*GRANT CONNECT SQL TO `[port`]*'

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -17,49 +17,45 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $DefaultExportPath = Get-DbatoolsConfigValue -FullName path.dbatoolsexport
         $AltExportPath = "$env:USERPROFILE\Documents"
-        try {
-            $random = Get-Random
-            $dbname1 = "dbatoolsci_exportdbalogin1$random"
-            $login1 = "dbatoolsci_exportdbalogin_login1$random"
-            $user1 = "dbatoolsci_exportdbalogin_user1$random"
+        $random = Get-Random
+        $dbname1 = "dbatoolsci_exportdbalogin1$random"
+        $login1 = "dbatoolsci_exportdbalogin_login1$random"
+        $user1 = "dbatoolsci_exportdbalogin_user1$random"
 
-            $dbname2 = "dbatoolsci_exportdbalogin2$random"
-            $login2 = "dbatoolsci_exportdbalogin_login2$random"
-            $user2 = "dbatoolsci_exportdbalogin_user2$random"
+        $dbname2 = "dbatoolsci_exportdbalogin2$random"
+        $login2 = "dbatoolsci_exportdbalogin_login2$random"
+        $user2 = "dbatoolsci_exportdbalogin_user2$random"
 
-            $server = Connect-DbaInstance -SqlInstance $script:instance2
-            $null = $server.Query("CREATE DATABASE [$dbname1]")
-            $null = $server.Query("CREATE LOGIN [$login1] WITH PASSWORD = 'GoodPass1234!'")
-            $server.Databases[$dbname1].ExecuteNonQuery("CREATE USER [$user1] FOR LOGIN [$login1]")
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = $server.Query("CREATE DATABASE [$dbname1]")
+        $null = $server.Query("CREATE LOGIN [$login1] WITH PASSWORD = 'GoodPass1234!'")
+        $server.Databases[$dbname1].ExecuteNonQuery("CREATE USER [$user1] FOR LOGIN [$login1]")
 
-            $null = $server.Query("CREATE DATABASE [$dbname2]")
-            $null = $server.Query("CREATE LOGIN [$login2] WITH PASSWORD = 'GoodPass1234!'")
-            $null = $server.Query("ALTER LOGIN [$login2] DISABLE")
-            $null = $server.Query("DENY CONNECT SQL TO [$login2]")
+        $null = $server.Query("CREATE DATABASE [$dbname2]")
+        $null = $server.Query("CREATE LOGIN [$login2] WITH PASSWORD = 'GoodPass1234!'")
+        $null = $server.Query("ALTER LOGIN [$login2] DISABLE")
+        $null = $server.Query("DENY CONNECT SQL TO [$login2]")
 
-            if ($server.VersionMajor -lt 11) {
-                $null = $server.Query("EXEC sys.sp_addsrvrolemember @rolename=N'dbcreator', @loginame=N'$login2'")
-            } else {
-                $null = $server.Query("ALTER SERVER ROLE [dbcreator] ADD MEMBER [$login2]")
-            }
-            $null = $server.Query("GRANT SELECT ON sys.databases TO [$login2] WITH GRANT OPTION")
-            $server.Databases[$dbname2].ExecuteNonQuery("CREATE USER [$user2] FOR LOGIN [$login2]")
-            $server.Databases[$dbname2].ExecuteNonQuery("GRANT SELECT ON sys.tables TO [$user2] WITH GRANT OPTION")
-        } catch {
-            $_
+        if ($server.VersionMajor -lt 11) {
+            $null = $server.Query("EXEC sys.sp_addsrvrolemember @rolename=N'dbcreator', @loginame=N'$login2'")
+        } else {
+            $null = $server.Query("ALTER SERVER ROLE [dbcreator] ADD MEMBER [$login2]")
         }
+        $server.Databases[$dbname2].ExecuteNonQuery("CREATE USER [$user2] FOR LOGIN [$login2]")
+        $server.Databases[$dbname2].ExecuteNonQuery("GRANT SELECT ON sys.tables TO [$user2] WITH GRANT OPTION")
+
     }
     AfterAll {
-        try {
-            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -Confirm:$false
-            Remove-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -Confirm:$false
+        Remove-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Confirm:$false
 
-            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname2 -Confirm:$false
-            Remove-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Confirm:$false
-        } catch { }
+        Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname2 -Confirm:$false
+        Remove-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Confirm:$false
         $timenow = (Get-Date -uformat "%m%d%Y%H")
         $ExportedCredential = Get-ChildItem $DefaultExportPath, $AltExportPath | Where-Object { $_.Name -match "$timenow\d{4}-login.sql|Dbatoolsci_login_CustomFile.sql" }
-        $null = Remove-Item -Path $($ExportedCredential.FullName) -ErrorAction SilentlyContinue
+        if ($ExportedCredential) {
+            $null = Remove-Item -Path $($ExportedCredential.FullName) -ErrorAction SilentlyContinue
+        }
     }
 
     Context "Executes with Exclude Parameters" {
@@ -104,9 +100,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         It "Should Export with object level permissions" {
             $results = Export-DbaLogin -SqlInstance $script:instance2 -Login $login2 -ObjectLevel -PassThru -WarningAction SilentlyContinue
-            $results | Should Match "$login2|$dbname2"
             $results | Should Not Match "$login1|$dbname1"
-            $results | Should Match "GRANT SELECT ON \[sys\]\.\[tables\] .*$login2.* WITH GRANT OPTION"
+            $results | Should Match "GRANT SELECT ON OBJECT::\[sys\]\.\[tables\] TO \[$user2\] WITH GRANT OPTION"
+            $results | Should Match "CREATE USER \[$user2\] FOR LOGIN \[$login2\]"
+            $results | Should Match "IF NOT EXISTS"
+            $results | Should Match "USE \[$dbname2\]"
         }
         foreach ($version in $((Get-Command $CommandName).Parameters.DestinationVersion.attributes.validvalues)) {
             It "Should Export for the SQLVersion $version" {

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'Login', 'ExcludeLogin', 'Database', 'ExcludeJobs', 'ExcludeDatabase', 'ExcludePassword', 'DefaultDatabase', 'Path', 'FilePath', 'Encoding', 'NoClobber', 'Append', 'BatchSeparator', 'DestinationVersion', 'NoPrefix', 'Passthru', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'Login', 'ExcludeLogin', 'Database', 'ExcludeJobs', 'ExcludeDatabase', 'ExcludePassword', 'DefaultDatabase', 'Path', 'FilePath', 'Encoding', 'NoClobber', 'Append', 'BatchSeparator', 'DestinationVersion', 'NoPrefix', 'Passthru', 'ObjectLevel', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -44,6 +44,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
             $null = $server.Query("GRANT SELECT ON sys.databases TO [$login2] WITH GRANT OPTION")
             $server.Databases[$dbname2].ExecuteNonQuery("CREATE USER [$user2] FOR LOGIN [$login2]")
+            $server.Databases[$dbname2].ExecuteNonQuery("GRANT SELECT ON sys.tables TO [$user2] WITH GRANT OPTION")
         } catch {
             $_
         }
@@ -75,7 +76,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results | Should Not Match 'Job'
         }
         It "Should exclude Go when exporting" {
-            $file = Export-DbaLogin -SqlInstance $script:instance2 -ExcludeDatabase -BatchSeparator '' -WarningAction SilentlyContinue
+            $file = Export-DbaLogin -SqlInstance $script:instance2 -ExcludeDatabase -BatchSeparator '' -ObjectLevel -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
             $results | Should Not Match 'Go'
@@ -100,6 +101,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $allfiles += $file.FullName
             $results | Should Not Match "$login2|$dbname2"
             $results | Should Match "$login1|$dbname1"
+        }
+        It "Should Export with object level permissions" {
+            $results = Export-DbaLogin -SqlInstance $script:instance2 -Login $login2 -ObjectLevel -PassThru -WarningAction SilentlyContinue
+            $results | Should Match "$login2|$dbname2"
+            $results | Should Not Match "$login1|$dbname1"
+            $results | Should Match "GRANT SELECT ON \[sys\]\.\[tables\] .*$login2.* WITH GRANT OPTION"
         }
         foreach ($version in $((Get-Command $CommandName).Parameters.DestinationVersion.attributes.validvalues)) {
             It "Should Export for the SQLVersion $version" {

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -72,10 +72,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results | Should Not Match 'Job'
         }
         It "Should exclude Go when exporting" {
-            $file = Export-DbaLogin -SqlInstance $script:instance2 -ExcludeDatabase -BatchSeparator '' -ObjectLevel -WarningAction SilentlyContinue
+            $file = Export-DbaLogin -SqlInstance $script:instance2 -BatchSeparator '' -ObjectLevel -WarningAction SilentlyContinue
             $results = Get-Content -Path $file -Raw
             $allfiles += $file.FullName
-            $results | Should Not Match 'Go'
+            $results | Should Not Match 'GO'
+            $results | Should Match "GRANT SELECT ON OBJECT::\[sys\]\.\[tables\] TO \[$user2\] WITH GRANT OPTION"
+            $results | Should Match "CREATE USER \[$user2\] FOR LOGIN \[$login2\]"
+            $results | Should Match "IF NOT EXISTS"
+            $results | Should Match "USE \[$dbname2\]"
         }
         It "Should exclude a specific login" {
             $file = Export-DbaLogin -SqlInstance $script:instance2 -ExcludeLogin $login1 -WarningAction SilentlyContinue


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6666 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix the bug introduced with login cloning feature
Make the function to support Object-level export to file, since switch exists

### Approach
Moving export out of the foreach loop.
Adding ObjectLevel support for Export-DbaLogin, which generates the file output
Using pre-defined scripting options to export user permissions

### Learning
`-BatchSeparator` parameter in this function should've been a switch `-NoBatchSeparator`, since any batch separator other than GO is not supported by SMO scripting. We can introduce that switch (I can add it to the PR) and prepare for BatchSeparator decommission without breaking backwards compatibility, and delaying the inevitable breaking change.
