### PR TITLE
Find dba orphaned file recurse

### DIFF
--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -150,8 +150,8 @@ function Find-DbaOrphanedFile {
                 )
                 SELECT DISTINCT f.fullpath
                 FROM fullpaths AS f
-                WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+ $($SystemFiles -join "','") + "' )
-                AND f.fs_fileextension IN('"+ $($FileTypes -join "','") + "')
+                WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '" + $($SystemFiles -join "','") + "' )
+                AND f.fs_fileextension IN('" + $($FileTypes -join "','") + "')
                 AND f.is_file = 1;
                 "
 
@@ -232,7 +232,7 @@ function Find-DbaOrphanedFile {
             }
 
             # Reset all the arrays
-            $sqlpaths = $userpaths = @(); $dirtreefiles = @{}
+            $sqlpaths = $userpaths = @(); $dirtreefiles = @{ }
 
             # Gather a list of files known to SQL Server
             $sqlfiles = Get-SqlFileStructure $server

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -232,7 +232,7 @@ function Find-DbaOrphanedFile {
             }
 
             # Reset all the arrays
-            $sqlpaths = @(); $dirtreefiles = @{}
+            $sqlpaths = $userpaths = @(); $dirtreefiles = @{}
 
             # Gather a list of files known to SQL Server
             $sqlfiles = Get-SqlFileStructure $server

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -150,8 +150,8 @@ function Find-DbaOrphanedFile {
                 )
                 SELECT DISTINCT f.fullpath
                 FROM fullpaths AS f
