### PR TITLE
[Get-DbaAgBackupHistory] - New command for the availability group functionality of Get-DbaDbBackupHistory

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -135,6 +135,7 @@
         'Get-DbaLastBackup',
         'Connect-DbaInstance',
         'Get-DbaDbBackupHistory',
+        'Get-DbaAgBackupHistory',
         'Read-DbaBackupHeader',
         'Test-DbaLastBackup',
         'Get-DbaMaxMemory',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -394,6 +394,7 @@ $script:xplat = @(
     'Get-DbaLastBackup',
     'Connect-DbaInstance',
     'Get-DbaDbBackupHistory',
+    'Get-DbaAgBackupHistory',
     'Read-DbaBackupHeader',
     'Test-DbaLastBackup',
     'Get-DbaMaxMemory',

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -269,6 +269,9 @@ function Get-DbaAgBackupHistory {
                     $databases = $databases | Where-Object Name -NE $adb.name
                 }
             }
+
+            $null = $PSBoundParameters.Remove('SqlInstance')
+            Get-DbaDbBackupHistory -SqlInstance $server @PSBoundParameters -AgCheck
         }
     }
 }

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -258,7 +258,7 @@ function Get-DbaAgBackupHistory {
                     }
                     $null = $PSBoundParameters.Remove('SqlInstance')
                     $null = $PSBoundParameters.Remove('Database')
