### PR TITLE
Fix #6685 and #6762 for Copy-DbaDbTableData and Copy-DbaDbViewData

### DIFF
--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -54,6 +54,7 @@ function Copy-DbaDbTableData {
     .PARAMETER Query
         Define a query to use as a source. Note: 3 or 4 part object names may be used as described in https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql
         Ensure to select all required columns. Calculated Columns or columns with default values may be excluded.
+        Note: Even when the -Query param is used a valid -Table or -View must be specified. This is due to the workflow used in the command.
 
     .PARAMETER AutoCreateTable
         Creates the destination table if it does not already exist, based off of the "Export..." script of the source table.
@@ -170,15 +171,21 @@ function Copy-DbaDbTableData {
         >> Destination = 'server1'
         >> Database = 'AdventureWorks2017'
         >> DestinationDatabase = 'AdventureWorks2017'
-        >> Table = '[Person].[EmailPromotion]'
+        >> Table = '[AdventureWorks2017].[Person].[EmailPromotion]'
         >> BatchSize = 10000
-        >> Query = "SELECT * FROM [Person].[Person] where EmailPromotion = 1"
+        >> Query = "SELECT * FROM [OtherDb].[Person].[Person] where EmailPromotion = 1"
         >> }
         >>
         PS C:\> Copy-DbaDbTableData @params
 
-        Copies data returned from the query on server1 into the AdventureWorks2017 on server1.
-        Copy is processed in BatchSize of 10000 rows. Presuming the Person.EmailPromotion exists already.
+        Copies data returned from the query on server1 into the AdventureWorks2017 on server1. Note that 3 or 4 part names can be used.
+        See the -Query param documentation for more details.
+        Copy is processed in BatchSize of 10000 rows. 
+    
+    .EXAMPLE
+       Copy-DbaDbTableData -SqlInstance sql1 -Database tempdb -View [tempdb].[dbo].[vw1] -DestinationTable [SampleDb].[SampleSchema].[SampleTable] -AutoCreateTable
+       
+       Copies all data from [tempdb].[dbo].[vw1] on instance sql1 to an auto-created table [SampleDb].[SampleSchema].[SampleTable] on instance sql1
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]

