### PR TITLE
Set-DbaExtendedProtection, shush and speed it

### DIFF
--- a/functions/Set-DbaExtendedProtection.ps1
+++ b/functions/Set-DbaExtendedProtection.ps1
@@ -145,8 +145,7 @@ function Set-DbaExtendedProtection {
                     ExtendedProtection = "$extendedProtection - $(switch ($extendedProtection) { 0 { "Off" } 1 { "Allowed" } 2 { "Required" } })"
                 }
             }
-
-            if ($PScmdlet.ShouldProcess("local", "Connecting to $instance to modify the ExtendedProtection value in $regRoot for $($instance.InstanceName)")) {
+            if (Test-ShouldProcess -Context $PSCmdlet -Target "local" -Action "Connecting to $instance to modify the ExtendedProtection value in $regRoot for $($instance.InstanceName)") {
                 try {
                     Invoke-Command2 -ComputerName $resolved.FullComputerName -Credential $Credential -ArgumentList $regRoot, $vsname, $instancename -ScriptBlock $scriptblock -ErrorAction Stop | Select-Object -Property * -ExcludeProperty PSComputerName, RunspaceId, PSShowComputerName
                     Write-Message -Level Critical -Message "ExtendedProtection was successfully set on $($resolved.FullComputerName) for the $instancename instance. The change takes effect immediately for new connections." -Target $instance

--- a/internal/functions/Test-ShouldProcess.ps1
+++ b/internal/functions/Test-ShouldProcess.ps1
@@ -1,4 +1,9 @@
 function Test-ShouldProcess {
+    <#
+    .SYNOPSIS
+        Internal function. To use instead of $PSCmdlet.ShouldProcess($x, "Message") as
+        Test-ShouldProcess -Context $PSCmdlet -Target $x -Action "Message"
+    #>
     param (
         $Context,
         [string]$Target,

--- a/internal/functions/Test-ShouldProcess.ps1
+++ b/internal/functions/Test-ShouldProcess.ps1
@@ -1,0 +1,9 @@
+function Test-ShouldProcess {
+    param (
+        $Context,
+        [string]$Target,
+        [string]$Action
+    )
+
+    $Context.ShouldProcess($Target, $Action)
+}

--- a/tests/Set-DbaExtendedProtection.Tests.ps1
+++ b/tests/Set-DbaExtendedProtection.Tests.ps1
@@ -19,28 +19,28 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -EnableException *>$null
             $results.ExtendedProtection -eq "0 - Off"
         }
-	}
-	Context "Command works when passed different values" {
-		BeforeAll {
-			Mock Test-ShouldProcess { $false } -ModuleName dbatools
+    }
+    Context "Command works when passed different values" {
+        BeforeAll {
+            Mock Test-ShouldProcess { $false } -ModuleName dbatools
             Mock Invoke-ManagedComputerCommand -MockWith {
-				param (
-				$ComputerName,
-				$Credential,
-				$ScriptBlock,
-				$EnableException
-			)
-			   $server = [DbaInstanceParameter[]]$script:instance1
-			   @{
-					DisplayName = "SQL Server ($($instance.InstanceName))"
-					AdvancedProperties = @(
-							@{
-								Name = 'REGROOT'
-								Value = 'Software\Microsoft\Microsoft SQL Server\MSSQL10_50.SQL2008R2SP2'
-							}
-						)
-				}
-			} -ModuleName dbatools
+                param (
+                $ComputerName,
+                $Credential,
+                $ScriptBlock,
+                $EnableException
+            )
+               $server = [DbaInstanceParameter[]]$script:instance1
+               @{
+                    DisplayName = "SQL Server ($($instance.InstanceName))"
+                    AdvancedProperties = @(
+                            @{
+                                Name = 'REGROOT'
+                                Value = 'Software\Microsoft\Microsoft SQL Server\MSSQL10_50.SQL2008R2SP2'
+                            }
+                        )
+                }
+            } -ModuleName dbatools
         }
         It "Set explicitly to '0 - Off' using text" {
             $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Off -EnableException -Verbose 4>&1

--- a/tests/Set-DbaExtendedProtection.Tests.ps1
+++ b/tests/Set-DbaExtendedProtection.Tests.ps1
@@ -16,34 +16,57 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {
         It "Default set and returns '0 - Off'" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -EnableException
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -EnableException *>$null
             $results.ExtendedProtection -eq "0 - Off"
+        }
+	}
+	Context "Command works when passed different values" {
+		BeforeAll {
+			Mock Test-ShouldProcess { $false } -ModuleName dbatools
+            Mock Invoke-ManagedComputerCommand -MockWith {
+				param (
+				$ComputerName,
+				$Credential,
+				$ScriptBlock,
+				$EnableException
+			)
+			   $server = [DbaInstanceParameter[]]$script:instance1
+			   @{
+					DisplayName = "SQL Server ($($instance.InstanceName))"
+					AdvancedProperties = @(
+							@{
+								Name = 'REGROOT'
+								Value = 'Software\Microsoft\Microsoft SQL Server\MSSQL10_50.SQL2008R2SP2'
+							}
+						)
+				}
+			} -ModuleName dbatools
         }
         It "Set explicitly to '0 - Off' using text" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Off -EnableException
-            $results.ExtendedProtection -eq "0 - Off"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Off -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 0'
         }
         It "Set explicitly to '0 - Off' using number" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 0 -EnableException
-            $results.ExtendedProtection -eq "0 - Off"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 0 -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 0'
         }
 
         It "Set explicitly to '1 - Allowed' using text" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Allowed -EnableException
-            $results.ExtendedProtection -eq "1 - Allowed"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Allowed -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 1'
         }
         It "Set explicitly to '1 - Allowed' using number" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 1 -EnableException
-            $results.ExtendedProtection -eq "1 - Allowed"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 1 -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 1'
         }
 
         It "Set explicitly to '2 - Required' using text" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Required -EnableException
-            $results.ExtendedProtection -eq "2 - Required"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value Required -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 2'
         }
         It "Set explicitly to '2 - Required' using number" {
-            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 2 -EnableException
-            $results.ExtendedProtection -eq "2 - Required"
+            $results = Set-DbaExtendedProtection -SqlInstance $script:instance1 -Value 2 -EnableException -Verbose 4>&1
+            $results[-1] = 'Value: 2'
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Tests for this lasted too damn long. 

### Approach
The only thing we tested was for the same result given different parameters for "Value", which the command accept both "text" and "numeric".
For 7 times (3 parameters x 2 "types" plus the default) the test ran, basically to do the same exact thing EXCEPT setting the proper value in the registry.
But we paid a hefty price.... we basically just needed to test that the reg value is set accordingly (multiple tests aggravated by querying WMI bening too damn slow).
So, change of plans :D 
We just test if the command works ONCE, with the default param.
And given we can't use classes as params (like enums, because of PS5), we just mock the s**t around it.

I was lucky already because the passed Value is outputted in the Verbose Stream (L134), so we check that.

I reintroduced also Test-ShouldProcess (https://github.com/sqlcollaborative/dbatools/pull/3325 , hopefully just "lost in translation" and not "removed for a good reason"), which we can definitely not enforce in any command but it's the only way to run pester tests (in this case definitely shushing the tests, but for things more complicated it makes perfect sense). 
Prolly I'll give the same treatment to other "big talkers" (Invoke-DbaDiagnosticQuery ^_^)


### Screenshots
WAS
![immagine](https://user-images.githubusercontent.com/122119/93148647-a80b7e00-f6f4-11ea-8929-7ca3287d0529.png)

IS
![immagine](https://user-images.githubusercontent.com/122119/93148677-b9548a80-f6f4-11ea-94a7-e647301c605a.png)

Also, took
![immagine](https://user-images.githubusercontent.com/122119/93148724-dd17d080-f6f4-11ea-8b62-c2caa7368ba1.png)

and now takes
![immagine](https://user-images.githubusercontent.com/122119/93148773-ffa9e980-f6f4-11ea-9ec3-8be29fd03029.png)


