### PR TITLE
Fix boolean logic and inline docs

### DIFF
--- a/functions/Remove-DbaAgentSchedule.ps1
+++ b/functions/Remove-DbaAgentSchedule.ps1
@@ -1,10 +1,10 @@
 function Remove-DbaAgentSchedule {
     <#
     .SYNOPSIS
-        Remove-DbaAgentJobSchedule removes a job schedule.
+        Remove-DbaAgentSchedule removes a job schedule.
 
     .DESCRIPTION
-        Remove-DbaAgentJobSchedule removes a job in the SQL Server Agent.
+        Remove-DbaAgentSchedule removes a job in the SQL Server Agent.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -116,7 +116,7 @@ function Remove-DbaAgentSchedule {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            if (-not $InputObject -and (-not $Schedule -or $ScheduleUid)) {
+            if (-not ($InputObject -or $Schedule -or $ScheduleUid)) {
                 Stop-Function -Message "Please enter the schedule or schedule uid"
             }
 


### PR DESCRIPTION

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix some boolean logic and the cmdlet name in the inline documentation

### Approach
Line 119, as originally written,

`if (-not $InputObject -and (-not $Schedule -or $ScheduleUid)) {`

would only allow you to get past this point if you have either $InputObject or have $Schedule and not have $ScheduleUid, which makes no sense and contradicts the error message.

I believe the `-not` should have been outside the parentheses, as in

`if (-not $InputObject -and -not ($Schedule -or $ScheduleUid)) {`

but it seems more clear to use the logical equivalent

`if (-not ($InputObject -or $Schedule -or $ScheduleUid)) {`

to say "If you don't have at least one of these, you may not continue"

### Commands to test
Neither of these should return the error "Please enter the schedule or schedule uid"

`Remove-DbaAgentSchedule -SqlInstance sql1 -ScheduleUid 'bf57fa7e-7720-4936-85a0-87d279db7eb7'`
`Remove-DbaAgentSchedule -SqlInstance sql1 -Schedule 'schedule1'`
