### PR TITLE
Update Set-DbaTempDbConfig.ps1

### DIFF
--- a/functions/Set-DbaTempDbConfig.ps1
+++ b/functions/Set-DbaTempDbConfig.ps1
@@ -206,13 +206,13 @@ function Set-DbaTempDbConfig {
             if ($LogPath -or $LogFileSize) {
                 $Filename = Split-Path $logfile.PhysicalName -Leaf
                 $LogicalName = $logfile.LogicalName
-                
+
                 if ($LogPath) {
-                    $NewPath = "$LogPath\$Filename"     
+                    $NewPath = "$LogPath\$Filename"
                 } else {
                     $NewPath = $logfile.PhysicalName
                 }
-                
+
                 if (-not($LogFileSize)) {
                     $LogFileSize = $logfile.SizeMb
                 }

--- a/functions/Set-DbaTempDbConfig.ps1
+++ b/functions/Set-DbaTempDbConfig.ps1
@@ -207,10 +207,10 @@ function Set-DbaTempDbConfig {
                 $Filename = Split-Path $logfile.PhysicalName -Leaf
                 $LogicalName = $logfile.LogicalName
                 
-                if ($logPath) {
+                if ($LogPath) {
                     $NewPath = "$LogPath\$Filename"     
                 } else {
-                    Split-Path $logfile.PhysicalName
+                    $NewPath = $logfile.PhysicalName
                 }
                 
                 if (-not($LogFileSize)) {


### PR DESCRIPTION
Updated Set-DbaTempDbConfig to move log file when no size option is passed and to resize the log file without moving it.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6895
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix an issue where the log files of tempdb weren't moved if the log file size wasn't passed.

### Approach
Update to function so it allows the process to flow to the correct code and build the appropriate SQL statement.


