### PR TITLE
*-DbaEndpoint - changed "EndPoint" to "Endpoint" and added an alias "Endpoint" for $name in New-DbaEndpoint

### DIFF
--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -103,6 +103,7 @@ function New-DbaEndpoint {
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [Alias("Endpoint")]
         [string]$Name,
         [ValidateSet('DatabaseMirroring', 'ServiceBroker', 'Soap', 'TSql')]
         [string]$Type = 'DatabaseMirroring',

--- a/functions/Remove-DbaEndpoint.ps1
+++ b/functions/Remove-DbaEndpoint.ps1
@@ -66,7 +66,7 @@ function Remove-DbaEndpoint {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [string[]]$EndPoint,
+        [string[]]$Endpoint,
         [switch]$AllEndpoints,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Endpoint[]]$InputObject,
@@ -78,7 +78,7 @@ function Remove-DbaEndpoint {
             return
         }
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -EndPoint $Endpoint
+            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -Endpoint $Endpoint
         }
 
         foreach ($ep in $InputObject) {

--- a/functions/Set-DbaEndpoint.ps1
+++ b/functions/Set-DbaEndpoint.ps1
@@ -67,7 +67,7 @@ function Set-DbaEndpoint {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [string[]]$EndPoint,
+        [string[]]$Endpoint,
         [string]$Owner,
         [ValidateSet('DatabaseMirroring', 'ServiceBroker', 'Soap', 'TSql')]
         [string]$Type,
@@ -82,7 +82,7 @@ function Set-DbaEndpoint {
             return
         }
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -EndPoint $Endpoint
+            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -Endpoint $Endpoint
         }
 
         $props = "Owner", "Type"

--- a/functions/Start-DbaEndpoint.ps1
+++ b/functions/Start-DbaEndpoint.ps1
@@ -66,7 +66,7 @@ function Start-DbaEndpoint {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [string[]]$EndPoint,
+        [string[]]$Endpoint,
         [switch]$AllEndpoints,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Endpoint[]]$InputObject,
@@ -78,7 +78,7 @@ function Start-DbaEndpoint {
             return
         }
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -EndPoint $Endpoint
+            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -Endpoint $Endpoint
         }
 
         foreach ($ep in $InputObject) {

--- a/functions/Stop-DbaEndpoint.ps1
+++ b/functions/Stop-DbaEndpoint.ps1
@@ -66,7 +66,7 @@ function Stop-DbaEndpoint {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [string[]]$EndPoint,
+        [string[]]$Endpoint,
         [switch]$AllEndpoints,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Endpoint[]]$InputObject,
@@ -78,7 +78,7 @@ function Stop-DbaEndpoint {
             return
         }
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -EndPoint $Endpoint
+            $InputObject += Get-DbaEndpoint -SqlInstance $instance -SqlCredential $SqlCredential -Endpoint $Endpoint
         }
 
         foreach ($ep in $InputObject) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
I accidentally discovered the different spelling, so I fixed that.
I think an alias is nice because then every command accepts the parameter -Endpoint. But I can remove it if desired.