### PR TITLE
New Function - Remove-DbaDbData

### DIFF
--- a/functions/Remove-DbaDbData.ps1
+++ b/functions/Remove-DbaDbData.ps1
@@ -1,0 +1,161 @@
+function Remove-DbaDbData {
+    <#
+    .SYNOPSIS
+        Removes all the date from a database(s) for each instance(s) of SQL Server.
+
+    .DESCRIPTION
+        This command truncates all the tables in a database. If there are foreign keys and/or views they are scripted out, then dropped before the truncate, and recreated after.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternate Windows or SQL Login Authentication. Accepts credential objects (Get-Credential).
+
+    .PARAMETER Database
+        The database(s) to process. This list is auto-populated from the server. If unspecified, all user databases will be processed.
+
+    .PARAMETER ExcludeDatabase
+        The database(s) to exclude. This list is auto-populated from the server.
+
+    .PARAMETER InputObject
+        Enables piped input from Get-DbaDatabase
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Role, Database
+        Author: Jess Pomfret (@jpomfret), jesspomfret.com
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaDbData
+
+    .EXAMPLE
+        PS C:\> Remove-DbaDbData -SqlInstance localhost -Database dbname
+
+        Removes all data from the dbname database on the local default SQL Server instance
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance mssql1 -Database AdventureWorks2017 | Remove-DbaDbData
+
+        Removes all data from AdventureWorks2017 on the mssql1 SQL Server Instance, uses piped input from Get-DbaDatabase.
+
+    .EXAMPLE
+        PS C:\> Remove-DbaDbData -SqlInstance mssql1 -ExcludeDatabase DBA -Confirm:$False
+
+        Removes all data from all databases on mssql1 except the DBA Database. Doesn't prompt for confirmation.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [DbaInstance[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [string]$Path = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
+        [switch]$EnableException
+    )
+
+    begin {
+        $null = Test-ExportDirectory -Path $Path
+    }
+    process {
+        if (-not $InputObject -and -not $SqlInstance) {
+            Stop-Function -Message "You must pipe in a database or a server, or specify a SqlInstance"
+            return
+        }
+
+        if ($SqlInstance) {
+            $InputObject = $SqlInstance
+        }
+
+        foreach ($input in $InputObject) {
+            $inputType = $input.GetType().FullName
+            switch ($inputType) {
+                'Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter' {
+                    Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
+                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $sqlcredential -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem
+                }
+                'Microsoft.SqlServer.Management.Smo.Server' {
+                    Write-Message -Level Verbose -Message "Processing Server through InputObject"
+                    $dbDatabases = Get-DbaDatabase -SqlInstance $input -SqlCredential $sqlcredential -Database $Database -ExcludeDatabase $ExcludeDatabase -ExcludeSystem
+                }
+                'Microsoft.SqlServer.Management.Smo.Database' {
+                    Write-Message -Level Verbose -Message "Processing Database through InputObject"
+                    $dbDatabases = $input | Where-Object { -not $_.IsSystemObject }
+                }
+                default {
+                    Stop-Function -Message "InputObject is not a server or database."
+                    return
+                }
+            }
+
+            foreach ($db in $dbDatabases) {
+                if ($Pscmdlet.ShouldProcess($db.Name, "Removing all data on $($db.Parent.Name)")) {
+                    write-host "working on $($db.Name)"
+                    $instance = $db.Parent
+
+                    try {
+
+                        # Collect up the objects we need to drop and recreate
+                        $objects = @()
+                        $objects += Get-DbaDbForeignKey -SqlInstance $instance -Database $db.Name
+                        $objects += Get-DbaDbView -SqlInstance $instance -Database $db.Name -ExcludeSystemView
+
+                        # Script out the create statements for objects
+                        $createOptions = New-DbaScriptingOption
+                        $createOptions.Permissions = $true
+                        $createOptions.ScriptBatchTerminator = $true
+                        $createOptions.AnsiFile = $true
+                        $null = $objects | Export-DbaScript -FilePath "$Path\$($db.Name)_Create.Sql" -ScriptingOptionsObject $createOptions
+
+                        # Script out the drop statements for objects
+                        $options = New-DbaScriptingOption
+                        $options.ScriptDrops = $true
+                        $null = $objects | Export-DbaScript -FilePath "$Path\$($db.Name)_Drop.Sql" -ScriptingOptionsObject $options
+                    } catch {
+                        Stop-Function -Message "Issue scripting out the drop\create scripts for objects in $db on instance $instance" -ErrorRecord $_
+                        return
+                    }
+
+                    try {
+                        if ($objects) {
+                            Invoke-DbaQuery -SqlInstance $instance -Database $db.Name -File "$Path\$($db.Name)_Drop.Sql"
+                        }
+
+                        $db.Tables | ForEach-Object { $_.TruncateData() }
+
+                        if ($objects) {
+                            Invoke-DbaQuery -SqlInstance $instance -Database $db.Name -File "$Path\$($db.Name)_Create.Sql"
+                        }
+                    } catch {
+                        Write-Message -Level warning -Message "Issue truncating tables in $sdb on instance $instance"
+                        Invoke-DbaQuery -SqlInstance $instance -Database $db.Name -File "$Path\$($db.Name)_Create.Sql"
+                    }
+                    if ($objects) {
+                        try {
+                            Remove-Item "$Path\$($db.Name)_Drop.Sql", "$Path\$($db.Name)_Create.Sql" -ErrorAction Stop
+                        } catch {
+                            Write-Message -Level warning -Message "Unable to clear up output files for $instance.$db"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/functions/Remove-DbaDbData.ps1
+++ b/functions/Remove-DbaDbData.ps1
@@ -25,6 +25,10 @@ function Remove-DbaDbData {
     .PARAMETER InputObject
         Enables piped input from Get-DbaDatabase
 
+    .PARAMETER Path
+        Specifies the directory where the file or files will be exported.
+        Will default to Path.DbatoolsExport Configuration entry
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 

--- a/tests/Remove-DbaDbData.Tests.ps1
+++ b/tests/Remove-DbaDbData.Tests.ps1
@@ -12,38 +12,111 @@ Describe "$CommandName Unit Tests" -Tags "UnitTests" {
         }
     }
 }
-<#
+
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
         $dbname1 = "dbatoolsci_$(Get-Random)"
         $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname1 -Owner sa
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query "
+
+        create table dept (
+            deptid int identity(1,1) primary key,
+            deptname varchar(10)
+        );
+
+        create table emp (
+            empid int identity(1,1) primary key,
+            deptid int,
+            CONSTRAINT FK_dept FOREIGN key (deptid) REFERENCES dept (deptid)
+            );
+
+        GO
+
+        Create View vw_emp as
+        Select empid from emp;
+        "
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -confirm:$false
     }
 
     Context "Functionality" {
-        It 'Removes Data' {
-            #$null = $server.Query("CREATE ROLE $role1", $dbname1)
-            #$null = $server.Query("CREATE ROLE $role2", $dbname1)
-            #$result0 = Get-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1
-            #Remove-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1 -confirm:$false
-            #$result1 = Get-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1
-            #
-            #$result0.Count | Should BeGreaterThan $result1.Count
-            #$result1.Name -contains $role1  | Should Be $false
-            #$result1.Name -contains $role2  | Should Be $false
-            $true | Should Be $false
+        BeforeAll {
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query "
+                insert into dept values ('hr');
+                insert into emp values (1);"
         }
 
-        It 'Foreign Keys are recreated' {
+        It 'Removes Data for a specified database' {
+            Remove-DbaDbData -SqlInstance $script:instance2 -Database $dbname1 -Confirm:$false
+            (Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query 'Select count(*) as rwCnt from dept').rwCnt | Should Be 0
+        }
 
+        $fkeys = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname1
+        It 'Foreign Keys are recreated' {
+            $fkeys.Name | Should Be 'FK_dept'
+        }
+
+        It 'Foreign Keys are trusted' {
+            $fkeys.IsChecked | Should Be $true
         }
 
         It 'Views are recreated' {
-
+            (Get-DbaDbView -SqlInstance $script:instance2 -Database $dbname1 -ExcludeSystemView).Name | Should Be 'vw_emp'
         }
     }
-#>
+
+    Context "Functionality - Pipe database" {
+        BeforeAll {
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query "
+                insert into dept values ('hr');
+                insert into emp values (1);"
+        }
+
+        It 'Removes Data for a specified database' {
+            Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 | Remove-DbaDbData -Confirm:$false
+            (Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query 'Select count(*) as rwCnt from dept').rwCnt | Should Be 0
+        }
+
+        $fkeys = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname1
+        It 'Foreign Keys are recreated' {
+            $fkeys.Name | Should Be 'FK_dept'
+        }
+
+        It 'Foreign Keys are trusted' {
+            $fkeys.IsChecked | Should Be $true
+        }
+
+        It 'Views are recreated' {
+            (Get-DbaDbView -SqlInstance $script:instance2 -Database $dbname1 -ExcludeSystemView).Name | Should Be 'vw_emp'
+        }
+    }
+
+    Context "Functionality - Pipe server" {
+        BeforeAll {
+            Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query "
+                insert into dept values ('hr');
+                insert into emp values (1);"
+        }
+
+        It 'Removes Data for a specified database' {
+            Connect-DbaInstance -SqlInstance $script:instance2 | Remove-DbaDbData -Database $dbname1 -Confirm:$false
+            (Invoke-DbaQuery -SqlInstance $script:instance2 -Database $dbname1 -Query 'Select count(*) as rwCnt from dept').rwCnt | Should Be 0
+        }
+
+        $fkeys = Get-DbaDbForeignKey -SqlInstance $script:instance2 -Database $dbname1
+        It 'Foreign Keys are recreated' {
+            $fkeys.Name | Should Be 'FK_dept'
+        }
+
+        It 'Foreign Keys are trusted' {
+            $fkeys.IsChecked | Should Be $true
+        }
+
+        It 'Views are recreated' {
+            (Get-DbaDbView -SqlInstance $script:instance2 -Database $dbname1 -ExcludeSystemView).Name | Should Be 'vw_emp'
+        }
+    }
+}

--- a/tests/Remove-DbaDbData.Tests.ps1
+++ b/tests/Remove-DbaDbData.Tests.ps1
@@ -1,0 +1,49 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags "UnitTests" {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'InputObject', 'Path', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+<#
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $dbname1 = "dbatoolsci_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $script:instance2 -Name $dbname1 -Owner sa
+    }
+    AfterAll {
+        $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname1 -confirm:$false
+    }
+
+    Context "Functionality" {
+        It 'Removes Data' {
+            #$null = $server.Query("CREATE ROLE $role1", $dbname1)
+            #$null = $server.Query("CREATE ROLE $role2", $dbname1)
+            #$result0 = Get-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1
+            #Remove-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1 -confirm:$false
+            #$result1 = Get-DbaDbRole -SqlInstance $script:instance2 -Database $dbname1
+            #
+            #$result0.Count | Should BeGreaterThan $result1.Count
+            #$result1.Name -contains $role1  | Should Be $false
+            #$result1.Name -contains $role2  | Should Be $false
+            $true | Should Be $false
+        }
+
+        It 'Foreign Keys are recreated' {
+
+        }
+
+        It 'Views are recreated' {
+
+        }
+    }
+#>


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Adds a new function `Remove-DbaDbData` that truncates all tables in a database.

### Approach
1. Scripts out foreign keys and views to a file in the dbatools export path
1. Drop FKs and views
1. Truncates all tables
1. Recreate FK and views

### Commands to test
Examples in the help

### Screenshots
![image](https://user-images.githubusercontent.com/981370/96496764-919b9980-1241-11eb-990d-38592d0b3661.png)

### Learning
[Truncate all the Tables in a Database with PowerShell](https://jesspomfret.com/truncate-all-the-tables/)