### PR TITLE
Improve data masking with separator functionality

### DIFF
--- a/functions/Get-DbaRandomizedValue.ps1
+++ b/functions/Get-DbaRandomizedValue.ps1
@@ -38,6 +38,9 @@ function Get-DbaRandomizedValue {
     .PARAMETER Symbol
         Use a symbol in front of the value i.e. $100,12
 
+    .PARAMETER Separator
+        Some masking types support separators
+
     .PARAMETER Value
         This is the value that needs to be used for several possible transformations.
         One example is the subtype "Shuffling" where the value will be shuffled.
@@ -104,6 +107,7 @@ function Get-DbaRandomizedValue {
         [string]$CharacterString = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
         [string]$Format,
         [string]$Symbol,
+        [string]$Separator,
         [string]$Value,
         [string]$Locale = 'en',
         [switch]$EnableException
@@ -418,6 +422,31 @@ function Get-DbaRandomizedValue {
                 'internet' {
                     if ($randSubType -eq 'password') {
                         $script:faker.Internet.Password($Max)
+                    } elseif ($randSubType -eq 'mac') {
+                        if ($Separator) {
+                            $script:faker.Internet.Mac($Separator)
+                        } else {
+                            if (-not $Format -or $Format -eq "##:##:##:##:##:##") {
+                                $script:faker.Internet.Mac()
+                            } elseif ($Format -eq "############") {
+                                $script:faker.Internet.Mac("")
+                            } else {
+                                $newMacArray = $Format.ToCharArray()
+
+                                $macAddress = $script:faker.Internet.Mac("")
+                                $macArray = $macAddress.ToCharArray()
+
+                                $macIndex = 0
+                                for ($i = 0; $i -lt $formatArray.Count; $i++) {
+                                    if ($newMacArray[$i] -eq "#") {
+                                        $newMacArray[$i] = $macArray[$macIndex]
+                                        $macIndex++
+                                    }
+                                }
+
+                                $newMacArray -join ""
+                            }
+                        }
                     } else {
                         $script:faker.Internet.$RandomizerSubType()
                     }

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -497,6 +497,7 @@ function New-DbaDbMaskingConfig {
                             MaskingType     = $result.MaskingType
                             SubType         = $result.MaskingSubType
                             Format          = $null
+                            Separator       = $null
                             Deterministic   = $false
                             Nullable        = $columnobject.Nullable
                             KeepNull        = $true

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -562,6 +562,7 @@ function New-DbaDbMaskingConfig {
                             MaskingType     = $type
                             SubType         = $subType
                             Format          = $null
+                            Separator       = $null
                             Deterministic   = $false
                             Nullable        = $columnobject.Nullable
                             KeepNull        = $true

--- a/tests/Get-DbaRandomizedValue.Tests.ps1
+++ b/tests/Get-DbaRandomizedValue.Tests.ps1
@@ -4,11 +4,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
         [object[]]$knownParameters = 'DataType', 'RandomizerType', 'RandomizerSubType', 'Min', 'Max', 'Precision', 'CharacterString', 'Format', 'Separator', 'Symbol', 'Locale', 'Value', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Get-DbaRandomizedValue.Tests.ps1
+++ b/tests/Get-DbaRandomizedValue.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'DataType', 'RandomizerType', 'RandomizerSubType', 'Min', 'Max', 'Precision', 'CharacterString', 'Format', 'Symbol', 'Locale', 'Value', 'EnableException'
+        [object[]]$knownParameters = 'DataType', 'RandomizerType', 'RandomizerSubType', 'Min', 'Max', 'Precision', 'CharacterString', 'Format', 'Separator', 'Symbol', 'Locale', 'Value', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The MAC addresses can only be generated with a different separator. For MAC addresses there are different formats that people may have to use

Normal formats are
- 112233445566
- 11:22:33:44:55:66
- 11-22-33-44-55-66
- 1122.3344.5566

The changes made make it possible for a user to either use the `Separator` or the `Format` property for a MAC address.
If both are set, the `Separator` property has priority over the `Format` property.

### Approach
The Bogus dll has a constructor for the MAC address which has the ability to set a separator. This can be anything from an empty string resulting in something like this `b034d076d683` or with a "-" in `13-3b-38-76-b9-79`

The second and third option for a MAC address can easily be set this way. The first and fourth option are more complicated.
There is no constructor in the Bogus library that allows for any formatting which is the case for other masking types.

To make this possible I added an extra property to the config file that can help with this

This is what has been done...

**Get-DbaRandomizedValue.ps1 **
1. Added `Separator` parameter
2. Made it possible to use both `separator` or `format` to get the correct MAC address

**Invoke-DbaDbDataMasking**
1. Improved the command to have better formatted and readable code
2. Setup Invoke

**New-DbaDbMaskingConfig.ps1**
1. Added `Separator` property for new masking configs

**Test-DbaDbDataMaskingConfig**
1. Added an option for allowed and required properties.

The tests have been done on an sample databases created like this

```sql
CREATE DATABASE MacTest
GO

CREATE TABLE MacTest.dbo.MacAdresses(
    ID INT NOT NULL PRIMARY KEY IDENTITY(1,1),
    MacAddress VARCHAR(20) NOT NULL
)

INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('A')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('B')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('C')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('D')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('E')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('F')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('G')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('H')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('I')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('J')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('K')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('L')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('M')
INSERT INTO MacTest.dbo.MacAdresses(MacAddress) VALUES('N')

SELECT * FROM MacTest.dbo.MacAdresses
```

The result

![image](https://user-images.githubusercontent.com/6154981/89578079-ea0dee00-d831-11ea-829a-91c31ee9e269.png)

The following JSON file has been used for the tests

```json
{
    "Name": "MacTest",
    "Type": "DataMaskingConfiguration",
    "Tables": [
        {
            "Name": "MacAdresses",
            "Schema": "dbo",
            "Columns": [
                {
                    "Name": "MacAddress",
                    "ColumnType": "varchar",
                    "CharacterString": null,
                    "MinValue": 10,
                    "MaxValue": 20,
                    "MaskingType": "Internet",
                    "SubType": "Mac",
                    "Format": null,
                    "Separator": null,
                    "Deterministic": false,
                    "Nullable": false,
                    "KeepNull": true,
                    "Composite": null,
                    "Action": null
                }
            ],
            "HasUniqueIndex": true
        }
    ]
}
```

### Commands to test
- Get-DbaRandomizedValue
- Invoke-DbaDbDataMasking
- New-DbaDbMaskingConfig
- Test-DbaDbDataMaskingConfig


### Screenshots

No changes to the JSON file
![image](https://user-images.githubusercontent.com/6154981/89578187-11fd5180-d832-11ea-945a-1b8e8e679e06.png)

Changed the following `Separator = null` into `Separator = "-"`
![image](https://user-images.githubusercontent.com/6154981/89578279-2f322000-d832-11ea-8b06-9386a378206d.png)

Changed the separator property back to `Separator: null` and set the format property to `Format: "############"`
![image](https://user-images.githubusercontent.com/6154981/89578437-6b658080-d832-11ea-9704-8137830cbb83.png)

Changed the format property to `Format: "###.###.###.###"`
![image](https://user-images.githubusercontent.com/6154981/89578472-7a4c3300-d832-11ea-8368-50631804a172.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