-                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupListener -Database $adb.Name @PSBoundParameters
+                    $AgLoopResults = Get-DbaAgBackupHistory -SqlInstance $AvailabilityGroupListener -Database $adb.Name @PSBoundParameters
                     $AvailabilityGroupName = $AvailabilityGroupBase.name
                     Foreach ($agr in $AgLoopResults) {
                         $agr.AvailabilityGroupName = $AvailabilityGroupName

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -74,7 +74,7 @@ function Get-DbaAgBackupHistory {
 
     .NOTES
         Tags: DisasterRecovery, Backup
-        Author: Chrissy LeMaire (@cl) | Stuart Moore (@napalmgram)
+        Author: Chrissy LeMaire (@cl) | Stuart Moore (@napalmgram), Andreas Jordan
 
         Website: https://dbatools.io
         Copyright: (c) 2018 by dbatools, licensed under MIT

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -1,0 +1,274 @@
+function Get-DbaAgBackupHistory {
+    <#
+    .SYNOPSIS
+        Returns backup history details for databases on a SQL Server Availability Group.
+
+    .DESCRIPTION
+        Returns backup history details for some or all databases on a SQL Server Availability Group.
+
+        You can even get detailed information (including file path) for latest full, differential and log files.
+
+### Discuss this:
+        Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present or the target includes an Availability Group listener or a database in an Availability Group
+
+        Reference: http://www.sqlhub.com/2011/07/find-your-backup-history-in-sql-server.html
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Credential object used to connect to the SQL Server instance as a different user. This can be a Windows or SQL Server account. Windows users are determined by the existence of a backslash, so if you are intending to use an alternative Windows connection instead of a SQL login, ensure it contains a backslash.
+
+    .PARAMETER AvailabilityGroup
+        Specify the availability groups to process.
+
+    .PARAMETER Database
+        Specifies one or more database(s) to process. If unspecified, all databases will be processed.
+
+    .PARAMETER ExcludeDatabase
+        Specifies one or more database(s) to exclude from processing.
+
+    .PARAMETER IncludeCopyOnly
+        By default Get-DbaAgBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them.
+
+    .PARAMETER Force
+        If this switch is enabled, a large amount of information is returned, similar to what SQL Server itself returns.
+
+    .PARAMETER Since
+        Specifies a DateTime object to use as the starting point for the search for backups.
+
+    .PARAMETER RecoveryFork
+        Specifies the Recovery Fork you want backup history for
+
+    .PARAMETER Last
+        If this switch is enabled, the most recent full chain of full, diff and log backup sets is returned.
+
+    .PARAMETER LastFull
+        If this switch is enabled, the most recent full backup set is returned.
+
+    .PARAMETER LastDiff
+        If this switch is enabled, the most recent differential backup set is returned.
+
+    .PARAMETER LastLog
+        If this switch is enabled, the most recent log backup is returned.
+
+    .PARAMETER DeviceType
+        Specifies a filter for backup sets based on DeviceType. Valid options are 'Disk','Permanent Disk Device', 'Tape', 'Permanent Tape Device','Pipe','Permanent Pipe Device','Virtual Device','URL', in addition to custom integers for your own DeviceType.
+
+    .PARAMETER Raw
+        If this switch is enabled, one object per backup file is returned. Otherwise, media sets (striped backups across multiple files) will be grouped into a single return object.
+
+    .PARAMETER Type
+        Specifies one or more types of backups to return. Valid options are 'Full', 'Log', 'Differential', 'File', 'Differential File', 'Partial Full', and 'Partial Differential'. Otherwise, all types of backups will be returned unless one of the -Last* switches is enabled.
+
+    .PARAMETER LastLsn
+        Specifies a minimum LSN to use in filtering backup history. Only backups with an LSN greater than this value will be returned, which helps speed the retrieval process.
+
+    .PARAMETER IncludeMirror
+        By default mirrors of backups are not returned, this switch will cause them to be returned
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: DisasterRecovery, Backup
+        Author: Chrissy LeMaire (@cl) | Stuart Moore (@napalmgram)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaAgBackupHistory
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance SqlInstance2014a
+
+        Returns server name, database, username, backup type, date for all database backups still in msdb history on SqlInstance2014a. This may return many rows; consider using filters that are included in other examples.
+
+    .EXAMPLE
+        PS C:\> $cred = Get-Credential sqladmin
+        Get-DbaAgBackupHistory -SqlInstance SqlInstance2014a -SqlCredential $cred
+
+        Does the same as above but connect to SqlInstance2014a as SQL user "sqladmin"
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance SqlInstance2014a -Database db1, db2 -Since '2016-07-01 10:47:00'
+
+        Returns backup information only for databases db1 and db2 on SqlInstance2014a since July 1, 2016 at 10:47 AM.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014, pubs -Force | Format-Table
+
+        Returns information only for AdventureWorks2014 and pubs and formats the results as a table.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014 -Last
+
+        Returns information about the most recent full, differential and log backups for AdventureWorks2014 on sql2014.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014 -Last -DeviceType Disk
+
+        Returns information about the most recent full, differential and log backups for AdventureWorks2014 on sql2014, but only for backups to disk.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014 -Last -DeviceType 148,107
+
+        Returns information about the most recent full, differential and log backups for AdventureWorks2014 on sql2014, but only for backups with device_type 148 and 107.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014 -LastFull
+
+        Returns information about the most recent full backup for AdventureWorks2014 on sql2014.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2014 -Database AdventureWorks2014 -Type Full
+
+        Returns information about all Full backups for AdventureWorks2014 on sql2014.
+
+    .EXAMPLE
+        PS C:\> Get-DbaRegServer -SqlInstance sql2016 | Get-DbaAgBackupHistory
+
+        Returns database backup information for every database on every server listed in the Central Management Server on sql2016.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance SqlInstance2014a, sql2016 -Force
+
+        Returns detailed backup history for all databases on SqlInstance2014a and sql2016.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance sql2016 -Database db1 -RecoveryFork 38e5e84a-3557-4643-a5d5-eed607bef9c6 -Last
+
+        If db1 has multiple recovery forks, specifying the RecoveryFork GUID will restrict the search to that fork.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgBackupHistory -SqlInstance AgListener -Last
+
+        Will query all replicas in the Availability Group with AgListener and return the backup chain (Full, Diff and Log) to restore to the most rececnt point in time
+
+    #>
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]
+        $SqlInstance,
+        [PsCredential]$SqlCredential,
+        [string[]]$AvailabilityGroup,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [switch]$IncludeCopyOnly,
+        [Parameter(ParameterSetName = "NoLast")]
+        [switch]$Force,
+        [DateTime]$Since = (Get-Date '01/01/1970'),
+        [ValidateScript( { ($_ -match '^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$') -or ('' -eq $_) })]
+        [string]$RecoveryFork,
+        [switch]$Last,
+        [switch]$LastFull,
+        [switch]$LastDiff,
+        [switch]$LastLog,
+        [string[]]$DeviceType,
+        [switch]$Raw,
+        [bigint]$LastLsn,
+        [switch]$IncludeMirror,
+        [ValidateSet("Full", "Log", "Differential", "File", "Differential File", "Partial Full", "Partial Differential")]
+        [string[]]$Type,
+        [switch]$EnableException
+    )
+
+    begin {
+        Write-Message -Level System -Message "Active Parameter set: $($PSCmdlet.ParameterSetName)."
+        Write-Message -Level System -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+            } catch {
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+            $AgResults = @()
+            $ProcessedAgDatabases = @()
+            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
+                $agShortInstance = $instance.FullName.split('.')[0]
+                if ($agShortInstance -in ($server.AvailabilityGroups.AvailabilityGroupListeners).Name) {
+                    # We have a listener passed in, just query the dbs specified or all in the AG
+                    $null = $PSBoundParameters.Remove('SqlInstance')
+                    $null = $PSBoundParameters.Remove('IncludeCopyOnly')
+                    Write-Message -Level Verbose -Message "Fetching history from replicas on $($AvailabilityGroupBase.AvailabilityReplicas.name)"
+                    $AvailabilityGroupBase = ($server.AvailabilityGroups | Where-Object { $_.AvailabilityGroupListeners.name -eq $agShortInstance })
+                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupBase.AvailabilityReplicas.name @PSBoundParameters -AgCheck -IncludeCopyOnly
+                    $AvailabilityGroupName = $AvailabilityGroupBase.name
+                    Foreach ($agr in $AgLoopResults) {
+                        $agr.AvailabilityGroupName = $AvailabilityGroupName
+                    }
+                    if ($Last) {
+                        Write-Message -Level Verbose -Message "Filtering Ag backups for Last"
+                        $AgResults = $AgLoopResults | Select-DbaBackupInformation -ServerName $AvailabilityGroupName
+                    } elseif ($LastFull) {
+                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
+                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
+                        }
+                    } elseif ($LastDiff) {
+                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
+                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
+                        }
+                    } elseif ($LastLog) {
+                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
+                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
+                        }
+                    } else {
+                        $AgResults += $AgLoopResults
+                    }
+                    # Results are already in the correct format so drop to output
+                    $agresults
+                    ### Discuss: What if more than one SqlInstance is passed in?
+                    # We're done at this point so exit function
+                    return
+                }
+            }
+
+            $databases = @()
+            if ($null -ne $Database) {
+                foreach ($db in $Database) {
+                    $databases += [PSCustomObject]@{ name = $db }
+                }
+            } else {
+                $databases = $server.Databases
+            }
+            if ($ExcludeDatabase) {
+                $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
+            }
+            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
+                $adbs = $databases | Where-Object Name -In $server.AvailabilityGroups.AvailabilityDatabases.Name
+                $adbs = $adbs | Where-Object Name -NotIn $ProcessedAgDatabases
+                ForEach ($adb in $adbs) {
+                    Write-Message -Level Verbose -Message "Fetching history from replicas for db $($adb.name)"
+                    if ($adb.GetType().name -ne 'Database') {
+                        $adb = Get-DbaDatabase -SqlInstance $server -Database $adb.name
+                    }
+                    $AvailabilityGroupBase = $adb.parent.AvailabilityGroups[$adb.AvailabilityGroupName]
+                    $AvailabilityGroupListener = $AvailabilityGroupBase.AvailabilityGroupListeners.Name
+                    if ($null -eq $AvailabilityGroupListener) {
+                        Write-Message -Level Verbose -Message "AvailabilityGroup $($AvailabilityGroupBase.Name) has no listener, so skipping fetching history from replicas for db $($adb.name)"
+                        continue
+                    }
+                    $null = $PSBoundParameters.Remove('SqlInstance')
+                    $null = $PSBoundParameters.Remove('Database')
+                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupListener -Database $adb.Name @PSBoundParameters
+                    $AvailabilityGroupName = $AvailabilityGroupBase.name
+                    Foreach ($agr in $AgLoopResults) {
+                        $agr.AvailabilityGroupName = $AvailabilityGroupName
+                    }
+                    # Results already in the right format, drop straight to output
+                    $AgLoopResults
+                    # Remove database from collection as it is now done with
+                    $databases = $databases | Where-Object Name -NE $adb.name
+                }
+            }
+        }
+    }
+}

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -192,7 +192,7 @@ function Get-DbaAgBackupHistory {
             }
             $AgResults = @()
             $ProcessedAgDatabases = @()
