### PR TITLE
Get-DbaDbBackupHistory - change AgCheck to SuppressAgCheck and use it in Backup-DbaDatabase

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -644,7 +644,7 @@ function Backup-DbaDatabase {
                             if ($server.VersionMajor -eq '8') {
                                 $HeaderInfo = Get-BackupAncientHistory -SqlInstance $server -Database $dbName
                             } else {
-                                $HeaderInfo = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbName @gbhSwitch -IncludeCopyOnly -RecoveryFork $db.RecoveryForkGuid | Sort-Object -Property End -Descending | Select-Object -First 1
+                                $HeaderInfo = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbName @gbhSwitch -IncludeCopyOnly -RecoveryFork $db.RecoveryForkGuid -SuppressAgCheck | Sort-Object -Property End -Descending | Select-Object -First 1
                             }
                             $Verified = $false
                             if ($Verify) {

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -229,7 +229,7 @@ function Get-DbaDbBackupHistory {
             }
             $AgResults = @()
             $ProcessedAgDatabases = @()
-            if (($server.AvailabilityGroups.count -gt 0) -and (-not $SuppressAgCheck)) {
+            if (($server.AvailabilityGroups.count -gt 0) -and ($SuppressAgCheck -ne $True)) {
                 $agShortInstance = $instance.FullName.split('.')[0]
                 if ($agShortInstance -in ($server.AvailabilityGroups.AvailabilityGroupListeners).Name) {
                     # We have a listener passed in, just query the dbs specified or all in the AG
@@ -309,7 +309,7 @@ function Get-DbaDbBackupHistory {
             if ($ExcludeDatabase) {
                 $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
             }
-            if (($server.AvailabilityGroups.count -gt 0) -and (-not $SuppressAgCheck)) {
+            if (($server.AvailabilityGroups.count -gt 0) -and ($SuppressAgCheck -ne $True)) {
                 $adbs = $databases | Where-Object Name -In $server.AvailabilityGroups.AvailabilityDatabases.Name
                 $adbs = $adbs | Where-Object Name -NotIn $ProcessedAgDatabases
                 ForEach ($adb in $adbs) {

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -152,6 +152,12 @@ function Get-DbaDbBackupHistory {
 
         Will query all replicas in the Availability Group with AgListener and return the backup chain (Full, Diff and Log) to restore to the most rececnt point in time
 
+    .EXAMPLE
+        PS C:\> $allAgReplicas = 'srv1\demoapp,14333', 'srv2\demoapp,14333', 'srv3\demoapp,14333'
+        PS C:\> Get-DbaDbBackupHistory -SqlInstance $allAgReplicas -Database DemoDatabase -SuppressAgCheck
+
+        Will query all replicas in the Availability Group but without internal determination of the replicas, so that it works for replicas with custom ports.
+
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -229,7 +229,7 @@ function Get-DbaDbBackupHistory {
             }
             $AgResults = @()
             $ProcessedAgDatabases = @()
-            if (($server.AvailabilityGroups.count -gt 0) -and (Test-Bound -Not SuppressAgCheck)) {
+            if (($server.AvailabilityGroups.count -gt 0) -and (-not $SuppressAgCheck)) {
                 $agShortInstance = $instance.FullName.split('.')[0]
                 if ($agShortInstance -in ($server.AvailabilityGroups.AvailabilityGroupListeners).Name) {
                     # We have a listener passed in, just query the dbs specified or all in the AG
@@ -309,7 +309,7 @@ function Get-DbaDbBackupHistory {
             if ($ExcludeDatabase) {
                 $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
             }
-            if (($server.AvailabilityGroups.count -gt 0) -and (Test-Bound -Not SuppressAgCheck)) {
+            if (($server.AvailabilityGroups.count -gt 0) -and (-not $SuppressAgCheck)) {
                 $adbs = $databases | Where-Object Name -In $server.AvailabilityGroups.AvailabilityDatabases.Name
                 $adbs = $adbs | Where-Object Name -NotIn $ProcessedAgDatabases
                 ForEach ($adb in $adbs) {

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -8,9 +8,9 @@ function Get-DbaDbBackupHistory {
 
         You can even get detailed information (including file path) for latest full, differential and log files.
 
-        Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present or the target includes an Availability Group listener or a database in an Availability Group
+        Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present or the target includes an Availability Group listener or a database in an Availability Group.
 
-        If an Availability Group listener is specified as the target, then all nodes in the Group will be queried to return backup history
+        If an Availability Group listener is specified as the target, then all nodes in the Group will be queried to return backup history.
 
         If a Sql Instance is specified and one of the target databases is in an Availability Group then the nodes hosting that AG will be queried as well, if the Availability Group has a listener.
 
@@ -29,7 +29,7 @@ function Get-DbaDbBackupHistory {
         Specifies one or more database(s) to exclude from processing.
 
     .PARAMETER IncludeCopyOnly
-        By default Get-DbaDbBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them
+        By default Get-DbaDbBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them.
 
     .PARAMETER Force
         If this switch is enabled, a large amount of information is returned, similar to what SQL Server itself returns.
@@ -38,7 +38,7 @@ function Get-DbaDbBackupHistory {
         Specifies a DateTime object to use as the starting point for the search for backups.
 
     .PARAMETER RecoveryFork
-        Specifies the Recovery Fork you want backup history for
+        Specifies the Recovery Fork you want backup history for.
 
     .PARAMETER Last
         If this switch is enabled, the most recent full chain of full, diff and log backup sets is returned.
@@ -65,15 +65,15 @@ function Get-DbaDbBackupHistory {
         Specifies a minimum LSN to use in filtering backup history. Only backups with an LSN greater than this value will be returned, which helps speed the retrieval process.
 
     .PARAMETER IncludeMirror
-        By default mirrors of backups are not returned, this switch will cause them to be returned
+        By default mirrors of backups are not returned, this switch will cause them to be returned.
+
+    .PARAMETER SuppressAgCheck
+        By default, when SqlInstance is part of an availability group, the history is also fetched from all replicas. If set, the history will be only fetched from SqlInstance.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-
-    .PARAMETER SuppressAgCheck
-        By default, when SqlInstance is part of an availability group, the history is also fetched from all replicas. If set, the history will be only fetched from SqlInstance.
 
     .NOTES
         Tags: DisasterRecovery, Backup
@@ -173,10 +173,10 @@ function Get-DbaDbBackupHistory {
         [switch]$LastLog,
         [string[]]$DeviceType,
         [switch]$Raw,
-        [bigint]$LastLsn,
-        [switch]$IncludeMirror,
         [ValidateSet("Full", "Log", "Differential", "File", "Differential File", "Partial Full", "Partial Differential")]
         [string[]]$Type,
+        [bigint]$LastLsn,
+        [switch]$IncludeMirror,
         [Alias("AgCheck")]
         [switch]$SuppressAgCheck,
         [switch]$EnableException

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror', 'AgCheck'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror', 'SuppressAgCheck'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
This change is not a classic bug fix, but it will help in situations described in #6604 and generally speed up Backup-DbaDatabase because in the call to get the record for the just taken backup it does not ask other instances.

I changed the name of a parameter to better reflect its purpose. And it makes this parameter a public parameter and not only an internal one. The name "SuppressAgCheck" is only an idea, it could also be "NoAgCheck" or some other name. But I think "AgCheck" is wrong because this is positiv, so I assume some kind of active check related to AGs - but the parameter itself is negative and suppresses some action. But I added an alias for backword compatibility, just in case someone uses this (internal) parameter.

I already mentioned this branch here: https://github.com/sqlcollaborative/dbatools/issues/6604#issuecomment-672638390 and hoped for a discussion on it. So with this pull request I want to get feedback on my ideas so that my ideas are not quietly lost.

I also fixed some case issues that VSCode reported.