-				WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+ $($SystemFiles -join "','") + "' )
-				AND f.fs_fileextension IN('"+ $($FileTypes -join "','") + "')
+                WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+ $($SystemFiles -join "','") + "' )
+                AND f.fs_fileextension IN('"+ $($FileTypes -join "','") + "')
                 AND f.is_file = 1;
                 "
 

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -38,8 +38,8 @@ function Find-DbaOrphanedFile {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .PARAMETER Recurse
-		If this switch is enabled, the command will search subdirectories of the Path parameter.
-		The Recurse switch has no effect on versions earlier than SQL Server 2005.
+        If this switch is enabled, the command will search subdirectories of the Path parameter.
+        The Recurse switch has no effect on versions earlier than SQL Server 2005.
 
     .NOTES
         Tags: Orphan, Database, DatabaseFile
@@ -138,29 +138,29 @@ function Find-DbaOrphanedFile {
                 "
 
             $query_files_sql = "
-				SELECT f.parent+N'\'+f.fs_filename AS fullpath
-				FROM #enum AS f"
+                SELECT f.parent+N'\'+f.fs_filename AS fullpath
+                FROM #enum AS f"
 
             $query_files_sql_cte = "
-				WITH fullpaths AS (
-					SELECT e.*
-					, CONVERT(nvarchar(2000),e.parent+N'\'+e.fs_filename) AS fullpath
-					FROM #enum e
-					WHERE e.parent_id IS NULL
-					UNION ALL
-					SELECT e.*
-					, CONVERT(nvarchar(2000),f.fullpath+N'\'+e.fs_filename) AS fullpath
-					FROM fullpaths f
-					INNER JOIN #enum e ON e.parent_id = f.id
-				)
-				SELECT DISTINCT f.fullpath
-				FROM fullpaths AS f"
+                WITH fullpaths AS (
+                    SELECT e.*
+                    , CONVERT(nvarchar(2000),e.parent+N'\'+e.fs_filename) AS fullpath
+                    FROM #enum e
+                    WHERE e.parent_id IS NULL
+                    UNION ALL
+                    SELECT e.*
+                    , CONVERT(nvarchar(2000),f.fullpath+N'\'+e.fs_filename) AS fullpath
+                    FROM fullpaths f
+                    INNER JOIN #enum e ON e.parent_id = f.id
+                )
+                SELECT DISTINCT f.fullpath
+                FROM fullpaths AS f"
 
             $query_files_sql_where = "
-				WHERE f.fs_filename NOT IN ( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '" + $($SystemFiles -join "','") + "' )
-				AND f.fs_fileextension IN ('" + $($FileTypes -join "','") + "')
-				AND f.is_file = 1;
-				"
+                WHERE f.fs_filename NOT IN ( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '" + $($SystemFiles -join "','") + "' )
+                AND f.fs_fileextension IN ('" + $($FileTypes -join "','") + "')
+                AND f.is_file = 1;
+                "
 
             # build the query string based on how many directories they want to enumerate
             $sql = $q1

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -150,7 +150,8 @@ function Find-DbaOrphanedFile {
                 )
                 SELECT DISTINCT f.fullpath
                 FROM fullpaths AS f
-                WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr' )
+				WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+$($SystemFiles -join "','")+"' )
+				AND f.fs_fileextension IN('"+$($FileTypes -join "','")+"')
                 AND f.is_file = 1;
                 "
 

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -150,8 +150,8 @@ function Find-DbaOrphanedFile {
                 )
                 SELECT DISTINCT f.fullpath
                 FROM fullpaths AS f
-				WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+$($SystemFiles -join "','")+"' )
-				AND f.fs_fileextension IN('"+$($FileTypes -join "','")+"')
+				WHERE f.fs_filename NOT IN( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '"+ $($SystemFiles -join "','") + "' )
+				AND f.fs_fileextension IN('"+ $($FileTypes -join "','") + "')
                 AND f.is_file = 1;
                 "
 

--- a/functions/Find-DbaOrphanedFile.ps1
+++ b/functions/Find-DbaOrphanedFile.ps1
@@ -137,11 +137,11 @@ function Find-DbaOrphanedFile {
                 WHERE e.parent IS NULL;
                 "
 
-			$query_files_sql = "
+            $query_files_sql = "
 				SELECT f.parent+N'\'+f.fs_filename AS fullpath
 				FROM #enum AS f"
 
-			$query_files_sql_cte = "
+            $query_files_sql_cte = "
 				WITH fullpaths AS (
 					SELECT e.*
 					, CONVERT(nvarchar(2000),e.parent+N'\'+e.fs_filename) AS fullpath
@@ -156,7 +156,7 @@ function Find-DbaOrphanedFile {
 				SELECT DISTINCT f.fullpath
 				FROM fullpaths AS f"
 
-			$query_files_sql_where = "
+            $query_files_sql_where = "
 				WHERE f.fs_filename NOT IN ( 'xtp', '5', '`$FSLOG', '`$HKv2', 'filestream.hdr', '" + $($SystemFiles -join "','") + "' )
 				AND f.fs_fileextension IN ('" + $($FileTypes -join "','") + "')
 				AND f.is_file = 1;
@@ -242,8 +242,8 @@ function Find-DbaOrphanedFile {
             # Reset all the arrays
             $sqlpaths = $userpaths = @(); $dirtreefiles = @{ }
 
-			# Turn off recursion for SQL Server 2000
-			If ($server.VersionMajor -lt 9) { $Recurse = $false }
+            # Turn off recursion for SQL Server 2000
+            If ($server.VersionMajor -lt 9) { $Recurse = $false }
 
             # Gather a list of files known to SQL Server
             $sqlfiles = Get-SqlFileStructure $server
@@ -269,7 +269,7 @@ function Find-DbaOrphanedFile {
             $dirtreefiles = $server.Databases['master'].ExecuteWithResults($sql).Tables[0] | ForEach-Object {
                 [PSCustomObject]@{
                     Fullpath       = $_.fullpath
-					ComparisonPath = ([IO.Path]::GetFullPath($(Format-Path $(Join-AdminUnc -Servername $server.ComputerName -Filepath $_.fullpath))))
+                    ComparisonPath = ([IO.Path]::GetFullPath($(Format-Path $(Join-AdminUnc -Servername $server.ComputerName -Filepath $_.fullpath))))
                 }
             }
 

--- a/internal/functions/Split-AdminUnc.ps1
+++ b/internal/functions/Split-AdminUnc.ps1
@@ -1,0 +1,28 @@
+function Split-AdminUnc {
+    <#
+    .SYNOPSIS
+    Internal function. Splits a path to a server name and local path.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Filepath
+    )
+
+    if (!$Filepath) { return }
+
+    if ($Filepath -match '^[A-Z]:\\') {
+        [PSCustomObject]@{
+            ServerName = $null
+            FilePath   = $Filepath
+        }
+    }
+
+    if ($Filepath -match '^\\\\(.*?)\\([A-Z])\$\\(.*)$') {
+        [PSCustomObject]@{
+            ServerName = $matches[1]
+            FilePath   = $matches[2] + ':\' + $matches[3]
+        }
+    }
+}

--- a/internal/functions/Split-AdminUnc.ps1
+++ b/internal/functions/Split-AdminUnc.ps1
@@ -5,24 +5,30 @@ function Split-AdminUnc {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory,ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$Filepath
-    )
+	)
 
-    if (!$Filepath) { return }
+	BEGIN {}
 
-    if ($Filepath -match '^[A-Z]:\\') {
-        [PSCustomObject]@{
-            ServerName = $null
-            FilePath   = $Filepath
-        }
-    }
+	PROCESS {
+		if (!$Filepath) { return }
 
-    if ($Filepath -match '^\\\\(.*?)\\([A-Z])\$\\(.*)$') {
-        [PSCustomObject]@{
-            ServerName = $matches[1]
-            FilePath   = $matches[2] + ':\' + $matches[3]
-        }
-    }
+		if ($Filepath -match '^[A-Z]:\\') {
+			[PSCustomObject]@{
+				ServerName = $null
+				FilePath   = $Filepath
+			}
+		}
+
+		if ($Filepath -match '^\\\\(.*?)\\([A-Z])\$\\(.*)$') {
+			[PSCustomObject]@{
+				ServerName = $matches[1]
+				FilePath   = $matches[2] + ':\' + $matches[3]
+			}
+		}
+	}
+
+	END {}
 }

--- a/internal/functions/Split-AdminUnc.ps1
+++ b/internal/functions/Split-AdminUnc.ps1
@@ -5,30 +5,30 @@ function Split-AdminUnc {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory,ValueFromPipeline)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$Filepath
-	)
+    )
 
-	BEGIN {}
+    BEGIN { }
 
-	PROCESS {
-		if (!$Filepath) { return }
+    PROCESS {
+        if (!$Filepath) { return }
 
-		if ($Filepath -match '^[A-Z]:\\') {
-			[PSCustomObject]@{
-				ServerName = $null
-				FilePath   = $Filepath
-			}
-		}
+        if ($Filepath -match '^[A-Z]:\\') {
+            [PSCustomObject]@{
+                ServerName = $null
+                FilePath   = $Filepath
+            }
+        }
 
-		if ($Filepath -match '^\\\\(.*?)\\([A-Z])\$\\(.*)$') {
-			[PSCustomObject]@{
-				ServerName = $matches[1]
-				FilePath   = $matches[2] + ':\' + $matches[3]
-			}
-		}
-	}
+        if ($Filepath -match '^\\\\(.*?)\\([A-Z])\$\\(.*)$') {
+            [PSCustomObject]@{
+                ServerName = $matches[1]
+                FilePath   = $matches[2] + ':\' + $matches[3]
+            }
+        }
+    }
 
-	END {}
+    END { }
 }

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -18,11 +18,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         BeforeAll {
             $dbname = "dbatoolsci_orphanedfile"
             $server = Connect-DbaInstance -SqlInstance $script:instance2
-            $defaultDataPath = $(Split-AdminUnc -Filepath (Get-SqlDefaultPaths $server data)).FilePath # one file as local path
-            $defaultTlogPath = $(Join-AdminUnc -Servername $server.ComputerName -Filepath (Get-SqlDefaultPaths $server log))  # other file as UNC path
-            $createDbSql = "CREATE DATABASE [$dbname] ON PRIMARY (NAME = [$($dbname)_DATA], FILENAME = '$defaultDataPath\$($dbname)_DATA.mdf') LOG ON  (NAME = [$($dbname)_TLOG], FILENAME = '$defaultTlogPath\$($dbname)_TLOG.ldf')"
-            Write-Host $createDbSql #testing
-            $null = $server.Query($createDbSql)
+            $null = $server.Query("CREATE DATABASE $dbname")
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
                 It "has failed setup" {

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'FileType', 'LocalOnly', 'RemoteOnly', 'EnableException', 'Recurse'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -21,16 +21,16 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $null = $server.Query("CREATE DATABASE $dbname")
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
-                it "has failed setup" {
-                    Set-TestInconclusive -message "Setup failed"
+                It "has failed setup" {
+                    Set-TestInconclusive -Message "Setup failed"
                 }
                 throw "has failed setup"
             }
-			$guid = (New-Guid).Guid
-			$userdir = New-Item -Path "$HOME\$guid" -ItemType Container
-			New-Item -Path $userdir -ItemType File -Name 'file1.txt' | Out-Null
-			New-Item -Path "$userdir\subdir" -ItemType Container | Out-Null
-			New-Item -Path "$userdir\subdir" -ItemType File -Name 'file2.txt' | Out-Null
+            $guid = (New-Guid).Guid
+            $userdir = New-Item -Path "$HOME\$guid" -ItemType Container
+            New-Item -Path $userdir -ItemType File -Name 'file1.txt' | Out-Null
+            New-Item -Path "$userdir\subdir" -ItemType Container | Out-Null
+            New-Item -Path "$userdir\subdir" -ItemType File -Name 'file2.txt' | Out-Null
         }
         AfterAll {
             Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
@@ -38,7 +38,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $null = Detach-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Force
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
         $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
-        $recurseresults  = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
+        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
 
         It "Has the correct default properties" {
             $ExpectedStdProps = 'ComputerName,InstanceName,SqlInstance,Filename,RemoteFilename'.Split(',')
@@ -62,11 +62,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         $results.FileName | Remove-Item
-		$userdir | Remove-Item -Recurse
+        $userdir | Remove-Item -Recurse
 
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
         $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
-        $recurseresults  = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
+        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
         It "Finds zero files after cleaning up" {
             $results.Count | Should Be 0
             $userpathresults.Count | Should Be 0

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -17,8 +17,15 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Orphaned files are correctly identified" {
         BeforeAll {
             $dbname = "dbatoolsci_orphanedfile"
-            $server = Connect-DbaInstance -SqlInstance $script:instance2
-            $null = $server.Query("CREATE DATABASE $dbname")
+			$server = Connect-DbaInstance -SqlInstance $script:instance2
+			$defaultDataPath = $(Split-AdminUnc -Filepath (Get-SqlDefaultPaths $server data)).FilePath # one file as local path
+			$defaultTlogPath = $(Join-AdminUnc -Servername $server.ComputerName -Filepath (Get-SqlDefaultPaths $server log))  # other file as UNC path
+			$createDbSql = "
+			CREATE DATABASE [$dbname] ON
+			PRIMARY (NAME = [$($dbname)_DATA], FILENAME = '$defaultDataPath\$($dbname)_DATA.mdf')
+			LOG ON  (NAME = [$($dbname)_TLOG], FILENAME = '$defaultTlogPath\$($dbname)_TLOG.ldf')
+			"
+            $null = $server.Query($createDbSql)
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
                 It "has failed setup" {

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'FileType', 'LocalOnly', 'RemoteOnly', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'FileType', 'LocalOnly', 'RemoteOnly', 'EnableException', 'Recurse'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -26,12 +26,19 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 }
                 throw "has failed setup"
             }
+			$guid = (New-Guid).Guid
+			$userdir = New-Item -Path "$HOME\$guid" -ItemType Container
+			New-Item -Path $userdir -ItemType File -Name 'file1.txt' | Out-Null
+			New-Item -Path "$userdir\subdir" -ItemType Container | Out-Null
+			New-Item -Path "$userdir\subdir" -ItemType File -Name 'file2.txt' | Out-Null
         }
         AfterAll {
             Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
         }
         $null = Detach-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Force
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
+        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
+        $recurseresults  = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
 
         It "Has the correct default properties" {
             $ExpectedStdProps = 'ComputerName,InstanceName,SqlInstance,Filename,RemoteFilename'.Split(',')
@@ -46,11 +53,24 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.Count | Should Be 2
         }
 
+        It "Finds 3 files: including $userdir" {
+            $userpathresults.Count | Should Be 3
+        }
+
+        It "Finds 4 files: recursing $userdir" {
+            $recurseresults.Count | Should Be 4
+        }
+
         $results.FileName | Remove-Item
+		$userdir | Remove-Item -Recurse
 
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
+        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
+        $recurseresults  = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
         It "Finds zero files after cleaning up" {
             $results.Count | Should Be 0
+            $userpathresults.Count | Should Be 0
+            $recurseresults.Count | Should Be 0
         }
     }
 }

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -18,14 +18,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         BeforeAll {
             $dbname = "dbatoolsci_orphanedfile"
             $server = Connect-DbaInstance -SqlInstance $script:instance2
-            $defaultDataPath = $(Split-AdminUnc -Filepath (Get-SqlDefaultPaths $server data)).FilePath # one file as local path
-            $defaultTlogPath = $(Join-AdminUnc -Servername $server.ComputerName -Filepath (Get-SqlDefaultPaths $server log))  # other file as UNC path
-            $createDbSql = "
-            CREATE DATABASE [$dbname] ON
-            PRIMARY (NAME = [$($dbname)_DATA], FILENAME = '$defaultDataPath\$($dbname)_DATA.mdf')
-            LOG ON  (NAME = [$($dbname)_TLOG], FILENAME = '$defaultTlogPath\$($dbname)_TLOG.ldf')
-            "
-            $null = $server.Query($createDbSql)
+            $null = $server.Query("CREATE DATABASE $dbname")
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
                 It "has failed setup" {

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -27,7 +27,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 throw "has failed setup"
             }
             $guid = (New-Guid).Guid
-            $userdir = New-Item -Path "$HOME\$guid" -ItemType Container
+            $userdir = New-Item -Path "C:\$guid" -ItemType Container
             New-Item -Path $userdir -ItemType File -Name 'file1.txt' | Out-Null
             New-Item -Path "$userdir\subdir" -ItemType Container | Out-Null
             New-Item -Path "$userdir\subdir" -ItemType File -Name 'file2.txt' | Out-Null
@@ -35,10 +35,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         AfterAll {
             Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Remove-DbaDatabase -Confirm:$false
         }
-        $null = Detach-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Force
+        $null = Dismount-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -Force
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
-        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
-        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
+        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir.FullName -FileType 'txt'
+        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir.FullName -FileType 'txt' -Recurse
 
         It "Has the correct default properties" {
             $ExpectedStdProps = 'ComputerName,InstanceName,SqlInstance,Filename,RemoteFilename'.Split(',')
@@ -65,8 +65,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $userdir | Remove-Item -Recurse
 
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2
-        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt'
-        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir -FileType 'txt' -Recurse
+        $userpathresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir.FullName -FileType 'txt'
+        $recurseresults = Find-DbaOrphanedFile -SqlInstance $script:instance2 -Path $userdir.FullName -FileType 'txt' -Recurse
         It "Finds zero files after cleaning up" {
             $results.Count | Should Be 0
             $userpathresults.Count | Should Be 0

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $null = $server.Query("CREATE DATABASE $dbname")
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {
-                it "has failed setup" {
+                It "has failed setup" {
                     Set-TestInconclusive -message "Setup failed"
                 }
                 throw "has failed setup"

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -27,7 +27,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                 throw "has failed setup"
             }
             $guid = (New-Guid).Guid
-            $userdir = New-Item -Path "C:\$guid" -ItemType Container
+            $userdir = New-Item -Path "\\$($server.Computername)\C$\$guid" -ItemType Container
             New-Item -Path $userdir -ItemType File -Name 'file1.txt' | Out-Null
             New-Item -Path "$userdir\subdir" -ItemType Container | Out-Null
             New-Item -Path "$userdir\subdir" -ItemType File -Name 'file2.txt' | Out-Null
@@ -61,7 +61,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $recurseresults.Count | Should Be 4
         }
 
-        $results.FileName | Remove-Item
+        $results.RemoteFileName | Remove-Item
         $userdir | Remove-Item -Recurse
 
         $results = Find-DbaOrphanedFile -SqlInstance $script:instance2

--- a/tests/Find-DbaOrphanedFile.Tests.ps1
+++ b/tests/Find-DbaOrphanedFile.Tests.ps1
@@ -17,14 +17,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Orphaned files are correctly identified" {
         BeforeAll {
             $dbname = "dbatoolsci_orphanedfile"
-			$server = Connect-DbaInstance -SqlInstance $script:instance2
-			$defaultDataPath = $(Split-AdminUnc -Filepath (Get-SqlDefaultPaths $server data)).FilePath # one file as local path
-			$defaultTlogPath = $(Join-AdminUnc -Servername $server.ComputerName -Filepath (Get-SqlDefaultPaths $server log))  # other file as UNC path
-			$createDbSql = "
-			CREATE DATABASE [$dbname] ON
-			PRIMARY (NAME = [$($dbname)_DATA], FILENAME = '$defaultDataPath\$($dbname)_DATA.mdf')
-			LOG ON  (NAME = [$($dbname)_TLOG], FILENAME = '$defaultTlogPath\$($dbname)_TLOG.ldf')
-			"
+            $server = Connect-DbaInstance -SqlInstance $script:instance2
+            $defaultDataPath = $(Split-AdminUnc -Filepath (Get-SqlDefaultPaths $server data)).FilePath # one file as local path
+            $defaultTlogPath = $(Join-AdminUnc -Servername $server.ComputerName -Filepath (Get-SqlDefaultPaths $server log))  # other file as UNC path
+            $createDbSql = "CREATE DATABASE [$dbname] ON PRIMARY (NAME = [$($dbname)_DATA], FILENAME = '$defaultDataPath\$($dbname)_DATA.mdf') LOG ON  (NAME = [$($dbname)_TLOG], FILENAME = '$defaultTlogPath\$($dbname)_TLOG.ldf')"
+            Write-Host $createDbSql #testing
             $null = $server.Query($createDbSql)
             $result = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname
             if ($result.count -eq 0) {

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -314,4 +314,4 @@ $Script:Manifest = Test-ModuleManifest -Path $ManifestPath -ErrorAction Silently
 #>
 
 # Expose versions of imported modules
-Get-Module | Select-Object Name,Version | Sort-Object Name
+Get-Module | Select-Object Name,Version | Sort-Object Name | Out-String | Write-Host

--- a/tests/dbatools.Tests.ps1
+++ b/tests/dbatools.Tests.ps1
@@ -312,3 +312,6 @@ $Script:Manifest = Test-ModuleManifest -Path $ManifestPath -ErrorAction Silently
     }
 }
 #>
+
+# Expose versions of imported modules
+Get-Module | Select-Object Name,Version | Sort-Object Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add a new parameter, -Recurse, to Find-DbaOrphanedFile that will enable recursive search of 
directories specified in the -Path parameter.

### Approach
<!-- How does this change solve that purpose -->
Update the logic to control the value of the 'depth' parameter passed to xp_dirtree when recursion is required (i.e. 0). 
Also update the SQL query to construct the full paths from the results returned.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Find-DbaOrphanedFile
