### PR TITLE
Invoke-DbaToolsFormatter, autodetect EOL

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -59,6 +59,16 @@ function Invoke-DbatoolsFormatter {
             }
 
             $content = Get-Content -Path $realPath -Raw -Encoding UTF8
+            if ($OSEOL -eq "`r`n") {
+                # See #5830, we are in Windows territory here
+                # Is the file containing at least one `r ?
+                $containsCR = ($content -split "`r").Length -gt 1
+                if (-not($containsCR)) {
+                    # If not, maybe even on Windows the user is using Unix-style endings, which are supported
+                    $OSEOL = "`n"
+                }
+            }
+
             #strip ending empty lines
             $content = $content -replace "(?s)$OSEOL\s*$"
             try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #5830 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
On Windows if the user prefers unix EOLs leave them be. 

### Approach
On Windows we check for ``` `r ``` presence. If none are found, then Unix-style is assumed as preferred

The unittest should cover the additional code