### PR TITLE
Start-DbaXeSession, StopAt fixes

### DIFF
--- a/functions/Start-DbaXESession.ps1
+++ b/functions/Start-DbaXESession.ps1
@@ -130,10 +130,11 @@ function Start-DbaXESession {
                 $name = "XE Session Stop - $session"
                 if ($Pscmdlet.ShouldProcess("$Server", "Making New XEvent StopJob for $session")) {
                     # Setup the schedule time
-                    #$time = $(($StopAt).ToString("HHmmss"))
 
                     # Create the schedule
-                    $schedule = New-DbaAgentSchedule -SqlInstance $server -Schedule $name -FrequencyType Once -StartDate $StopAt
+                    $StartDateDatePart = Get-Date -Date $StopAt -format 'yyyyMMdd'
+                    $StartDateTimePart = Get-Date -Date $StopAt -format 'HHmmss'
+                    $schedule = New-DbaAgentSchedule -SqlInstance $server -Schedule $name -FrequencyType Once -StartDate $StartDateDatePart -StartTime $StartDateTimePart -Force
 
                     # Create the job and attach the schedule
                     $job = New-DbaAgentJob -SqlInstance $server -Job $name -Schedule $schedule -DeleteLevel Always -Force
@@ -165,7 +166,7 @@ function Start-DbaXESession {
                     Start-XESessions $xeSessions
 
                     if ($StopAt) {
-                        New-StopJob -xeSessions $xeSessions -StopAt $stopat
+                        New-StopJob -xeSessions $xeSessions -StopAt $StopAt
                     }
                 }
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6483 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Making it work with -StopAt. Not sure when the functionality was lost.

### Approach
New-DbaAgentSchedule takes StartDate and StartTime now, so we pass to each it's piece according to the docs.

### Commands to test
see the new added test (so we'll be sure in the future everything still works fine)
