### PR TITLE
get-dbabackuphistory, fixed test

### DIFF
--- a/tests/Get-DbaDbBackupHistory.Tests.ps1
+++ b/tests/Get-DbaDbBackupHistory.Tests.ps1
@@ -110,8 +110,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
 
     Context "Testing LastFull regression test for #6730" {
-        # skipping until niph addresses this
-        It -Skip "gathers the last full even in a forked scenario" {
+        It "gathers the last full even in a forked scenario" {
             $dbname = $dbnameForked
             $database = $server.Databases[$dbname]
 
@@ -129,6 +128,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $interResults = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbname | Sort-Object -Property End
             # create a fork restoring from the second backup sorted by date
             $null = $interResults[1] | Restore-DbaDatabase -SqlInstance $server -WithReplace
+            
+            #Sleep here because "End" has only second resolution (no ms there).
+            #If we're too fast Sort-Object -Property End doesn't always work, as we want $allHistory[0] to be the last backup indeed
+            Start-Sleep -Seconds 1
+
             $null = Backup-DbaDatabase -SqlInstance $server -Database $dbname -Type Full -BackupDirectory $DestBackupDir
 
             $allHistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbname | Sort-Object -Property End -Descending


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test 9 million times in a 2008 instance configured as appveyor and in other 9 instances other 7 zillion times and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Reintroduce the regr test that once in a while failed

### Approach
Added a Sleep, 'cause times registered in msdb are truncated to full second. So if the restore is speedy enough, ordering by End DESC and keeping the first didn't return the actual thing we went to look for.

HOPEFULLY this is more stable now ^__^
