### PR TITLE
Revert "moved Tables.Refresh() to Get-DbaDbTable"

### DIFF
--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -301,10 +301,8 @@ function Copy-DbaDbViewData {
                         $tempTableName = "$($sqlview.Name)_table"
                         $createquery = "SELECT * INTO tempdb..$tempTableName FROM [$($sqlview.Schema)].[$($sqlview.Name)] WHERE 1=2"
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $createquery -EnableException
-                        if ($sqlview.Table -eq 'tempdb') {
-                            #refreshing table list to make sure get-dbadbtable will find the new table
-                            $server.Databases['tempdb'].Tables.Refresh($true)
-                        }
+                        #refreshing table list to make sure get-dbadbtable will find the new table
+                        $server.Databases['tempdb'].Tables.Refresh($true)
                         $tempTable = Get-DbaDbTable -SqlInstance $server -Database tempdb -Table $tempTableName
                         $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -417,7 +417,7 @@ function Copy-DbaDbViewData {
                             RowsCopied          = $rowstotal
                             Elapsed             = [prettytimespan]$elapsed.Elapsed
                         }
-                    }                   }
+                    }
                 } catch {
                     Stop-Function -Message "Something went wrong" -ErrorRecord $_ -Target $server -continue
                 }

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -301,6 +301,10 @@ function Copy-DbaDbViewData {
                         $tempTableName = "$($sqlview.Name)_table"
                         $createquery = "SELECT * INTO tempdb..$tempTableName FROM [$($sqlview.Schema)].[$($sqlview.Name)] WHERE 1=2"
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $createquery -EnableException
+                        if ($sqlview.Table -eq 'tempdb') {
+                            #refreshing table list to make sure get-dbadbtable will find the new table
+                            $server.Databases['tempdb'].Tables.Refresh($true)
+                        }
                         $tempTable = Get-DbaDbTable -SqlInstance $server -Database tempdb -Table $tempTableName
                         $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
                         Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
@@ -413,7 +417,7 @@ function Copy-DbaDbViewData {
                             RowsCopied          = $rowstotal
                             Elapsed             = [prettytimespan]$elapsed.Elapsed
                         }
-                    }
+                    }                   }
                 } catch {
                     Stop-Function -Message "Something went wrong" -ErrorRecord $_ -Target $server -continue
                 }

--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -148,7 +148,9 @@ function Export-DbaScript {
     )
     begin {
         $null = Test-ExportDirectory -Path $Path
-        $executingUser = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+        if ($IsWindows -ne $false) {
+            $executingUser = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+        } else { $executingUser = $env:USER }
         $commandName = $MyInvocation.MyCommand.Name
         $prefixArray = @()
 

--- a/functions/Get-DbaDbTable.ps1
+++ b/functions/Get-DbaDbTable.ps1
@@ -132,7 +132,6 @@ function Get-DbaDbTable {
             $server = $db.Parent
             Write-Message -Level Verbose -Message "Processing $db"
 
-            $db.Tables.Refresh($true) # This will ensure the list of tables is up-to-date
             if ($fqtns) {
                 $tables = @()
                 foreach ($fqtn in $fqtns) {

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -15,8 +15,35 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
+        function Remove-TempObjects {
+            param ($dbs)
+            function Remove-TempObject {
+                param ($db, $object)
+                $db.Query("DECLARE @obj int = OBJECT_ID('$object'); IF @obj IS NOT NULL
+                BEGIN
+                    IF (SELECT type_desc FROM sys.objects WHERE object_id = @obj) = 'VIEW' DROP VIEW $object
+                    ELSE DROP TABLE $object
+                END")
+            }
+            foreach ($d in $dbs) {
+                Remove-TempObject $d dbo.dbatoolsci_example
+                Remove-TempObject $d dbo.dbatoolsci_example2
+                Remove-TempObject $d dbo.dbatoolsci_example3
+                Remove-TempObject $d dbo.dbatoolsci_example4
+                Remove-TempObject $d dbo.dbatoolsci_view_example
+                Remove-TempObject $d dbo.dbatoolsci_view_example2
+                Remove-TempObject $d dbo.dbatoolsci_view_example3
+                Remove-TempObject $d dbo.dbatoolsci_view_example4
+                Remove-TempObject $d dbo.dbatoolsci_view_will_exist
+                Remove-TempObject $d dbo.dbatoolsci_view_example_table
+                Remove-TempObject $d dbo.dbatoolsci_view_example2_table
+                Remove-TempObject $d dbo.dbatoolsci_view_example3_table
+                Remove-TempObject $d dbo.dbatoolsci_view_example4_table
+            }
+        }
         $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database tempdb
         $db2 = Get-DbaDatabase -SqlInstance $script:instance2 -Database tempdb
+        Remove-TempObjects $db, $db2
         $null = $db.Query("CREATE TABLE dbo.dbatoolsci_example (id int);
             INSERT dbo.dbatoolsci_example
             SELECT top 10 1
@@ -39,22 +66,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             FROM sys.objects")
     }
     AfterAll {
-        try {
-            $null = $db.Query("DROP TABLE dbo.dbatoolsci_example")
-            $null = $db.Query("DROP TABLE dbo.dbatoolsci_example2")
-            $null = $db.Query("DROP TABLE dbo.dbatoolsci_example3")
-            $null = $db.Query("DROP TABLE dbo.dbatoolsci_example4")
-            $null = $db.Query("DROP VIEW dbo.dbatoolsci_view_example")
-            $null = $db.Query("DROP VIEW dbo.dbatoolsci_view_example2")
-            $null = $db.Query("DROP VIEW dbo.dbatoolsci_view_example3")
-            $null = $db.Query("DROP VIEW dbo.dbatoolsci_view_example4")
-            $null = $db2.Query("DROP TABLE dbo.dbatoolsci_view_example3")
-            $null = $db2.Query("DROP TABLE dbo.dbatoolsci_view_example4")
-            $null = $db2.Query("DROP TABLE dbo.dbatoolsci_view_example")
-            $null = $db.Query("DROP TABLE dbo.dbatoolsci_view_will_exist")
-        } catch {
-            $null = 1
-        }
+        Remove-TempObjects $db, $db2
     }
 
     It "copies the table data" {

--- a/tests/Invoke-DbaDbClone.Tests.ps1
+++ b/tests/Invoke-DbaDbClone.Tests.ps1
@@ -14,11 +14,12 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
-    $dbname = "dbatoolsci_clonetest"
-    $clonedb = "dbatoolsci_clonetest_CLONE"
-    $clonedb2 = "dbatoolsci_clonetest_CLONE2"
     Context "Command functions as expected" {
         BeforeAll {
+            $dbname = "dbatoolsci_clonetest"
+            $clonedb = "dbatoolsci_clonetest_CLONE"
+            $clonedb2 = "dbatoolsci_clonetest_CLONE2"
+
             $server = Connect-DbaInstance -SqlInstance $script:instance2
             $server.Query("CREATE DATABASE $dbname")
         }


### PR DESCRIPTION
This reverts commit fec9f06b0eb655491668db966529061d9cae4479.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6646 fixes #6722 🤞  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
We shouldn't force users to perform an expensive operation

### Approach
Move the refresh back to where it belongs

