### PR TITLE
Disable/Enable-DbaTraceFlag - Update docs

### DIFF
--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -5,7 +5,7 @@ function Disable-DbaTraceFlag {
 
     .DESCRIPTION
         The function will disable a Trace Flag that is currently running globally on the SQL Server instance(s) listed.
-        These are not persisted after a restart, use Set-DbaStartupParameter to set them to persist after restarts.er
+        These are not persisted after a restart, use Set-DbaStartupParameter to set them to persist after restarts.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.

--- a/functions/Disable-DbaTraceFlag.ps1
+++ b/functions/Disable-DbaTraceFlag.ps1
@@ -4,7 +4,8 @@ function Disable-DbaTraceFlag {
         Disable a Global Trace Flag that is currently running
 
     .DESCRIPTION
-        The function will disable a Trace Flag that is currently running globally on the SQL Server instance(s) listed
+        The function will disable a Trace Flag that is currently running globally on the SQL Server instance(s) listed.
+        These are not persisted after a restart, use Set-DbaStartupParameter to set them to persist after restarts.er
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.

--- a/functions/Enable-DbaTraceFlag.ps1
+++ b/functions/Enable-DbaTraceFlag.ps1
@@ -4,7 +4,8 @@ function Enable-DbaTraceFlag {
         Enable Global Trace Flag(s)
 
     .DESCRIPTION
-        The function will set one or multiple trace flags on the SQL Server instance(s) listed
+        The function will set one or multiple trace flags on the SQL Server instance(s) listed.
+        These are not persisted after a restart, use Set-DbaStartupParameter to set them to persist after restarts.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -44,11 +45,6 @@ function Enable-DbaTraceFlag {
         PS C:\> Enable-DbaTraceFlag -SqlInstance sql2016 -TraceFlag 1117, 1118
 
         Enable multiple trace flags on SQL Server instance sql2016
-
-    .EXAMPLE
-        PS C:\> Disable-DbaTraceFlag -SqlInstance sql2016_1, sql2016_2 -TraceFlag 6532,7314
-
-        Disable more than 1 globally running trace flags on more than 1 SQL Server instances sql2016_1 and sql2016_2
     #>
     [CmdletBinding()]
     param (


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6859 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Address any confusion that the Enable and Disable-DbaTraceFlag will not persist the changes through a restart. `Set-DbaStartupParameter` is used for persisting through a restart.

![image](https://user-images.githubusercontent.com/11204251/93607172-980ecb00-f98e-11ea-998c-c597c239cbbd.png)
