### PR TITLE
Get-DbaDbBackupHistory - Use last last_recovery_fork_guid with -Last*

### DIFF
--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -482,6 +482,8 @@ function Get-DbaDbBackupHistory {
                     #     and given the lsn are composed in the first part by the VLF SeqID, it happens seldomly that for the same database_name backupset holds
                     #     last_lsn out of order. To avoid this behaviour, we filter by database_guid choosing the guid that has MAX(backup_finish_date), as we know
                     #     last_lsn cannot be out-of-order for the same database, and the same database cannot have different database_guid
+                    #   - because someone could restore a very old backup with low lsn values and continue to use this database we filter
+                    #     not only by database_guid but also by the recovery fork of the last backup (see issue #6730 for more details)
                     $sql += "SELECT
                         a.BackupSetRank,
                         a.Server,

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -564,12 +564,10 @@ function Get-DbaDbBackupHistory {
                         JOIN msdb..backupmediaset AS mediaset ON mediafamily.media_set_id = mediaset.media_set_id
                         JOIN msdb..backupset AS backupset ON backupset.media_set_id = mediaset.media_set_id
                         JOIN (
-                            SELECT database_guid, last_recovery_fork_guid
-                            FROM (SELECT database_guid, last_recovery_fork_guid, ROW_NUMBER() OVER (ORDER BY backup_finish_date DESC) AS rn
-                                  FROM msdb..backupset
-                                  WHERE database_name = '$($db.Name)'
-                                 ) AS bs
-                            WHERE rn = 1
+                            SELECT TOP 1 database_guid, last_recovery_fork_guid
+                            FROM msdb..backupset
+                            WHERE database_name = '$($db.Name)'
+                            ORDER BY backup_finish_date DESC
                             ) AS last_guids ON last_guids.database_guid = backupset.database_guid AND last_guids.last_recovery_fork_guid = backupset.last_recovery_fork_guid
                     WHERE (type = '$first' OR type = '$second')
                     $whereCopyOnly


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6730 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Do not take backups from old recovery forks into account when getting the last backup, because they might have higher LSNs.

### Approach
When -LastFull, -LastDiff or -LastLog is used, then only take backups from the last used database_guid and last_recovery_fork_guid into account.

### Commands to test
I documented a demo here: https://github.com/sqlcollaborative/dbatools/issues/6730#issuecomment-674019765

@Stuart-Moore I still can not test this on systems older then SQL Server 2014. I don't use new colums and the only new function is ROW_NUMBER() wich was introduced in SQL Server 2005. So I don't see a risk with old versions here.