### PR TITLE
Set-DbaTcpPort - Add parameter Restart to restart the service

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -291,7 +291,7 @@ function Invoke-DbaAdvancedInstall {
     }
     # change port after the installation
     if ($Port) {
-        $null = Set-DbaTcpPort -SqlInstance "$($ComputerName)\$($InstanceName)" -Credential $Credential -Port $Port -EnableException:$EnableException -Confirm:$false
+        $null = Set-DbaTcpPort -SqlInstance "$($ComputerName)\$($InstanceName)" -Credential $Credential -Port $Port -Restart -EnableException:$EnableException -Confirm:$false
     }
     # restart if necessary
     try {

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -102,10 +102,10 @@ function Set-DbaTcpPort {
             $tcp = $wmiinstance.ServerProtocols | Where-Object {
                 $_.DisplayName -eq 'TCP/IP'
             }
-            $IpAddress = $tcp.IpAddresses | Where-Object {
+            $ip = $tcp.IpAddresses | Where-Object {
                 $_.IpAddress -eq $IpAddress
             }
-            $tcpPort = $IpAddress.IpAddressProperties | Where-Object {
+            $tcpPort = $ip.IpAddressProperties | Where-Object {
                 $_.Name -eq 'TcpPort'
             }
 

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -171,6 +171,8 @@ function Set-DbaTcpPort {
                         }
                     }
                 }
+            } else {
+                Write-Message -Level Warning -Message "Setting port to $Port for $wmiInstanceName was successful, but restart of SQL Server service is required for the new value to be used"
             }
         }
     }

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -141,13 +141,12 @@ function Set-DbaTcpPort {
         foreach ($instance in $SqlInstance) {
             $wmiInstanceName = $instance.InstanceName
             $computerName = $instance.ComputerName
+            $resolvedComputerName = (Resolve-DbaNetworkName -ComputerName $computerName).FullComputerName
 
             if ($Pscmdlet.ShouldProcess($computerName, "Setting port to $Port for $wmiInstanceName")) {
                 try {
-                    $computerName = $instance.ComputerName
-                    $resolved = Resolve-DbaNetworkName -ComputerName $computerName
-                    Write-Message -Level Verbose -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$($resolved.FullComputerName)'"
-                    Invoke-ManagedComputerCommand -ComputerName $resolved.FullComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
+                    Write-Message -Level Verbose -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$resolvedComputerName'"
+                    Invoke-ManagedComputerCommand -ComputerName $resolvedComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
                 } catch {
                     try {
                         Write-Message -Level Verbose -Message "Fallback: Trying Invoke-ManagedComputerCommand with ComputerName = '$computerName'"
@@ -161,8 +160,8 @@ function Set-DbaTcpPort {
             if ($Restart) {
                 if ($Pscmdlet.ShouldProcess($computerName, "Restarting service for $wmiInstanceName")) {
                     try {
-                        Write-Message -Level Verbose -Message "Trying Restart-DbaService with ComputerName = '$($resolved.FullComputerName)'"
-                        Restart-DbaService -ComputerName $resolved.FullComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
+                        Write-Message -Level Verbose -Message "Trying Restart-DbaService with ComputerName = '$resolvedComputerName'"
+                        Restart-DbaService -ComputerName $resolvedComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
                     } catch {
                         try {
                             Write-Message -Level Verbose -Message "Fallback: Trying Restart-DbaService with ComputerName = '$computerName'"

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -146,11 +146,11 @@ function Set-DbaTcpPort {
                 try {
                     $computerName = $instance.ComputerName
                     $resolved = Resolve-DbaNetworkName -ComputerName $computerName
-                    Write-Message -Level Debug -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$($resolved.FullComputerName)'"
+                    Write-Message -Level Verbose -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$($resolved.FullComputerName)'"
                     Invoke-ManagedComputerCommand -ComputerName $resolved.FullComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
                 } catch {
                     try {
-                        Write-Message -Level Debug -Message "Fallback: Trying Invoke-ManagedComputerCommand with ComputerName = '$computerName'"
+                        Write-Message -Level Verbose -Message "Fallback: Trying Invoke-ManagedComputerCommand with ComputerName = '$computerName'"
                         Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
                     } catch {
                         Stop-Function -Message "Failure setting port to $Port for $wmiInstanceName on $computerName" -Continue
@@ -161,11 +161,11 @@ function Set-DbaTcpPort {
             if ($Restart) {
                 if ($Pscmdlet.ShouldProcess($computerName, "Restarting service for $wmiInstanceName")) {
                     try {
-                        Write-Message -Level Debug -Message "Trying Restart-DbaService with ComputerName = '$($resolved.FullComputerName)'"
+                        Write-Message -Level Verbose -Message "Trying Restart-DbaService with ComputerName = '$($resolved.FullComputerName)'"
                         Restart-DbaService -ComputerName $resolved.FullComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
                     } catch {
                         try {
-                            Write-Message -Level Debug -Message "Fallback: Trying Restart-DbaService with ComputerName = '$computerName'"
+                            Write-Message -Level Verbose -Message "Fallback: Trying Restart-DbaService with ComputerName = '$computerName'"
                             Restart-DbaService -ComputerName $computerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
                         } catch {
                             Stop-Function -Message "Failure restarting service for $wmiInstanceName on $computerName" -Continue

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -161,11 +161,11 @@ function Set-DbaTcpPort {
                 if ($Pscmdlet.ShouldProcess($computerName, "Restarting service for $wmiInstanceName")) {
                     try {
                         Write-Message -Level Verbose -Message "Trying Restart-DbaService with ComputerName = '$resolvedComputerName'"
-                        Restart-DbaService -ComputerName $resolvedComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
+                        $null = Restart-DbaService -ComputerName $resolvedComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
                     } catch {
                         try {
                             Write-Message -Level Verbose -Message "Fallback: Trying Restart-DbaService with ComputerName = '$computerName'"
-                            Restart-DbaService -ComputerName $computerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
+                            $null = Restart-DbaService -ComputerName $computerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
                         } catch {
                             Stop-Function -Message "Failure restarting service for $wmiInstanceName on $computerName" -Continue
                         }

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -74,7 +74,7 @@ function Set-DbaTcpPort {
         [parameter(Mandatory)]
         [ValidateRange(1, 65535)]
         [int]$Port,
-        [IpAddress[]]$IpAddress,
+        [IpAddress]$IpAddress,
         [switch]$Restart,
         [switch]$EnableException
     )

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -10,16 +10,19 @@ function Set-DbaTcpPort {
         The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
-        Credential object used to connect to the SQL Server instance as a different user
+        Credential object used to connect to the SQL Server instance as a different user.
 
     .PARAMETER Credential
-        Credential object used to connect to the Windows server itself as a different user (like SQL Configuration Manager)
+        Credential object used to connect to the Windows server itself as a different user (like SQL Configuration Manager).
 
     .PARAMETER Port
         TCPPort that SQLService should listen on.
 
     .PARAMETER IpAddress
-        Which IpAddress should the portchange , if omitted allip (0.0.0.0) will be changed with the new port number.
+        Which IpAddress should the portchange , if omitted AllIP (0.0.0.0) will be changed with the new port number.
+
+    .PARAMETER Restart
+        The Database Engine begins listening on a new port when restarted. Use this switch to restart the service, so that the new settings become effective.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -48,6 +51,11 @@ function Set-DbaTcpPort {
         Sets the port number 1433 for all IP Addresses on the default instance on sql2017. Prompts for confirmation.
 
     .EXAMPLE
+        PS C:\> Set-DbaTcpPort -SqlInstance sql2017 -Port 1433 -Restart
+
+        Sets the port number 1433 for all IP Addresses on the default instance on sql2017. Prompts for confirmation. Restarts the service.
+
+    .EXAMPLE
         PS C:\> Set-DbaTcpPort -SqlInstance winserver\sqlexpress -IpAddress 192.168.1.22 -Port 1433 -Confirm:$false
 
         Sets the port number 1433 for IP 192.168.1.22 on the sqlexpress instance on winserver. Does not prompt for confirmation.
@@ -67,6 +75,7 @@ function Set-DbaTcpPort {
         [ValidateRange(1, 65535)]
         [int]$Port,
         [IpAddress[]]$IpAddress,
+        [switch]$Restart,
         [switch]$EnableException
     )
 
@@ -137,12 +146,30 @@ function Set-DbaTcpPort {
                 try {
                     $computerName = $instance.ComputerName
                     $resolved = Resolve-DbaNetworkName -ComputerName $computerName
+                    Write-Message -Level Debug -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$($resolved.FullComputerName)'"
                     Invoke-ManagedComputerCommand -ComputerName $resolved.FullComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
                 } catch {
                     try {
+                        Write-Message -Level Debug -Message "Fallback: Trying Invoke-ManagedComputerCommand with ComputerName = '$computerName'"
                         Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -ScriptBlock $scriptblock -ArgumentList $instance.ComputerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
                     } catch {
                         Stop-Function -Message "Failure setting port to $Port for $wmiInstanceName on $computerName" -Continue
+                    }
+                }
+            }
+
+            if ($Restart) {
+                if ($Pscmdlet.ShouldProcess($computerName, "Restarting service for $wmiInstanceName")) {
+                    try {
+                        Write-Message -Level Debug -Message "Trying Restart-DbaService with ComputerName = '$($resolved.FullComputerName)'"
+                        Restart-DbaService -ComputerName $resolved.FullComputerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
+                    } catch {
+                        try {
+                            Write-Message -Level Debug -Message "Fallback: Trying Restart-DbaService with ComputerName = '$computerName'"
+                            Restart-DbaService -ComputerName $computerName -InstanceName $wmiInstanceName -Type Engine -Force -Credential $Credential
+                        } catch {
+                            Stop-Function -Message "Failure restarting service for $wmiInstanceName on $computerName" -Continue
+                        }
                     }
                 }
             }

--- a/tests/Set-DbaTcpPort.Tests.ps1
+++ b/tests/Set-DbaTcpPort.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Port', 'IpAddress', 'EnableException'
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'Port', 'IpAddress', 'Restart', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #6865 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Be able to silently restart the service so that the new value is used. Will fix issues with Install-DbaInstance when using -Port

### Approach
Added new parameter Restart

### Commands to test
see help

I have also slightly reworked the code, I hope thats ok.