--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -47,18 +47,17 @@ function Copy-DbaDbTableData {
         The table you want to use as destination. If not specified, it is assumed to be the same of Table
 
     .PARAMETER Query
-        If you want to copy only a portion of a table or selected tables, specify the query.
-        Ensure to select all required columns. Calculated Columns or columns with default values may be excluded.
-        The tablename should be a full three-part name in form [Database].[Schema].[Table]
+        Define a query to use as a source. Note: 3 or 4 part object names may be used as described in https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql
+        Ensure to select all required columns. Calculated Columns or columns with default values may be excluded.        
 
     .PARAMETER AutoCreateTable
         Creates the destination table if it does not already exist, based off of the "Export..." script of the source table.
 
     .PARAMETER BatchSize
-        The BatchSize for the import defaults to 5000.
+        The BatchSize for the import defaults to 50000.
 
     .PARAMETER NotifyAfter
-        Sets the option to show the notification after so many rows of import
+        Sets the option to show the notification after so many rows of import. The default is 5000 rows.
 
     .PARAMETER NoTableLock
         If this switch is enabled, a table lock (TABLOCK) will not be placed on the destination table. By default, this operation will lock the destination table while running.
@@ -87,7 +86,7 @@ function Copy-DbaDbTableData {
         If this switch is enabled, the destination table will be truncated after prompting for confirmation.
 
     .PARAMETER BulkCopyTimeOut
-        Value in seconds for the BulkCopy operations timeout. The default is 30 seconds.
+        Value in seconds for the BulkCopy operations timeout. The default is 5000 seconds.
 
     .PARAMETER InputObject
         Enables piping of Table objects from Get-DbaDbTable
@@ -186,6 +185,7 @@ function Copy-DbaDbTableData {
         [string]$Database,
         [string]$DestinationDatabase,
         [string[]]$Table,
+        [string[]]$View, # Copy-DbaDbTableData and Copy-DbaDbViewData are consolidated to reduce maintenance cost, so this param is specific to calls of Copy-DbaDbViewData 
         [string]$Query,
         [switch]$AutoCreateTable,
         [int]$BatchSize = 50000,
@@ -199,7 +199,7 @@ function Copy-DbaDbTableData {
         [switch]$Truncate,
         [int]$bulkCopyTimeOut = 5000,
         [Parameter(ValueFromPipeline)]
-        [Microsoft.SqlServer.Management.Smo.Table[]]$InputObject,
+        [Microsoft.SqlServer.Management.Smo.TableViewBase[]]$InputObject,
         [switch]$EnableException
     )
 
@@ -220,55 +220,69 @@ function Copy-DbaDbTableData {
     }
 
     process {
-        if ((Test-Bound -Not -ParameterName Table, SqlInstance) -and (Test-Bound -Not -ParameterName InputObject)) {
-            Stop-Function -Message "You must pipe in a table or specify SqlInstance, Database and Table."
+        if ((Test-Bound -Not -ParameterName Table, View, SqlInstance) -and (Test-Bound -Not -ParameterName InputObject)) {
+            Stop-Function -Message "You must pipe in a table or specify SqlInstance, Database and [View|Table]."
             return
         }
-
+        
+        # determine if -Table or -View was used
+        $SourceObject = $Table
+        if ((Test-Bound -ParameterName View) -and (Test-Bound -ParameterName Table)) {
+            Stop-Function -Message "Only one of [View|Table] may be specified."
+            return
+        }
+        elseif ( Test-Bound -ParameterName View ) {
+            $SourceObject = $View
+        }
+        
         if ($SqlInstance) {
             if ((Test-Bound -Not -ParameterName Database)) {
-                Stop-Function -Message "Database is required when passing a SqlInstance" -Target $Table
+                Stop-Function -Message "Database is required when passing a SqlInstance" -Target $SourceObject
                 return
             }
 
             if ((Test-Bound -Not -ParameterName Destination, DestinationDatabase, DestinationTable)) {
-                Stop-Function -Message "Cannot copy $Table into itself. One of destination Server, Database or Table must be specified " -Target $Table
+                Stop-Function -Message "Cannot copy $SourceObject into itself. One of the parameters Destination (Server), DestinationDatabase, or DestinationTable must be specified " -Target $SourceObject
                 return
             }
 
             try {
-                $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+                # Ensuring that the default db connection is to the passed in $Database instead of the master db. This way callers don't have to remember to do 3 part queries.
+                $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
-                return
-            }
-
-            if ($Database -notin $server.Databases.Name) {
-                Stop-Function -Message "Database $Database doesn't exist on $server"
+                Stop-Function -Message "Error occurred while establishing connection to $SqlInstance and database $Database" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
                 return
             }
 
             try {
-                foreach ($tbl in $Table) {
-                    $dbTable = Get-DbaDbTable -SqlInstance $server -Table $tbl -Database $Database -EnableException -Verbose:$false
-                    if ($dbTable.Count -eq 1) {
-                        $InputObject += $dbTable
+                foreach ($sourceDataObject in $SourceObject) {
+                    $dbObject = $null
+                    
+                    if ( Test-Bound -ParameterName View ) {
+                        $dbObject = Get-DbaDbView -SqlInstance $server -View $sourceDataObject -Database $Database -EnableException -Verbose:$false
+                    }
+                    else {
+                        $dbObject = Get-DbaDbTable -SqlInstance $server -Table $sourceDataObject -Database $Database -EnableException -Verbose:$false
+                    }
+                    
+                    if ($dbObject.Count -eq 1) {
+                        $InputObject += $dbObject
                     } else {
-                        Stop-Function -Message "The table $tbl matches $($dbTable.Count) objects. Unable to determine which object to copy" -Continue
+                        Stop-Function -Message "The table $tbl matches $($dbObject.Count) objects. Unable to determine which object to copy" -Continue
                     }
                 }
             } catch {
-                Stop-Function -Message "Unable to determine source table : $Table"
+                Stop-Function -Message "Unable to determine source : $SourceObject"
                 return
             }
         }
 
-        foreach ($sqltable in $InputObject) {
-            $Database = $sqltable.Parent.Name
-            $server = $sqltable.Parent.Parent
-
+        foreach ($sqlObject in $InputObject) {
+            $Database = $sqlObject.Parent.Name
+            $server = $sqlObject.Parent.Parent
+            
             if ((Test-Bound -Not -ParameterName DestinationTable)) {
-                $DestinationTable = '[' + $sqltable.Schema + '].[' + $sqltable.Name + ']'
+                $DestinationTable = '[' + $sqlObject.Schema + '].[' + $sqlObject.Name + ']'
             }
 
             $newTableParts = Get-ObjectNameParts -ObjectName $DestinationTable
@@ -295,19 +309,42 @@ function Copy-DbaDbTableData {
                     Stop-Function -Message "Database $DestinationDatabase doesn't exist on $destServer"
                     return
                 }
-
+                
                 $desttable = Get-DbaDbTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false | Select-Object -First 1
                 if (-not $desttable -and $AutoCreateTable) {
                     try {
-                        $tablescript = $sqltable | Export-DbaScript -Passthru | Out-String
+                        $tablescript = $null
+                        $schemaNameToReplace = $null
+                        $tableNameToReplace = $null
+                        if ( Test-Bound -ParameterName View ) {
+                            #select view into tempdb to generate script
+                            $tempTableName = "$($sqlObject.Name)_table"
+                            $createquery = "SELECT * INTO tempdb..$tempTableName FROM [$($sqlObject.Schema)].[$($sqlObject.Name)] WHERE 1=2"
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $createquery -EnableException
+                            #refreshing table list to make sure get-dbadbtable will find the new table
+                            $server.Databases['tempdb'].Tables.Refresh($true)
+                            $tempTable = Get-DbaDbTable -SqlInstance $server -Database tempdb -Table $tempTableName                            
+                            # need these for generating the script of the table and then replacing the schema and name                            
+                            $schemaNameToReplace = $tempTable.Schema
+                            $tableNameToReplace = $tempTable.Name
+                            $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
+                            # cleanup
+                            Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
+                        }
+                        else {
+                            $tablescript = $sqlObject | Export-DbaScript -Passthru | Out-String
+                            $schemaNameToReplace = $sqlObject.Schema
+                            $tableNameToReplace = $sqlObject.Name
+                        }            
+
                         #replacing table name
                         if ($newTableParts.Name) {
-                            $rX = "(CREATE TABLE \[$([regex]::Escape($sqltable.Schema))\]\.\[)$([regex]::Escape($sqltable.Name))(\]\()"
+                            $rX = "(CREATE TABLE \[$([regex]::Escape($schemaNameToReplace))\]\.\[)$([regex]::Escape($tableNameToReplace))(\]\()"
                             $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Name)`$2"
                         }
                         #replacing table schema
                         if ($newTableParts.Schema) {
-                            $rX = "(CREATE TABLE \[)$([regex]::Escape($sqltable.Schema))(\]\.\[$([regex]::Escape($newTableParts.Name))\]\()"
+                            $rX = "(CREATE TABLE \[)$([regex]::Escape($schemaNameToReplace))(\]\.\[$([regex]::Escape($newTableParts.Name))\]\()"
                             $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Schema)`$2"
                         }
 
@@ -331,9 +368,9 @@ function Copy-DbaDbTableData {
                 $connstring = $destServer.ConnectionContext.ConnectionString
 
                 if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
-                    $fqtnfrom = "$sqltable"
+                    $fqtnfrom = "$sqlObject"
                 } else {
-                    $fqtnfrom = "$($server.Databases[$Database]).$sqltable"
+                    $fqtnfrom = "$($server.Databases[$Database]).$sqlObject"
                 }
 
                 if ($destServer.DatabaseEngineType -eq "SqlAzureDatabase") {
@@ -400,8 +437,8 @@ function Copy-DbaDbTableData {
                         [pscustomobject]@{
                             SourceInstance      = $server.Name
                             SourceDatabase      = $Database
-                            SourceSchema        = $sqltable.Schema
-                            SourceTable         = $sqltable.Name
+                            SourceSchema        = $sqlObject.Schema
+                            SourceTable         = $sqlObject.Name
                             DestinationInstance = $destServer.Name
                             DestinationDatabase = $DestinationDatabase
                             DestinationSchema   = $desttable.Schema

--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -235,8 +235,7 @@ function Copy-DbaDbTableData {
         if ((Test-Bound -ParameterName View) -and (Test-Bound -ParameterName Table)) {
             Stop-Function -Message "Only one of [View|Table] may be specified."
             return
-        }
-        elseif ( Test-Bound -ParameterName View ) {
+        } elseif ( Test-Bound -ParameterName View ) {
             $SourceObject = $View
         }
         
@@ -265,8 +264,7 @@ function Copy-DbaDbTableData {
                     
                     if ( Test-Bound -ParameterName View ) {
                         $dbObject = Get-DbaDbView -SqlInstance $server -View $sourceDataObject -Database $Database -EnableException -Verbose:$false
-                    }
-                    else {
+                    } else {
                         $dbObject = Get-DbaDbTable -SqlInstance $server -Table $sourceDataObject -Database $Database -EnableException -Verbose:$false
                     }
                     
@@ -335,8 +333,7 @@ function Copy-DbaDbTableData {
                             $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
                             # cleanup
                             Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
-                        }
-                        else {
+                        } else {
                             $tablescript = $sqlObject | Export-DbaScript -Passthru | Out-String
                             $schemaNameToReplace = $sqlObject.Schema
                             $tableNameToReplace = $sqlObject.Name
@@ -420,7 +417,7 @@ function Copy-DbaDbTableData {
                         # Add RowCount output
                         $bulkCopy.Add_SqlRowsCopied( {
                                 $RowsPerSec = [math]::Round($args[1].RowsCopied / $elapsed.ElapsedMilliseconds * 1000.0, 1)
-                                Write-Progress -id 1 -activity "Inserting rows" -Status ([System.String]::Format("{0} rows ({1} rows/sec)", $args[1].RowsCopied, $RowsPerSec))
+                                Write-Progress -Id 1 -Activity "Inserting rows" -Status ([System.String]::Format("{0} rows ({1} rows/sec)", $args[1].RowsCopied, $RowsPerSec))
                             })
                     }
 
@@ -431,7 +428,7 @@ function Copy-DbaDbTableData {
                         $TotalTime = [math]::Round($elapsed.Elapsed.TotalSeconds, 1)
                         Write-Message -Level Verbose -Message "$RowsTotal rows inserted in $TotalTime sec"
                         if ($rowCount -is [int]) {
-                            Write-Progress -id 1 -activity "Inserting rows" -status "Complete" -Completed
+                            Write-Progress -Id 1 -Activity "Inserting rows" -Status "Complete" -Completed
                         }
 
                         $server.ConnectionContext.SqlConnectionObject.Close()

--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -180,7 +180,7 @@ function Copy-DbaDbTableData {
 
         Copies data returned from the query on server1 into the AdventureWorks2017 on server1. Note that 3 or 4 part names can be used.
         See the -Query param documentation for more details.
-        Copy is processed in BatchSize of 10000 rows. 
+        Copy is processed in BatchSize of 10000 rows.
     
     .EXAMPLE
        Copy-DbaDbTableData -SqlInstance sql1 -Database tempdb -View [tempdb].[dbo].[vw1] -DestinationTable [SampleDb].[SampleSchema].[SampleTable] -AutoCreateTable

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -43,18 +43,17 @@ function Copy-DbaDbViewData {
         The table you want to use as destination. If not specified, it is assumed to be the same of View
 
     .PARAMETER Query
-        If you want to copy only a portion of a view or selected views, specify the query.
+        Define a query to use as a source. Note: 3 or 4 part object names may be used as described in https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql
         Ensure to select all required columns. Calculated Columns or columns with default values may be excluded.
-        The tablename should be a full three-part name in form [Database].[Schema].[Table]
 
     .PARAMETER AutoCreateTable
         Creates the destination table if it does not already exist, based off of the "Export..." script of the source table.
 
     .PARAMETER BatchSize
-        The BatchSize for the import defaults to 5000.
+        The BatchSize for the import defaults to 50000.
 
     .PARAMETER NotifyAfter
-        Sets the option to show the notification after so many rows of import
+        Sets the option to show the notification after so many rows of import. The default is 5000 rows.
 
     .PARAMETER NoTableLock
         If this switch is enabled, a table lock (TABLOCK) will not be placed on the destination table. By default, this operation will lock the destination table while running.
@@ -83,7 +82,7 @@ function Copy-DbaDbViewData {
         If this switch is enabled, the destination table will be truncated after prompting for confirmation.
 
     .PARAMETER BulkCopyTimeOut
-        Value in seconds for the BulkCopy operations timeout. The default is 30 seconds.
+        Value in seconds for the BulkCopy operations timeout. The default is 5000 seconds.
 
     .PARAMETER InputObject
         Enables piping of View objects from Get-DbaDbView
@@ -195,231 +194,11 @@ function Copy-DbaDbViewData {
         [switch]$Truncate,
         [int]$bulkCopyTimeOut = 5000,
         [Parameter(ValueFromPipeline)]
-        [Microsoft.SqlServer.Management.Smo.View[]]$InputObject,
+        [Microsoft.SqlServer.Management.Smo.TableViewBase[]]$InputObject,
         [switch]$EnableException
     )
 
-    begin {
-
-        $bulkCopyOptions = 0
-        $options = "TableLock", "CheckConstraints", "FireTriggers", "KeepIdentity", "KeepNulls", "Default"
-
-        foreach ($option in $options) {
-            $optionValue = Get-Variable $option -ValueOnly -ErrorAction SilentlyContinue
-            if ($option -eq "TableLock" -and (!$NoTableLock)) {
-                $optionValue = $true
-            }
-            if ($optionValue -eq $true) {
-                $bulkCopyOptions += $([Data.SqlClient.SqlBulkCopyOptions]::$option).value__
-            }
-        }
-    }
-
-    process {
-        if ((Test-Bound -Not -ParameterName View, SqlInstance) -and (Test-Bound -Not -ParameterName InputObject)) {
-            Stop-Function -Message "You must pipe in a view or specify SqlInstance, Database and View."
-            return
-        }
-
-        if ($SqlInstance) {
-            if ((Test-Bound -Not -ParameterName Database)) {
-                Stop-Function -Message "Database is required when passing a SqlInstance" -Target $View
-                return
-            }
-
-            if ((Test-Bound -Not -ParameterName Destination, DestinationDatabase, DestinationTable)) {
-                Stop-Function -Message "Cannot copy $View into itself. One of destination Server, Database or View must be specified " -Target $View
-                return
-            }
-
-            try {
-                $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
-                return
-            }
-
-            if ($Database -notin $server.Databases.Name) {
-                Stop-Function -Message "Database $Database doesn't exist on $server"
-                return
-            }
-
-            try {
-                foreach ($vw in $View) {
-                    $dbView = Get-DbaDbView -SqlInstance $server -View $vw -Database $Database -EnableException -Verbose:$false
-                    if ($dbView.Count -eq 1) {
-                        $InputObject += $dbView
-                    } else {
-                        Stop-Function -Message "The view $vw matches $($dbView.Count) objects. Unable to determine which object to copy" -Continue
-                    }
-                }
-            } catch {
-                Stop-Function -Message "Unable to determine source view : $View"
-                $ex = $_.Exception
-                Write-Message -Level warning $ex.Message
-                return
-            }
-        }
-
-        foreach ($sqlview in $InputObject) {
-            $Database = $sqlview.Parent.Name
-            $server = $sqlview.Parent.Parent
-
-            if ((Test-Bound -Not -ParameterName DestinationTable)) {
-                $DestinationTable = '[' + $sqlview.Schema + '].[' + $sqlview.Name + ']'
-            }
-
-            $newTableParts = Get-ObjectNameParts -ObjectName $DestinationTable
-            #using FQTN to determine database name
-            if ($newTableParts.Database) {
-                $DestinationDatabase = $newTableParts.Database
-            } elseif ((Test-Bound -Not -ParameterName DestinationDatabase)) {
-                $DestinationDatabase = $Database
-            }
-
-            if (-not $Destination) {
-                $Destination = $server
-            }
-
-            foreach ($destinationserver in $Destination) {
-                try {
-                    $destServer = Connect-SqlInstance -SqlInstance $destinationserver -SqlCredential $DestinationSqlCredential
-                } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $destinationserver
-                    return
-                }
-
-                if ($DestinationDatabase -notin $destServer.Databases.Name) {
-                    Stop-Function -Message "Database $DestinationDatabase doesn't exist on $destServer"
-                    return
-                }
-
-                $desttable = Get-DbaDbTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false | Select-Object -First 1
-                if (-not $desttable -and $AutoCreateTable) {
-                    try {
-                        #select view into tempdb to generate script
-                        $tempTableName = "$($sqlview.Name)_table"
-                        $createquery = "SELECT * INTO tempdb..$tempTableName FROM [$($sqlview.Schema)].[$($sqlview.Name)] WHERE 1=2"
-                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query $createquery -EnableException
-                        #refreshing table list to make sure get-dbadbtable will find the new table
-                        $server.Databases['tempdb'].Tables.Refresh($true)
-                        $tempTable = Get-DbaDbTable -SqlInstance $server -Database tempdb -Table $tempTableName
-                        $tablescript = $tempTable | Export-DbaScript -Passthru | Out-String
-                        Invoke-DbaQuery -SqlInstance $server -Database $Database -Query "DROP TABLE tempdb..$tempTableName" -EnableException
-                        #replacing table name
-                        if ($newTableParts.Name) {
-                            $rX = "(CREATE TABLE \[$([regex]::Escape($tempTable.Schema))\]\.\[)$([regex]::Escape($tempTable.Name))(\]\()"
-                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Name)`$2"
-                        }
-                        #replacing table schema
-                        if ($newTableParts.Schema) {
-                            $rX = "(CREATE TABLE \[)$([regex]::Escape($tempTable.Schema))(\]\.\[$([regex]::Escape($newTableParts.Name))\]\()"
-                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Schema)`$2"
-                        }
-
-                        if ($PSCmdlet.ShouldProcess($destServer, "Creating new table: $DestinationTable")) {
-                            Write-Message -Message "New table script: $tablescript" -Level VeryVerbose
-                            Invoke-DbaQuery -SqlInstance $destServer -Database $DestinationDatabase -Query "$tablescript" -EnableException # add some string assurance there
-                            #table list was updated, let's grab a fresh one
-                            $destServer.Databases[$DestinationDatabase].Tables.Refresh()
-                            $desttable = Get-DbaDbTable -SqlInstance $destServer -Table $DestinationTable -Database $DestinationDatabase -Verbose:$false
-                            Write-Message -Message "New table created: $desttable" -Level Verbose
-                        }
-                    } catch {
-                        Stop-Function -Message "Unable to determine destination table: $DestinationTable" -ErrorRecord $_
-                        return
-                    }
-                }
-                if (-not $desttable) {
-                    Stop-Function -Message "Table $DestinationTable cannot be found in $DestinationDatabase. Use -AutoCreateTable to automatically create the table on the destination." -Continue
-                }
-
-                $connstring = $destServer.ConnectionContext.ConnectionString
-
-                if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
-                    $fqtnfrom = "$sqlview"
-                } else {
-                    $fqtnfrom = "$($server.Databases[$Database]).$sqlview"
-                }
-
-                if ($destServer.DatabaseEngineType -eq "SqlAzureDatabase") {
-                    $fqtndest = "$desttable"
-                } else {
-                    $fqtndest = "$($destServer.Databases[$DestinationDatabase]).$desttable"
-                }
-
-                if ($fqtndest -eq $fqtnfrom -and $server.Name -eq $destServer.Name -and (Test-Bound -ParameterName Query -Not)) {
-                    Stop-Function -Message "Cannot copy $fqtnfrom on $($server.Name) into $fqtndest on ($destServer.Name). Source and Destination must be different " -Target $View
-                    return
-                }
-
-
-                if (Test-Bound -ParameterName Query -Not) {
-                    $Query = "SELECT * FROM $fqtnfrom"
-                    $sourceLabel = $fqtnfrom
-                } else {
-                    $sourceLabel = "Query"
-                }
-                try {
-                    if ($Truncate -eq $true) {
-                        if ($Pscmdlet.ShouldProcess($destServer, "Truncating table $fqtndest")) {
-                            Invoke-DbaQuery -SqlInstance $destServer -Database $DestinationDatabase -Query "TRUNCATE TABLE $fqtndest" -EnableException
-                        }
-                    }
-                    if ($Pscmdlet.ShouldProcess($server, "Copy data from $sourceLabel")) {
-                        $cmd = $server.ConnectionContext.SqlConnectionObject.CreateCommand()
-                        $cmd.CommandTimeout = 0
-                        $cmd.CommandText = $Query
-                        if ($server.ConnectionContext.IsOpen -eq $false) {
-                            $server.ConnectionContext.SqlConnectionObject.Open()
-                        }
-                        $bulkCopy = New-Object Data.SqlClient.SqlBulkCopy("$connstring;Database=$DestinationDatabase", $bulkCopyOptions)
-                        $bulkCopy.DestinationTableName = $fqtndest
-                        $bulkCopy.EnableStreaming = $true
-                        $bulkCopy.BatchSize = $BatchSize
-                        $bulkCopy.NotifyAfter = $NotifyAfter
-                        $bulkCopy.BulkCopyTimeOut = $BulkCopyTimeOut
-
-                        $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
-                        # Add RowCount output
-                        $bulkCopy.Add_SqlRowsCopied( {
-                                $RowsPerSec = [math]::Round($args[1].RowsCopied / $elapsed.ElapsedMilliseconds * 1000.0, 1)
-                                Write-Progress -id 1 -activity "Inserting rows" -Status ([System.String]::Format("{0} rows ({1} rows/sec)", $args[1].RowsCopied, $RowsPerSec))
-                            })
-                    }
-
-                    if ($Pscmdlet.ShouldProcess($destServer, "Writing rows to $fqtndest")) {
-                        $reader = $cmd.ExecuteReader()
-                        $bulkCopy.WriteToServer($reader)
-                        $RowsTotal = Get-BulkRowsCopiedCount $bulkCopy
-                        $TotalTime = [math]::Round($elapsed.Elapsed.TotalSeconds, 1)
-                        Write-Message -Level Verbose -Message "$RowsTotal rows inserted in $TotalTime sec"
-                        if ($rowCount -is [int]) {
-                            Write-Progress -id 1 -activity "Inserting rows" -status "Complete" -Completed
-                        }
-
-                        $server.ConnectionContext.SqlConnectionObject.Close()
-                        $bulkCopy.Close()
-                        $bulkCopy.Dispose()
-                        $reader.Close()
-
-                        [pscustomobject]@{
-                            SourceInstance      = $server.Name
-                            SourceDatabase      = $Database
-                            SourceSchema        = $sqlview.Schema
-                            SourceView          = $sqlview.Name
-                            DestinationInstance = $destServer.Name
-                            DestinationDatabase = $DestinationDatabase
-                            DestinationSchema   = $desttable.Schema
-                            DestinationTable    = $desttable.Name
-                            RowsCopied          = $rowstotal
-                            Elapsed             = [prettytimespan]$elapsed.Elapsed
-                        }
-                    }
-                } catch {
-                    Stop-Function -Message "Something went wrong" -ErrorRecord $_ -Target $server -continue
-                }
-            }
-        }
+    process {        
+        Copy-DbaDbTableData @PSBoundParameters
     }
 }

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -34,10 +34,9 @@ function Copy-DbaDbViewData {
         The database to copy the table to. If not specified, it is assumed to be the same of Database
 
     .PARAMETER View
-        Define a specific view you would like to use as source. You can specify a three-part name like db.sch.vw.
+        Specify a view to use as a source. You can specify a two-part name or a three-part name such as db.sch.vw.
         If the object has special characters please wrap them in square brackets [ ].
-        This dbo.First.View will try to find view named 'View' on schema 'First' and database 'dbo'.
-        The correct way to find view named 'First.View' on schema 'dbo' is passing dbo.[First.View]
+        Example: [SampleDB].[First].[View] will try to find the view named 'View' in the schema 'First' and the database 'SampleDB'.
 
     .PARAMETER DestinationTable
         The table you want to use as destination. If not specified, it is assumed to be the same of View
@@ -198,7 +197,7 @@ function Copy-DbaDbViewData {
         [switch]$EnableException
     )
 
-    process {        
+    process {
         Copy-DbaDbTableData @PSBoundParameters
     }
 }

--- a/functions/Copy-DbaDbViewData.ps1
+++ b/functions/Copy-DbaDbViewData.ps1
@@ -44,6 +44,7 @@ function Copy-DbaDbViewData {
     .PARAMETER Query
         Define a query to use as a source. Note: 3 or 4 part object names may be used as described in https://docs.microsoft.com/en-us/sql/t-sql/language-elements/transact-sql-syntax-conventions-transact-sql
         Ensure to select all required columns. Calculated Columns or columns with default values may be excluded.
+        Note: Even when the -Query param is used a valid -Table or -View must be specified. This is due to the workflow used in the command.
 
     .PARAMETER AutoCreateTable
         Creates the destination table if it does not already exist, based off of the "Export..." script of the source table.
@@ -160,15 +161,15 @@ function Copy-DbaDbViewData {
         >> Destination = 'server1'
         >> Database = 'AdventureWorks2017'
         >> DestinationDatabase = 'AdventureWorks2017'
-        >> View = '[Person].[EmailPromotion]'
+        >> View = '[AdventureWorks2017].[Person].[EmailPromotion]'
         >> BatchSize = 10000
-        >> Query = "SELECT * FROM [Person].[Person] where EmailPromotion = 1"
+        >> Query = "SELECT * FROM [OtherDb].[Person].[Person] where EmailPromotion = 1"
         >> }
         >>
         PS C:\> Copy-DbaDbViewData @params
 
         Copies data returned from the query on server1 into the AdventureWorks2017 on server1.
-        Copy is processed in BatchSize of 10000 rows. Presuming the Person.EmailPromotion exists already.
+        Copy is processed in BatchSize of 10000 rows. See the -Query param documentation for more details.
 
     #>
     [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess)]

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -58,7 +58,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     It "copies the table data to another instance" {
-        $null = Copy-DbaDbTableData -SqlInstance $script:instance1 -Destination $script:instance2 -Database tempdb -Table dbatoolsci_example -DestinationTable dbatoolsci_example3
+        $null = Copy-DbaDbTableData -SqlInstance $script:instance1 -Destination $script:instance2 -Database tempdb -Table tempdb.dbo.dbatoolsci_example -DestinationTable dbatoolsci_example3
         $table1count = $db.Query("select id from dbo.dbatoolsci_example")
         $table2count = $db2.Query("select id from dbo.dbatoolsci_example3")
         $table1count.Count | Should -Be $table2count.Count
@@ -74,6 +74,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     It "supports piping more than one table" {
         $results = Get-DbaDbTable -SqlInstance $script:instance1 -Database tempdb -Table dbatoolsci_example2, dbatoolsci_example | Copy-DbaDbTableData -DestinationTable dbatoolsci_example3
         $results.Count | Should -Be 2
+        $results.RowsCopied | Measure-Object -Sum | Select -Expand Sum | Should -Be 20
     }
 
     It "opens and closes connections properly" {

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -3,7 +3,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
-    Context "Validate parameters" {        
+    Context "Validate parameters" {
         It "Should only contain our specific parameters" {
             [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
             [object[]]$knownParameters = 'AutoCreateTable', 'BatchSize', 'bulkCopyTimeOut', 'CheckConstraints', 'Database', 'Destination', 'DestinationDatabase', 'DestinationSqlCredential', 'DestinationTable', 'EnableException', 'FireTriggers', 'InputObject', 'KeepIdentity', 'KeepNulls', 'NoTableLock', 'NotifyAfter', 'Query', 'SqlCredential', 'SqlInstance', 'Table', 'Truncate', 'View'
@@ -121,11 +121,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     
     It "Copy data using a query that uses a 3 part query" {
         $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
-        $result.RowsCopied | Should -Be 1
-    }
-    
-    It "Copy data using a query that uses a 4 part query" {
-        $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM [$($db2.Parent.Name)].tempdb.dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
         $result.RowsCopied | Should -Be 1
     }
 }

--- a/tests/Copy-DbaDbTableData.Tests.ps1
+++ b/tests/Copy-DbaDbTableData.Tests.ps1
@@ -3,12 +3,13 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
-    Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Destination', 'DestinationSqlCredential', 'Database', 'DestinationDatabase', 'Table', 'Query', 'AutoCreateTable', 'BatchSize', 'NotifyAfter', 'DestinationTable', 'NoTableLock', 'CheckConstraints', 'FireTriggers', 'KeepIdentity', 'KeepNulls', 'Truncate', 'bulkCopyTimeOut', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+    Context "Validate parameters" {        
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+            [object[]]$knownParameters = 'AutoCreateTable', 'BatchSize', 'bulkCopyTimeOut', 'CheckConstraints', 'Database', 'Destination', 'DestinationDatabase', 'DestinationSqlCredential', 'DestinationTable', 'EnableException', 'FireTriggers', 'InputObject', 'KeepIdentity', 'KeepNulls', 'NoTableLock', 'NotifyAfter', 'Query', 'SqlCredential', 'SqlInstance', 'Table', 'Truncate', 'View'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -93,16 +94,38 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
 
     It "Should return nothing if Source and Destination are same" {
         $result = Copy-DbaDbTableData -SqlInstance $script:instance1 -Database tempdb -Table dbatoolsci_example -Truncate
-        $result | Should Be $null
+        $result | Should -Be $null
     }
 
     It "Should warn if the destinaton table doesn't exist" {
         $result = Copy-DbaDbTableData -SqlInstance $script:instance1 -Database tempdb -Table dbatoolsci_example -DestinationTable dbatoolsci_doesntexist -WarningVariable tablewarning
+        $result | Should -Be $null
         $tablewarning | Should -match Auto
     }
 
     It "automatically creates the table" {
         $result = Copy-DbaDbTableData -SqlInstance $script:instance1 -Database tempdb -Table dbatoolsci_example -DestinationTable dbatoolsci_willexist -AutoCreateTable
         $result.DestinationTable | Should -Be 'dbatoolsci_willexist'
+    }
+    
+    It "Should warn if the source database doesn't exist" {
+        $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb_invalid -Table dbatoolsci_example -DestinationTable dbatoolsci_doesntexist -WarningVariable tablewarning
+        $result | Should -Be $null
+        $tablewarning | Should -match "cannot open database"
+    }
+    
+    It "Copy data using a query that relies on the default source database" {
+        $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
+        $result.RowsCopied | Should -Be 1
+    }
+    
+    It "Copy data using a query that uses a 3 part query" {
+        $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
+        $result.RowsCopied | Should -Be 1
+    }
+    
+    It "Copy data using a query that uses a 4 part query" {
+        $result = Copy-DbaDbTableData -SqlInstance $script:instance2 -Database tempdb -Table dbo.dbatoolsci_example4 -Query "SELECT TOP (1) Id FROM [$($db2.Parent.Name)].tempdb.dbo.dbatoolsci_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
+        $result.RowsCopied | Should -Be 1
     }
 }

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -70,14 +70,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         Remove-TempObjects $db, $db2
     }
 
-    It "copies the table data" {
+    It "copies the view data" {
         $null = Copy-DbaDbViewData -SqlInstance $script:instance1 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_example2
         $table1count = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table2count = $db.Query("select id from dbo.dbatoolsci_example2")
         $table1count.Count | Should -Be $table2count.Count
     }
 
-    It "copies the table data to another instance" {
+    It "copies the view data to another instance" {
         $null = Copy-DbaDbViewData -SqlInstance $script:instance1 -Destination $script:instance2 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_example3
         $table1count = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table2count = $db2.Query("select id from dbo.dbatoolsci_view_example3")
@@ -91,9 +91,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $table1count.Count | Should -Be $table2count.Count
     }
 
-    It "supports piping more than one table" {
+    It "supports piping more than one view" {
         $results = Get-DbaDbView -SqlInstance $script:instance1 -Database tempdb -View dbatoolsci_view_example2, dbatoolsci_view_example | Copy-DbaDbViewData -DestinationTable dbatoolsci_example3
         $results.Count | Should -Be 2
+        $results.RowsCopied | Measure-Object -Sum | Select -Expand Sum | Should -Be 20
     }
 
     It "opens and closes connections properly" {
@@ -119,7 +120,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     It "Should warn if the destination table doesn't exist" {
-        $result = Copy-DbaDbViewData -SqlInstance $script:instance1 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_does_not_exist -WarningVariable tablewarning
+        $result = Copy-DbaDbViewData -SqlInstance $script:instance1 -Database tempdb -View tempdb.dbo.dbatoolsci_view_example -DestinationTable dbatoolsci_view_does_not_exist -WarningVariable tablewarning
         $result | Should -Be $null
         $tablewarning | Should -match Auto
     }

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -3,7 +3,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
-    Context "Validate parameters" {        
+    Context "Validate parameters" {
         It "Should only contain our specific parameters" {
             [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm') }
             [object[]]$knownParameters = 'AutoCreateTable', 'BatchSize', 'bulkCopyTimeOut', 'CheckConstraints', 'Database', 'Destination', 'DestinationDatabase', 'DestinationSqlCredential', 'DestinationTable', 'EnableException', 'FireTriggers', 'InputObject', 'KeepIdentity', 'KeepNulls', 'NoTableLock', 'NotifyAfter', 'Query', 'SqlCredential', 'SqlInstance', 'Truncate', 'View'
@@ -142,11 +142,6 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     
     It "Copy data using a query that uses a 3 part query" {
         $result = Copy-DbaDbViewData -SqlInstance $script:instance1 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
-        $result.RowsCopied | Should -Be 1
-    }
-    
-    It "Copy data using a query that uses a 4 part query" {
-        $result = Copy-DbaDbViewData -SqlInstance $script:instance1 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM [$($db.Parent.Name)].tempdb.dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
         $result.RowsCopied | Should -Be 1
     }
 }

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -40,7 +40,7 @@ function Split-ArrayInParts($array, [int]$parts) {
 Describe "$ModuleName style" -Tag 'Compliance' {
     <#
     Ensures common formatting standards are applied:
-    - OTSB style, courtesy of PSSA's Invoke-Formatter, is what dbatools uses
+    - OTBS style, courtesy of PSSA's Invoke-Formatter, is what dbatools uses
     - UTF8 without BOM is what is going to be used in PS Core, so we adopt this standard for dbatools
     #>
     $AllFiles = Get-ChildItem -Path $ModulePath -File -Recurse -Filter '*.ps*1' | Where-Object Name -ne 'allcommands.ps1'
@@ -64,7 +64,7 @@ Describe "$ModuleName style" -Tag 'Compliance' {
         $results = $jobs | Receive-Job
 
         foreach ($f in $results) {
-            It "$f is adopting OTSB formatting style. Please run Invoke-DbatoolsFormatter against the failing file and commit the changes." {
+            It "$f is not compliant with the OTBS formatting style. Please run Invoke-DbatoolsFormatter against the failing file and commit the changes." {
                 1 | Should -Be 0
             }
         }


### PR DESCRIPTION
Summary of changes:

- Ensure the -Database param value is used when connecting to the source server so that 3 part queries are not mandatory as mentioned in Issue #6685
- Refactor the copy table and copy view commands to consolidate code and reduce maintenance cost
- Add integration tests for the ‘Query’ param
- Update the help documentation for Issue #6762

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [] Nunit test is included
 - [x] Documentation
 - [] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
1. Modify the default behavior for the server connection to improve usability of these commands.  More commentary is [here](https://github.com/sqlcollaborative/dbatools/issues/6685#issuecomment-682592849).
2. Consolidate the code since there was a high degree of overlap.

### Approach
<!-- How does this change solve that purpose -->
The refactoring of the code allows for backwards compatibility to be maintained and reduces the overall maintenance cost.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
No changes were made to the way the commands are invoked. See the examples in the help documentation and the pester tests


