### PR TITLE
Fix issue 6167 for Find-DbaDbUnusedIndex to include index size and row count

### DIFF
--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -85,6 +85,12 @@ function Find-DbaDbUnusedIndex {
 
         Finds unused indexes on all databases on sql2016
 
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sql2019 | Find-DbaDbUnusedIndex -UserSeeksLessThan 10 -UserScansLessThan 100 -UserLookupsLessThan 1000
+
+        Finds 'unused' indexes with user_seeks < 10, user_scans < 100, and user_lookups < 1000 on all databases on sql2019.
+        Note that these additional parameters provide flexibility to define what is considered an 'unused' index.
+
     #>
     [CmdletBinding()]
     param (
@@ -94,12 +100,12 @@ function Find-DbaDbUnusedIndex {
         [object[]]$Database,
         [object[]]$ExcludeDatabase,
         [switch]$IgnoreUptime,
+        [ValidateRange(1, 1000000)][int]$UserSeeksLessThan = 1,
+        [ValidateRange(1, 1000000)][int]$UserScansLessThan = 1,
+        [ValidateRange(1, 1000000)][int]$UserLookupsLessThan = 1,
         [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
-        [switch]$EnableException,
-        [ValidateRange(1, 1000000)][Int]$UserSeeksLessThan = 1,
-        [ValidateRange(1, 1000000)][Int]$UserScansLessThan = 1,
-        [ValidateRange(1, 1000000)][Int]$UserLookupsLessThan = 1
+        [switch]$EnableException
     )
     begin {
         # Support Compression 2008+

--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -167,8 +167,8 @@ function Find-DbaDbUnusedIndex {
         JOIN sys.schemas s
             ON t.schema_id = s.schema_id
         JOIN sys.indexes i
-            ON i.object_id = t.object_id LEFT OUTER
-        JOIN sys.dm_db_index_usage_stats iu
+            ON i.object_id = t.object_id
+        LEFT OUTER JOIN sys.dm_db_index_usage_stats iu
             ON iu.object_id = i.object_id
                 AND iu.index_id = i.index_id
         JOIN CTE_IndexSpace indexSpace

--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -25,7 +25,7 @@ function Find-DbaDbUnusedIndex {
         Specifies the database(s) to exclude from processing. Options for this list are auto-populated from the server.
 
     .PARAMETER IgnoreUptime
-        Less than 7 days uptime can mean that analysis of unused indexes is unreliable, and normally no results will be returned. By setting this option results will be returned even if the Instance has been running for less that 7 days.
+        Less than 7 days uptime can mean that analysis of unused indexes is unreliable, and normally no results will be returned. By setting this option results will be returned even if the Instance has been running for less than 7 days.
 
     .PARAMETER InputObject
         Enables piping from Get-DbaDatabase
@@ -34,6 +34,30 @@ function Find-DbaDbUnusedIndex {
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .PARAMETER UserSeeksLessThan
+        Specify a custom threshold for user seeks. The default for this parameter is 1.
+        The valid values are between 1 and 1000000 to provide flexibility on the definition of 'unused' indexes.
+        Note: The resulting WHERE clause uses the AND operator:
+        user_seeks < $UserSeeksLessThan
+        AND user_scans < $UserScansLessThan
+        AND user_lookups < $UserLookupsLessThan
+
+    .PARAMETER UserScansLessThan
+        Specify a custom threshold for user scans. The default for this parameter is 1.
+        The valid values are between 1 and 1000000 to provide flexibility on the definition of 'unused' indexes.
+        Note: The resulting WHERE clause uses the AND operator:
+        user_seeks < $UserSeeksLessThan
+        AND user_scans < $UserScansLessThan
+        AND user_lookups < $UserLookupsLessThan
+
+    .PARAMETER UserLookupsLessThan
+        Specify a custom threshold for user lookups. The default for this parameter is 1.
+        The valid values are between 1 and 1000000 to provide flexibility on the definition of 'unused' indexes.
+        Note: The resulting WHERE clause uses the AND operator:
+        user_seeks < $UserSeeksLessThan
+        AND user_scans < $UserScansLessThan
+        AND user_lookups < $UserLookupsLessThan
 
     .NOTES
         Tags: Index
@@ -72,11 +96,40 @@ function Find-DbaDbUnusedIndex {
         [switch]$IgnoreUptime,
         [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
-        [switch]$EnableException
+        [switch]$EnableException,
+        [ValidateRange(1, 1000000)][Int]$UserSeeksLessThan = 1,
+        [ValidateRange(1, 1000000)][Int]$UserScansLessThan = 1,
+        [ValidateRange(1, 1000000)][Int]$UserLookupsLessThan = 1
     )
     begin {
         # Support Compression 2008+
-        $sql = "SELECT  SERVERPROPERTY('MachineName') AS ComputerName,
+        $sql = "
+        ;WITH
+            CTE_IndexSpace
+        AS
+        (
+            SELECT
+				s.object_id							AS object_id
+            ,	s.index_id							AS index_id
+            ,	SUM(s.used_page_count) * 8 / 1024.0	AS IndexSizeMB
+            ,	SUM(p.[rows]) 						AS [RowCount]
+            --REPLACEPARAMCTE
+            FROM
+				sys.dm_db_partition_stats AS s
+            INNER JOIN
+				sys.partitions p WITH (NOLOCK)
+				    ON s.[partition_id] = p.[partition_id]
+                    AND s.[object_id] = p.[object_id]
+                    AND s.index_id = p.index_id
+            WHERE
+				s.index_id > 0 -- Exclude HEAPS
+                AND OBJECT_SCHEMA_NAME(s.[object_id]) <> 'sys'
+            GROUP BY
+				s.[object_id]
+            ,	s.index_id
+            --REPLACEPARAMCTE
+        )
+        SELECT  SERVERPROPERTY('MachineName') AS ComputerName,
         ISNULL(SERVERPROPERTY('InstanceName'), 'MSSQLSERVER') AS InstanceName,
         SERVERPROPERTY('ServerName') AS SqlInstance, DB_NAME(database_id) AS 'Database'
         ,s.name AS 'Schema'
@@ -101,6 +154,9 @@ function Find-DbaDbUnusedIndex {
         ,last_system_scan  as 'LastSystemScan'
         ,last_system_lookup  as 'LastSystemLookup'
         ,last_system_update as 'LastSystemUpdate'
+        ,COALESCE(indexSpace.IndexSizeMB, 0) AS 'IndexSizeMB'
+        ,COALESCE(indexSpace.[RowCount], 0) AS 'RowCount'
+        --REPLACEPARAMSELECT
         FROM sys.tables t
         JOIN sys.schemas s
             ON t.schema_id = s.schema_id
@@ -109,17 +165,32 @@ function Find-DbaDbUnusedIndex {
         JOIN sys.dm_db_index_usage_stats iu
             ON iu.object_id = i.object_id
                 AND iu.index_id = i.index_id
+        JOIN CTE_IndexSpace indexSpace
+            ON indexSpace.index_id = i.index_id
+                AND indexSpace.object_id = i.object_id
         WHERE iu.database_id = DB_ID()
                 AND OBJECTPROPERTY(i.[object_id], 'IsMSShipped') = 0
-                AND user_seeks = 0
-                AND user_scans = 0
-                AND user_lookups = 0
+                AND user_seeks < $UserSeeksLessThan
+                AND user_scans < $UserScansLessThan
+                AND user_lookups < $UserLookupsLessThan
                 AND i.type_desc NOT IN ('HEAP', 'CLUSTERED COLUMNSTORE')"
+
+        # Replacement values for the SQL above
+        $replaceParamCTE = "--REPLACEPARAMCTE"
+        $replaceValueCTE = ", p.data_compression_desc"
+        $replaceParamSelect = "--REPLACEPARAMSELECT"
+        $replaceValueSelect = ", indexSpace.data_compression_desc AS CompressionDescription"
     }
 
     process {
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
+        }
+
+        # Return a warning if the database specified was not found
+        if ($null -eq $InputObject -or $InputObject.Count -eq 0) {
+            Write-Message -Level Warning -Message "Database [$Database] was not found on [$SqlInstance]."
+            continue
         }
 
         foreach ($db in $InputObject) {
@@ -162,8 +233,17 @@ function Find-DbaDbUnusedIndex {
                 Write-Message -Level Verbose -Message "The SQL Service on $instance was restarted on $lastRestart, which may not be long enough for a solid evaluation."
             }
 
+            <#
+                Data compression was added in SQL 2008, so add in the additional compression description column for versions 2008 or higher.
+            #>
+            $sqlToRun = $sql
+
+            if ($server.VersionMajor -gt 9) {
+                $sqlToRun = $sqlToRun.Replace($replaceParamCTE, $replaceValueCTE).Replace($replaceParamSelect, $replaceValueSelect)
+            }
+
             try {
-                $db.Query($sql)
+                $db.Query($sqlToRun)
             } catch {
                 Stop-Function -Message "Issue gathering indexes" -Category InvalidOperation -ErrorRecord $_ -Target $db
             }

--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -109,24 +109,24 @@ function Find-DbaDbUnusedIndex {
         AS
         (
             SELECT
-				s.object_id							AS object_id
-            ,	s.index_id							AS index_id
-            ,	SUM(s.used_page_count) * 8 / 1024.0	AS IndexSizeMB
-            ,	SUM(p.[rows]) 						AS [RowCount]
+                s.object_id                         AS object_id
+            ,   s.index_id                          AS index_id
+            ,   SUM(s.used_page_count) * 8 / 1024.0 AS IndexSizeMB
+            ,   SUM(p.[rows])                       AS [RowCount]
             --REPLACEPARAMCTE
             FROM
-				sys.dm_db_partition_stats AS s
+                sys.dm_db_partition_stats AS s
             INNER JOIN
-				sys.partitions p WITH (NOLOCK)
-				    ON s.[partition_id] = p.[partition_id]
+                sys.partitions p WITH (NOLOCK)
+                    ON s.[partition_id] = p.[partition_id]
                     AND s.[object_id] = p.[object_id]
                     AND s.index_id = p.index_id
             WHERE
-				s.index_id > 0 -- Exclude HEAPS
+                s.index_id > 0 -- Exclude HEAPS
                 AND OBJECT_SCHEMA_NAME(s.[object_id]) <> 'sys'
             GROUP BY
-				s.[object_id]
-            ,	s.index_id
+                s.[object_id]
+            ,...s.index_id
             --REPLACEPARAMCTE
         )
         SELECT  SERVERPROPERTY('MachineName') AS ComputerName,

--- a/functions/Find-DbaDbUnusedIndex.ps1
+++ b/functions/Find-DbaDbUnusedIndex.ps1
@@ -126,7 +126,7 @@ function Find-DbaDbUnusedIndex {
                 AND OBJECT_SCHEMA_NAME(s.[object_id]) <> 'sys'
             GROUP BY
                 s.[object_id]
-            ,...s.index_id
+            ,   s.index_id
             --REPLACEPARAMCTE
         )
         SELECT  SERVERPROPERTY('MachineName') AS ComputerName,

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -59,7 +59,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
             foreach ($row in $results) {
                 if ($row["IndexName"] -eq $indexName) {
+                    Write-Message -Level Debug -Message "$($indexName) was found on $($script:instance2) in database $($dbName)"
                     $testSQLinstance2 = $true
+                } else {
+                    Write-Message -Level Warning -Message "$($indexName) was not found on $($script:instance2) in database $($dbName)"
                 }
             }
 
@@ -82,6 +85,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
                     $row = $results[0]
                 } else {
+                    Write-Message -Level Warning -Message "Unexpected results returned from $($SqlInstance): $($results)"
                     $testSQLinstance2 = $false
                 }
 
@@ -89,7 +93,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                     [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
 
                     if ( @(Compare-Object -ReferenceObject $expectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
+                        Write-Message -Level Debug -Message "Columns matched on $($script:instance2)"
                         $testSQLinstance2 = $true
+                    } else {
+                        Write-Message -Level Warning -Message "The columns specified in the expectedColumnList variable do not match these returned columns from $($script:instance2): $($columnNamesReturned)"
                     }
                 }
             }

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -23,17 +23,17 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
-            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex testing connection to $script:instance3"
-            Test-DbaConnection -SqlInstance $script:instance3
+            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex testing connection to $script:instance2"
+            Test-DbaConnection -SqlInstance $script:instance2
 
-            $server3 = Connect-DbaInstance -SqlInstance $script:instance3
+            $server3 = Connect-DbaInstance -SqlInstance $script:instance2
 
             $random = Get-Random
             $dbName = "dbatoolsci_$random"
 
             Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex setting up the new database $dbName"
-            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
-            New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbName -Confirm:$false
+            New-DbaDatabase -SqlInstance $script:instance2 -Name $dbName
 
             $indexName = "dbatoolsci_index_$random"
             $tableName = "dbatoolsci_table_$random"
@@ -49,30 +49,30 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         AfterAll {
             Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex removing the database $dbName"
-            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbName -Confirm:$false
         }
 
         It "Should find the 'unused' index on each test sql instance" {
-            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance3 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
+            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance2 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
 
-            $testSQLInstance3 = $false
+            $testSQLinstance2 = $false
 
             foreach ($row in $results) {
                 if ($row["IndexName"] -eq $indexName) {
-                    $testSQLInstance3 = $true
+                    $testSQLinstance2 = $true
                 }
             }
 
-            $testSQLInstance3 | Should -Be $true
+            $testSQLinstance2 | Should -Be $true
         }
 
 
         It "Should return the expected columns on each test sql instance" {
             [object[]]$expectedColumnArray = 'CompressionDescription', 'ComputerName', 'Database', 'IndexId', 'IndexName', 'IndexSizeMB', 'InstanceName', 'LastSystemLookup', 'LastSystemScan', 'LastSystemSeek', 'LastSystemUpdate', 'LastUserLookup', 'LastUserScan', 'LastUserSeek', 'LastUserUpdate', 'ObjectId', 'RowCount', 'Schema', 'SqlInstance', 'SystemLookup', 'SystemScans', 'SystemSeeks', 'SystemUpdates', 'Table', 'TypeDesc', 'UserLookups', 'UserScans', 'UserSeeks', 'UserUpdates'
 
-            $testSQLInstance3 = $false
+            $testSQLinstance2 = $false
 
-            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance3 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
+            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance2 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
 
             if ( ($null -ne $results) ) {
                 $row = $null
@@ -82,19 +82,19 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
                     $row = $results[0]
                 } else {
-                    $testSQLInstance3 = $false
+                    $testSQLinstance2 = $false
                 }
 
                 if ($null -ne $row) {
                     [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
 
                     if ( @(Compare-Object -ReferenceObject $expectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
-                        $testSQLInstance3 = $true
+                        $testSQLinstance2 = $true
                     }
                 }
             }
 
-            $testSQLInstance3 | Should -Be $true
+            $testSQLinstance2 | Should -Be $true
         }
     }
 }

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -1,11 +1,11 @@
-$script:UnusedIndexCommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$script:UnusedIndexCommandName Unit Tests" -Tag 'UnitTests' {
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         It "Should only contain our specific parameters" {
-            [object[]]$params = (Get-Command $script:UnusedIndexCommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
             [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IgnoreUptime', 'InputObject', 'EnableException', 'UserSeeksLessThan', 'UserScansLessThan', 'UserLookupsLessThan'
             $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
 
@@ -20,22 +20,15 @@ Describe "$script:UnusedIndexCommandName Unit Tests" -Tag 'UnitTests' {
 #>
 
 
-Describe "$script:UnusedIndexCommandName Integration Tests" -Tags "IntegrationTests" {
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
-            $server1 = Connect-DbaInstance -SqlInstance $script:instance1
-            $server2 = Connect-DbaInstance -SqlInstance $script:instance2
             $server3 = Connect-DbaInstance -SqlInstance $script:instance3
 
             $random = Get-Random
             $dbName = "dbatoolsci_$random"
 
-            Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbName -Confirm:$false
-            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbName -Confirm:$false
             Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
-
-            New-DbaDatabase -SqlInstance $script:instance1 -Name $dbName
-            New-DbaDatabase -SqlInstance $script:instance2 -Name $dbName
             New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
 
             $indexName = "dbatoolsci_index_$random"
@@ -45,13 +38,10 @@ Describe "$script:UnusedIndexCommandName Integration Tests" -Tags "IntegrationTe
                     CREATE INDEX $indexName ON $tableName (ID);
                     INSERT INTO $tableName (ID) VALUES (1);
                     SELECT ID FROM $tableName;"
-            $null = $server1.Query($sql)
-            $null = $server2.Query($sql)
+
             $null = $server3.Query($sql)
         }
         AfterAll {
-            Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbName -Confirm:$false
-            Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbName -Confirm:$false
             Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
         }
 
@@ -78,11 +68,9 @@ Describe "$script:UnusedIndexCommandName Integration Tests" -Tags "IntegrationTe
                 return $false
             }
 
-            $testSQLInstance1 = checkIfIndexIsReturned $script:instance1 $dbName $indexName 10
-            $testSQLInstance2 = checkIfIndexIsReturned $script:instance2 $dbName $indexName 10
             $testSQLInstance3 = checkIfIndexIsReturned $script:instance3 $dbName $indexName 10
 
-            ($testSQLInstance1 -and $testSQLInstance2 -and $testSQLInstance3) | Should -Be $true
+            $testSQLInstance3 | Should -Be $true
         }
 
         It "Should return the expected columns on each test sql instance" {
@@ -126,11 +114,9 @@ Describe "$script:UnusedIndexCommandName Integration Tests" -Tags "IntegrationTe
                 return $false
             }
 
-            $testSQLInstance1 = checkReturnedColumns $script:instance1 $dbName $expectedColumnArray 10
-            $testSQLInstance2 = checkReturnedColumns $script:instance2 $dbName $expectedColumnArray 10
             $testSQLInstance3 = checkReturnedColumns $script:instance3 $dbName $expectedColumnArray 10
 
-            ($testSQLInstance1 -and $testSQLInstance2 -and $testSQLInstance3) | Should -Be $true
+            $testSQLInstance3 | Should -Be $true
         }
     }
 }

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -23,129 +23,70 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
-            try {
-                Write-Message -Level Debug -Message "Connecting to $script:instance3"
+            $server3 = Connect-DbaInstance -SqlInstance $script:instance3
 
-                try {
-                    $connectionResults = Test-DbaConnection -SqlInstance $script:instance3 -EnableException
+            $random = Get-Random
+            $dbName = "dbatoolsci_$random"
 
-                    Write-Message -Level Warning -Message "Connection result for $script:instance3 was: $($connectionResults.ConnectSuccess)"
-                } catch {
-                    Write-Message -Level Warning -Message "$($_) : $($_.ScriptStackTrace)"
-                }
+            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
+            New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
 
-                $server3 = Connect-DbaInstance -SqlInstance $script:instance3
+            $indexName = "dbatoolsci_index_$random"
+            $tableName = "dbatoolsci_table_$random"
+            $sql = "USE $dbName;
+                    CREATE TABLE $tableName (ID INTEGER);
+                    CREATE INDEX $indexName ON $tableName (ID);
+                    INSERT INTO $tableName (ID) VALUES (1);
+                    SELECT ID FROM $tableName;
+                    WAITFOR DELAY '00:00:05'; -- for slower systems allow the query optimizer engine to catch up and update sys.dm_db_index_usage_stats"
 
-                $random = Get-Random
-                $dbName = "dbatoolsci_$random"
-
-                Write-Message -Level Debug -Message "Setting up the new database $dbName"
-                Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
-                New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
-
-                $indexName = "dbatoolsci_index_$random"
-                $tableName = "dbatoolsci_table_$random"
-                $sql = "USE $dbName;
-                        CREATE TABLE $tableName (ID INTEGER);
-                        CREATE INDEX $indexName ON $tableName (ID);
-                        INSERT INTO $tableName (ID) VALUES (1);
-                        SELECT ID FROM $tableName;
-                        WAITFOR DELAY '00:00:05'; -- for slower systems allow the query optimizer engine to catch up and update sys.dm_db_index_usage_stats"
-
-                $null = $server3.Query($sql)
-            } catch {
-                Write-Message -Level Warning -Message "$($_): $($_.ScriptStackTrace)"
-            }
+            $null = $server3.Query($sql)
         }
+
         AfterAll {
-            try {
-                Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false -EnableException
-            } catch {
-                Write-Message -Level Warning -Message "Unable to drop database $dbName due to $($_): $($_.ScriptStackTrace)"
-            }
+            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false -EnableException
         }
 
         It "Should find the 'unused' index on each test sql instance" {
-            Function checkIfIndexIsReturned {
-                param(
-                    [string]$SqlInstance,
-                    [string]$Database,
-                    [string]$IndexNameToCheck,
-                    [int]$Threshold
-                )
-
-                $results = Find-DbaDbUnusedIndex -SqlInstance $SqlInstance -Database $Database -IgnoreUptime -UserSeeksLessThan $Threshold -UserScansLessThan $Threshold -UserLookupsLessThan $Threshold
-
-                foreach ($row in $results) {
-                    if ($row["IndexName"] -eq $IndexNameToCheck) {
-                        Write-Message -Level Debug -Message "$($IndexNameToCheck) was found on $($SqlInstance) in database $($Database)"
-                        return $true
-                    }
-                }
-
-                Write-Message -Level Warning -Message "$($IndexNameToCheck) was not found on $($SqlInstance) in database $($Database)"
-
-                return $false
-            }
+            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance3 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
 
             $testSQLInstance3 = $false
 
-            try {
-                $testSQLInstance3 = checkIfIndexIsReturned $script:instance3 $dbName $indexName 10
-            } catch {
-                Write-Message -Level Warning -Message "$($_): $($_.ScriptStackTrace)"
+            foreach ($row in $results) {
+                if ($row["IndexName"] -eq $indexName) {
+                    $testSQLInstance3 = $true
+                }
             }
 
             $testSQLInstance3 | Should -Be $true
         }
 
+
         It "Should return the expected columns on each test sql instance" {
-
             [object[]]$expectedColumnArray = 'CompressionDescription', 'ComputerName', 'Database', 'IndexId', 'IndexName', 'IndexSizeMB', 'InstanceName', 'LastSystemLookup', 'LastSystemScan', 'LastSystemSeek', 'LastSystemUpdate', 'LastUserLookup', 'LastUserScan', 'LastUserSeek', 'LastUserUpdate', 'ObjectId', 'RowCount', 'Schema', 'SqlInstance', 'SystemLookup', 'SystemScans', 'SystemSeeks', 'SystemUpdates', 'Table', 'TypeDesc', 'UserLookups', 'UserScans', 'UserSeeks', 'UserUpdates'
-
-            Function checkReturnedColumns {
-                param(
-                    [string]$SqlInstance,
-                    [string]$Database,
-                    [object[]]$ExpectedColumnArray,
-                    [int]$Threshold
-                )
-
-                $results = Find-DbaDbUnusedIndex -SqlInstance $SqlInstance -Database $Database -IgnoreUptime -UserSeeksLessThan $Threshold -UserScansLessThan $Threshold -UserLookupsLessThan $Threshold
-
-                if ( ($null -ne $results) ) {
-                    $row = $null
-                    # if one row is returned $results will be a System.Data.DataRow, otherwise it will be an object[] of System.Data.DataRow
-                    if ($results -is [System.Data.DataRow]) {
-                        $row = $results
-                    } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
-                        $row = $results[0]
-                    } else {
-                        Write-Message -Level Warning -Message "Unexpected results returned from $($SqlInstance): $($results)"
-                        return $false
-                    }
-
-                    [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
-
-                    if ( @(Compare-Object -ReferenceObject $ExpectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
-                        Write-Message -Level Debug -Message "Columns matched on $($SqlInstance)"
-                        return $true
-                    } else {
-                        Write-Message -Level Warning -Message "The columns specified in the expectedColumnList variable do not match these returned columns from $($SqlInstance): $($columnNamesReturned)"
-                    }
-                } else {
-                    Write-Message -Level Warning -Message "No results were returned from $($SqlInstance)"
-                }
-
-                return $false
-            }
 
             $testSQLInstance3 = $false
 
-            try {
-                $testSQLInstance3 = checkReturnedColumns $script:instance3 $dbName $expectedColumnArray 10
-            } catch {
-                Write-Message -Level Warning -Message "$($_): $($_.ScriptStackTrace)"
+            $results = Find-DbaDbUnusedIndex -SqlInstance $script:instance3 -Database $dbName -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10
+
+            if ( ($null -ne $results) ) {
+                $row = $null
+                # if one row is returned $results will be a System.Data.DataRow, otherwise it will be an object[] of System.Data.DataRow
+                if ($results -is [System.Data.DataRow]) {
+                    $row = $results
+                } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
+                    $row = $results[0]
+                } else {
+                    $testSQLInstance3 = $false
+                }
+
+                if ($null -ne $row) {
+                    [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
+
+                    if ( @(Compare-Object -ReferenceObject $expectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
+                        $testSQLInstance3 = $true
+                    }
+                }
             }
 
             $testSQLInstance3 | Should -Be $true

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -23,29 +23,33 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
-            Write-Message -Level Warning -Message "Debugging AppVeyor issue: Connecting to $script:instance3"
+            try {
+                Write-Message -Level Warning -Message "Debugging AppVeyor issue: Connecting to $script:instance3"
 
-            $server3 = Connect-DbaInstance -SqlInstance $script:instance3
+                $server3 = Connect-DbaInstance -SqlInstance $script:instance3
 
-            $random = Get-Random
-            $dbName = "dbatoolsci_$random"
+                $random = Get-Random
+                $dbName = "dbatoolsci_$random"
 
-            Write-Message -Level Warning -Message "Debugging AppVeyor issue: Setting up the new database $dbName"
-            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
-            New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
+                Write-Message -Level Warning -Message "Debugging AppVeyor issue: Setting up the new database $dbName"
+                Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
+                New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
 
-            $indexName = "dbatoolsci_index_$random"
-            $tableName = "dbatoolsci_table_$random"
-            $sql = "USE $dbName;
-                    CREATE TABLE $tableName (ID INTEGER);
-                    CREATE INDEX $indexName ON $tableName (ID);
-                    INSERT INTO $tableName (ID) VALUES (1);
-                    SELECT ID FROM $tableName;
-                    WAITFOR DELAY '00:00:05'; -- for slower systems allow the query optimizer engine to catch up and update sys.dm_db_index_usage_stats"
+                $indexName = "dbatoolsci_index_$random"
+                $tableName = "dbatoolsci_table_$random"
+                $sql = "USE $dbName;
+                        CREATE TABLE $tableName (ID INTEGER);
+                        CREATE INDEX $indexName ON $tableName (ID);
+                        INSERT INTO $tableName (ID) VALUES (1);
+                        SELECT ID FROM $tableName;
+                        WAITFOR DELAY '00:00:05'; -- for slower systems allow the query optimizer engine to catch up and update sys.dm_db_index_usage_stats"
 
-            $null = $server3.Query($sql)
+                $null = $server3.Query($sql)
 
-            Write-Message -Level Warning -Message "Debugging AppVeyor issue: Completed BeforeAll"
+                Write-Message -Level Warning -Message "Debugging AppVeyor issue: Completed BeforeAll"
+            } catch {
+                Write-Message -Level Warning -Message "Exception during BeforeAll: $_.ScriptStackTrace"
+            }
         }
         AfterAll {
             Write-Message -Level Warning -Message "Debugging AppVeyor issue: AfterAll now removing $dbName"
@@ -80,7 +84,13 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
 
             Write-Message -Level Warning -Message "Debugging AppVeyor issue: Connecting to $script:instance3 to check $dbName for $indexName"
-            $testSQLInstance3 = checkIfIndexIsReturned $script:instance3 $dbName $indexName 10
+            $testSQLInstance3 = $false
+
+            try {
+                $testSQLInstance3 = checkIfIndexIsReturned $script:instance3 $dbName $indexName 10
+            } catch {
+                Write-Message -Level Warning -Message "Exception during checkIfIndexIsReturned: $_.ScriptStackTrace"
+            }
 
             $testSQLInstance3 | Should -Be $true
         }
@@ -127,7 +137,13 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             }
 
             Write-Message -Level Warning -Message "Debugging AppVeyor issue: Connecting to $script:instance3 to check columns returned from $dbName"
-            $testSQLInstance3 = checkReturnedColumns $script:instance3 $dbName $expectedColumnArray 10
+            $testSQLInstance3 = $false
+
+            try {
+                $testSQLInstance3 = checkReturnedColumns $script:instance3 $dbName $expectedColumnArray 10
+            } catch {
+                Write-Message -Level Warning -Message "Exception during checkReturnedColumns: $_.ScriptStackTrace"
+            }
 
             $testSQLInstance3 | Should -Be $true
         }

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -23,11 +23,15 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Verify basics of the Find-DbaDbUnusedIndex command" {
         BeforeAll {
+            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex testing connection to $script:instance3"
+            Test-DbaConnection -SqlInstance $script:instance3
+
             $server3 = Connect-DbaInstance -SqlInstance $script:instance3
 
             $random = Get-Random
             $dbName = "dbatoolsci_$random"
 
+            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex setting up the new database $dbName"
             Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
             New-DbaDatabase -SqlInstance $script:instance3 -Name $dbName
 
@@ -44,7 +48,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         AfterAll {
-            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false -EnableException
+            Write-Message -Level Warning -Message "Find-DbaDbUnusedIndex removing the database $dbName"
+            Remove-DbaDatabase -SqlInstance $script:instance3 -Database $dbName -Confirm:$false
         }
 
         It "Should find the 'unused' index on each test sql instance" {

--- a/tests/Find-DbaDbUnusedIndex.Tests.ps1
+++ b/tests/Find-DbaDbUnusedIndex.Tests.ps1
@@ -1,14 +1,15 @@
-$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+$script:UnusedIndexCommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
-Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+Describe "$script:UnusedIndexCommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IgnoreUptime', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $script:UnusedIndexCommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IgnoreUptime', 'InputObject', 'EnableException', 'UserSeeksLessThan', 'UserScansLessThan', 'UserLookupsLessThan'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -17,3 +18,108 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
     for more guidence.
 #>
+
+
+Describe "$script:UnusedIndexCommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Verify basics of the Find-DbaDbUnusedIndex command" {
+        BeforeAll {
+            $server1 = Connect-DbaInstance -SqlInstance $script:instance1
+            $server2 = Connect-DbaInstance -SqlInstance $script:instance2
+            $server3 = Connect-DbaInstance -SqlInstance $script:instance3
+            $random = Get-Random
+            $indexName = "dbatoolsci_index_$random"
+            $tableName = "dbatoolsci_table_$random"
+            $sql = "CREATE TABLE $tableName (ID INTEGER);
+                    CREATE INDEX $indexName ON $tableName (ID);
+                    INSERT INTO $tableName (ID) VALUES (1);
+                    SELECT ID FROM $tableName;"
+            $null = $server1.Query($sql, 'tempdb')
+            $null = $server2.Query($sql, 'tempdb')
+            $null = $server3.Query($sql, 'tempdb')
+        }
+        AfterAll {
+            $sql = "DROP TABLE $tableName;"
+            $null = $server1.Query($sql, 'tempdb')
+            $null = $server2.Query($sql, 'tempdb')
+            $null = $server3.Query($sql, 'tempdb')
+        }
+
+        It "Should find the 'unused' index on each test sql instance" {
+            Function checkIfIndexIsReturned {
+                param(
+                    [string]$SqlInstance,
+                    [string]$Database,
+                    [string]$IndexNameToCheck,
+                    [int]$Threshold
+                )
+
+                $results = Find-DbaDbUnusedIndex -SqlInstance $SqlInstance -Database $Database -IgnoreUptime -UserSeeksLessThan $Threshold -UserScansLessThan $Threshold -UserLookupsLessThan $Threshold
+
+                foreach ($row in $results) {
+                    if ($row["IndexName"] -eq $IndexNameToCheck) {
+                        Write-Host "$($IndexNameToCheck) was found on $($SqlInstance)"
+                        return $true
+                    }
+                }
+
+                Write-Host "$($IndexNameToCheck) was not found on $($SqlInstance)"
+
+                return $false
+            }
+
+            $testSQLInstance1 = checkIfIndexIsReturned $script:instance1 tempdb $indexName 10
+            $testSQLInstance2 = checkIfIndexIsReturned $script:instance2 tempdb $indexName 10
+            $testSQLInstance3 = checkIfIndexIsReturned $script:instance3 tempdb $indexName 10
+
+            ($testSQLInstance1 -and $testSQLInstance2 -and $testSQLInstance3) | Should -Be $true
+        }
+
+        It "Should return the expected columns on each test sql instance" {
+
+            [object[]]$expectedColumnArray = 'CompressionDescription', 'ComputerName', 'Database', 'IndexId', 'IndexName', 'IndexSizeMB', 'InstanceName', 'LastSystemLookup', 'LastSystemScan', 'LastSystemSeek', 'LastSystemUpdate', 'LastUserLookup', 'LastUserScan', 'LastUserSeek', 'LastUserUpdate', 'ObjectId', 'RowCount', 'Schema', 'SqlInstance', 'SystemLookup', 'SystemScans', 'SystemSeeks', 'SystemUpdates', 'Table', 'TypeDesc', 'UserLookups', 'UserScans', 'UserSeeks', 'UserUpdates'
+
+            Function checkReturnedColumns {
+                param(
+                    [string]$SqlInstance,
+                    [string]$Database,
+                    [object[]]$ExpectedColumnArray,
+                    [int]$Threshold
+                )
+
+                $results = Find-DbaDbUnusedIndex -SqlInstance $SqlInstance -Database $Database -IgnoreUptime -UserSeeksLessThan $Threshold -UserScansLessThan $Threshold -UserLookupsLessThan $Threshold
+
+                if ( ($null -ne $results) ) {
+                    $row = $null
+                    # if one row is returned $results will be a System.Data.DataRow, otherwise it will be an object[] of System.Data.DataRow
+                    if ($results -is [System.Data.DataRow]) {
+                        $row = $results
+                    } elseif ($results -is [Object[]] -and $results.Count -gt 0) {
+                        $row = $results[0]
+                    } else {
+                        Write-Host "Unexpected results returned from $($SqlInstance): $($results)"
+                        return $false
+                    }
+
+                    [object[]]$columnNamesReturned = @($row | Get-Member -MemberType Property | Select-Object -Property Name | ForEach-Object { $_.Name })
+
+                    if ( @(Compare-Object -ReferenceObject $ExpectedColumnArray -DifferenceObject $columnNamesReturned).Count -eq 0 ) {
+                        Write-Host "Columns matched on $($SqlInstance)"
+                        return $true
+                    } else {
+                        Write-Host "The columns specified in the expectedColumnList variable do not match these returned columns from $($SqlInstance): $($columnNamesReturned)"
+                    }
+                } else {
+                    Write-Host "No results were returned from $($SqlInstance)"
+                }
+
+                return $false
+            }
+
+            $testSQLInstance1 = checkReturnedColumns $script:instance1 tempdb $expectedColumnArray 10
+            $testSQLInstance2 = checkReturnedColumns $script:instance2 tempdb $expectedColumnArray 10
+            $testSQLInstance3 = checkReturnedColumns $script:instance3 tempdb $expectedColumnArray 10
+
+            ($testSQLInstance1 -and $testSQLInstance2 -and $testSQLInstance3) | Should -Be $true
+        }
+    }
+}


### PR DESCRIPTION
Fix #6167 for Find-DbaDbUnusedIndex to include index size and row count.

1. Added in the index size and row count columns to the result set. The compression description is also added for SQL 2008 or higher.
2. Added 3 new optional params to allow callers to more flexibly define 'unused' indexes.
3. Added a warning message if the database provided by the caller does not exist.
4. Added 2 integration tests.


<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6167 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fixing issue #6167

### Approach
<!-- How does this change solve that purpose -->
New columns are added into the returned result set.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Find-DbaDbUnusedIndex -SqlInstance "enter name here" -Database "enter name here" -IgnoreUptime -UserSeeksLessThan 10 -UserScansLessThan 10 -UserLookupsLessThan 10

The pester test now contains integration tests and has sample command invocations.

