### PR TITLE
Invoke-DbaAdvancedInstall - Add Restart-DbaService after Set-DbaTcpPort

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -292,6 +292,7 @@ function Invoke-DbaAdvancedInstall {
     # change port after the installation
     if ($Port) {
         $null = Set-DbaTcpPort -SqlInstance "$($ComputerName)\$($InstanceName)" -Credential $Credential -Port $Port -EnableException:$EnableException -Confirm:$false
+        $null = Restart-DbaService -ComputerName $computerName -InstanceName $InstanceName -Credential $Credential -Type Engine -Force -EnableException:$EnableException -Confirm:$false
     }
     # restart if necessary
     try {

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -292,7 +292,12 @@ function Invoke-DbaAdvancedInstall {
     # change port after the installation
     if ($Port) {
         $null = Set-DbaTcpPort -SqlInstance "$($ComputerName)\$($InstanceName)" -Credential $Credential -Port $Port -EnableException:$EnableException -Confirm:$false
-        $null = Restart-DbaService -ComputerName $computerName -InstanceName $InstanceName -Credential $Credential -Type Engine -Force -EnableException:$EnableException -Confirm:$false
+        try {
+            $null = Restart-DbaService -ComputerName $computerName -InstanceName $InstanceName -Credential $Credential -Type Engine -Force -EnableException:$EnableException -Confirm:$false
+        } catch {
+            $output.Notes += "Port for $($ComputerName)\$($InstanceName) has been changed, but instance restart failed. Restart of instance is necessary for the new settings to become effective."
+        }
+
     }
     # restart if necessary
     try {

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -293,9 +293,9 @@ function Invoke-DbaAdvancedInstall {
     if ($Port) {
         $null = Set-DbaTcpPort -SqlInstance "$($ComputerName)\$($InstanceName)" -Credential $Credential -Port $Port -EnableException:$EnableException -Confirm:$false
         try {
-            $null = Restart-DbaService -ComputerName $computerName -InstanceName $InstanceName -Credential $Credential -Type Engine -Force -EnableException:$EnableException -Confirm:$false
+            $null = Restart-DbaService -ComputerName $ComputerName -InstanceName $InstanceName -Credential $Credential -Type Engine -Force -EnableException:$EnableException -Confirm:$false
         } catch {
-            $output.Notes += "Port for $($ComputerName)\$($InstanceName) has been changed, but instance restart failed. Restart of instance is necessary for the new settings to become effective."
+            $output.Notes += "Port for $($ComputerName)\$($InstanceName) has been changed, but instance restart failed ($_). Restart of instance is necessary for the new settings to become effective."
         }
 
     }

--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -17,6 +17,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
         Mock -CommandName Set-DbaPrivilege -ModuleName dbatools -MockWith { }
         Mock -CommandName Set-DbaTcpPort -ModuleName dbatools -MockWith { }
+        Mock -CommandName Restart-DbaService -ModuleName dbatools -MockWith { }
         Mock -CommandName Get-DbaCmObject -ModuleName dbatools -MockWith { [pscustomobject]@{NumberOfCores = 24 } } -ParameterFilter { $ClassName -eq 'Win32_processor' }
         # mock searching for setup, proper file should always it find
         Mock -CommandName Find-SqlInstanceSetup -MockWith {

--- a/tests/Invoke-DbaAdvancedInstall.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedInstall.Tests.ps1
@@ -17,6 +17,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
         Mock -CommandName Set-DbaPrivilege -ModuleName dbatools -MockWith {}
         Mock -CommandName Set-DbaTcpPort -ModuleName dbatools -MockWith {}
+        Mock -CommandName Restart-DbaService -ModuleName dbatools -MockWith {}
         Mock -CommandName Get-DbaCmObject -ModuleName dbatools -MockWith { [pscustomobject]@{NumberOfCores = 24} } -ParameterFilter { $ClassName -eq 'Win32_processor' }
         # mock searching for setup, proper file should always it find
         Mock -CommandName Find-SqlInstanceSetup -MockWith {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6865 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Port changes need a restart of service to be active

### Approach
Just restart the service

We discussed further adjustments to Set-DbaTcpPort on slack, but then got stuck. To at least fix the bug, I would like to implement this change as soon as possible.