### PR TITLE
Fixes for Diag notebook function and test

### DIFF
--- a/functions/New-DbaDiagnosticAdsNotebook.ps1
+++ b/functions/New-DbaDiagnosticAdsNotebook.ps1
@@ -122,7 +122,7 @@ function New-DbaDiagnosticAdsNotebook {
             }
         }
 
-        $diagnosticScriptPath = Get-ChildItem -Path "$($script:PSModuleRoot)\bin\diagnosticquery\" -Filter "SQLServerDiagnosticQueries_$($TargetVersion)_??????.sql" | Select-Object -First 1
+        $diagnosticScriptPath = Get-ChildItem -Path "$($script:PSModuleRoot)\bin\diagnosticquery\" -Filter "SQLServerDiagnosticQueries_$($TargetVersion).sql" | Select-Object -First 1
 
         if (-not $diagnosticScriptPath) {
             Stop-Function -Message "No diagnostic queries available for `$TargetVersion = $TargetVersion"

--- a/tests/New-DbaDiagnosticAdsNotebook.Tests.ps1
+++ b/tests/New-DbaDiagnosticAdsNotebook.Tests.ps1
@@ -18,13 +18,18 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $file = "c:\temp\myNotebook.ipynb"
     }
     AfterAll {
-        $null = Remove-Item -Path $file
+        $null = Remove-Item -Path $file -ErrorAction SilentlyContinue
     }
     Context "creates notebook" {
+        It "should create a file" {
+            $notebook = New-DbaDiagnosticAdsNotebook -TargetVersion 2017 -Path $file -IncludeDatabaseSpecific
+            $notebook | Should Not BeNullOrEmpty
+        }
+
         It "returns a file that includes specific phrases" {
             $results = New-DbaDiagnosticAdsNotebook -TargetVersion 2017 -Path $file -IncludeDatabaseSpecific
-            $text = $results | Get-Content
-            $text -match "information for current instance"
+            $results | Should Not BeNullOrEmpty
+            ($results | Get-Content) -contains "information for current instance"
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #6930 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
New-DbaDiagnosticAdsNotebook 
- function was failing to create notebook
- test was not failing
- error was thrown when trying to remove item that didn't exist

### Approach
- Fixed the wildcard search for the sql diagnostic queries
- Added additional test to ensure a file was created
- stopped remove-item from throwing error - tests will fail if the notebook doesn't exist now

### Commands to test
Create a notebook:
```
 New-DbaDiagnosticAdsNotebook -TargetVersion 2017 -Path $file -IncludeDatabaseSpecific
```

Run tests:
```
invoke-pester .\tests\New-DbaDiagnosticAdsNotebook.Tests.ps1
```
Before fix to function:
![image](https://user-images.githubusercontent.com/981370/96580147-c3f3d800-12cf-11eb-909f-6a284f997caf.png)
After fix to function:
![image](https://user-images.githubusercontent.com/981370/96580181-ce15d680-12cf-11eb-8be2-eaf3a97ca54d.png)



### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
