### PR TITLE
proposal for pester tests compatible with pester4-5

### DIFF
--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         It "Should only contain our specific parameters" {
+            $CommandName = (Get-Item $PSCommandPath).Name.Replace(".Tests.ps1", "")
             [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
             [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Query', 'QueryTimeout', 'File', 'SqlObject', 'As', 'SqlParameters', 'AppendServerInstance', 'MessagesToOutput', 'InputObject', 'ReadOnly', 'EnableException', 'CommandType'
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty


### PR DESCRIPTION
As discussed on Slack, weird proposal to make syntax more akin to what Pester4 expects (e.g. -Be instead of -Be) which on Pester5 is required.

Also, this apparently (hence the "proposal" name of the branch) makes it work in both Pester4 and Pester5.

Picked up a few things in the process:
- initialization needs to be in a BeforeAll
- no code should run in Context
- `$MyInvocation.MyCommand.Name` is not relied upon anymore
  - hence `$CommandName = (Get-Item $PSCommandPath).Name.Replace(".Tests.ps1", "")`
- `-Throw` matched with a "contains" approach on Pester4. Pester5 needs to include a wildcard such as in `-Like`
  - hence ```$PesterV5Throw = ''
    if ((Get-Command Invoke-Pester -ErrorAction SilentlyContinue).Version -ge '5.0.0') {
        $PesterV5Throw = '*'
    }``` , agreed, it can be more nice, but this is just for show
- validate params stealed from @wsmelton 's "new" method, seems perfectly legit
- setting costants.ps1 moved to the BeforeAll of integrationtests (it seems that setting it in the "global" BeforeAll doesn't work)

Think this as a starting point and not a finalized proposal, I'm sure more things will come up (e.g. for tests with mocks) but at least it enables who does tests to be more in line with what Pester4 started to introduce (leaving compat with Pester3 style, which a lot of our tests still rely upon) and what Pester5 expects (no backwards compat).
For the vast majority of our tests this kind of rewrite is not a big deal and moves us a lot forward.

Again, this is to start make moves to make sure we CAN test with Pester5 when such a need will arise. My only con right now with Pester5 is that it doesn't support coverage report.

