### PR TITLE
New-DbaEndPoint: removed sslport and http options

### DIFF
--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -20,7 +20,7 @@ function New-DbaEndpoint {
         The name of the endpoint. If a name is not specified, one will be auto-generated.
 
     .PARAMETER Type
-        The type of endpoint. Defaults to DatabaseMirroring. Options: DatabaseMirroring, ServiceBroker, Soap, TSql
+        The type of endpoint. Defaults to DatabaseMirroring. Options: DatabaseMirroring, ServiceBroker, TSql
 
     .PARAMETER Protocol
         The type of protocol. Defaults to tcp. Options: Tcp, NamedPipes, Via, SharedMemory
@@ -101,7 +101,7 @@ function New-DbaEndpoint {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string]$Name,
-        [ValidateSet('DatabaseMirroring', 'ServiceBroker', 'Soap', 'TSql')]
+        [ValidateSet('DatabaseMirroring', 'ServiceBroker', 'TSql')]
         [string]$Type = 'DatabaseMirroring',
         [ValidateSet('Tcp', 'NamedPipes', 'Via', 'SharedMemory')]
         [string]$Protocol = 'Tcp',

--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -23,7 +23,7 @@ function New-DbaEndpoint {
         The type of endpoint. Defaults to DatabaseMirroring. Options: DatabaseMirroring, ServiceBroker, Soap, TSql
 
     .PARAMETER Protocol
-        The type of protocol. Defaults to tcp. Options: Tcp, NamedPipes, Http, Via, SharedMemory
+        The type of protocol. Defaults to tcp. Options: Tcp, NamedPipes, Via, SharedMemory
 
     .PARAMETER Role
         The type of role. Defaults to All. Options: All, None, Partner, Witness
@@ -35,9 +35,6 @@ function New-DbaEndpoint {
 
     .PARAMETER Port
         Port for TCP. If one is not provided, it will be auto-generated.
-
-    .PARAMETER SslPort
-        Port for SSL.
 
     .PARAMETER Certificate
         Database certificate used for authentication.
@@ -106,7 +103,7 @@ function New-DbaEndpoint {
         [string]$Name,
         [ValidateSet('DatabaseMirroring', 'ServiceBroker', 'Soap', 'TSql')]
         [string]$Type = 'DatabaseMirroring',
-        [ValidateSet('Tcp', 'NamedPipes', 'Http', 'Via', 'SharedMemory')]
+        [ValidateSet('Tcp', 'NamedPipes', 'Via', 'SharedMemory')]
         [string]$Protocol = 'Tcp',
         [ValidateSet('All', 'None', 'Partner', 'Witness')]
         [string]$Role = 'All',
@@ -117,7 +114,6 @@ function New-DbaEndpoint {
         [string]$Certificate,
         [System.Net.IPAddress]$IPAddress = '0.0.0.0',
         [int]$Port,
-        [int]$SslPort,
         [string]$Owner,
         [switch]$EnableException
     )
@@ -174,9 +170,6 @@ function New-DbaEndpoint {
                         $endpoint.Protocol.Tcp.ListenerIPAddress = $IPAddress
                         $endpoint.Protocol.Tcp.ListenerPort = $tcpPort
                         $endpoint.Payload.DatabaseMirroring.ServerMirroringRole = [Microsoft.SqlServer.Management.Smo.ServerMirroringRole]::$Role
-                        if (Test-Bound -ParameterName SslPort) {
-                            $endpoint.Protocol.Http.SslPort = $SslPort
-                        }
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryption = [Microsoft.SqlServer.Management.Smo.EndpointEncryption]::$EndpointEncryption
                         $endpoint.Payload.DatabaseMirroring.EndpointEncryptionAlgorithm = [Microsoft.SqlServer.Management.Smo.EndpointEncryptionAlgorithm]::$EncryptionAlgorithm
                     }

--- a/tests/New-DbaEndpoint.Tests.ps1
+++ b/tests/New-DbaEndpoint.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'IPAddress', 'EncryptionAlgorithm', 'Certificate', 'Port', 'SslPort', 'Owner', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Type', 'Protocol', 'Role', 'EndpointEncryption', 'IPAddress', 'EncryptionAlgorithm', 'Certificate', 'Port', 'Owner', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
It didn't work anyway. Usually I try to support old stuff but it would be too much work for no payoff. I had to go back to SQL 2008 to create an HTTP endpoint and even then it yelled at me. 

![image](https://user-images.githubusercontent.com/8278033/93004394-d4819780-f546-11ea-9ab2-eb777c6036d0.png)

Now I'm unsure if Via, SharedMemory and NamedPipes belongs there either.