### PR TITLE
Fix 6637 for Invoke-DbaDbDecryptObject

### DIFF
--- a/functions/Invoke-DbaDbDecryptObject.ps1
+++ b/functions/Invoke-DbaDbDecryptObject.ps1
@@ -196,12 +196,12 @@ function Invoke-DbaDbDecryptObject {
             $databaseCollection = $server.Databases | Where-Object { $_.Name -in $Database }
 
             # Use the table's schema for the trigger's schema. The schema name is not returned as a property for triggers (except in the URN).
-            $triggerSchema = @{label="Schema";expression={$_.Parent.Schema}}
+            $triggerSchema = @{label = "Schema"; expression = { $_.Parent.Schema } }
 
             # Loop through each of databases
             foreach ($db in $databaseCollection) {
 
-                $triggers = @($db.Tables | Where-Object { $_.IsSystemObject -eq $false } | ForEach-Object {$_.Triggers})
+                $triggers = @($db.Tables | Where-Object { $_.IsSystemObject -eq $false } | ForEach-Object { $_.Triggers })
 
                 # Get the objects
                 if ($ObjectName) {

--- a/tests/Invoke-DbaDbDecryptObject.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ObjectName', 'EncodingType', 'ExportDestination', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+            [object[]]$knownParameters = 'Database', 'EnableException', 'EncodingType', 'ExportDestination', 'ObjectName', 'SqlCredential', 'SqlInstance'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -27,13 +27,25 @@ Describe "$CommandName Integration Tests" -Tags "UnitTests" {
         # Create the database
         $db = New-DbaDatabase -SqlInstance $script:instance1 -Name $dbname
 
+        if ($null -ne $script:instance2SQLUserName) {
+            $instance2SecurePassword = ConvertTo-SecureString -String $script:instance2SQLPassword -AsPlainText -Force
+            $instance2SqlCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $script:instance2SQLUserName, $instance2SecurePassword
+        }
+
+        Remove-DbaDatabase -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -Database $dbname -Confirm:$false
+        $instance2Db = New-DbaDatabase -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -Name $dbname
+
+        # test object for usage with sql credential
+        $remoteDacSampleEncryptedView = "CREATE VIEW dbo.dbatoolsci_test_remote_dac_vw WITH ENCRYPTION AS SELECT 'remoteDac' as TestFeature;"
+        $instance2Db.Query($remoteDacSampleEncryptedView)
+
         # Setup the code for the encrypted function
-        $queryFunction = "
+        $queryScalarFunction = "
 -- =============================================
 -- Author:        Sander Stad
--- Description:   Dummy encrypted function to test the command
+-- Description:   Dummy encrypted scalar function to test the command
 -- =============================================
-CREATE FUNCTION DummyEncryptedFunction
+CREATE FUNCTION dbo.DummyEncryptedScalarFunction
 (
     @param1 varchar(100)
 )
@@ -52,8 +64,39 @@ BEGIN
 
 END
         "
-        # Create the encrypted function
-        $db.Query($queryFunction)
+        # Create the encrypted scalar function
+        $db.Query($queryScalarFunction)
+
+        # Setup the code for the encrypted inline function
+        $queryInlineTVF = "
+CREATE FUNCTION dbo.DummyEncryptedInlineTVF
+(
+    @Id INTEGER
+)
+RETURNS TABLE 
+WITH ENCRYPTION 
+AS 
+    RETURN SELECT @@SERVERNAME AS ServerName, @@VERSION AS Version, @Id AS Id;
+        "
+        # Create the encrypted inline TVF
+        $db.Query($queryInlineTVF)
+
+        # Setup the code for the encrypted table valued function
+        $queryTableValuedFunction = "
+CREATE FUNCTION dbo.DummyEncryptedTableValuedFunction
+(
+    @Id INTEGER
+)
+RETURNS @r TABLE(i INTEGER)
+WITH ENCRYPTION 
+AS 
+BEGIN 
+    INSERT INTO @r (i) VALUES (@Id)
+    RETURN 
+END;
+        "
+        # Create the encrypted table valued function
+        $db.Query($queryTableValuedFunction)
 
         # Setup the query for the encrypted stored procedure
         $queryStoredProcedure = "
@@ -61,7 +104,7 @@ END
 -- Author:        Sander Stad
 -- Description:   Dummy encrypted stored procedure to test the command
 -- =============================================
-CREATE PROCEDURE DummyEncryptedFunctionStoredProcedure
+CREATE PROCEDURE dbo.DummyEncryptedStoredProcedure
     @param1 VARCHAR(100)
 WITH ENCRYPTION
 AS
@@ -78,44 +121,179 @@ END
         # Create the encrypted stored procedure
         $db.Query($queryStoredProcedure)
 
+        # Setup the code for the encrypted view
+        $setupView = "
+CREATE VIEW dbo.dbatoolsci_test_vw
+WITH ENCRYPTION
+AS 
+SELECT 1 AS Id;"
+        # Create the encrypted view
+        $db.Query($setupView)
+        
+        # Create a schema to test with
+        $db.Query("CREATE SCHEMA dbatools")
+
+        # Setup the code for the encrypted trigger
+        $setupTable = "
+CREATE TABLE dbatools.dbatoolsci_tab1
+(
+    Id INTEGER
+);"
+        $db.Query($setupTable)
+
+        $setupTrigger = "
+CREATE TRIGGER dbatools.dbatoolsci_test_trigger 
+ON dbatools.dbatoolsci_tab1
+WITH ENCRYPTION
+INSTEAD OF DELETE
+AS
+BEGIN
+    RAISERROR ('Invoke-DbaDbDecryptObject.Tests', 16, 10);
+END;"
+        # Create the encrypted trigger
+        $db.Query($setupTrigger)
+
+        # Setup the code for an encrypted view in a schema other than dbo
+        $setupViewInSchema = "
+CREATE VIEW dbatools.dbatoolsci_test_schema_vw
+WITH ENCRYPTION 
+AS 
+SELECT 'dbatools' as SchemaName;"
+        # Create the encrypted view
+        $db.Query($setupViewInSchema)
+
+        # Create another schema to test with
+        $db.Query("CREATE SCHEMA dbatools2")
+
+        # Setup the code for an encrypted view in another schema other than dbo
+        $setupAnotherViewInSchema = "
+CREATE VIEW dbatools2.dbatoolsci_test_schema_vw
+WITH ENCRYPTION 
+AS 
+SELECT 'dbatools2' as SchemaName;"
+        # Create the encrypted view
+        $db.Query($setupAnotherViewInSchema)
+
+        # Setup the code for a view that has UTF8 characters
+        $setupViewWithUTF8 = "CREATE VIEW dbo.dbatoolsci_test_UTF8_vw
+WITH ENCRYPTION
+AS
+SELECT 'áéíñóú¡¿' as SampleUTF8;"
+        # Create the encrypted view
+        $db.Query($setupViewWithUTF8)
+
         # Check if DAC is enabled
         $config = Get-DbaSpConfigure -SqlInstance $script:instance1 -ConfigName RemoteDacConnectionsEnabled
         if ($config.ConfiguredValue -ne 1) {
             Set-DbaSpConfigure -SqlInstance $script:instance1 -ConfigName RemoteDacConnectionsEnabled -Value $true
+        }
+
+        $instance2Config = Get-DbaSpConfigure -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -ConfigName RemoteDacConnectionsEnabled
+        if ($instance2Config.ConfiguredValue -ne 1) {
+            Set-DbaSpConfigure -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -ConfigName RemoteDacConnectionsEnabled -Value $true
         }
     }
 
     AfterAll {
         # Remove the database if it exists
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -Database $dbname -Confirm:$false
 
         # Set the original configuration
         Set-DbaSpConfigure -SqlInstance $script:instance1 -ConfigName RemoteDacConnectionsEnabled -Value $config.ConfiguredValue -WarningAction SilentlyContinue
+        Set-DbaSpConfigure -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -ConfigName RemoteDacConnectionsEnabled -Value $instance2Config.ConfiguredValue -WarningAction SilentlyContinue
     }
 
+    # these tests are marked as skip to ensure the AppVeyor sql instances are not impacted negatively. These tests can be run locally.
     Context "DAC enabled" {
         # too much messing around punts appveyor
         It -Skip "Should throw error" {
             Set-DbaSpConfigure -SqlInstance $script:instance1 -Name RemoteDacConnectionsEnabled -Value $false
-            Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedFunctionStoredProcedure -WarningVariable warn -WarningAction SilentlyContinue
+            Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedStoredProcedure -WarningVariable warn -WarningAction SilentlyContinue
             $error[0].Exception | Should -BeLike "*DAC is not enabled for instance*"
             Set-DbaSpConfigure -SqlInstance $script:instance1 -Name RemoteDacConnectionsEnabled -Value $true -WarningAction SilentlyContinue
         }
     }
 
-    Context "Decrypt Function" {
+    Context "Decrypt Scalar Function" {
         It -Skip "Should be successful" {
-            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedFunction
-            $result.Script | Should -Be $queryFunction
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedScalarFunction
+            $result.Script | Should -Be $queryScalarFunction
+        }
+    }
 
+    Context "Decrypt Inline TVF" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedInlineTVF
+            $result.Script | Should -Be $queryInlineTVF
+        }
+    }
+
+    Context "Decrypt TVF" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedTableValuedFunction
+            $result.Script | Should -Be $queryTableValuedFunction
         }
     }
 
     Context "Decrypt Stored Procedure" {
         It -Skip "Should be successful" {
-            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedFunctionStoredProcedure
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName DummyEncryptedStoredProcedure
             $result.Script | Should -Be $queryStoredProcedure
+        }
+    }
+    
+    Context "Decrypt view" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_vw
+            $result.Script | Should -Be $setupView
+        }
+    }
 
