### PR TITLE
Resolve-DbaNetworkName - Changed return to continue because of foreach

### DIFF
--- a/functions/Resolve-DbaNetworkName.ps1
+++ b/functions/Resolve-DbaNetworkName.ps1
@@ -70,7 +70,7 @@ function Resolve-DbaNetworkName {
         PS C:\> Resolve-DbaNetworkName -ComputerName sql2014
 
         Returns a custom object displaying InputName, ComputerName, IPAddress, DNSHostName, DNSDomain, Domain, DNSHostEntry, FQDN, DNSHostEntry for sql2014
-        
+
     .EXAMPLE
         PS C:\> Resolve-DbaNetworkName -ComputerName sql2016, sql2014
 
@@ -185,7 +185,8 @@ function Resolve-DbaNetworkName {
             }
             if ($Turbo) {
                 # that's a finish line for a Turbo mode
-                return $result
+                $result
+                continue
             }
 
             # finding out which IP to use by pinging all of them. The first to respond is the one.


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Be able to use more than one $ComputerName and the -Turbo mode

### Approach
Corrected the wrong use of "return" and changed that to the correct "continue".
