### PR TITLE
Connect-DbaInstance - Remove unnecessary code to fix a bug when using [System.Data.SqlClient.SqlConnection] as -SqlInstance.

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -514,7 +514,7 @@ function Connect-DbaInstance {
                         $serverconn.AccessToken = $accesstoken
                     }
                     $null = $serverconn.Connect()
-                    Write-Message -Level Debug -Message "will build server with serverconn"
+                    Write-Message -Level Debug -Message "will build server with [Microsoft.SqlServer.Management.Common.ServerConnection]serverconn (serverconn.ServerInstance = '$($serverconn.ServerInstance)')"
                     $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
                     Write-Message -Level Debug -Message "server was build with server.Name = '$($server.Name)'"
                     # Make ComputerName easily available in the server object
@@ -563,8 +563,8 @@ function Connect-DbaInstance {
             #region Input Object was anything else
             Write-Message -Level Debug -Message "Input Object was anything else, so not full smo and we have to go on and build one"
             if ($instance.Type -like "SqlConnection") {
-                Write-Message -Level Debug -Message "instance.Type -like SqlConnection - so we build server with Smo.Server"
-                Write-Message -Level Debug -Message "will build server with instance.InputObject of type '$($instance.InputObject.GetType().Name)'"
+                Write-Message -Level Debug -Message "instance.Type -like SqlConnection"
+                Write-Message -Level Debug -Message "will build server with [System.Data.SqlClient.SqlConnection]instance.InputObject (instance.InputObject.DataSource = '$($instance.InputObject.DataSource)')   "
                 $server = New-Object Microsoft.SqlServer.Management.Smo.Server($instance.InputObject)
                 Write-Message -Level Debug -Message "server was build with server.Name = '$($server.Name)'"
 
@@ -626,7 +626,7 @@ function Connect-DbaInstance {
                 $sqlconn = New-Object System.Data.SqlClient.SqlConnection $connstring
                 $serverconn = New-Object Microsoft.SqlServer.Management.Common.ServerConnection $sqlconn
                 $null = $serverconn.Connect()
-                Write-Message -Level Debug -Message "will build server with serverconn"
+                Write-Message -Level Debug -Message "will build server with [Microsoft.SqlServer.Management.Common.ServerConnection]serverconn (serverconn.ServerInstance = '$($serverconn.ServerInstance)')"
                 $server = New-Object Microsoft.SqlServer.Management.Smo.Server $serverconn
                 Write-Message -Level Debug -Message "server was build with server.Name = '$($server.Name)'"
             } elseif (-not $isAzure) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -540,7 +540,7 @@ function Connect-DbaInstance {
             if ($instance.Type -like "Server" -or ($isAzure -and $instance.InputObject.ConnectionContext.IsOpen)) {
                 Write-Message -Level Debug -Message "instance.Type -like Server (or Azure) - so we have already the full smo"
                 if ($instance.InputObject.ConnectionContext.IsOpen -eq $false) {
-                    Write-Message -Level Debug -Message "We connect to the instance"
+                    Write-Message -Level Debug -Message "We connect to the instance with instance.InputObject.ConnectionContext.Connect()"
                     $instance.InputObject.ConnectionContext.Connect()
                 }
                 if ($SqlConnectionOnly) {
@@ -569,7 +569,7 @@ function Connect-DbaInstance {
                 Write-Message -Level Debug -Message "server was build with server.Name = '$($server.Name)'"
 
                 if ($server.ConnectionContext.IsOpen -eq $false) {
-                    Write-Message -Level Debug -Message "We connect to the server"
+                    Write-Message -Level Debug -Message "We connect to the server with server.ConnectionContext.Connect()"
                     $server.ConnectionContext.Connect()
                 }
                 if ($SqlConnectionOnly) {
@@ -746,16 +746,17 @@ function Connect-DbaInstance {
                         # When the Connect method is called, the connection is not automatically released.
                         # The Disconnect method must be called explicitly to release the connection to the connection pool.
                         # https://docs.microsoft.com/en-us/sql/relational-databases/server-management-objects-smo/create-program/disconnecting-from-an-instance-of-sql-server
-                        Write-Message -Level Debug -Message "We try nonpooled connection"
+                        Write-Message -Level Debug -Message "We try nonpooled connection with server.ConnectionContext.Connect()"
                         $server.ConnectionContext.Connect()
                     } elseif ($authtype -eq "Windows Authentication with Credential") {
+                        Write-Message -Level Debug -Message "We have authtype -eq Windows Authentication with Credential"
                         # Make it connect in a natural way, hard to explain.
                         # See https://docs.microsoft.com/en-us/sql/relational-databases/server-management-objects-smo/create-program/connecting-to-an-instance-of-sql-server
                         $null = $server.Information.Version
                         if ($server.ConnectionContext.IsOpen -eq $false) {
                             # Sometimes, however, the above may not connect as promised. Force it.
                             # See https://github.com/sqlcollaborative/dbatools/pull/4426
-                            Write-Message -Level Debug -Message "We try connection - authtype -eq Windows Authentication with Credential"
+                            Write-Message -Level Debug -Message "We try connection with server.ConnectionContext.Connect()"
                             $server.ConnectionContext.Connect()
                         }
                     } else {
@@ -763,7 +764,7 @@ function Connect-DbaInstance {
                             # SqlConnectionObject.Open() enables connection pooling does not support
                             # alternative Windows Credentials and passes default credentials
                             # See https://github.com/sqlcollaborative/dbatools/pull/3809
-                            Write-Message -Level Debug -Message "We try connection - the else path"
+                            Write-Message -Level Debug -Message "We try connection with server.ConnectionContext.SqlConnectionObject.Open()"
                             $server.ConnectionContext.SqlConnectionObject.Open()
                         }
                     }

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -78,6 +78,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
+        It "connects using a connection object" {
+            [System.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance1;Initial Catalog=tempdb;Integrated Security=True;"
+            $server = Connect-DbaInstance -SqlInstance $sqlconnection
+            $server.ComputerName -eq ([DbaInstance]$script:instance1).ComputerName | Should Be $true
+            $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
         It "sets connectioncontext parameters that are provided" {
             $params = @{
                 'BatchSeparator'           = 'GO'

--- a/tests/Connect-DbaInstance.Tests.ps1
+++ b/tests/Connect-DbaInstance.Tests.ps1
@@ -85,6 +85,23 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $server.Databases.Name.Count -gt 0 | Should Be $true
         }
 
+        It "connects - instance2" {
+            $server = Connect-DbaInstance -SqlInstance $script:instance2
+            $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
+        It "connects using a connection string - instance2" {
+            $server = Connect-DbaInstance -SqlInstance "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
+            $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
+        It "connects using a connection object - instance2" {
+            [System.Data.SqlClient.SqlConnection]$sqlconnection = "Data Source=$script:instance2;Initial Catalog=tempdb;Integrated Security=True;"
+            $server = Connect-DbaInstance -SqlInstance $sqlconnection
+            $server.ComputerName -eq ([DbaInstance]$script:instance2).ComputerName | Should Be $true
+            $server.Databases.Name.Count -gt 0 | Should Be $true
+        }
+
         It "sets connectioncontext parameters that are provided" {
             $params = @{
                 'BatchSeparator'           = 'GO'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Enable the usage of [System.Data.SqlClient.SqlConnection] as -SqlInstance.

### Approach
I just deleted the old code.
In this code, $instance was reset with `[DbaInstanceParameter]$instance = New-Object Microsoft.SqlServer.Management.Smo.Server($instance.InputObject)`. This way later in the code testing for type Server was true and the custom properties were not added.
I think because of the parameter definition `[DbaInstanceParameter[]]$SqlInstance` this code is not needed anymore - every object that is passed to SqlInstance is converted to [DbaInstanceParameter]. 

### Commands to test
```
[System.Data.SqlClient.SqlConnection]$sqlConnection = 'Data Source=TCP:sqlix.ordix.de\pstest,14331;User ID=sa;Password=P@ssw0rd'
$sqlConnection
[DbaInstance]$sqlConnection
$server = Connect-DbaInstance -SqlInstance $sqlConnection -Debug
$server | Format-Table -Property Name, ComputerName, DbaInstanceName, NetPort, NetName, DomainInstanceName, ComputerNamePhysicalNetBIOS
$server.Query('SELECT @@VERSION')
```

### Screenshots
Old code:
![image](https://user-images.githubusercontent.com/66946165/93668700-90365000-fa8e-11ea-95d3-5583b9124bfe.png)
New code:
![image](https://user-images.githubusercontent.com/66946165/93668821-7a755a80-fa8f-11ea-8307-8bf5c0a852ab.png)