+    Context "Decrypt trigger in a schema other than dbo" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_trigger
+            $result.Script | Should -Be $setupTrigger
+        }
+    }
+
+    Context "Decrypt objects with the same name but in different schemas" {
+        It -Skip "Should be successful" {
+            @(Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_schema_vw).Count | Should -Be 2
+        }
+    }
+
+    Context "Decrypt view with UTF8" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_UTF8_vw -EncodingType UTF8
+            $result.Script | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "Decrypt view and use a destination folder" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_vw -ExportDestination .
+            (Get-Content $result.OutputFile | Out-String).Trim() | Should -Be $setupView.Trim()
+            Remove-Item $result.OutputFile
+        }
+    }
+
+    # Note: this integration test takes about 3.5 minutes because it searches all objects and can be commented out if troubleshooting the other tests.
+    Context "Decrypt all encrypted objects and use a destination folder" {
+        It -Skip "Should be successful" {
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ExportDestination .
+            @($result | Where-Object { $_.Type -eq 'StoredProcedure' }).Count       | Should -Be 1
+            @($result | Where-Object { $_.Type -eq 'Trigger' }).Count               | Should -Be 1
+            @($result | Where-Object { $_.Type -eq 'UserDefinedFunction' }).Count   | Should -Be 3
+            @($result | Where-Object { $_.Type -eq 'View' }).Count                  | Should -Be 4
+        }
+    }
+
+    Context "Connect to an instance (ideally a remote instance) using a SqlCredential and decrypt an object" {
+        It -Skip "Should be successful" {   
+            $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -Database $dbname -ObjectName dbatoolsci_test_remote_dac_vw -ExportDestination .
+            (Get-Content $result.OutputFile | Out-String).Trim() | Should -Be $remoteDacSampleEncryptedView.Trim()
+            Remove-Item $result.OutputFile
         }
     }
 }

