### PR TITLE
Write Once for Export-DbaScript

### DIFF
--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -292,7 +292,7 @@ function Export-DbaScript {
                                     } else {
                                         $scriptpart = "$scriptpart`r`n"
                                     }
-                                    $scriptpart #| Out-File -FilePath $scriptPath -Encoding $encoding -Append
+                                    $scriptpart
                                 }
                                 $scriptInFull | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                                 $ScriptingOptionsObject.FileName = $soFileName
@@ -304,7 +304,7 @@ function Export-DbaScript {
                                 } else {
                                     $scriptpart = "$scriptpart`r`n"
                                 }
-                                $scriptpart #| Out-File -FilePath $scriptPath -Encoding $encoding -Append
+                                $scriptpart
                             }
                             $scriptInFull | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                         }

--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -286,25 +286,27 @@ function Export-DbaScript {
                                 $ScriptingOptionsObject.FileName = $soFileName
                             } else {
                                 $ScriptingOptionsObject.FileName = $null
-                                foreach ($scriptpart in $scripter.EnumScript($object)) {
+                                $scriptInFull = foreach ($scriptpart in $scripter.EnumScript($object)) {
                                     if ($BatchSeparator) {
                                         $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
                                     } else {
                                         $scriptpart = "$scriptpart`r`n"
                                     }
-                                    $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
+                                    $scriptpart #| Out-File -FilePath $scriptPath -Encoding $encoding -Append
                                 }
+                                $scriptInFull | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                                 $ScriptingOptionsObject.FileName = $soFileName
                             }
                         } else {
-                            foreach ($scriptpart in $scripter.EnumScript($object)) {
+                            $scriptInFull = foreach ($scriptpart in $scripter.EnumScript($object)) {
                                 if ($BatchSeparator) {
                                     $scriptpart = "$scriptpart`r`n$BatchSeparator`r`n"
                                 } else {
                                     $scriptpart = "$scriptpart`r`n"
                                 }
-                                $scriptpart | Out-File -FilePath $scriptPath -Encoding $encoding -Append
+                                $scriptpart #| Out-File -FilePath $scriptPath -Encoding $encoding -Append
                             }
+                            $scriptInFull | Out-File -FilePath $scriptPath -Encoding $encoding -Append
                         }
                     }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Was having an issue writing out a ~20,000 row table using `Get-DbaDbTable | Export-DbaScript`  and read #6093 which led me down the path of optimization and figuring why it was running slow in my case.

### Approach
<!-- How does this change solve that purpose -->
 Not sure if there was a data integrity reason for writing one line at a time, but it seems like it would be better to build the object in memory and then write it once. This approach sped up my script save time from ~15min to <30sec.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```
$tableData = Get-DbaDbTable ....
$tableData | Export-DbaScript ...
```
