### PR TITLE
Get-DbaBuildReference, allow test to run on RTM

### DIFF
--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -151,11 +151,13 @@ Describe "$commandname Integration Tests" -Tags 'IntegrationTests' {
                     $b.MatchType | Should Be "Exact"
                     $b.KBLevel | Should BeIn $r.KBLevel
                 }
-                $kbMatch = Get-DbaBuildReference -KB ($r.KBLevel | Select-Object -First 1)
-                $kbMatch | Should -Not -BeNullOrEmpty
-                foreach ($m in $kbMatch) {
-                    $m.MatchType | Should Be "Exact"
-                    $m.KBLevel | Should BeIn $r.KBLevel
+                if ($r.KBLevel) { #can be a RTM which has no corresponding KB
+                    $kbMatch = Get-DbaBuildReference -KB ($r.KBLevel | Select-Object -First 1)
+                    $kbMatch | Should -Not -BeNullOrEmpty
+                    foreach ($m in $kbMatch) {
+                        $m.MatchType | Should Be "Exact"
+                        $m.KBLevel | Should BeIn $r.KBLevel
+                    }
                 }
                 $spLevel = $r.SPLevel | Where-Object { $_ -ne 'LATEST' }
                 $versionMatch = Get-DbaBuildReference -MajorVersion $r.NameLevel -ServicePack $spLevel -CumulativeUpdate $r.CULevel


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Test failed on live instances of those are on a RTM level, which has no corresponding KB.
Fixed bypassing the unrannable test if RTM are found, otherwise all runs as always.