--- a/tests/Invoke-DbaDbDecryptObject.Tests.ps1
+++ b/tests/Invoke-DbaDbDecryptObject.Tests.ps1
@@ -5,10 +5,10 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         It "Should only contain our specific parameters" {
-            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
             [object[]]$knownParameters = 'Database', 'EnableException', 'EncodingType', 'ExportDestination', 'ObjectName', 'SqlCredential', 'SqlInstance'
             $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should -Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -73,9 +73,9 @@ CREATE FUNCTION dbo.DummyEncryptedInlineTVF
 (
     @Id INTEGER
 )
-RETURNS TABLE 
-WITH ENCRYPTION 
-AS 
+RETURNS TABLE
+WITH ENCRYPTION
+AS
     RETURN SELECT @@SERVERNAME AS ServerName, @@VERSION AS Version, @Id AS Id;
         "
         # Create the encrypted inline TVF
@@ -88,11 +88,11 @@ CREATE FUNCTION dbo.DummyEncryptedTableValuedFunction
     @Id INTEGER
 )
 RETURNS @r TABLE(i INTEGER)
-WITH ENCRYPTION 
-AS 
-BEGIN 
+WITH ENCRYPTION
+AS
+BEGIN
     INSERT INTO @r (i) VALUES (@Id)
-    RETURN 
+    RETURN
 END;
         "
         # Create the encrypted table valued function