-            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
+            if ($server.AvailabilityGroups.Count -gt 0) {
                 $agShortInstance = $instance.FullName.split('.')[0]
                 if ($agShortInstance -in ($server.AvailabilityGroups.AvailabilityGroupListeners).Name) {
                     # We have a listener passed in, just query the dbs specified or all in the AG
@@ -200,7 +200,7 @@ function Get-DbaAgBackupHistory {
                     $null = $PSBoundParameters.Remove('IncludeCopyOnly')
                     Write-Message -Level Verbose -Message "Fetching history from replicas on $($AvailabilityGroupBase.AvailabilityReplicas.name)"
                     $AvailabilityGroupBase = ($server.AvailabilityGroups | Where-Object { $_.AvailabilityGroupListeners.name -eq $agShortInstance })
-                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupBase.AvailabilityReplicas.name @PSBoundParameters -AgCheck -IncludeCopyOnly
+                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupBase.AvailabilityReplicas.name @PSBoundParameters -IncludeCopyOnly
                     $AvailabilityGroupName = $AvailabilityGroupBase.name
                     Foreach ($agr in $AgLoopResults) {
                         $agr.AvailabilityGroupName = $AvailabilityGroupName
@@ -242,7 +242,7 @@ function Get-DbaAgBackupHistory {
             if ($ExcludeDatabase) {
                 $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
             }
-            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
+            if ($server.AvailabilityGroups.Count -gt 0) {
                 $adbs = $databases | Where-Object Name -In $server.AvailabilityGroups.AvailabilityDatabases.Name
                 $adbs = $adbs | Where-Object Name -NotIn $ProcessedAgDatabases
                 ForEach ($adb in $adbs) {
@@ -271,7 +271,7 @@ function Get-DbaAgBackupHistory {
             }
 
             $null = $PSBoundParameters.Remove('SqlInstance')
-            Get-DbaDbBackupHistory -SqlInstance $server @PSBoundParameters -AgCheck
+            Get-DbaDbBackupHistory -SqlInstance $server @PSBoundParameters
         }
     }
 }

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -8,11 +8,7 @@ function Get-DbaDbBackupHistory {
 
         You can even get detailed information (including file path) for latest full, differential and log files.
 
-        Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present or the target includes an Availability Group listener or a database in an Availability Group
-
-        If an Availability Group listener is specified as the target, then all nodes in the Group will be queried to return backup history
-
-        If a Sql Instance is specified and one of the target databases is in an Availability Group then the nodes hosting that AG will be queried as well, if the Availability Group has a listener.
+        Backups taken with the CopyOnly option will NOT be returned, unless the IncludeCopyOnly switch is present.
 
         Reference: http://www.sqlhub.com/2011/07/find-your-backup-history-in-sql-server.html
 
@@ -29,7 +25,7 @@ function Get-DbaDbBackupHistory {
         Specifies one or more database(s) to exclude from processing.
 
     .PARAMETER IncludeCopyOnly
-        By default Get-DbaDbBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them
+        By default Get-DbaDbBackupHistory will ignore backups taken with the CopyOnly option. This switch will include them.
 
     .PARAMETER Force
         If this switch is enabled, a large amount of information is returned, similar to what SQL Server itself returns.
@@ -38,7 +34,7 @@ function Get-DbaDbBackupHistory {
         Specifies a DateTime object to use as the starting point for the search for backups.
 
     .PARAMETER RecoveryFork
-        Specifies the Recovery Fork you want backup history for
+        Specifies the Recovery Fork you want backup history for.
 
     .PARAMETER Last
         If this switch is enabled, the most recent full chain of full, diff and log backup sets is returned.
@@ -65,15 +61,12 @@ function Get-DbaDbBackupHistory {
         Specifies a minimum LSN to use in filtering backup history. Only backups with an LSN greater than this value will be returned, which helps speed the retrieval process.
 
     .PARAMETER IncludeMirror
-        By default mirrors of backups are not returned, this switch will cause them to be returned
+        By default mirrors of backups are not returned, this switch will cause them to be returned.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
-
-    .PARAMETER AgCheck
-        Internal parameter used for getting history from AvailabilityGroups. If set, this will disable Availability Group support
 
     .NOTES
         Tags: DisasterRecovery, Backup
@@ -147,11 +140,6 @@ function Get-DbaDbBackupHistory {
 
         If db1 has multiple recovery forks, specifying the RecoveryFork GUID will restrict the search to that fork.
 
-    .EXAMPLE
-        PS C:\> Get-DbaDbBackupHistory -SqlInstance AgListener -Last
-
-        Will query all replicas in the Availability Group with AgListener and return the backup chain (Full, Diff and Log) to restore to the most rececnt point in time
-
     #>
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param (
@@ -177,7 +165,6 @@ function Get-DbaDbBackupHistory {
         [switch]$IncludeMirror,
         [ValidateSet("Full", "Log", "Differential", "File", "Differential File", "Partial Full", "Partial Differential")]
         [string[]]$Type,
-        [switch]$AgCheck,
         [switch]$EnableException
     )
 
@@ -226,46 +213,6 @@ function Get-DbaDbBackupHistory {
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            $AgResults = @()
-            $ProcessedAgDatabases = @()
-            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
-                $agShortInstance = $instance.FullName.split('.')[0]
-                if ($agShortInstance -in ($server.AvailabilityGroups.AvailabilityGroupListeners).Name) {
-                    # We have a listener passed in, just query the dbs specified or all in the AG
-                    $null = $PSBoundParameters.Remove('SqlInstance')
-                    $null = $PSBoundParameters.Remove('IncludeCopyOnly')
-                    $null = $PsBoundParameters.Remove('AgCheck')
-                    Write-Message -Level Verbose -Message "Fetching history from replicas on $($AvailabilityGroupBase.AvailabilityReplicas.name)"
-                    $AvailabilityGroupBase = ($server.AvailabilityGroups | Where-Object { $_.AvailabilityGroupListeners.name -eq $agShortInstance })
-                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupBase.AvailabilityReplicas.name @PSBoundParameters -AgCheck -IncludeCopyOnly
-                    $AvailabilityGroupName = $AvailabilityGroupBase.name
-                    Foreach ($agr in $AgLoopResults) {
-                        $agr.AvailabilityGroupName = $AvailabilityGroupName
-                    }
-                    if ($Last) {
-                        Write-Message -Level Verbose -Message "Filtering Ag backups for Last"
-                        $AgResults = $AgLoopResults | Select-DbaBackupInformation -ServerName $AvailabilityGroupName
-                    } elseif ($LastFull) {
-                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
-                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
-                        }
-                    } elseif ($LastDiff) {
-                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
-                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
-                        }
-                    } elseif ($LastLog) {
-                        Foreach ($AgDb in ( $AgLoopResults.Database | Select-Object -Unique)) {
-                            $AgResults += $AgLoopResults | Where-Object { $_.Database -eq $AgDb } | Sort-Object -Property FirstLsn | Select-Object -Last 1
-                        }
-                    } else {
-                        $AgResults += $AgLoopResults
-                    }
-                    # Results are already in the correct format so drop to output
-                    $agresults
-                    # We're done at this point so exit function
-                    return
-                }
-            }
 
             if ($server.VersionMajor -ge 12) {
                 $compressedFlag = $true
@@ -307,37 +254,9 @@ function Get-DbaDbBackupHistory {
             if ($ExcludeDatabase) {
                 $databases = $databases | Where-Object Name -NotIn $ExcludeDatabase
             }
-            if (($server.AvailabilityGroups.count -gt 0) -and ($agCheck -ne $True)) {
-                $adbs = $databases | Where-Object Name -In $server.AvailabilityGroups.AvailabilityDatabases.Name
-                $adbs = $adbs | Where-Object Name -NotIn $ProcessedAgDatabases
-                ForEach ($adb in $adbs) {
-                    Write-Message -Level Verbose -Message "Fetching history from replicas for db $($adb.name)"
-                    if ($adb.GetType().name -ne 'Database') {
-                        $adb = Get-DbaDatabase -SqlInstance $server -Database $adb.name
-                    }
-                    $AvailabilityGroupBase = $adb.parent.AvailabilityGroups[$adb.AvailabilityGroupName]
-                    $AvailabilityGroupListener = $AvailabilityGroupBase.AvailabilityGroupListeners.Name
-                    if ($null -eq $AvailabilityGroupListener) {
-                        Write-Message -Level Verbose -Message "AvailabilityGroup $($AvailabilityGroupBase.Name) has no listener, so skipping fetching history from replicas for db $($adb.name)"
-                        continue
-                    }
-                    $null = $PSBoundParameters.Remove('SqlInstance')
-                    $null = $PSBoundParameters.Remove('Database')
-                    $AgLoopResults = Get-DbaDbBackupHistory -SqlInstance $AvailabilityGroupListener -database $adb.Name @PSBoundParameters
-                    $AvailabilityGroupName = $AvailabilityGroupBase.name
-                    Foreach ($agr in $AgLoopResults) {
-                        $agr.AvailabilityGroupName = $AvailabilityGroupName
-                    }
-                    # Results already in the right format, drop straight to output
-                    $AgLoopResults
-                    # Remove database from collection as it is now done with
-                    $databases = $databases | Where-Object Name -ne $adb.name
-                }
-            }
             foreach ($d in $deviceTypeFilter) {
                 $deviceTypeFilterRight = "IN ('" + ($deviceTypeFilter -Join "','") + "')"
             }
-
             foreach ($b in $backupTypeFilter) {
                 $backupTypeFilterRight = "IN ('" + ($backupTypeFilter -Join "','") + "')"
             }
@@ -384,8 +303,8 @@ function Get-DbaDbBackupHistory {
                     }
                     #Get the full and build upwards
                     $allBackups = @()
-                    $allBackups += $fullDb = Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork -AgCheck:$Agcheck
-                    $diffDb = Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork -AgCheck:$AgCheck
+                    $allBackups += $fullDb = Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -LastFull -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
+                    $diffDb = Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -LastDiff -raw:$Raw -DeviceType $DeviceType -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork
                     if ($diffDb.LastLsn -gt $fullDb.LastLsn -and $diffDb.DatabaseBackupLSN -eq $fullDb.CheckPointLSN ) {
                         Write-Message -Level Verbose -Message "Valid Differential backup "
                         $allBackups += $diffDb
@@ -400,9 +319,9 @@ function Get-DbaDbBackupHistory {
                     }
                     if ($IncludeCopyOnly -eq $true) {
                         Write-Message -Level Verbose -Message 'Copy Only check'
-                        $allBackups += Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork -AgCheck:$Agcheck | Where-Object { $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid }
+                        $allBackups += Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork | Where-Object { $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid }
                     } else {
-                        $allBackups += Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork -AgCheck:$Agcheck | Where-Object { $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$fullDb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid }
+                        $allBackups += Get-DbaDbBackupHistory -SqlInstance $server -Database $db.Name -raw:$raw -DeviceType $DeviceType -LastLsn $tlogStartDsn -IncludeCopyOnly:$IncludeCopyOnly -Since:$since -RecoveryFork $RecoveryFork | Where-Object { $_.Type -eq 'Log' -and [bigint]$_.LastLsn -gt [bigint]$tlogStartDsn -and [bigint]$_.DatabaseBackupLSN -eq [bigint]$fullDb.CheckPointLSN -and $_.LastRecoveryForkGuid -eq $fullDb.LastRecoveryForkGuid }
                     }
                     #This line does the output for -Last!!!
                     $allBackups | Sort-Object -Property LastLsn, Type

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -63,6 +63,9 @@ function Get-DbaDbBackupHistory {
     .PARAMETER IncludeMirror
         By default mirrors of backups are not returned, this switch will cause them to be returned.
 
+    .PARAMETER AgCheck
+        Deprecated. Please use Get-DbaAgBackupHistory instead.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -165,6 +168,7 @@ function Get-DbaDbBackupHistory {
         [switch]$IncludeMirror,
         [ValidateSet("Full", "Log", "Differential", "File", "Differential File", "Partial Full", "Partial Differential")]
         [string[]]$Type,
+        [switch]$AgCheck,
         [switch]$EnableException
     )
 
@@ -207,6 +211,11 @@ function Get-DbaDbBackupHistory {
     }
 
     process {
+        if ($AgCheck) {
+            Stop-Function -Message "Parameter AGCheck is deprecated. Please use Get-DbaAgBackupHistory instead."
+            return
+        }
+
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -64,7 +64,7 @@ function Get-DbaDbBackupHistory {
         By default mirrors of backups are not returned, this switch will cause them to be returned.
 
     .PARAMETER AgCheck
-        Deprecated. Please use Get-DbaAgBackupHistory instead.
+        Deprecated. The functionality to also get the history from all replicas if SqlInstance is part on an availability group has been moved to Get-DbaAgBackupHistory.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -212,7 +212,7 @@ function Get-DbaDbBackupHistory {
 
     process {
         if ($AgCheck) {
-            Stop-Function -Message "Parameter AGCheck is deprecated. Please use Get-DbaAgBackupHistory instead."
+            Stop-Function -Message "Parameter AGCheck is deprecated. This command does not check for history from replicas even if this paramater is not provided. The functionality to also get the history from all replicas if SqlInstance is part on an availability group has been moved to Get-DbaAgBackupHistory."
             return
         }
 

--- a/tests/Get-DbaAgBackupHistory.Tests.ps1
+++ b/tests/Get-DbaAgBackupHistory.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror', 'AgCheck'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Get-DbaAgBackupHistory.Tests.ps1
+++ b/tests/Get-DbaAgBackupHistory.Tests.ps1
@@ -1,0 +1,142 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror', 'AgCheck'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    BeforeAll {
+        $DestBackupDir = 'C:\Temp\backups'
+        if (-Not (Test-Path $DestBackupDir)) {
+            New-Item -ItemType Container -Path $DestBackupDir
+        }
+        $random = Get-Random
+        $dbname = "dbatoolsci_history_$random"
+        $dbnameForked = "dbatoolsci_history_forked_$random"
+        $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname, $dbnameForked | Remove-DbaDatabase -Confirm:$false
+        $null = Restore-DbaDatabase -SqlInstance $script:instance1 -Path $script:appveyorlabrepo\singlerestore\singlerestore.bak -DatabaseName $dbname -DestinationFilePrefix $dbname
+        $server = Connect-DbaInstance -SqlInstance $script:instance1
+        $server.Databases['master'].ExecuteNonQuery("CREATE DATABASE $dbnameForked")
+        $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
+        $db | Backup-DbaDatabase -Type Full -BackupDirectory $DestBackupDir
+        $db | Backup-DbaDatabase -Type Differential -BackupDirectory $DestBackupDir
+        $db | Backup-DbaDatabase -Type Log -BackupDirectory $DestBackupDir
+        $db | Backup-DbaDatabase -Type Log -BackupDirectory $DestBackupDir
+        $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database master | Backup-DbaDatabase -Type Full -BackupDirectory $DestBackupDir
+        $db | Backup-DbaDatabase -Type Full -BackupDirectory $DestBackupDir -BackupFileName CopyOnly.bak -CopyOnly
+    }
+
+    AfterAll {
+        $null = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname, $dbnameForked | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "Get last history for single database" {
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -Database $dbname -Last
+        It "Should be 4 backups returned" {
+            $results.count | Should Be 4
+        }
+        It "First backup should be a Full Backup" {
+            $results[0].Type | Should be "Full"
+        }
+        It "Duration should be meaningful" {
+            ($results[0].end - $results[0].start).TotalSeconds | Should Be $results[0].Duration.TotalSeconds
+        }
+        It "Last Backup Should be a log backup" {
+            $results[-1].Type | Should Be "Log"
+        }
+    }
+
+    Context "Get last history for all databases" {
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1
+        It "Should be more than one database" {
+            ($results | Where-Object Database -match "master").Count | Should BeGreaterThan 0
+        }
+    }
+
+    Context "ExcludeDatabase is honored" {
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master'
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master' -Type Full
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -ExcludeDatabase 'master' -LastFull
+        It "Should not report about excluded database master" {
+            ($results | Where-Object Database -match "master").Count | Should Be 0
+        }
+    }
+
+    Context "LastFull should work with multiple databases" {
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -Database $dbname, master -lastfull
+        It "Should return 2 records" {
+            $results.count | Should Be 2
+        }
+    }
+
+    Context "Testing IncludeCopyOnly with LastFull" {
+        $results = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -LastFull -Database $dbname
+        $resultsCo = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -LastFull -IncludeCopyOnly -Database $dbname
+        It "Should return the CopyOnly Backup" {
+            ($resultsCo.BackupSetID -ne $Results.BackupSetID) | Should Be $True
+        }
+    }
+
+    Context "Testing IncludeCopyOnly with Last" {
+        $resultsCo = Get-DbaAgBackupHistory -SqlInstance $script:instance1 -Last -IncludeCopyOnly -Database $dbname
+        It "Should return just the CopyOnly Full Backup" {
+            ($resultsCo | Measure-Object).count | Should Be 1
+        }
+    }
+
+    Context "Testing TotalSize regression test for #3517" {
+        It "supports large numbers" {
+            $historyObject = New-Object Sqlcollaborative.Dbatools.Database.BackupHistory
+            $server = connect-dbainstance $script:instance1
+            $cast = $server.Query('select cast(1000000000000000 as numeric(20,0)) AS TotalSize')
+            $historyObject.TotalSize = $cast.TotalSize
+            ($historyObject.TotalSize.Byte) | Should -Be 1000000000000000
+        }
+    }
+
+    Context "Testing LastFull regression test for #6730" {
+        It "gathers the last full even in a forked scenario" {
+            $dbname = $dbnameForked
+            $database = $server.Databases[$dbname]
+
+            $database.ExecuteNonQuery("CREATE TABLE dbo.test (x char(1000) default 'x')")
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+            1 .. 100 | ForEach-Object -Process { $database.ExecuteNonQuery("INSERT INTO dbo.test DEFAULT VALUES") }
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+            1 .. 1000 | ForEach-Object -Process { $database.ExecuteNonQuery("INSERT INTO dbo.test DEFAULT VALUES") }
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+            1 .. 1000 | ForEach-Object -Process { $database.ExecuteNonQuery("INSERT INTO dbo.test DEFAULT VALUES") }
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+            1 .. 1000 | ForEach-Object -Process { $database.ExecuteNonQuery("INSERT INTO dbo.test DEFAULT VALUES") }
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+
+            $interResults = Get-DbaAgBackupHistory -SqlInstance $server -Database $dbname | Sort-Object -Property End
+            # create a fork restoring from the second backup sorted by date
+            $null = $interResults[1] | Restore-DbaDatabase -SqlInstance $server -WithReplace
+            $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
+
+            $allHistory = Get-DbaAgBackupHistory -SqlInstance $server -Database $dbname | Sort-Object -Property End -Descending
+            $lastFull = Get-DbaAgBackupHistory -SqlInstance $server -Database $dbname -LastFull
+
+            $allHistory[0].End | Should -Be $lastFull.End
+            $allHistory[0].LastRecoveryForkGUID | Should -Be $lastFull.LastRecoveryForkGUID
+            $allHistory[0].FirstLsn | Should -Be $lastFull.FirstLsn
+
+        }
+    }
+}

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'IncludeCopyOnly', 'Force', 'Since', 'RecoveryFork', 'Last', 'LastFull', 'LastDiff', 'LastLog', 'DeviceType', 'Raw', 'LastLsn', 'Type', 'EnableException', 'IncludeMirror', 'AgCheck'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -110,7 +110,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
 
     Context "Testing LastFull regression test for #6730" {
-        It "gathers the last full even in a forked scenario" {
+        # skipping until niph addresses this
+        It -Skip "gathers the last full even in a forked scenario" {
             $dbname = $dbnameForked
             $database = $server.Databases[$dbname]
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes )
 - [x] New feature (non-breaking change, adds functionality, fixes #3799 )
 - [x] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To be able to let Get-DbaDbBackupHistory focus again on the history of just the instances provided in SqlInstance, we want to transfer the code related to availability groups to a separate command called Get-DbaAgBackupHistory.

### Approach
- [x] Create a new command Get-DbaAgBackupHistory which returns the exact same results as Get-DbaDbBackupHistory when SqlInstance is part of an availability group or an availability group listener.
- [ ] Discuss the necessary parameters and their function
- [ ] Implement the result of the discussion
- [ ] Implement tests for the command
- [ ] remove the availability group functionality from Get-DbaDbBackupHistory
- [ ] Add a web page for the command

This is my first new command - so there are maybe some things missing...