### PR TITLE
Fixed date conversions in Get-DbaRandomizedValue

### DIFF
--- a/functions/Get-DbaRandomizedValue.ps1
+++ b/functions/Get-DbaRandomizedValue.ps1
@@ -173,13 +173,13 @@ function Get-DbaRandomizedValue {
         }
 
         if (-not $Min) {
-            if ($DataType.ToLower() -ne "date" -and $RandomizerType.ToLower() -ne "date") {
+            if ($DataType.ToLower() -notlike "date*" -and $RandomizerType.ToLower() -notlike "date*") {
                 $Min = 1
             }
         }
 
         if (-not $Max) {
-            if ($DataType.ToLower() -ne "date" -and $RandomizerType.ToLower() -ne "date") {
+            if ($DataType.ToLower() -notlike "date*" -and $RandomizerType.ToLower() -notlike "date*") {
                 $Max = 255
             }
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6920  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The date data types were not converted correctly due to the min and max values set

### Approach
Exclude the other date data types 

### Commands to test
Get-DbaRandomizedValue -DataType date
Get-DbaRandomizedValue -DataType datetime
Get-DbaRandomizedValue -DataType datetime2
Get-DbaRandomizedValue -DataType smalldatetime -Min (Get-Date).AddDays(-10) -Max  (Get-Date).AddDays(-5)

### Screenshots
![image](https://user-images.githubusercontent.com/6154981/96311594-1c924f00-100a-11eb-913c-d9c63f3ab701.png)


### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
