### PR TITLE
Fix Log Shipping command to exclude monitor procedure when server is higher than 2012

### DIFF
--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -246,7 +246,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
-            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The check for the major version should return a value but it was based on a variable that does not have that property.

### Approach
Changed the check to use the correct variable and now it returns the right value

### Commands to test
New-DbaLogShippingSecondaryDatabase

### Screenshots
![afbeelding](https://user-images.githubusercontent.com/6154981/91577553-28865c80-e949-11ea-9021-216f35cb0b55.png)
