### PR TITLE
Fix #6636 for New-DbaAgentSchedule

### DIFF
--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -29,7 +29,12 @@ function New-DbaAgentSchedule {
     .PARAMETER FrequencyType
         A value indicating when a job is to be executed.
 
-        Allowed values: Once, Daily, Weekly, Monthly, MonthlyRelative, AgentStart or IdleComputer
+        Allowed values: 'Once', 'OneTime', 'Daily', 'Weekly', 'Monthly', 'MonthlyRelative', 'AgentStart', 'AutoStart', 'IdleComputer', 'OnIdle'
+
+        The following synonyms provide flexibility to the allowed values for this function parameter:
+        Once=OneTime
+        AgentStart=AutoStart
+        IdleComputer=OnIdle
 
         If force is used the default will be "Once".
 
@@ -46,7 +51,13 @@ function New-DbaAgentSchedule {
     .PARAMETER FrequencySubdayType
         Specifies the units for the subday FrequencyInterval.
 
-        Allowed values: Time, Seconds, Minutes, or Hours
+        Allowed values: 'Once', 'Time', 'Seconds', 'Second', 'Minutes', 'Minute', 'Hours', 'Hour'
+
+        The following synonyms provide flexibility to the allowed values for this function parameter:
+        Once=Time
+        Seconds=Second
+        Minutes=Minute
+        Hours=Hour
 
     .PARAMETER FrequencySubdayInterval
         The number of subday type periods to occur between each execution of a job.
@@ -132,11 +143,11 @@ function New-DbaAgentSchedule {
         [object[]]$Job,
         [object]$Schedule,
         [switch]$Disabled,
-        [ValidateSet('Once', 'Daily', 'Weekly', 'Monthly', 'MonthlyRelative', 'AgentStart', 'IdleComputer')]
+        [ValidateSet('Once', 'OneTime', 'Daily', 'Weekly', 'Monthly', 'MonthlyRelative', 'AgentStart', 'AutoStart', 'IdleComputer', 'OnIdle')]
         [object]$FrequencyType,
         [ValidateSet('EveryDay', 'Weekdays', 'Weekend', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)]
         [object[]]$FrequencyInterval,
-        [ValidateSet('Time', 'Seconds', 'Minutes', 'Hours')]
+        [ValidateSet('Once', 'Time', 'Seconds', 'Second', 'Minutes', 'Minute', 'Hours', 'Hour')]
         [object]$FrequencySubdayType,
         [int]$FrequencySubdayInterval,
         [ValidateSet('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')]
@@ -166,12 +177,15 @@ function New-DbaAgentSchedule {
             [int]$FrequencyType =
             switch ($FrequencyType) {
                 "Once" { 1 }
+                "OneTime" { 1 }
                 "Daily" { 4 }
                 "Weekly" { 8 }
                 "Monthly" { 16 }
                 "MonthlyRelative" { 32 }
                 "AgentStart" { 64 }
+                "AutoStart" { 64 }
                 "IdleComputer" { 128 }
+                "OnIdle" { 128 }
                 default { 1 }
             }
         }
@@ -180,10 +194,14 @@ function New-DbaAgentSchedule {
         if (!$FrequencySubdayType -or $FrequencySubdayType) {
             [int]$FrequencySubdayType =
             switch ($FrequencySubdayType) {
+                "Once" { 1 }
                 "Time" { 1 }
                 "Seconds" { 2 }
+                "Second" { 2 }
                 "Minutes" { 4 }
+                "Minute" { 4 }
                 "Hours" { 8 }
+                "Hour" { 8 }
                 default { 1 }
             }
         }

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -15,6 +15,16 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "UnitTests" {
     BeforeAll {
+        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+        $server1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $server2 = Connect-DbaInstance -SqlInstance $script:instance2
+
+        $sqlAgentServer1 = Get-DbaService -ComputerName $server1.ComputerName -InstanceName $server1.DbaInstanceName -Type Agent
+        Write-Message -Level Warning -Message "The SQL Agent service for instance1 has state=$($sqlAgentServer1.State) and start mode=$($sqlAgentServer1.StartMode)"
+
+        $sqlAgentServer2 = Get-DbaService -ComputerName $server2.ComputerName -InstanceName $server2.DbaInstanceName -Type Agent
+        Write-Message -Level Warning -Message "The SQL Agent service for instance2 has state=$($sqlAgentServer2.State) and start mode=$($sqlAgentServer2.StartMode)"
+
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest -FrequencyType Weekly -FrequencyInterval 2 -FrequencyRecurrenceFactor 1 -StartTime 020000  -Force
         $null = New-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
@@ -94,12 +104,29 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
         }
 
         $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
     }
     AfterAll {
+        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest, Issue_6636_Once, Issue_6636_Once_Copy, Issue_6636_Hour, Issue_6636_Hour_Copy, Issue_6636_Minute, Issue_6636_Minute_Copy, Issue_6636_Second, Issue_6636_Second_Copy, Issue_6636_OneTime, Issue_6636_OneTime_Copy, Issue_6636_AutoStart, Issue_6636_AutoStart_Copy, Issue_6636_OnIdle, Issue_6636_OnIdle_Copy
-        $schedules.DROP()
+
+        if ($null -ne $schedules) {
+            $schedules.DROP()
+        } else {
+            Write-Message -Level Warning -Message "The schedules from $script:instance2 were returned as null"
+        }
+
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest
-        $schedules.DROP()
+
+        if ($null -ne $schedules) {
+            $schedules.DROP()
+        } else {
+            Write-Message -Level Warning -Message "The schedules from $script:instance1 were returned as null"
+        }
+
+        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
     }
 
     Context "Gets the list of Schedules" {

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -15,19 +15,19 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "UnitTests" {
     BeforeAll {
-        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
-        $server1 = Connect-DbaInstance -SqlInstance $script:instance1
+        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($script:instance3) and instance2=$($script:instance2)"
+        $server3 = Connect-DbaInstance -SqlInstance $script:instance3
         $server2 = Connect-DbaInstance -SqlInstance $script:instance2
 
-        $sqlAgentServer1 = Get-DbaService -ComputerName $server1.ComputerName -InstanceName $server1.DbaInstanceName -Type Agent
-        Write-Message -Level Warning -Message "The SQL Agent service for instance1 has state=$($sqlAgentServer1.State) and start mode=$($sqlAgentServer1.StartMode)"
+        $sqlAgentServer3 = Get-DbaService -ComputerName $server3.ComputerName -InstanceName $server3.DbaInstanceName -Type Agent
+        Write-Message -Level Warning -Message "The SQL Agent service for instance3 has state=$($sqlAgentServer3.State) and start mode=$($sqlAgentServer3.StartMode)"
 
         $sqlAgentServer2 = Get-DbaService -ComputerName $server2.ComputerName -InstanceName $server2.DbaInstanceName -Type Agent
         Write-Message -Level Warning -Message "The SQL Agent service for instance2 has state=$($sqlAgentServer2.State) and start mode=$($sqlAgentServer2.StartMode)"
 
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest -FrequencyType Weekly -FrequencyInterval 2 -FrequencyRecurrenceFactor 1 -StartTime 020000  -Force
-        $null = New-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
+        $null = New-DbaAgentSchedule -SqlInstance $script:instance3 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
         $scheduleParams = @{
             SqlInstance               = $script:instance2
             Schedule                  = 'Issue_6636_Once'
@@ -105,10 +105,10 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
 
         $null = New-DbaAgentSchedule @ScheduleParams -Force
 
-        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($script:instance3) and instance2=$($script:instance2)"
     }
     AfterAll {
-        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($script:instance3) and instance2=$($script:instance2)"
 
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest, Issue_6636_Once, Issue_6636_Once_Copy, Issue_6636_Hour, Issue_6636_Hour_Copy, Issue_6636_Minute, Issue_6636_Minute_Copy, Issue_6636_Second, Issue_6636_Second_Copy, Issue_6636_OneTime, Issue_6636_OneTime_Copy, Issue_6636_AutoStart, Issue_6636_AutoStart_Copy, Issue_6636_OnIdle, Issue_6636_OnIdle_Copy
 
@@ -118,15 +118,15 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
             Write-Message -Level Warning -Message "The schedules from $script:instance2 were returned as null"
         }
 
-        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance3 -Schedule dbatoolsci_MonthlyTest
 
         if ($null -ne $schedules) {
             $schedules.DROP()
         } else {
-            Write-Message -Level Warning -Message "The schedules from $script:instance1 were returned as null"
+            Write-Message -Level Warning -Message "The schedules from $script:instance3 were returned as null"
         }
 
-        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance3=$($script:instance3) and instance2=$($script:instance2)"
     }
 
     Context "Gets the list of Schedules" {
@@ -138,7 +138,7 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
 
     Context "Handles multiple instances" {
         It "Results contain two instances" {
-            $results = Get-DbaAgentSchedule -SqlInstance $script:instance2, $script:instance1
+            $results = Get-DbaAgentSchedule -SqlInstance $script:instance2, $script:instance3
             ($results | Select-Object SqlInstance -Unique).Count | Should -Be 2
         }
     }

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -15,7 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "UnitTests" {
     BeforeAll {
-        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "BeforeAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
         $server1 = Connect-DbaInstance -SqlInstance $script:instance1
         $server2 = Connect-DbaInstance -SqlInstance $script:instance2
 
@@ -105,10 +105,10 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
 
         $null = New-DbaAgentSchedule @ScheduleParams -Force
 
-        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "BeforeAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
     }
     AfterAll {
-        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "AfterAll start: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
 
         $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest, Issue_6636_Once, Issue_6636_Once_Copy, Issue_6636_Hour, Issue_6636_Hour_Copy, Issue_6636_Minute, Issue_6636_Minute_Copy, Issue_6636_Second, Issue_6636_Second_Copy, Issue_6636_OneTime, Issue_6636_OneTime_Copy, Issue_6636_AutoStart, Issue_6636_AutoStart_Copy, Issue_6636_OnIdle, Issue_6636_OnIdle_Copy
 
@@ -126,7 +126,7 @@ Describe "$commandname Integration Tests" -Tags "UnitTests" {
             Write-Message -Level Warning -Message "The schedules from $script:instance1 were returned as null"
         }
 
-        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance2) and instance2=$($script:instance2)"
+        Write-Message -Level Warning -Message "AfterAll end: Get-DbaAgentSchedule.Tests.ps1 testing with instance1=$($script:instance1) and instance2=$($script:instance2)"
     }
 
     Context "Gets the list of Schedules" {

--- a/tests/Get-DbaAgentSchedule.Tests.ps1
+++ b/tests/Get-DbaAgentSchedule.Tests.ps1
@@ -4,67 +4,275 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'ScheduleUid', 'Id', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Schedule', 'ScheduleUid', 'Id', 'EnableException'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
 
-Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+Describe "$commandname Integration Tests" -Tags "UnitTests" {
     BeforeAll {
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
         $null = New-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest -FrequencyType Weekly -FrequencyInterval 2 -FrequencyRecurrenceFactor 1 -StartTime 020000  -Force
+        $null = New-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
+        $scheduleParams = @{
+            SqlInstance               = $script:instance2
+            Schedule                  = 'Issue_6636_Once'
+            FrequencyInterval         = 1
+            FrequencyRecurrenceFactor = 0
+            FrequencySubdayInterval   = 0
+            FrequencySubdayType       = 'Time'
+            FrequencyType             = 'Daily'
+            StartTime                 = '230000'
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        $scheduleParams = @{
+            SqlInstance               = $script:instance2
+            Schedule                  = 'Issue_6636_Hour'
+            FrequencyInterval         = 1
+            FrequencyRecurrenceFactor = 0
+            FrequencySubdayInterval   = 1
+            FrequencySubdayType       = 'Hours'
+            FrequencyType             = 'Daily'
+            StartTime                 = '230000'
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        $scheduleParams = @{
+            SqlInstance               = $script:instance2
+            Schedule                  = 'Issue_6636_Minute'
+            FrequencyInterval         = 1
+            FrequencyRecurrenceFactor = 0
+            FrequencySubdayInterval   = 30
+            FrequencySubdayType       = 'Minutes'
+            FrequencyType             = 'Daily'
+            StartTime                 = '230000'
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        $scheduleParams = @{
+            SqlInstance               = $script:instance2
+            Schedule                  = 'Issue_6636_Second'
+            FrequencyInterval         = 1
+            FrequencyRecurrenceFactor = 0
+            FrequencySubdayInterval   = 10
+            FrequencySubdayType       = 'Seconds'
+            FrequencyType             = 'Daily'
+            StartTime                 = '230000'
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        # frequency type additions for issue 6636
+        $scheduleParams = @{
+            SqlInstance   = $script:instance2
+            Schedule      = "Issue_6636_OneTime"
+            FrequencyType = "OneTime"
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        $scheduleParams = @{
+            SqlInstance   = $script:instance2
+            Schedule      = "Issue_6636_AutoStart"
+            FrequencyType = "AutoStart"
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
+
+        $scheduleParams = @{
+            SqlInstance   = $script:instance2
+            Schedule      = "Issue_6636_OnIdle"
+            FrequencyType = "OnIdle"
+        }
+
+        $null = New-DbaAgentSchedule @ScheduleParams -Force
     }
-    Afterall {
-        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest
-        $Schedules.DROP()
+    AfterAll {
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest, Issue_6636_Once, Issue_6636_Once_Copy, Issue_6636_Hour, Issue_6636_Hour_Copy, Issue_6636_Minute, Issue_6636_Minute_Copy, Issue_6636_Second, Issue_6636_Second_Copy, Issue_6636_OneTime, Issue_6636_OneTime_Copy, Issue_6636_AutoStart, Issue_6636_AutoStart_Copy, Issue_6636_OnIdle, Issue_6636_OnIdle_Copy
+        $schedules.DROP()
+        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance1 -Schedule dbatoolsci_MonthlyTest
+        $schedules.DROP()
     }
 
     Context "Gets the list of Schedules" {
-        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2
         It "Results are not empty" {
-            $results | Should Not BeNullOrEmpty
+            $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_WeeklyTest, dbatoolsci_MonthlyTest
+            $results.Count | Should -Be 2
         }
     }
-    
+
     Context "Handles multiple instances" {
-        $null = New-DbaAgentSchedule -SqlInstance $script:instance3 -Schedule dbatoolsci_MonthlyTest -FrequencyType Monthly -FrequencyInterval 10 -FrequencyRecurrenceFactor 1 -Force
-        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2,$script:instance3
         It "Results contain two instances" {
+            $results = Get-DbaAgentSchedule -SqlInstance $script:instance2, $script:instance1
             ($results | Select-Object SqlInstance -Unique).Count | Should -Be 2
         }
-        $schedules = Get-DbaAgentSchedule -SqlInstance $script:instance3 -schedule dbatoolsci_MonthlyTest
-        $Schedules.DROP()
     }
 
     Context "Monthly schedule is correct" {
-        $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyTest
-        It "Should  get one schedule" {
-            $results.count | Should Be 1
-        }
-        It "Results are not empty" {
-            $results | Should Not BeNullOrEmpty
-        }
-        It "Should have the name MonthlyTest" {
-            $results.ScheduleName | Should Be "dbatoolsci_MonthlyTest"
-        }
-        It "Should have a frequency of 10" {
-            $results.FrequencyInterval | Should Be 10
-        }
-        It "Should be enabled" {
-            $results.IsEnabled | Should Be $true
-        }
-        It "SqlInstance should not be null" {
-            $results.SqlInstance | Should Not BeNullOrEmpty
-        }
-        It "Should have correct description" {
-            $datetimeFormat = (Get-culture).DateTimeFormat
+        It "verify schedule components" {
+            $results = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule dbatoolsci_MonthlyTest
+
+            $results.count                  | Should -Be 1
+            $results                        | Should -Not -BeNullOrEmpty
+            $results.ScheduleName           | Should -Be "dbatoolsci_MonthlyTest"
+            $results.FrequencyInterval      | Should -Be 10
+            $results.IsEnabled              | Should -Be $true
+            $results.SqlInstance            | Should -Not -BeNullOrEmpty
+            $datetimeFormat = (Get-Culture).DateTimeFormat
             $startDate = Get-Date $results.ActiveStartDate -Format $datetimeFormat.ShortDatePattern
             $startTime = Get-Date '00:00:00' -Format $datetimeFormat.LongTimePattern
-            $results.Description | Should Be "Occurs every month on day 10 of that month at $startTime. Schedule will be used starting on $startDate."
+            $results.Description            | Should -Be "Occurs every month on day 10 of that month at $startTime. Schedule will be used starting on $startDate."
+        }
+    }
+
+    Context "Issue 6636 - provide flexibility in the FrequencySubdayType and FrequencyType input params based on the return values from the SMO object JobServer.SharedSchedules" {
+        It "Ensure frequency subday type of 'Once' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Once
+
+            $scheduleParams = @{
+                SqlInstance               = $script:instance2
+                Schedule                  = 'Issue_6636_Once_Copy'
+                FrequencyInterval         = $result.FrequencyInterval
+                FrequencyRecurrenceFactor = $result.FrequencyRecurrenceFactor
+                FrequencySubdayInterval   = $result.FrequencySubDayInterval
+                FrequencySubdayType       = $result.FrequencySubdayTypes # "Once"
+                FrequencyType             = $result.FrequencyTypes
+                StartTime                 = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Once_Copy
+
+            $result.ScheduleName            | Should -Be "Issue_6636_Once_Copy"
+            $result.FrequencySubdayTypes    | Should -Be "Once"
+        }
+
+        It "Ensure frequency subday type of 'Hour' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Hour
+
+            $scheduleParams = @{
+                SqlInstance               = $script:instance2
+                Schedule                  = 'Issue_6636_Hour_Copy'
+                FrequencyInterval         = $result.FrequencyInterval
+                FrequencyRecurrenceFactor = $result.FrequencyRecurrenceFactor
+                FrequencySubdayInterval   = $result.FrequencySubDayInterval
+                FrequencySubdayType       = $result.FrequencySubdayTypes # "Hour"
+                FrequencyType             = $result.FrequencyTypes
+                StartTime                 = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Hour_Copy
+
+            $result.ScheduleName            | Should -Be "Issue_6636_Hour_Copy"
+            $result.FrequencySubdayTypes    | Should -Be "Hour"
+        }
+
+        It "Ensure frequency subday type of 'Minute' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Minute
+
+            $scheduleParams = @{
+                SqlInstance               = $script:instance2
+                Schedule                  = 'Issue_6636_Minute_Copy'
+                FrequencyInterval         = $result.FrequencyInterval
+                FrequencyRecurrenceFactor = $result.FrequencyRecurrenceFactor
+                FrequencySubdayInterval   = $result.FrequencySubDayInterval
+                FrequencySubdayType       = $result.FrequencySubdayTypes # "Minute"
+                FrequencyType             = $result.FrequencyTypes
+                StartTime                 = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Minute_Copy
+
+            $result.ScheduleName            | Should -Be "Issue_6636_Minute_Copy"
+            $result.FrequencySubdayTypes    | Should -Be "Minute"
+        }
+
+        It "Ensure frequency subday type of 'Second' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Second
+
+            $scheduleParams = @{
+                SqlInstance               = $script:instance2
+                Schedule                  = 'Issue_6636_Second_Copy'
+                FrequencyInterval         = $result.FrequencyInterval
+                FrequencyRecurrenceFactor = $result.FrequencyRecurrenceFactor
+                FrequencySubdayInterval   = $result.FrequencySubDayInterval
+                FrequencySubdayType       = $result.FrequencySubdayTypes # "Second"
+                FrequencyType             = $result.FrequencyTypes
+                StartTime                 = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_Second_Copy
+
+            $result.ScheduleName            | Should -Be "Issue_6636_Second_Copy"
+            $result.FrequencySubdayTypes    | Should -Be "Second"
+        }
+
+        It "Ensure frequency type of 'OneTime' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_OneTime
+
+            $scheduleParams = @{
+                SqlInstance   = $script:instance2
+                Schedule      = 'Issue_6636_OneTime_Copy'
+                FrequencyType = $result.FrequencyTypes # OneTime
+                StartTime     = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_OneTime_Copy
+
+            $result.ScheduleName    | Should -Be "Issue_6636_OneTime_Copy"
+            $result.FrequencyTypes  | Should -Be "OneTime"
+        }
+
+        It "Ensure frequency type of 'AutoStart' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_AutoStart
+
+            $scheduleParams = @{
+                SqlInstance   = $script:instance2
+                Schedule      = 'Issue_6636_AutoStart_Copy'
+                FrequencyType = $result.FrequencyTypes # AutoStart
+                StartTime     = $result.ActiveStartTimeOfDay.ToString().Replace(":", "")
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_AutoStart_Copy
+
+            $result.ScheduleName    | Should -Be "Issue_6636_AutoStart_Copy"
+            $result.FrequencyTypes  | Should -Be "AutoStart"
+        }
+
+        It "Ensure frequency type of 'OnIdle' is usable" {
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_OnIdle
+
+            $scheduleParams = @{
+                SqlInstance   = $script:instance2
+                Schedule      = 'Issue_6636_OnIdle_Copy'
+                FrequencyType = $result.FrequencyTypes # OnIdle
+            }
+
+            $newSchedule = New-DbaAgentSchedule @ScheduleParams -Force
+
+            $result = Get-DbaAgentSchedule -SqlInstance $script:instance2 -Schedule Issue_6636_OnIdle_Copy
+
+            $result.ScheduleName    | Should -Be "Issue_6636_OnIdle_Copy"
+            $result.FrequencyTypes  | Should -Be "OnIdle"
         }
     }
 }

--- a/tests/New-DbaAgentSchedule.Tests.ps1
+++ b/tests/New-DbaAgentSchedule.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'Schedule', 'Disabled', 'FrequencyType', 'FrequencyInterval', 'FrequencySubdayType', 'FrequencySubdayInterval', 'FrequencyRelativeInterval', 'FrequencyRecurrenceFactor', 'StartDate', 'EndDate', 'StartTime', 'EndTime', 'Force', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'Schedule', 'Disabled', 'FrequencyType', 'FrequencyInterval', 'FrequencySubdayType', 'FrequencySubdayInterval', 'FrequencyRelativeInterval', 'FrequencyRecurrenceFactor', 'StartDate', 'EndDate', 'StartTime', 'EndTime', 'Force', 'EnableException'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -25,187 +25,218 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job 'dbatoolsci_newschedule'
     }
 
-    Context "Should create schedules based on static frequency" {
+    Context "Should create schedules based on frequency type" {
         BeforeAll {
-            $results = New-Object System.collections.arraylist
+            $results = @{}
+
+            $scheduleOptions = @('Once', 'OneTime', 'Daily', 'Weekly', 'Monthly', 'MonthlyRelative', 'AgentStart', 'AutoStart', 'IdleComputer', 'OnIdle')
+
+            foreach ($frequency in $scheduleOptions) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequency"
+                    Job                       = 'dbatoolsci_newschedule'
+                    FrequencyType             = $frequency
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencyInterval         = '1'
+                    FrequencyRelativeInterval = 'First'
+                }
+
+                if ($frequency -notin @('IdleComputer', 'OnIdle')) {
+                    $results[$frequency] = $(New-DbaAgentSchedule -StartDate $start -StartTime '010000' -EndDate $end -EndTime '020000' @variables)
+                } else {
+                    $results[$frequency] = $(New-DbaAgentSchedule -Disabled -Force @variables)
+                }
+            }
         }
         AfterAll {
             $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-                Where-Object {$_.name -like 'dbatools*'} |
+                Where-Object { $_.name -like 'dbatools*' } |
                 Remove-DbaAgentSchedule -Confirm:$false -Force
             Remove-Variable -Name results
         }
 
-        foreach ($frequency in ('Once', 'AgentStart', 'IdleComputer')) {
-            $variables = @{SqlInstance    = $script:instance2
-                Schedule                  = "dbatoolsci_$frequency"
-                Job                       = 'dbatoolsci_newschedule'
-                FrequencyType             = $frequency
-                FrequencyRecurrenceFactor = '1'
-            }
-
-            if ($frequency -ne 'IdleComputer') {
-                $results.add($(New-DbaAgentSchedule -StartDate $start -StartTime '010000' -EndDate $end -EndTime '020000' @variables))
-            } else {
-                $results.add($(New-DbaAgentSchedule -Disabled -Force @variables))
-            }
-        }
-
         It "Should have Results" {
-            $results | Should Not BeNullOrEmpty
-        }
-        foreach ($r in $results) {
-            It "$($r.name) Should be a schedule on an existing job" {
-                $($r.parent) | Should Be 'dbatoolsci_newschedule'
-            }
-        }
-    }
-
-    Context "Should create schedules based on calendar frequency" {
-        BeforeAll {
-            $results = New-Object System.collections.arraylist
-        }
-        AfterAll {
-            $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-                Where-Object {$_.name -like 'dbatools*'} |
-                Remove-DbaAgentSchedule -Confirm:$false -Force
-            Remove-Variable -Name results
+            $results | Should -Not -BeNullOrEmpty
         }
 
-        foreach ($frequency in ('Daily', 'Weekly', 'Monthly', 'MonthlyRelative')) {
-            $variables = @{SqlInstance    = $script:instance2
-                Schedule                  = "dbatoolsci_$frequency"
-                Job                       = 'dbatoolsci_newschedule'
-                FrequencyType             = $frequency
-                FrequencyRecurrenceFactor = '1'
-                FrequencyInterval         = '1'
-                FrequencyRelativeInterval = 'First'
-                StartDate                 = $start
-                StartTime                 = '010000'
-                EndDate                   = $end
-                EndTime                   = '020000'
-            }
+        It "Should be a schedule on an existing job and have the correct frequency type" {
+            foreach ($key in $results.keys) {
+                $($results[$key].parent)        | Should -Be 'dbatoolsci_newschedule'
+                $results[$key].FrequencyTypes   | Should -BeIn $scheduleOptions
 
-            $results.add( $(New-DbaAgentSchedule @variables))
-        }
-
-        It "Should have Results" {
-            $results | Should Not BeNullOrEmpty
-        }
-        foreach ($r in $results) {
-            It "$($r.name) Should be a schedule on an existing job" {
-                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+                if ($key -in @('IdleComputer', 'OnIdle')) {
+                    $results[$key].FrequencyTypes   | Should -Be "OnIdle"
+                } elseif ($key -in @('Once', 'OneTime')) {
+                    $results[$key].FrequencyTypes   | Should -Be "OneTime"
+                } elseif ($key -in @('AgentStart', 'AutoStart')) {
+                    $results[$key].FrequencyTypes   | Should -Be "AutoStart"
+                } else {
+                    $results[$key].FrequencyTypes   | Should -Be $key
+                }
             }
         }
     }
 
     Context "Should create schedules with various frequency interval" {
         BeforeAll {
-            $results = New-Object System.collections.arraylist
+            $results = @{}
+
+            foreach ($frequencyinterval in ('EveryDay', 'Weekdays', 'Weekend', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
+                    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)) {
+
+                if ($frequencyinterval -is [int]) {
+                    $frequencyType = "Monthly"
+                } else {
+                    $frequencyType = "Weekly"
+                }
+
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequencyinterval"
+                    Job                       = 'dbatoolsci_newschedule'
+                    FrequencyType             = $frequencyType
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencyInterval         = $frequencyinterval
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $results[$frequencyinterval] = $(New-DbaAgentSchedule @variables)
+            }
         }
         AfterAll {
             $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-                Where-Object {$_.name -like 'dbatools*'} |
+                Where-Object { $_.name -like 'dbatools*' } |
                 Remove-DbaAgentSchedule -Confirm:$false -Force
             Remove-Variable -Name results
         }
 
-        foreach ($frequencyinterval in ('EveryDay', 'Weekdays', 'Weekend', 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday',
-                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31)) {
-            $variables = @{SqlInstance    = $script:instance2
-                Schedule                  = "dbatoolsci_$frequencyinterval"
-                Job                       = 'dbatoolsci_newschedule'
-                FrequencyType             = 'Daily'
-                FrequencyRecurrenceFactor = '1'
-                FrequencyInterval         = $frequencyinterval
-                StartDate                 = $start
-                StartTime                 = '010000'
-                EndDate                   = $end
-                EndTime                   = '020000'
-            }
-
-            $results.add( $(New-DbaAgentSchedule @variables))
-        }
-
         It "Should have Results" {
-            $results | Should Not BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
-        foreach ($r in $results) {
-            It "$($r.name) Should be a schedule on an existing job" {
-                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+
+        It "Should be a schedule on an existing job and have the correct interval for the frequency type" {
+            foreach ($key in $results.keys) {
+                $($results[$key].parent) | Should -Be 'dbatoolsci_newschedule'
+
+                if ($results[$key].FrequencyTypes -eq "Monthly") {
+                    $results[$key].FrequencyInterval | Should -Be $key
+                } elseif ($results[$key].FrequencyTypes -eq "Weekly") {
+                    switch ($key) {
+                        "Sunday" { $results[$key].FrequencyInterval | Should -Be 1 }
+                        "Monday" { $results[$key].FrequencyInterval | Should -Be 2 }
+                        "Tuesday" { $results[$key].FrequencyInterval | Should -Be 4 }
+                        "Wednesday" { $results[$key].FrequencyInterval | Should -Be 8 }
+                        "Thursday" { $results[$key].FrequencyInterval | Should -Be 16 }
+                        "Friday" { $results[$key].FrequencyInterval | Should -Be 32 }
+                        "Saturday" { $results[$key].FrequencyInterval | Should -Be 64 }
+                        "Weekdays" { $results[$key].FrequencyInterval | Should -Be 62 }
+                        "Weekend" { $results[$key].FrequencyInterval | Should -Be 65 }
+                        "EveryDay" { $results[$key].FrequencyInterval | Should -Be 127 }
+                    }
+                }
             }
         }
     }
 
     Context "Should create schedules with various frequency subday type" {
         BeforeAll {
-            $results = New-Object System.collections.arraylist
+            $results = @{}
+
+            $scheduleOptions = @('Time', 'Once', 'Second', 'Seconds', 'Minute', 'Minutes', 'Hour', 'Hours')
+
+            foreach ($frequencySubdayType in $scheduleOptions) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequencySubdayType"
+                    Job                       = 'dbatoolsci_newschedule'
+                    FrequencyType             = 'Daily'
+                    FrequencyInterval         = '1'
+                    FrequencyRecurrenceFactor = '1'
+                    FrequencySubdayInterval   = 10
+                    FrequencySubdayType       = $frequencySubdayType
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $results[$frequencySubdayType] = $(New-DbaAgentSchedule @variables)
+            }
         }
         AfterAll {
             $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-                Where-Object {$_.name -like 'dbatools*'} |
+                Where-Object { $_.name -like 'dbatools*' } |
                 Remove-DbaAgentSchedule -Confirm:$false -Force
             Remove-Variable -Name results
         }
 
-        foreach ($FrequencySubdayType in ('Time', 'Seconds', 'Minutes', 'Hours')) {
-            $variables = @{SqlInstance    = $script:instance2
-                Schedule                  = "dbatoolsci_$FrequencySubdayType"
-                Job                       = 'dbatoolsci_newschedule'
-                FrequencyRecurrenceFactor = '1'
-                FrequencySubdayInterval   = '1'
-                FrequencySubdayType       = $FrequencySubdayType
-                StartDate                 = $start
-                StartTime                 = '010000'
-                EndDate                   = $end
-                EndTime                   = '020000'
-            }
-
-            $results.add( $(New-DbaAgentSchedule @variables))
-        }
-
         It "Should have Results" {
-            $results | Should Not BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
-        foreach ($r in $results) {
-            It "$($r.name) Should be a schedule on an existing job" {
-                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+
+        It "Should be a schedule on an existing job and have a valid frequency subday type" {
+            foreach ($key in $results.keys) {
+                $($results[$key].parent)            | Should -Be 'dbatoolsci_newschedule'
+                $results[$key].FrequencySubdayTypes | Should -BeIn $scheduleOptions
+
+                if ($key -in @('Second', 'Seconds')) {
+                    $results[$key].FrequencySubdayTypes   | Should -Be "Second"
+                } elseif ($key -in @('Minute', 'Minutes')) {
+                    $results[$key].FrequencySubdayTypes   | Should -Be "Minute"
+                } elseif ($key -in @('Hour', 'Hours')) {
+                    $results[$key].FrequencySubdayTypes   | Should -Be "Hour"
+                } elseif ($key -in @('Once', 'Time')) {
+                    $results[$key].FrequencySubdayTypes   | Should -Be "Once"
+                } else {
+                    $results[$key].FrequencySubdayTypes   | Should -Be $key
+                }
             }
         }
     }
 
     Context "Should create schedules with various frequency relative interval" {
         BeforeAll {
-            $results = New-Object System.collections.arraylist
+            $results = @{}
+
+            # Unused (value of 0) is not valid for sp_add_jobschedule when using the MonthlyRelative frequency type, so 'Unused' has been removed from this test.
+            $scheduleOptions = @('First', 'Second', 'Third', 'Fourth', 'Last')
+
+            foreach ($frequencyRelativeInterval in $scheduleOptions) {
+                $variables = @{SqlInstance    = $script:instance2
+                    Schedule                  = "dbatoolsci_$frequencyRelativeInterval"
+                    Job                       = 'dbatoolsci_newschedule'
+                    FrequencyType             = 'MonthlyRelative'           # required to set the FrequencyRelativeInterval
+                    FrequencyRecurrenceFactor = '2'                         # every 2 months
+                    FrequencyRelativeInterval = $frequencyRelativeInterval  # 'First', 'Second', 'Third', 'Fourth', 'Last'
+                    FrequencyInterval         = '6'                         # Friday or day 6
+                    FrequencySubDayInterval   = '1'                         # daily frequency 1="occurs once at..." or "occurs every..."
+                    FrequencySubDayType       = 'Once'
+                    StartDate                 = $start
+                    StartTime                 = '010000'
+                    EndDate                   = $end
+                    EndTime                   = '020000'
+                }
+
+                $results[$frequencyRelativeInterval] = $(New-DbaAgentSchedule @variables)
+            }
         }
         AfterAll {
             $null = Get-DbaAgentSchedule -SqlInstance $script:instance2 |
-                Where-Object {$_.name -like 'dbatools*'} |
+                Where-Object { $_.name -like 'dbatools*' } |
                 Remove-DbaAgentSchedule -Confirm:$false -Force
             Remove-Variable -Name results
         }
 
-        foreach ($FrequencyRelativeInterval in ('Unused', 'First', 'Second', 'Third', 'Fourth', 'Last')) {
-            $variables = @{SqlInstance    = $script:instance2
-                Schedule                  = "dbatoolsci_$FrequencyRelativeInterval"
-                Job                       = 'dbatoolsci_newschedule'
-                FrequencyRecurrenceFactor = '1'
-                FrequencyRelativeInterval = $FrequencyRelativeInterval
-                StartDate                 = $start
-                StartTime                 = '010000'
-                EndDate                   = $end
-                EndTime                   = '020000'
-            }
-
-            $results.add( $(New-DbaAgentSchedule @variables))
-        }
-
         It "Should have Results" {
-            $results | Should Not BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
-        foreach ($r in $results) {
-            It "$($r.name) Should be a schedule on an existing job" {
-                $($r.parent) | Should Be 'dbatoolsci_newschedule'
+
+        It "Should be a schedule on an existing job and have a valid frequency relative interval" {
+            foreach ($key in $results.keys) {
+                $($results[$key].parent)                    | Should -Be 'dbatoolsci_newschedule'
+                $results[$key].FrequencyRelativeIntervals   | Should -BeIn $scheduleOptions
+                $results[$key].FrequencyRelativeIntervals   | Should -Be $key
             }
         }
     }


### PR DESCRIPTION
- Fixes #6636 by adding flexible parameter values since JobServer.SharedSchedules returns slightly different values when the Get-DbaAgentSchedule is called.
- Added integration tests to validate the flexible param values for both the New-DbaAgentSchedule and Get-DbaAgentSchedule.
- Modifed the pre-existing tests to improve test coverage.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6636 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Increasing the flexibility of the input params per the request in #6636.

### Approach
<!-- How does this change solve that purpose -->
Acceptable param values have been updated.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the pester tests for examples:  New-DbaAgentSchedule.Tests.ps1 and Get-DbaAgentSchedule.Tests.ps1
