### PR TITLE
buildreference, separate Update function

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -528,6 +528,7 @@
         'Get-DbaAgentJobOutputFile',
         'Set-DbaAgentJobOutputFile',
         'Get-DbaBuildReference',
+        'Update-DbaBuildReference',
         'New-DbaDacProfile'
         'Import-DbaXESessionTemplate',
         'Export-DbaXESessionTemplate',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -764,6 +764,7 @@ $script:xplat = @(
     'Export-DbaDbRole',
     'Export-DbaServerRole',
     'Get-DbaBuildReference',
+    'Update-DbaBuildReference',
     'Install-DbaFirstResponderKit',
     'Install-DbaWhoIsActive',
     'Update-Dbatools',

--- a/functions/Get-DbaBuildReference.ps1
+++ b/functions/Get-DbaBuildReference.ps1
@@ -36,7 +36,7 @@ function Get-DbaBuildReference {
         For MFA support, please use Connect-DbaInstance.
 
     .PARAMETER Update
-        Looks online for the most up to date reference, replacing the local one.
+        Adding this switch will look online for the most up to date reference, optionally replacing the local one.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -112,6 +112,71 @@ function Get-DbaBuildReference {
 
     begin {
 
+        #region verifying parameters
+        $isPipelineSqlInstance = $PSCmdlet.MyInvocation.ExpectingInput
+        $ComplianceSpec = @()
+        $ComplianceSpecExclusiveParams = @('Build', 'Kb', @( 'MajorVersion', 'ServicePack', 'CumulativeUpdate'), 'SqlInstance')
+        foreach ($exclParamGroup in $ComplianceSpecExclusiveParams) {
+            foreach ($exclParam in $exclParamGroup) {
+                if ($exclParam -eq 'SqlInstance') {
+                    if ($isPipelineSqlInstance -or (Test-Bound -ParameterName 'SqlInstance')) {
+                        $ComplianceSpec += $exclParam
+                    }
+                } else {
+                    if (Test-Bound -ParameterName $exclParam) {
+                        $ComplianceSpec += $exclParam
+                        break
+                    }
+                }
+            }
+        }
+        if ($ComplianceSpec.Length -eq 0 -and (Test-Bound -Not -ParameterName 'Update') -and (-not($isPipelineSqlInstance))) {
+            Stop-Function -Category InvalidArgument -Message "You need to choose at least one parameter."
+            return
+        }
+        if ($ComplianceSpec.Length -gt 1) {
+            Stop-Function -Category InvalidArgument -Message "$($ComplianceSpec -join ', ') are mutually exclusive. Please choose one or the other. Quitting."
+            return
+        }
+        if (((Test-Bound -ParameterName 'ServicePack') -or (Test-Bound -ParameterName 'CumulativeUpdate')) -and (Test-Bound -Not -ParameterName 'MajorVersion')) {
+            Stop-Function -Category InvalidArgument -Message "-MajorVersion is required when specifying SP or CU."
+            return
+        }
+        if ($MajorVersion) {
+            if ($MajorVersion -match '^(SQL)?(\d{4}(R2)?)$') {
+                $MajorVersion = $Matches[2]
+            } else {
+                Stop-Function -Message "Incorrect SQL Server version format: use SQL2XXX or just 2XXXX - SQL2012, SQL2008R2"
+                return
+            }
+            if (!$ServicePack) {
+                $ServicePack = 'RTM'
+            }
+            if ($ServicePack -match '^(SP)?\s*(\d+)$') {
+                if ($Matches[2] -eq '0') {
+                    $ServicePack = 'RTM'
+                } else {
+                    $ServicePack = 'SP' + $Matches[2]
+                }
+            } elseif ($ServicePack -notmatch '^RTM$') {
+                Stop-Function -Message "Incorrect SQL Server service pack format: use SPX, X or RTM, where X is a service pack number"
+                return
+            }
+            if ($CumulativeUpdate) {
+                if ($CumulativeUpdate -match '^(CU)?\s*(\d+)$') {
+                    if ($Matches[2] -eq '0') {
+                        $CumulativeUpdate = ''
+                    } else {
+                        $CumulativeUpdate = 'CU' + $Matches[2]
+                    }
+                } else {
+                    Stop-Function -Message "Incorrect SQL Server cumulative update format: use CUX or X, where X is a cumulative update number"
+                    return
+                }
+            }
+        }
+        #endregion verifying parameters
+
         #region Helper functions
         function Get-DbaBuildReferenceIndex {
             [CmdletBinding()]
@@ -152,26 +217,15 @@ function Get-DbaBuildReference {
                 $module_time = Get-Date $module_content.LastUpdated
                 $data_time = Get-Date $data_content.LastUpdated
 
-                $offline_time = $module_time
                 if ($module_time -gt $data_time) {
                     Copy-Item -Path $orig_idxfile -Destination $writable_idxfile -Force -ErrorAction Stop
                     $result = $module_content
                 } else {
                     $result = $data_content
-                    $offline_time = $data_time
                 }
                 # If Update is passed, try to fetch from online resource and store into the writeable
                 if ($Update) {
-                    $WebContent = Get-DbaBuildReferenceIndexOnline -EnableException $EnableException
-                    if ($null -ne $WebContent) {
-                        $webdata_content = $WebContent.Content | ConvertFrom-Json
-                        $webdata_time = Get-Date $webdata_content.LastUpdated
-                        if ($webdata_time -gt $offline_time) {
-                            Write-Message -Level Output -Message "Index updated correctly, last update on: $(Get-Date -Date $webdata_time -Format s), was $(Get-Date -Date $offline_time -Format s)"
-                            $WebContent.Content | Out-File $writable_idxfile -Encoding utf8 -ErrorAction Stop
-                            $result = Get-Content $writable_idxfile -Raw | ConvertFrom-Json
-                        }
-                    }
+                    Update-DbaBuildReference -EnableException -ErrorAction Stop
                 }
             }
 
@@ -188,27 +242,6 @@ function Get-DbaBuildReference {
             $result.Data | Select-Object @{ Name = "VersionObject"; Expression = { [version]$_.Version } }, *
         }
 
-        function Get-DbaBuildReferenceIndexOnline {
-            [CmdletBinding()]
-            param (
-                [bool]
-                $EnableException
-            )
-            $url = Get-DbatoolsConfigValue -Name 'assets.sqlbuildreference'
-            try {
-                $WebContent = Invoke-TlsWebRequest $url -UseBasicParsing -ErrorAction Stop
-            } catch {
-                try {
-                    Write-Message -Level Verbose -Message "Probably using a proxy for internet access, trying default proxy settings"
-                    (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
-                    $WebContent = Invoke-TlsWebRequest $url -UseBasicParsing -ErrorAction Stop
-                } catch {
-                    Write-Message -Level Warning -Message "Couldn't download updated index from $url"
-                    return
-                }
-            }
-            return $WebContent
-        }
 
         function Resolve-DbaBuild {
             [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
@@ -318,66 +351,8 @@ function Get-DbaBuildReference {
         }
     }
     process {
+
         if (Test-FunctionInterrupt) { return }
-
-        #region verifying parameters
-        $ComplianceSpec = @()
-        $ComplianceSpecExclusiveParams = @('Build', 'Kb', @( 'MajorVersion', 'ServicePack', 'CumulativeUpdate'), 'SqlInstance')
-        foreach ($exclParamGroup in $ComplianceSpecExclusiveParams) {
-            foreach ($exclParam in $exclParamGroup) {
-                if (Test-Bound -Parameter $exclParam) {
-                    $ComplianceSpec += $exclParam
-                    break
-                }
-            }
-        }
-        if ($ComplianceSpec.Length -gt 1) {
-            Stop-Function -Category InvalidArgument -Message "$($ComplianceSpec -join ', ') are mutually exclusive. Please choose one or the other. Quitting."
-            return
-        }
-        if ($ComplianceSpec.Length -eq 0) {
-            Stop-Function -Category InvalidArgument -Message "You need to choose at least one parameter."
-            return
-        }
-        if (((Test-Bound -Parameter ServicePack) -or (Test-Bound -Parameter CumulativeUpdate)) -and (Test-Bound -Not -Parameter MajorVersion)) {
-            Stop-Function -Category InvalidArgument -Message "-MajorVersion is required when specifying SP or CU."
-            return
-        }
-        if ($MajorVersion) {
-            if ($MajorVersion -match '^(SQL)?(\d{4}(R2)?)$') {
-                $MajorVersion = $Matches[2]
-            } else {
-                Stop-Function -Message "Incorrect SQL Server version format: use SQL2XXX or just 2XXXX - SQL2012, SQL2008R2"
-                return
-            }
-            if (!$ServicePack) {
-                $ServicePack = 'RTM'
-            }
-            if ($ServicePack -match '^(SP)?\s*(\d+)$') {
-                if ($Matches[2] -eq '0') {
-                    $ServicePack = 'RTM'
-                } else {
-                    $ServicePack = 'SP' + $Matches[2]
-                }
-            } elseif ($ServicePack -notmatch '^RTM$') {
-                Stop-Function -Message "Incorrect SQL Server service pack format: use SPX, X or RTM, where X is a service pack number"
-                return
-            }
-            if ($CumulativeUpdate) {
-                if ($CumulativeUpdate -match '^(CU)?\s*(\d+)$') {
-                    if ($Matches[2] -eq '0') {
-                        $CumulativeUpdate = ''
-                    } else {
-                        $CumulativeUpdate = 'CU' + $Matches[2]
-                    }
-                } else {
-                    Stop-Function -Message "Incorrect SQL Server cumulative update format: use CUX or X, where X is a cumulative update number"
-                    return
-                }
-            }
-        }
-        #endregion verifying parameters
-
 
         foreach ($instance in $SqlInstance) {
             #region Ensure the connection is established

--- a/functions/Update-DbaBuildReference.ps1
+++ b/functions/Update-DbaBuildReference.ps1
@@ -1,0 +1,108 @@
+function Update-DbaBuildReference {
+    <#
+    .SYNOPSIS
+        Updates the local reference looking online for the most up to date.
+
+    .DESCRIPTION
+        This function updates the local json files containing all the infos about SQL builds.
+        It uses the setting 'assets.sqlbuildreference' to fetch it.
+        To see your current setting, use Get-DbatoolsConfigValue -Name 'assets.sqlbuildreference'
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: SqlBuild
+        Author: Simone Bizzotto (@niphold) | Friedrich Weinmann (@FredWeinmann)
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Update-DbaBuildReference
+
+    .EXAMPLE
+        PS C:\> Update-DbaBuildReference
+
+        Looks online if there is a newer version of the build reference
+
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    [CmdletBinding(DefaultParameterSetName = 'Build')]
+    param (
+        [switch]$EnableException
+    )
+
+    begin {
+        function Get-DbaBuildReferenceIndexOnline {
+            [CmdletBinding()]
+            param (
+                [bool]
+                $EnableException
+            )
+            $url = Get-DbatoolsConfigValue -Name 'assets.sqlbuildreference'
+            try {
+                $WebContent = Invoke-TlsWebRequest $url -UseBasicParsing -ErrorAction Stop
+            } catch {
+                try {
+                    Write-Message -Level Verbose -Message "Probably using a proxy for internet access, trying default proxy settings"
+                    (New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+                    $WebContent = Invoke-TlsWebRequest $url -UseBasicParsing -ErrorAction Stop
+                } catch {
+                    Write-Message -Level Warning -Message "Couldn't download updated index from $url"
+                    return
+                }
+            }
+            return $WebContent
+        }
+
+    }
+    process {
+        $Moduledirectory = $script:PSModuleRoot
+        $orig_idxfile = Resolve-Path "$Moduledirectory\bin\dbatools-buildref-index.json"
+        $DbatoolsData = Get-DbatoolsConfigValue -Name 'Path.DbatoolsData'
+        $writable_idxfile = Join-Path $DbatoolsData "dbatools-buildref-index.json"
+
+        if (-not (Test-Path $orig_idxfile)) {
+            Write-Message -Level Warning -Message "Unable to read local SQL build reference file. Please check your module integrity or reinstall dbatools."
+        }
+
+        if ((-not (Test-Path $orig_idxfile)) -and (-not (Test-Path $writable_idxfile))) {
+            throw "Build reference file not found, please check module health."
+        }
+
+        # If no writable copy exists, create one and return the module original
+        if (-not (Test-Path $writable_idxfile)) {
+            Copy-Item -Path $orig_idxfile -Destination $writable_idxfile -Force -ErrorAction Stop
+        }
+
+        # Else, if both exist, update the writeable if necessary and return the current version
+        elseif (Test-Path $orig_idxfile) {
+            $module_content = Get-Content $orig_idxfile -Raw | ConvertFrom-Json
+            $data_content = Get-Content $writable_idxfile -Raw | ConvertFrom-Json
+
+            $module_time = Get-Date $module_content.LastUpdated
+            $data_time = Get-Date $data_content.LastUpdated
+
+            $offline_time = $module_time
+            if ($module_time -gt $data_time) {
+                Copy-Item -Path $orig_idxfile -Destination $writable_idxfile -Force -ErrorAction Stop
+            } else {
+                $offline_time = $data_time
+            }
+        }
+        $WebContent = Get-DbaBuildReferenceIndexOnline -EnableException $EnableException
+        if ($null -ne $WebContent) {
+            $webdata_content = $WebContent.Content | ConvertFrom-Json
+            $webdata_time = Get-Date $webdata_content.LastUpdated
+            if ($webdata_time -gt $offline_time) {
+                Write-Message -Level Output -Message "Index updated correctly, last update on: $(Get-Date -Date $webdata_time -Format s), was $(Get-Date -Date $offline_time -Format s)"
+                $WebContent.Content | Out-File $writable_idxfile -Encoding utf8 -ErrorAction Stop
+            }
+        }
+
+    }
+}

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -14,42 +14,59 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Unit Test" -Tags Unittest {
-    $ModuleBase = (Get-Module -Name dbatools | Where-Object ModuleBase -notmatch net).ModuleBase
-    $idxfile = "$ModuleBase\bin\dbatools-buildref-index.json"
+    BeforeAll {
+        $ModuleBase = (Get-Module -Name dbatools | Where-Object ModuleBase -notmatch net).ModuleBase
+        $idxfile = "$ModuleBase\bin\dbatools-buildref-index.json"
+    }
+
     Context 'Validate data in json is correct' {
         It "the json file is there" {
             $result = Test-Path $idxfile
-            $result | Should Be $true
+            $result | Should -Be $true
         }
         It "the json can be parsed" {
             $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
-            $IdxRef | Should BeOfType System.Object
+            $IdxRef | Should -BeOfType System.Object
         }
     }
     Context 'Validate LastUpdated property' {
-        $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+        BeforeAll {
+            $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+        }
         It "Has a proper LastUpdated property" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated
-            $lastupdate | Should BeOfType System.DateTime
+            $lastupdate | Should -BeOfType System.DateTime
         }
         It "LastUpdated is updated regularly (keeps everybody on their toes)" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated
-            $lastupdate | Should BeGreaterThan (Get-Date).AddDays(-45)
+            $lastupdate | Should -BeGreaterThan (Get-Date).AddDays(-45)
         }
         It "LastUpdated is not in the future" {
             $lastupdate = Get-Date -Date $IdxRef.LastUpdated
-            $lastupdate | Should BeLessThan (Get-Date)
+            $lastupdate | Should -BeLessThan (Get-Date)
         }
     }
     Context 'Validate Data property' {
-        $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+        BeforeAll {
+            $IdxRef = Get-Content $idxfile -raw | ConvertFrom-Json
+            $Groups = @{ }
+            $OrderedKeys = @()
+            foreach ($el in $IdxRef.Data) {
+                $ver = $el.Version.Split('.')[0 .. 1] -join '.'
+                if (!($Groups.ContainsKey($ver))) {
+                    $Groups[$ver] = New-Object System.Collections.ArrayList
+                    $OrderedKeys += $ver
+                }
+                $null = $Groups[$ver].Add($el)
+            }
+        }
         It "Data is a proper array" {
-            $IdxRef.Data.Length | Should BeGreaterThan 100
+            $IdxRef.Data.Length | Should -BeGreaterThan 100
         }
         It "Each Datum has a Version property" {
             $DataLength = $IdxRef.Data.Length
             $DataWithVersion = ($IdxRef.Data.Version | Where-Object { $_ }).Length
-            $DataLength | Should Be $DataWithVersion
+            $DataLength | Should -Be $DataWithVersion
         }
         It "Each version is correctly parsable" {
             $Versions = $IdxRef.Data.Version | Where-Object { $_ }
@@ -58,16 +75,16 @@ Describe "$CommandName Unit Test" -Tags Unittest {
                 $dots = $ver.split('.').Length - 1
                 if ($dots -ne 2) {
                     if ($dots[0] -le 15) {
-                        $dots | Should Be 3
+                        $dots | Should -Be 3
                     } else {
-                        $dots | Should Be 4
+                        $dots | Should -Be 4
                     }
                 }
                 try {
                     $splitted | ForEach-Object { [convert]::ToInt32($_) }
                 } catch {
                     # I know. But someone can find a method to output a custom message ?
-                    $splitted -join '.' | Should Be "Composed by integers"
+                    $splitted -join '.' | Should -Be "Composed by integers"
                 }
             }
         }
@@ -78,59 +95,84 @@ Describe "$CommandName Unit Test" -Tags Unittest {
                 "$($splitted[0].toString('00'))$($splitted[1].toString('00'))$($splitted[2].toString('0000'))"
             }
             $SortedVersions = $Naturalized | Sort-Object
-            ($SortedVersions -join ",") | Should Be ($Naturalized -join ",")
+            ($SortedVersions -join ",") | Should -Be ($Naturalized -join ",")
         }
         It "Names are at least 8" {
             $Names = $IdxRef.Data.Name | Where-Object { $_ }
-            $Names.Length | Should BeGreaterThan 7
+            $Names.Length | Should -BeGreaterThan 7
         }
     }
+    Context "Params mutual exclusion" {
+        It "Doesn't accept 'Build', 'Kb', 'SqlInstance" {
+            { Get-DbaBuildReference -Build '10.0.1600' -Kb '4052908' -SqlInstance 'localhost' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'Kb'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -Kb '4052908' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'SqlInstance'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -SqlInstance 'localhost' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'SqlInstance'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -SqlInstance 'localhost' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'MajorVersion'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -MajorVersion '2016' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'ServicePack'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -ServicePack 'SP2' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'Build', 'CumulativeUpdate'" {
+            { Get-DbaBuildReference -Build '10.0.1600' -CumulativeUpdate 'CU2' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'ServicePack' without 'MajorVersion'" {
+            { Get-DbaBuildReference -ServicePack 'SP2' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+        It "Doesn't accept 'CumulativeUpdate' without 'MajorVersion'" {
+            { Get-DbaBuildReference -CumulativeUpdate 'CU2' -EnableException -ErrorAction Stop } | Should -Throw
+        }
+    }
+    Context "Passing just -Update works, see #6823" {
+        function Get-DbaBuildReferenceIndexOnline { }
+        Mock Get-DbaBuildReferenceIndexOnline -MockWith { } -ModuleName dbatools
+        Get-DbaBuildReference -Update -WarningVariable warnings 3>$null
+        $warnings | Should -BeNullOrEmpty
+    }
+
     # These are groups by major release (aka "Name")
-    $IdxRef = Get-Content $idxfile -Raw | ConvertFrom-Json
-    $Groups = @{ }
-    $OrderedKeys = @()
-    foreach ($el in $IdxRef.Data) {
-        $ver = $el.Version.Split('.')[0 .. 1] -join '.'
-        if (!($Groups.ContainsKey($ver))) {
-            $Groups[$ver] = New-Object System.Collections.ArrayList
-            $OrderedKeys += $ver
-        }
-        $null = $Groups[$ver].Add($el)
-    }
     foreach ($g in $OrderedKeys) {
         $Versions = $Groups[$g]
         Context "Properties Check, for major release $g" {
             It "has the first element with a Name" {
-                $Versions[0].Name | Should BeLike "20*"
+                $Versions[0].Name | Should -BeLike "20*"
             }
             It "No multiple Names around" {
-                ($Versions.Name | Where-Object { $_ }).Count | Should Be 1
+                ($Versions.Name | Where-Object { $_ }).Count | Should -Be 1
             }
             It "has a single version tagged as RTM" {
-                ($Versions.SP -eq 'RTM').Count | Should Be 1
+                ($Versions.SP -eq 'RTM').Count | Should -Be 1
             }
             It "SP Property is formatted correctly" {
-                $Versions.SP | Where-Object { $_ } | Should Match '^RTM$|^SP[\d]+$|^RC'
+                $Versions.SP | Where-Object { $_ } | Should -Match '^RTM$|^SP[\d]+$|^RC'
             }
             It "CU Property is formatted correctly" {
                 $CUMatch = $Versions.CU | Where-Object { $_ }
                 if ($CUMatch) {
-                    $CUMatch | Should Match '^CU[\d]+$'
+                    $CUMatch | Should -Match '^CU[\d]+$'
                 }
             }
             It "SPs are ordered correctly" {
                 $SPs = $Versions.SP | Where-Object { $_ }
-                ($SPs | Select-Object -First 1) | Should BeIn 'RTM', 'RC'
+                ($SPs | Select-Object -First 1) | Should -BeIn 'RTM', 'RC'
                 $ActualSPs = $SPs | Where-Object { $_ -match '^SP[\d]+$' }
                 $OrderedActualSPs = $ActualSPs | Sort-Object
-                ($ActualSPs -join ',') | Should Be ($OrderedActualSPs -join ',')
+                ($ActualSPs -join ',') | Should -Be ($OrderedActualSPs -join ',')
             }
             # see https://github.com/sqlcollaborative/dbatools/pull/2466
             It "KBList has only numbers on it" {
                 $NotNumbers = $Versions.KBList | Where-Object { $_ } | Where-Object { $_ -notmatch '^[\d]+$' }
                 if ($NotNumbers.Count -ne 0) {
                     foreach ($Nn in $NotNumbers) {
-                        $Nn | Should Be "Composed by integers"
+                        $Nn | Should -Be "Composed by integers"
                     }
                 }
             }
@@ -139,34 +181,48 @@ Describe "$CommandName Unit Test" -Tags Unittest {
 }
 
 Describe "$commandname Integration Tests" -Tags 'IntegrationTests' {
+    Context "piping and params" {
+        BeforeAll {
+            $server1 = Connect-DbaInstance -SqlInstance $script:instance1
+            $server2 = Connect-DbaInstance -SqlInstance $script:instance2
+        }
+        It "works when instances are piped" {
+            $res = @($server1, $server2) | Get-DbaBuildReference
+            $res.Count | Should -Be 2
+        }
+        It "doesn't work when passed both piped instances and, e.g., -Kb (params mutual exclusion)" {
+            { @($server1, $server2) | Get-DbaBuildReference -Kb -EnableException } | Should -Throw
+        }
+    }
     Context "Test retrieving version from instances" {
         $results = Get-DbaBuildReference -SqlInstance $script:instance1, $script:instance2
         It "Should return an exact match" {
             $results | Should -Not -BeNullOrEmpty
             foreach ($r in $results) {
-                $r.MatchType | Should Be "Exact"
+                $r.MatchType | Should -Be "Exact"
                 $buildMatch = Get-DbaBuildReference -Build $r.BuildLevel
                 $buildMatch | Should -Not -BeNullOrEmpty
                 foreach ($b in $buildMatch) {
-                    $b.MatchType | Should Be "Exact"
-                    $b.KBLevel | Should BeIn $r.KBLevel
+                    $b.MatchType | Should -Be "Exact"
+                    $b.KBLevel | Should -BeIn $r.KBLevel
                 }
-                if ($r.KBLevel) { #can be a RTM which has no corresponding KB
+                if ($r.KBLevel) {
+                    #can be a RTM which has no corresponding KB
                     $kbMatch = Get-DbaBuildReference -KB ($r.KBLevel | Select-Object -First 1)
                     $kbMatch | Should -Not -BeNullOrEmpty
                     foreach ($m in $kbMatch) {
-                        $m.MatchType | Should Be "Exact"
-                        $m.KBLevel | Should BeIn $r.KBLevel
+                        $m.MatchType | Should -Be "Exact"
+                        $m.KBLevel | Should -BeIn $r.KBLevel
                     }
                 }
                 $spLevel = $r.SPLevel | Where-Object { $_ -ne 'LATEST' }
                 $versionMatch = Get-DbaBuildReference -MajorVersion $r.NameLevel -ServicePack $spLevel -CumulativeUpdate $r.CULevel
                 $versionMatch | Should -Not -BeNullOrEmpty
                 foreach ($v in $versionMatch) {
-                    $v.MatchType | Should Be "Exact"
-                    $v.NameLevel | Should Be $r.NameLevel
-                    $spLevel | Should BeIn $v.SPLevel
-                    $v.CULevel | Should Be $r.CULevel
+                    $v.MatchType | Should -Be "Exact"
+                    $v.NameLevel | Should -Be $r.NameLevel
+                    $spLevel | Should -BeIn $v.SPLevel
+                    $v.CULevel | Should -Be $r.CULevel
                 }
             }
         }

--- a/tests/Update-DbaBuildReference.Tests.ps1
+++ b/tests/Update-DbaBuildReference.Tests.ps1
@@ -17,7 +17,7 @@ Describe "$CommandName Unit Test" -Tags Unittest {
         It "calls the internal function" {
             function Get-DbaBuildReferenceIndexOnline { }
             Mock Get-DbaBuildReferenceIndexOnline -MockWith { } -ModuleName dbatools
-            { Update-DbaBuildReference } | Should -Not -Throw
+            { Update-DbaBuildReference -EnableException -ErrorAction Stop } | Should -Not -Throw
         }
         It "errors out when cannot download" {
             Mock Get-DbaBuildReferenceIndexOnline -MockWith { throw "cannot download" } -ModuleName dbatools

--- a/tests/Update-DbaBuildReference.Tests.ps1
+++ b/tests/Update-DbaBuildReference.Tests.ps1
@@ -1,0 +1,27 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        It "Should only contain our specific parameters" {
+            [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+            [object[]]$knownParameters = 'EnableException'
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Unit Test" -Tags Unittest {
+    Context "not much" {
+        It "calls the internal function" {
+            function Get-DbaBuildReferenceIndexOnline { }
+            Mock Get-DbaBuildReferenceIndexOnline -MockWith { } -ModuleName dbatools
+            { Update-DbaBuildReference } | Should -Not -Throw
+        }
+        It "errors out when cannot download" {
+            Mock Get-DbaBuildReferenceIndexOnline -MockWith { throw "cannot download" } -ModuleName dbatools
+            { Update-DbaBuildReference -EnableException -ErrorAction Stop } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #6823 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Allowing just a simple `Get-DbaBuildReference -Update` and spawning a brand new `Update-DbaBuildReference`

### Approach
Moved out the part of the code that does the update and call it within Get-DbaBuildReference.
Moved in the begin block the param validation. 
Was moved out just for [piping support](https://github.com/sqlcollaborative/dbatools/pull/4869) but ..... welcome `$PSCmdlet.MyInvocation.ExpectingInput` in dbatools. This feels like "the way" but feel free to chime in.
Maybe Test-Bound could do something around it ?
Feel free to update the wording inside help of `Update-DbaBuildReference`, I'm not good at describing things and I'm yawning ^_^'

### Commands to test
I added a metric ton, would have helped having them all there already to see if I broke something (see $ComplianceSpecExclusiveParams). 
Thanks to @wsmelton wonderful job of tidying up the issues and commenting nicely I was able to catch up with https://github.com/sqlcollaborative/dbatools/pull/4869 ..... but it should have been put in as a regression test.
