### PR TITLE
New-/Get-DbaEndpoint - Added IPAddress and fixed SslPort

### DIFF
--- a/functions/Get-DbaEndpoint.ps1
+++ b/functions/Get-DbaEndpoint.ps1
@@ -83,7 +83,9 @@ function Get-DbaEndpoint {
             foreach ($end in $endpoints) {
                 Write-Message -Level Verbose -Message "Getting endpoint $($end.Name) on $($server.Name)"
                 if ($end.Protocol.Tcp.ListenerPort) {
-                    if ($instance.ComputerName -match '\.') {
+                    if ($end.Protocol.Tcp.ListenerIPAddress -ne [System.Net.IPAddress]'0.0.0.0') {
+                        $dns = $end.Protocol.Tcp.ListenerIPAddress
+                    } elseif ($instance.ComputerName -match '\.') {
                         $dns = $instance.ComputerName
                     } else {
                         try {
@@ -106,9 +108,10 @@ function Get-DbaEndpoint {
                 Add-Member -Force -InputObject $end -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                 Add-Member -Force -InputObject $end -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
                 Add-Member -Force -InputObject $end -MemberType NoteProperty -Name Fqdn -Value $fqdn
+                Add-Member -Force -InputObject $end -MemberType NoteProperty -Name IPAddress -Value $end.Protocol.Tcp.ListenerIPAddress
                 Add-Member -Force -InputObject $end -MemberType NoteProperty -Name Port -Value $end.Protocol.Tcp.ListenerPort
                 if ($end.Protocol.Tcp.ListenerPort) {
-                    Select-DefaultView -InputObject $end -Property ComputerName, InstanceName, SqlInstance, ID, Name, Port, EndpointState, EndpointType, Owner, IsAdminEndpoint, Fqdn, IsSystemObject
+                    Select-DefaultView -InputObject $end -Property ComputerName, InstanceName, SqlInstance, ID, Name, IPAddress, Port, EndpointState, EndpointType, Owner, IsAdminEndpoint, Fqdn, IsSystemObject
                 } else {
                     Select-DefaultView -InputObject $end -Property ComputerName, InstanceName, SqlInstance, ID, Name, EndpointState, EndpointType, Owner, IsAdminEndpoint, Fqdn, IsSystemObject
                 }

--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -36,6 +36,9 @@ function New-DbaEndpoint {
     .PARAMETER Port
         Port for TCP. If one is not provided, it will be auto-generated.
 
+    .PARAMETER SslPort
+        Port for SSL.
+
     .PARAMETER Certificate
         Database certificate used for authentication.
 
@@ -114,6 +117,7 @@ function New-DbaEndpoint {
         [string]$Certificate,
         [System.Net.IPAddress]$IPAddress = '0.0.0.0',
         [int]$Port,
+        [int]$SslPort,
         [string]$Owner,
         [switch]$EnableException
     )
@@ -170,6 +174,9 @@ function New-DbaEndpoint {
                         $endpoint.Protocol.Tcp.ListenerIPAddress = $IPAddress
                         $endpoint.Protocol.Tcp.ListenerPort = $tcpPort
                         $endpoint.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::$Role
+                        if (Test-Bound -ParameterName SslPort) {
+                            $endpoint.Protocol.Http.SslPort = $SslPort
+                        }
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::$EndpointEncryption
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::$EncryptionAlgorithm
                     }

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'EncryptionAlgorithm', 'Certificate', 'Port', 'SslPort', 'Owner', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'IPAddress', 'EncryptionAlgorithm', 'Certificate', 'Port', 'SslPort', 'Owner', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I have a client who wants to use a dedicated network for hadr communication, so we bind the hadr_endpoint only on one ipadress in a special network. This parameter was missing, so I had to use SQL. I want to use dbatools the next time...

Also removed SslPort as this is not a property of the smo (try to use it and you'll see - or have a look at https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.tcpprotocol?view=sql-smo-160).

Changed the Get- to return a Fqdn with ipaddress if not 0.0.0.0, because this is most likely what is needed for Add-DbaAgReplica. But we can discuss that point.

I have not updated the tests because other pull requests are pending and they would conflict on the tests for parameters.

Other issues I found while coding:
```
                $thisport = (Get-DbaEndpoint -SqlInstance $server).Protocol.Tcp
                $measure = $thisport | Measure-Object ListenerPort -Maximum

                if ($thisport.ListenerPort -eq 0) {
                    $tcpPort = 5022
                } elseif ($measure.Maximum) {
                    $maxPort = $measure.Maximum
                    #choose a random port that is greater than the current max port
                    $tcpPort = $maxPort + (New-Object Random).Next(1, 500)
                } else {
                    $maxPort = 5000
                    #choose a random port that is greater than the current max port
                    $tcpPort = $maxPort + (New-Object Random).Next(1, 500)
                }
```
I think that this does not works as expected - I would just use 5022 as a default if mirroring and otherwise fail if port is not provided. With more than one instance on a system, the instance can not know if 5022 is not used by another instance on that machine. So just checking an local instance is just "weigh in safety" and not garantied to work.

```
                    if ($Certificate) {
                        $outscript = $endpoint.Script()
                        $outscript = $outscript.Replace("ROLE = ALL,", "ROLE = ALL, AUTHENTICATION = CERTIFICATE $cert,")
                        $server.Query($outscript)
```
This only works if $Role = 'All', otherwise the replace would not work.



For all that like Screenshots, here we go:

![image](https://user-images.githubusercontent.com/66946165/92642602-c03c6100-f2e0-11ea-875a-fd8b8291d43e.png)

