### PR TITLE
buildreference, introduce retired kbs

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2020-10-02T00:00:00",
+    "LastUpdated": "2020-10-08T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",
@@ -3988,6 +3988,12 @@
             "KBList": "4505830"
         },
         {
+            "CU": "CU9",
+            "Version": "13.0.5479",
+            "KBList": "4515435",
+            "Retired": true
+        },
+        {
             "CU": "CU10",
             "Version": "13.0.5492",
             "KBList": "4524334"
@@ -4246,6 +4252,12 @@
             "CU": "CU6",
             "Version": "15.0.4053",
             "KBList": "4563110"
+        },
+        {
+            "CU": "CU7",
+            "Version": "15.0.4063",
+            "KBList": "4570012",
+            "Retired": true
         },
         {
             "CU": "CU8",

--- a/functions/Get-DbaBuildReference.ps1
+++ b/functions/Get-DbaBuildReference.ps1
@@ -331,9 +331,15 @@ function Get-DbaBuildReference {
                 $Detected.KB = $el.KBList
                 if (($Build -and $el.Version -eq $Build) -or ($Kb -and $el.KBList -eq $currentKb)) {
                     $Detected.MatchType = 'Exact'
+                    if ($el.Retired) {
+                        $Detected.Warning = "This version has been officially retired by Microsoft"
+                    }
                     break
                 } elseif ($MajorVersion -and $Detected.SP -contains $ServicePack -and (!$CumulativeUpdate -or ($el.CU -and $el.CU -eq $CumulativeUpdate))) {
                     $Detected.MatchType = 'Exact'
+                    if ($el.Retired) {
+                        $Detected.Warning = "This version has been officially retired by Microsoft"
+                    }
                     break
                 }
             }

--- a/functions/Test-DbaBuild.ps1
+++ b/functions/Test-DbaBuild.ps1
@@ -226,6 +226,7 @@ function Test-DbaBuild {
                             VersionObject = $el.VersionObject
                             SP            = $lastsp
                             CU            = $el.CU
+                            Retired       = $el.Retired
                         }
                     }
                 }
@@ -244,7 +245,7 @@ function Test-DbaBuild {
                         $targetedBuild = $SPsAndCUs | Where-Object SP -eq $targetSPName | Select-Object -First 1
                     }
                     if ($ParsedMaxBehind.ContainsKey('CU')) {
-                        [string[]]$AllCUs = ($SPsAndCUs | Where-Object VersionObject -gt $targetedBuild.VersionObject).CU | Select-Object -Unique
+                        [string[]]$AllCUs = ($SPsAndCUs | Where-Object VersionObject -gt $targetedBuild.VersionObject | Where-Object Retired -ne $true).CU | Select-Object -Unique
                         if ($AllCUs.Length -gt 0) {
                             #CU after the targeted build available
                             $targetCU = $AllCUs.Length - $ParsedMaxBehind['CU'] - 1

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -132,10 +132,18 @@ Describe "$CommandName Unit Test" -Tags Unittest {
         }
     }
     Context "Passing just -Update works, see #6823" {
-        function Get-DbaBuildReferenceIndexOnline { }
-        Mock Get-DbaBuildReferenceIndexOnline -MockWith { } -ModuleName dbatools
-        Get-DbaBuildReference -Update -WarningVariable warnings 3>$null
-        $warnings | Should -BeNullOrEmpty
+        It 'works with -Update' {
+            function Get-DbaBuildReferenceIndexOnline { }
+            Mock Get-DbaBuildReferenceIndexOnline -MockWith { } -ModuleName dbatools
+            Get-DbaBuildReference -Update -WarningVariable warnings 3>$null
+            $warnings | Should -BeNullOrEmpty
+        }
+    }
+    Context "Retired KBs" {
+        It 'Handles retired KBs' {
+            $result = Get-DbaBuildReference -Build '13.0.5479'
+            $result.Warning | Should -Be 'This version has been officially retired by Microsoft' 
+        }
     }
 
     # These are groups by major release (aka "Name")

--- a/tests/Get-DbaBuildReference.Tests.ps1
+++ b/tests/Get-DbaBuildReference.Tests.ps1
@@ -142,7 +142,7 @@ Describe "$CommandName Unit Test" -Tags Unittest {
     Context "Retired KBs" {
         It 'Handles retired KBs' {
             $result = Get-DbaBuildReference -Build '13.0.5479'
-            $result.Warning | Should -Be 'This version has been officially retired by Microsoft' 
+            $result.Warning | Should -Be 'This version has been officially retired by Microsoft'
         }
     }
 

--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -11,6 +11,18 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
+    Context "Retired KBs" {
+        It "Handles retired kbs" {
+            $result = Test-DbaBuild -Build '13.0.5479' -Latest
+            $result.Warning | Should -Be 'This version has been officially retired by Microsoft'
+            $latestCUfor2019 = (Test-DbaBuild -Build '15.0.4003' -MaxBehind '0CU').CUTarget.Replace('CU', '')
+            #CU7 for 2019 was retired
+            [int]$behindforCU7 = [int]$latestCUfor2019 - 7
+            $goBackTo = "$($behindforCU7)CU"
+            $result = Test-DbaBuild -Build '15.0.4003' -MaxBehind $goBackTo
+            $result.CUTarget | Should -Be 'CU6'
+        }
+    }
 }
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 

### Purpose
Handle retired KBs. Took a while (sorry) but we do need to manage them somehow.

### Approach
Add the "Retired" attribute to the build, make sure that Get-DbaBuildReference returns a warning if the build is "officially retired".
Test-DbaBuild recognizes the same warning but additionally skips that version if -MaxBehind is passed.

### Commands to test
Look at the added tests

### Screenshots
![image](https://user-images.githubusercontent.com/122119/95518856-3efdea00-09c4-11eb-88d9-880247fece77.png)
![image](https://user-images.githubusercontent.com/122119/95518959-710f4c00-09c4-11eb-90b7-057a36217cc0.png)

As soon as the buildref is committed to the other repo, this is the result

![image](https://user-images.githubusercontent.com/122119/95519052-a320ae00-09c4-11eb-95aa-c78426c41f6a.png)

and, of course, if it is indeed the last cu to be retired, it will keep the "latest cu" column ticked in the previous one, so if CU8 didn't exist yet, it'll show this
![image](https://user-images.githubusercontent.com/122119/95519167-dc591e00-09c4-11eb-9f63-c6705626aac6.png)