@@ -125,11 +125,11 @@ END
         $setupView = "
 CREATE VIEW dbo.dbatoolsci_test_vw
 WITH ENCRYPTION
-AS 
+AS
 SELECT 1 AS Id;"
         # Create the encrypted view
         $db.Query($setupView)
-        
+
         # Create a schema to test with
         $db.Query("CREATE SCHEMA dbatools")
 
@@ -142,7 +142,7 @@ CREATE TABLE dbatools.dbatoolsci_tab1
         $db.Query($setupTable)
 
         $setupTrigger = "
-CREATE TRIGGER dbatools.dbatoolsci_test_trigger 
+CREATE TRIGGER dbatools.dbatoolsci_test_trigger
 ON dbatools.dbatoolsci_tab1
 WITH ENCRYPTION
 INSTEAD OF DELETE
@@ -156,8 +156,8 @@ END;"
         # Setup the code for an encrypted view in a schema other than dbo
         $setupViewInSchema = "
 CREATE VIEW dbatools.dbatoolsci_test_schema_vw
-WITH ENCRYPTION 
-AS 
+WITH ENCRYPTION
+AS
 SELECT 'dbatools' as SchemaName;"
         # Create the encrypted view
         $db.Query($setupViewInSchema)
@@ -168,8 +168,8 @@ SELECT 'dbatools' as SchemaName;"
         # Setup the code for an encrypted view in another schema other than dbo
         $setupAnotherViewInSchema = "
 CREATE VIEW dbatools2.dbatoolsci_test_schema_vw
-WITH ENCRYPTION 
-AS 
+WITH ENCRYPTION
+AS
 SELECT 'dbatools2' as SchemaName;"
         # Create the encrypted view
         $db.Query($setupAnotherViewInSchema)
@@ -242,7 +242,7 @@ SELECT 'áéíñóú¡¿' as SampleUTF8;"
             $result.Script | Should -Be $queryStoredProcedure
         }
     }
-    
+
     Context "Decrypt view" {
         It -Skip "Should be successful" {
             $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance1 -Database $dbname -ObjectName dbatoolsci_test_vw
@@ -290,7 +290,7 @@ SELECT 'áéíñóú¡¿' as SampleUTF8;"
     }
 
     Context "Connect to an instance (ideally a remote instance) using a SqlCredential and decrypt an object" {
-        It -Skip "Should be successful" {   
+        It -Skip "Should be successful" {
             $result = Invoke-DbaDbDecryptObject -SqlInstance $script:instance2 -SqlCredential $instance2SqlCredential -Database $dbname -ObjectName dbatoolsci_test_remote_dac_vw -ExportDestination .
             (Get-Content $result.OutputFile | Out-String).Trim() | Should -Be $remoteDacSampleEncryptedView.Trim()
             Remove-Item $result.OutputFile

--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -6,6 +6,8 @@ if (Test-Path "$PSScriptRoot\constants.local.ps1") {
     $script:dbatoolsci_computer = "localhost"
     $script:instance1 = "localhost\sql2008r2sp2"
     $script:instance2 = "localhost\sql2016"
+    $script:instance2SQLUserName = $null # placeholders for -SqlCredential testing
+    $script:instance2SQLPassword = $null
     $script:instance3 = "localhost\sql2017"
     $script:instance2_detailed = "localhost,14333\sql2016" #Just to make sure things parse a port properly
     $script:appveyorlabrepo = "C:\github\appveyor-lab"


### PR DESCRIPTION
- Fixed the template for inline TVF as described in issue 6637
- Fixed the usage of the SqlCredential
- Added support for triggers
- Added support for objects in schemas other than dbo
- Added the OutputFile to the return value
- Added more integration tests

The -skip param is set on the integration tests so as to not cause any issues with DAC on the AppVeyor instances.

Test results on local sql instances without the -Skip was:
Tests Passed: 13, Failed: 0, Skipped: 0 NotRun: 0

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6637 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Fix the issue described in #6637 and expand the support for object decryption. See above for more details.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the pester tests for different scenarios.

### Learning
Helpful links:
https://sqlperformance.com/2016/05/sql-performance/the-internals-of-with-encryption
https://stackoverflow.com/questions/53222960/is-it-possible-to-create-a-microsoft-smo-sql-connection-using-server-credentials
