### PR TITLE
Make automap work with pipe delimited files

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -560,8 +560,14 @@ function Import-DbaCsv {
                                 try {
                                     $firstline = Get-Content -Path $file -TotalCount 1 -ErrorAction Stop
                                     $ColumnMapping = @{ }
-                                    $firstline -split $Delimiter | ForEach-Object {
-                                        $ColumnMapping.Add($_, $_)
+                                    # turns out split doesn't play nicely with | below we conditionally escape it
+                                    if ($Delimiter -eq "|") {
+                                        $ColumnMapColumns = $firstline -split '\|'
+                                    } else {
+                                        $ColumnMapColumns = $firstline -split $Delimiter
+                                    }
+                                    foreach ($ColumnMapColumn in $ColumnMapColumns) {
+                                        $ColumnMapping.Add($ColumnMapColumn, $ColumnMapColumn)
                                     }
                                     $ColumnMap += $ColumnMapping
                                 } catch {


### PR DESCRIPTION
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #6763  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Get automap functionality to work with a pipe delimited input file when importing data into an existing table

### Approach
I check if the delimiter is a pipe and conditionally escape it for the split command.  I couldn't find a more elegant way to do this than the way I did.  I suspect someone with more PowerShell-Fu write this a bit more elegantly and I hope they pipe up with a suggestion so I can learn.

### Commands to test
I didn't test this change to the module itself, instead I wrote this code

    $firstline = Get-Content -Path $($FileItem.FullName) -TotalCount 1 -ErrorAction Stop
    $ColumnMapping = @{ }
    $firstline -split '\|' | ForEach-Object {
        $ColumnMapping.Add($_, $_)
    }
    $ColumnMap += $ColumnMapping

and passed the $ColumnMap into Import-DbaCsv's ColumnMap parameter.
