### PR TITLE
Add default quoted and escape characters to help text

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -124,15 +124,18 @@ function Import-DbaCsv {
         The progress bar is pretty but can slow down imports. Use this parameter to quietly import.
 
     .PARAMETER Quote
-        Defines the default quote character wrapping every field.  Default is ".
+        Defines the default quote character wrapping every field.
+        Default: double-quotes
 
     .PARAMETER Escape
         Defines the default escape character letting insert quotation characters inside a quoted field.
 
-        The escape character can be the same as the quote character.  Default is ".
+        The escape character can be the same as the quote character.
+        Default: double-quotes
 
     .PARAMETER Comment
-        Defines the default comment character indicating that a line is commented out. Default is #.
+        Defines the default comment character indicating that a line is commented out.
+        Default: hashtag
 
     .PARAMETER TrimmingOption
         Determines which values should be trimmed. Default is "None". Options are All, None, UnquotedOnly and QuotedOnly.

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -124,12 +124,12 @@ function Import-DbaCsv {
         The progress bar is pretty but can slow down imports. Use this parameter to quietly import.
 
     .PARAMETER Quote
-        Defines the default quote character wrapping every field.
+        Defines the default quote character wrapping every field.  Default is ".
 
     .PARAMETER Escape
         Defines the default escape character letting insert quotation characters inside a quoted field.
 
-        The escape character can be the same as the quote character.
+        The escape character can be the same as the quote character.  Default is ".
 
     .PARAMETER Comment
         Defines the default comment character indicating that a line is commented out. Default is #.


### PR DESCRIPTION
### Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Improve documentation

### Approach
<!-- How does this change solve that purpose -->
Lines 279 and 280 set the default values for the quote and escape characters.  This PR adds that information to the help text.
