### PR TITLE
formatter, require 1.18.2 till problems with 1.19.1 get sorted out

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -39,17 +39,18 @@ function Invoke-DbatoolsFormatter {
     begin {
         $invokeFormatterVersion = (Get-Command Invoke-Formatter -ErrorAction SilentlyContinue).Version
         $HasInvokeFormatter = $null -ne $invokeFormatterVersion
+        $ScriptAnalyzerCorrectVersion = '1.18.2'
         if (!($HasInvokeFormatter)) {
-            Stop-Function -Message "You need PSScriptAnalyzer version 1.18.2 installed"
-            Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '1.18.2'"
+            Stop-Function -Message "You need PSScriptAnalyzer version $ScriptAnalyzerCorrectVersion installed"
+            Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '$ScriptAnalyzerCorrectVersion'"
         } else {
-            if ($invokeFormatterVersion -ne '1.18.2') {
+            if ($invokeFormatterVersion -ne $ScriptAnalyzerCorrectVersion) {
                 Remove-Module PSScriptAnalyzer
                 try {
-                    Import-Module PSScriptAnalyzer -RequiredVersion '1.18.2' -ErrorAction Stop
+                    Import-Module PSScriptAnalyzer -RequiredVersion $ScriptAnalyzerCorrectVersion -ErrorAction Stop
                 } catch {
-                    Stop-Function -Message "Please install PSScriptAnalyzer 1.18.2"
-                    Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '1.18.2'"
+                    Stop-Function -Message "Please install PSScriptAnalyzer $ScriptAnalyzerCorrectVersion"
+                    Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '$ScriptAnalyzerCorrectVersion'"
                 }
             }
         }

--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -37,9 +37,21 @@ function Invoke-DbatoolsFormatter {
         [switch]$EnableException
     )
     begin {
-        $HasInvokeFormatter = $null -ne (Get-Command Invoke-Formatter -ErrorAction SilentlyContinue).Version
+        $invokeFormatterVersion = (Get-Command Invoke-Formatter -ErrorAction SilentlyContinue).Version
+        $HasInvokeFormatter = $null -ne $invokeFormatterVersion
         if (!($HasInvokeFormatter)) {
-            Stop-Function -Message "You need a recent version of PSScriptAnalyzer installed"
+            Stop-Function -Message "You need PSScriptAnalyzer version 1.18.2 installed"
+            Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '1.18.2'"
+        } else {
+            if ($invokeFormatterVersion -ne '1.18.2') {
+                Remove-Module PSScriptAnalyzer
+                try {
+                    Import-Module PSScriptAnalyzer -RequiredVersion '1.18.2' -ErrorAction Stop
+                } catch {
+                    Stop-Function -Message "Please install PSScriptAnalyzer 1.18.2"
+                    Write-Message -Level Warning "     Install-Module -Name PSScriptAnalyzer -RequiredVersion '1.18.2'"
+                }
+            }
         }
         $CBHRex = [regex]'(?smi)\s+\<\#[^#]*\#\>'
         $CBHStartRex = [regex]'(?<spaces>[ ]+)\<\#'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Make sure users use the same module version we use in appveyor to check formatting.
Issues around PSSA 1.19.1 "breaking" changes have been listed on slack.
Long story short: VSCode and PSSA no longer match exactly, and it doesn't seem something we can "tune".
New PSSA capitalizes correctly commands and their parameters (wow) but also changes all operators to the correct casing (i.e. `-In` over `-in`, `-EQ` over `-eq`, etc).

