### PR TITLE
Add-DbaAgReplica + New-DbaAvailabilityGroup - Added parameter EndpointUrl

### DIFF
--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -9,7 +9,7 @@ function Add-DbaAgReplica {
         Automatically creates a database mirroring endpoint if required.
 
     .PARAMETER SqlInstance
-        The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
+        The target SQL Server instance. Server version must be SQL Server version 2012 or higher.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
@@ -36,7 +36,7 @@ function Add-DbaAgReplica {
         If an endpoint must be created, the name "hadr_endpoint" will be used. If an alternative is preferred, use Endpoint.
 
     .PARAMETER EndpointUrl
-        By default, the property Fqdn of the database mirroring endpoint is used as EndpointUrl.
+        By default, the property Fqdn of Get-DbaEndpoint is used as EndpointUrl.
 
         Use EndpointUrl if a different URL is required due to special network configurations.
         EndpointUrl has to be in format 'TCP://system-address:port'.
@@ -107,7 +107,8 @@ function Add-DbaAgReplica {
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
-        [DbaInstanceParameter[]]$SqlInstance,
+        [parameter(Mandatory)]
+        [DbaInstanceParameter]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string]$Name,
         [ValidateSet('AsynchronousCommit', 'SynchronousCommit')]
@@ -131,11 +132,6 @@ function Add-DbaAgReplica {
         [switch]$EnableException
     )
     process {
-        if (Test-Bound -Not SqlInstance, InputObject) {
-            Stop-Function -Message "You must supply either -SqlInstance or an Input Object"
-            return
-        }
-
         if ($EndpointUrl -and ($EndpointUrl -notmatch 'TCP://.+:\d+')) {
             Stop-Function -Message "EndpointUrl not in correct format 'TCP://system-address:port'"
             return
@@ -233,11 +229,11 @@ function Add-DbaAgReplica {
                         $null = Join-DbaAvailabilityGroup -SqlInstance $instance -SqlCredential $SqlCredential -AvailabilityGroup $InputObject.Name
                         $agreplica.Alter()
                     }
-                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name ComputerName -value $agreplica.Parent.ComputerName
-                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name InstanceName -value $agreplica.Parent.InstanceName
-                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name SqlInstance -value $agreplica.Parent.SqlInstance
-                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name AvailabilityGroup -value $agreplica.Parent.Name
-                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name Replica -value $agreplica.Name # backwards compat
+                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name ComputerName -Value $agreplica.Parent.ComputerName
+                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name InstanceName -Value $agreplica.Parent.InstanceName
+                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name SqlInstance -Value $agreplica.Parent.SqlInstance
+                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name AvailabilityGroup -Value $agreplica.Parent.Name
+                    Add-Member -Force -InputObject $agreplica -MemberType NoteProperty -Name Replica -Value $agreplica.Name # backwards compat
 
                     Select-DefaultView -InputObject $agreplica -Property $defaults
                 } catch {

--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -1,18 +1,18 @@
 function Add-DbaAgReplica {
     <#
     .SYNOPSIS
-        Adds a replica to an availability group on a SQL Server instance.
+        Adds a replica to an availability group on one or more SQL Server instances.
 
     .DESCRIPTION
-        Adds a replica to an availability group on a SQL Server instance.
+        Adds a replica to an availability group on one or more SQL Server instances.
 
-        Automatically creates a database mirroring endpoint if required.
+        Automatically creates database mirroring endpoints if required.
 
     .PARAMETER SqlInstance
-        The target SQL Server instance. Server version must be SQL Server version 2012 or higher.
+        The target SQL Server instance or instances. Server version must be SQL Server version 2012 or higher.
 
     .PARAMETER SqlCredential
-        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+        Login to the target instances using alternative credentials. Accepts PowerShell credentials (Get-Credential).
 
         Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
 
@@ -20,6 +20,8 @@ function Add-DbaAgReplica {
 
     .PARAMETER Name
         The name of the replica. Defaults to the SQL Server instance name.
+
+        This parameter is only supported if the replica is added to just one instance.
 
     .PARAMETER AvailabilityMode
         Sets the availability mode of the availability group replica. Options are: AsynchronousCommit and SynchronousCommit. SynchronousCommit is default.
@@ -39,7 +41,7 @@ function Add-DbaAgReplica {
         By default, the property Fqdn of Get-DbaEndpoint is used as EndpointUrl.
 
         Use EndpointUrl if a different URL is required due to special network configurations.
-        EndpointUrl has to be in format 'TCP://system-address:port'.
+        EndpointUrl has to be an array of strings in format 'TCP://system-address:port', one entry for every instance.
         See details at: https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/specify-endpoint-url-adding-or-modifying-availability-replica
 
     .PARAMETER Passthru
@@ -49,13 +51,20 @@ function Add-DbaAgReplica {
         Enables piping from Get-DbaAvailabilityGroup.
 
     .PARAMETER ConnectionModeInPrimaryRole
-        Specifies the connection intent modes of an Availability Replica in primary role. AllowAllConnections by default.
+        Specifies the connection intent mode of an Availability Replica in primary role. AllowAllConnections by default.
 
     .PARAMETER ConnectionModeInSecondaryRole
-        Specifies the connection modes of an Availability Replica in secondary role. AllowAllConnections by default.
+        Specifies the connection intent mode of an Availability Replica in secondary role. AllowAllConnections by default.
+
+    .PARAMETER ReadOnlyRoutingList
+        Sets the read only routing ordered list of replica server names to use when redirecting read-only connections through this availability replica.
+
+        This parameter is only supported if the replica is added to just one instance.
 
     .PARAMETER ReadonlyRoutingConnectionUrl
         Sets the read only routing connection url for the availability replica.
+
+        This parameter is only supported if the replica is added to just one instance.
 
     .PARAMETER SeedingMode
         Specifies how the secondary replica will be initially seeded.
@@ -108,7 +117,7 @@ function Add-DbaAgReplica {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
     param (
         [parameter(Mandatory)]
-        [DbaInstanceParameter]$SqlInstance,
+        [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string]$Name,
         [ValidateSet('AsynchronousCommit', 'SynchronousCommit')]
@@ -123,8 +132,9 @@ function Add-DbaAgReplica {
         [ValidateSet('Automatic', 'Manual')]
         [string]$SeedingMode,
         [string]$Endpoint,
-        [string]$EndpointUrl,
+        [string[]]$EndpointUrl,
         [switch]$Passthru,
+        [string[]]$ReadOnlyRoutingList,
         [string]$ReadonlyRoutingConnectionUrl,
         [string]$Certificate,
         [parameter(ValueFromPipeline, Mandatory)]
@@ -132,8 +142,21 @@ function Add-DbaAgReplica {
         [switch]$EnableException
     )
     process {
-        if ($EndpointUrl -and ($EndpointUrl -notmatch 'TCP://.+:\d+')) {
-            Stop-Function -Message "EndpointUrl not in correct format 'TCP://system-address:port'"
+        if ($EndpointUrl) {
+            if ($EndpointUrl.Count -ne $SqlInstance.Count) {
+                Stop-Function -Message "The number of elements in EndpointUrl is not correct"
+                return
+            }
+            foreach ($epUrl in $EndpointUrl) {
+                if ($epUrl -notmatch 'TCP://.+:\d+') {
+                    Stop-Function -Message "EndpointUrl '$epUrl' not in correct format 'TCP://system-address:port'"
+                    return
+                }
+            }
+        }
+
+        if ($ReadonlyRoutingConnectionUrl -and ($ReadonlyRoutingConnectionUrl -notmatch 'TCP://.+:\d+')) {
+            Stop-Function -Message "ReadonlyRoutingConnectionUrl not in correct format 'TCP://system-address:port'"
             return
         }
 
@@ -171,7 +194,8 @@ function Add-DbaAgReplica {
                 try {
                     $replica = New-Object Microsoft.SqlServer.Management.Smo.AvailabilityReplica -ArgumentList $InputObject, $Name
                     if ($EndpointUrl) {
-                        $replica.EndpointUrl = $EndpointUrl
+                        $epUrl, $EndpointUrl = $EndpointUrl
+                        $replica.EndpointUrl = $epUrl
                     } else {
                         $replica.EndpointUrl = $ep.Fqdn
                     }
@@ -183,7 +207,11 @@ function Add-DbaAgReplica {
                     }
                     $replica.BackupPriority = $BackupPriority
 
-                    if ($ReadonlyRoutingConnectionUrl) {
+                    if ($ReadonlyRoutingList -and $server.VersionMajor -ge 13) {
+                        $replica.ReadonlyRoutingList = $ReadonlyRoutingList
+                    }
+
+                    if ($ReadonlyRoutingConnectionUrl -and $server.VersionMajor -ge 13) {
                         $replica.ReadonlyRoutingConnectionUrl = $ReadonlyRoutingConnectionUrl
                     }
 

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -108,7 +108,7 @@ function New-DbaAvailabilityGroup {
         If an endpoint must be created, the name "hadr_endpoint" will be used. If an alternative is preferred, use Endpoint.
 
     .PARAMETER EndpointUrl
-        By default, the property Fqdn of the database mirroring endpoints is used as EndpointUrl.
+        By default, the property Fqdn of Get-DbaEndpoint is used as EndpointUrl.
 
         Use EndpointUrl if different URLs are required due to special network configurations.
         EndpointUrl has to an array of strings in format 'TCP://system-address:port', one entry for every instance.

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -107,6 +107,14 @@ function New-DbaAvailabilityGroup {
 
         If an endpoint must be created, the name "hadr_endpoint" will be used. If an alternative is preferred, use Endpoint.
 
+    .PARAMETER EndpointUrl
+        By default, the property Fqdn of the database mirroring endpoints is used as EndpointUrl.
+
+        Use EndpointUrl if different URLs are required due to special network configurations.
+        EndpointUrl has to an array of strings in format 'TCP://system-address:port', one entry for every instance.
+        First entry for the primary instance, following entries for secondary instances in the order they show up in Secondary.
+        See details regarding the format at: https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/specify-endpoint-url-adding-or-modifying-availability-replica
+
     .PARAMETER ConnectionModeInPrimaryRole
         Specifies the connection intent modes of an Availability Replica in primary role. AllowAllConnections by default.
 
@@ -193,6 +201,11 @@ function New-DbaAvailabilityGroup {
         Creates a new availability group with a primary replica on sql1 and a secondary on sql2. Automatically adds the database pubs.
 
     .EXAMPLE
+        PS C:\> New-DbaAvailabilityGroup -Primary sql1 -Secondary sql2 -Name ag1 -Database pubs -EndpointUrl 'TCP://sql1.specialnet.local:5022', 'TCP://sql2.specialnet.local:5022'
+
+        Creates a new availability group with a primary replica on sql1 and a secondary on sql2 with custom endpoint urls. Automatically adds the database pubs.
+
+    .EXAMPLE
         PS C:\> $cred = Get-Credential sqladmin
         PS C:\> $params = @{
         >> Primary = "sql1"
@@ -252,6 +265,7 @@ function New-DbaAvailabilityGroup {
         [ValidateSet('Automatic', 'Manual')]
         [string]$SeedingMode = 'Manual',
         [string]$Endpoint,
+        [string[]]$EndpointUrl,
         [string]$ReadonlyRoutingConnectionUrl,
         [string]$Certificate,
         # network
@@ -271,6 +285,19 @@ function New-DbaAvailabilityGroup {
         if ($Force -and $Secondary -and (-not $SharedPath -and -not $UseLastBackup) -and ($SeedingMode -ne 'Automatic')) {
             Stop-Function -Message "SharedPath or UseLastBackup is required when Force is used"
             return
+        }
+
+        if ($EndpointUrl) {
+            if ($EndpointUrl.Count -ne (1 + $Secondary.Count)) {
+                Stop-Function -Message "The number of elements in EndpointUrl is not correct"
+                return
+            }
+            foreach ($epUrl in $EndpointUrl) {
+                if ($epUrl -notmatch 'TCP://.+:\d+') {
+                    Stop-Function -Message "EndpointUrl '$epUrl' not in correct format 'TCP://system-address:port'"
+                    return
+                }
+            }
         }
 
         if ($ConnectionModeInSecondaryRole) {
@@ -450,6 +477,11 @@ function New-DbaAvailabilityGroup {
                     Certificate                   = $Certificate
                 }
 
+                if ($EndpointUrl) {
+                    $epUrl, $EndpointUrl = $EndpointUrl
+                    $replicaparams += @{EndpointUrl = $epUrl }
+                }
+
                 if ($server.VersionMajor -ge 13) {
                     $replicaparams += @{SeedingMode = $SeedingMode }
                 }
@@ -494,6 +526,11 @@ function New-DbaAvailabilityGroup {
             if ($Pscmdlet.ShouldProcess($second.Name, "Adding replica to availability group named $Name")) {
                 try {
                     # Add replicas
+                    if ($EndpointUrl) {
+                        $epUrl, $EndpointUrl = $EndpointUrl
+                        $replicaparams['EndpointUrl'] = $epUrl
+                    }
+
                     $null = Add-DbaAgReplica @replicaparams -EnableException -SqlInstance $second
                 } catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Target $second -Continue

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -111,7 +111,7 @@ function New-DbaAvailabilityGroup {
         By default, the property Fqdn of Get-DbaEndpoint is used as EndpointUrl.
 
         Use EndpointUrl if different URLs are required due to special network configurations.
-        EndpointUrl has to an array of strings in format 'TCP://system-address:port', one entry for every instance.
+        EndpointUrl has to be an array of strings in format 'TCP://system-address:port', one entry for every instance.
         First entry for the primary instance, following entries for secondary instances in the order they show up in Secondary.
         See details regarding the format at: https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/specify-endpoint-url-adding-or-modifying-availability-replica
 

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'EndpointUrl', 'ReadOnlyRoutingList', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadOnlyRoutingList', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadOnlyRoutingList', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'EndpointUrl', 'ReadOnlyRoutingList', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'EndpointUrl', 'ReadOnlyRoutingList', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -7,13 +7,11 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadOnlyRoutingList', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
-
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
         Remove-DbaAvailabilityGroup -SqlInstance $server -AvailabilityGroup $agname -Confirm:$false

--- a/tests/Add-DbaAgReplica.Tests.ps1
+++ b/tests/Add-DbaAgReplica.Tests.ps1
@@ -5,7 +5,8 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'EndpointUrl', 'ReadOnlyRoutingList', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'Passthru', 'ReadOnlyRoutingList', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'Primary', 'PrimarySqlCredential', 'Secondary', 'SecondarySqlCredential', 'Name', 'DtcSupport', 'ClusterType', 'AutomatedBackupPreference', 'FailureConditionLevel', 'HealthCheckTimeout', 'Basic', 'DatabaseHealthTrigger', 'Passthru', 'Database', 'SharedPath', 'UseLastBackup', 'Force', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'IPAddress', 'SubnetMask', 'Port', 'Dhcp', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'Primary', 'PrimarySqlCredential', 'Secondary', 'SecondarySqlCredential', 'Name', 'DtcSupport', 'ClusterType', 'AutomatedBackupPreference', 'FailureConditionLevel', 'HealthCheckTimeout', 'Basic', 'DatabaseHealthTrigger', 'Passthru', 'Database', 'SharedPath', 'UseLastBackup', 'Force', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'Endpoint', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'Certificate', 'IPAddress', 'SubnetMask', 'Port', 'Dhcp', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6786, fixes #5859 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Especially on docker, but also on complex network designs it may be necessary to use custom endpoint URLs for the replicas instead of using the algorithm of Get-DbaEndpoint.

### Approach
I added a new parameter on Add-DbaAgReplica and New-DbaAvailabilityGroup.

### Commands to test
Follow these instructions: https://dbatools.io/docker/
Only change the line with `New-DbaAvailabilityGroup` to:
```
New-DbaAvailabilityGroup @params -EndpointUrl 'TCP://dockersql1:5022', 'TCP://dockersql2:5023' -Verbose
```
Test the health of replicas and database with:
```
Get-DbaAgReplica -SqlInstance $instance[0] | Format-Table
Get-DbaAgDatabase -SqlInstance $instance | Format-Table
```

### Output
```
AUSFÜHRLICH: Ausführen des Vorgangs "Setting up availability group named test-ag and adding primary replica" für das Ziel "localhost".
AUSFÜHRLICH: [12:48:05][Get-DbaEndpoint] Getting endpoint hadr_endpoint on GALLOPER
AUSFÜHRLICH: Ausführen des Vorgangs "Adding replica to availability group named test-ag" für das Ziel "localhost,14333".
AUSFÜHRLICH: [12:48:05][Get-DbaEndpoint] Getting endpoint hadr_endpoint on localhost,14333
AUSFÜHRLICH: Ausführen des Vorgangs "New-DbaAvailabilityGroup" für das Ziel "Joining localhost,14333 to test-ag".
AUSFÜHRLICH: Ausführen des Vorgangs "Seeding mode is automatic. Adding CreateAnyDatabase permissions to availability group." für das Ziel "GALLOPER".
AUSFÜHRLICH: Ausführen des Vorgangs "Seeding mode is automatic. Adding CreateAnyDatabase permissions to availability group." für das Ziel "localhost,14333".
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Setting Default timestampformat
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] 1 database to backup
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Backup database [pubs]
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Creating full backup
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Building file name
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Building backup path
AUSFÜHRLICH: [12:48:07][Backup-DbaDatabase] Devices added
AUSFÜHRLICH: [12:48:08][Get-DbaDbBackupHistory] Processing pubs
AUSFÜHRLICH: [12:48:08][Get-DbaDbBackupHistory] Executing sql query on [GALLOPER].
AUSFÜHRLICH: [12:48:08][Get-DbaDbBackupHistory] Processing as grouped output.
AUSFÜHRLICH: [12:48:08][Get-DbaDbBackupHistory] 1 result-groups found.
AUSFÜHRLICH: [12:48:12][Add-DbaAgDatabase] Error joining database to availability group | Cannot join database 'pubs' to availability group 'test-ag'.  The database has already joined the availabili
ty group.  This is an informational message.  No user action is required.


ComputerName               : localhost
InstanceName               : MSSQLSERVER
SqlInstance                : dockersql1
LocalReplicaRole           : Primary
AvailabilityGroup          : test-ag
PrimaryReplica             : dockersql1
ClusterType                : None
DtcSupportEnabled          : False
AutomatedBackupPreference  : Secondary
AvailabilityReplicas       : {dockersql1, dockersql2}
AvailabilityDatabases      : {pubs}
AvailabilityGroupListeners : {}


ComputerName InstanceName SqlInstance AvailabilityGroup Name            Role ConnectionState RollupSynchronizationState  AvailabilityMode BackupPriority EndpointUrl           SessionTimeout Failove
                                                                                                                                                                                                rMode
------------ ------------ ----------- ----------------- ----            ---- --------------- --------------------------  ---------------- -------------- -----------           -------------- -------
localhost    MSSQLSERVER  dockersql1  test-ag           dockersql1   Primary       Connected               Synchronized SynchronousCommit             50 TCP://dockersql1:5022             10  Manual
localhost    MSSQLSERVER  dockersql1  test-ag           dockersql2 Secondary       Connected               Synchronized SynchronousCommit             50 TCP://dockersql2:5023             10  Manual

ComputerName InstanceName SqlInstance AvailabilityGroup Replica   Name SynchronizationState IsFailoverReady IsJoined IsSuspended
------------ ------------ ----------- ----------------- -------   ---- -------------------- --------------- -------- -----------
localhost    MSSQLSERVER  dockersql1  test-ag           localhost pubs         Synchronized            True     True       False
localhost    MSSQLSERVER  dockersql2  test-ag           localhost pubs         Synchronized            True     True       False
```
