### PR TITLE
Change Message of Stop-Function to include $instance after failure of Connect-DbaInstance or Connect-SqlInstance

### DIFF
--- a/functions/Disable-DbaFilestream.ps1
+++ b/functions/Disable-DbaFilestream.ps1
@@ -89,7 +89,7 @@ function Disable-DbaFilestream {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failure connecting to $computer" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # Instance level

--- a/functions/Disable-DbaStartupProcedure.ps1
+++ b/functions/Disable-DbaStartupProcedure.ps1
@@ -94,7 +94,7 @@ function Disable-DbaStartupProcedure {
                 try {
                     $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
                 } catch {
-                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
+                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
                 $db = $server.Databases['master']
 

--- a/functions/Enable-DbaStartupProcedure.ps1
+++ b/functions/Enable-DbaStartupProcedure.ps1
@@ -73,7 +73,7 @@ function Enable-DbaStartupProcedure {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
             } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $server -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             Write-Message -Level Verbose -Message "Getting startup procedures for $instance"
 

--- a/functions/Export-DbaSysDbUserObject.ps1
+++ b/functions/Export-DbaSysDbUserObject.ps1
@@ -77,7 +77,7 @@ function Export-DbaSysDbUserObject {
                 try {
                     $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
 
                 if (!(Test-SqlSa -SqlInstance $server -SqlCredential $SqlCredential)) {

--- a/functions/Get-DbaAvailabilityGroup.ps1
+++ b/functions/Get-DbaAvailabilityGroup.ps1
@@ -79,7 +79,7 @@ function Get-DbaAvailabilityGroup {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             } catch {
-                Stop-Function -Message "Failure." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if (-not $server.IsHadrEnabled) {

--- a/functions/Get-DbaDbMail.ps1
+++ b/functions/Get-DbaDbMail.ps1
@@ -62,7 +62,7 @@ function Get-DbaDbMail {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failure" -Category Connectiondbmail -dbmailRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             try {

--- a/functions/Get-DbaDbMailHistory.ps1
+++ b/functions/Get-DbaDbMailHistory.ps1
@@ -72,7 +72,7 @@ function Get-DbaDbMailHistory {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failure" -Category Connectiondbmail -dbmailRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $sql = "SELECT SERVERPROPERTY('MachineName') AS ComputerName,

--- a/functions/Get-DbaDbMailLog.ps1
+++ b/functions/Get-DbaDbMailLog.ps1
@@ -72,7 +72,7 @@ function Get-DbaDbMailLog {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failure" -Category Connectiondbmail -dbmailRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $sql = "SELECT SERVERPROPERTY('MachineName') AS ComputerName,

--- a/functions/Get-DbaStartupProcedure.ps1
+++ b/functions/Get-DbaStartupProcedure.ps1
@@ -66,7 +66,7 @@ function Get-DbaStartupProcedure {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlcredential
             } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             Write-Message -Level Verbose -Message "Getting startup procedures for $servername"
 

--- a/functions/Invoke-DbaDbDataGenerator.ps1
+++ b/functions/Invoke-DbaDbDataGenerator.ps1
@@ -165,7 +165,7 @@ function Invoke-DbaDbDataGenerator {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Database) {

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -344,7 +344,7 @@ function Invoke-DbaQuery {
                 }
                 $server = Connect-DbaInstance @connDbaInstanceParams
             } catch {
-                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $conncontext = $server.ConnectionContext
             try {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Having more info for the user, especially when passing more instances to SqlInstance.

### Approach
I just used the message that was already used in most commands.

Sometimes also changed the Target to the correct value.
Sometimes added Category.
Sometimes changed dbmailRecord to ErrorRecord because Stop-Function does not have that parameter.