### PR TITLE
Export-DbaInstance - Append doesn't do what it appears

### DIFF
--- a/functions/Export-DbaInstance.ps1
+++ b/functions/Export-DbaInstance.ps1
@@ -144,7 +144,7 @@ function Export-DbaInstance {
         [ValidateSet('Databases', 'Logins', 'AgentServer', 'Credentials', 'LinkedServers', 'SpConfigure', 'CentralManagementServer', 'DatabaseMail', 'SysDbUserObjects', 'SystemTriggers', 'BackupDevices', 'Audits', 'Endpoints', 'ExtendedEvents', 'PolicyManagement', 'ResourceGovernor', 'ServerAuditSpecifications', 'CustomErrors', 'ServerRoles', 'AvailabilityGroups', 'ReplicationSettings')]
         [string[]]$Exclude,
         [string]$BatchSeparator = 'GO',
-        [switch]$Append,
+        [switch]$Append = $true,
         [Microsoft.SqlServer.Management.Smo.ScriptingOptions]$ScriptingOption,
         [switch]$NoPrefix = $false,
         [switch]$ExcludePassword,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6918  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
This is probably going to be a temporary measure until #5380 is completed but my hope is that we'll help people get what they're expecting in the meantime. Addresses #6918

In #5380 a `-Append` switch was proposed and I _think_ the intention there was to have a single file exported which contains _all_ scripts for the instance. But this being defaulted to `$false` (well, `$null`) prevents the complete scripts from being produced in the current implementation where we have one script per "group" and there are multiple object types per "group" (such as Agent and DBMail).

If I'm exporting AgentServer, I would expect _everything_ for AgentServer to be exported. For DBMail, if we don't export everything, DBMail isn't fully configured by the script that's produced - configuration, accounts, profiles & server settings aren't there.


### Approach
Default `-Append` to `$true`. I'm defaulting to this because it is what people expect from the function - 
### Commands to test
`Export-DbaInstance -sqlinstance MYINSTANCE`

With `-Append` set to `$true` (which will now be the default), Agent Operators, Schedules, Proxies, etc. should be included in the` X-sqlagent.sql` script.
With `-Append` set to `$false`, Agent Operators, Schedules, Proxies, etc. will be included in the` X-sqlagent.sql` script.