### PR TITLE
Make Add-DbaDbRoleMember show a warning if user not found

### DIFF
--- a/functions/Add-DbaDbRoleMember.ps1
+++ b/functions/Add-DbaDbRoleMember.ps1
@@ -148,7 +148,7 @@ function Add-DbaDbRoleMember {
                             }
                         }
                     } else {
-                        Write-Message -Level 'Verbose' -Message "User $username does not exist in $db on $instance"
+                        Write-Message -Level 'Warning' -Message "User $username does not exist in $db on $instance"
                     }
                 }
             }


### PR DESCRIPTION
If Add-DbaDdbRoleMember is called to add a user to a database role, but that user doesn't have a login the call fails silently. Have changed the message from 'Verbose' to 'Warning' to make this more obvious.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I spent too long trying to figure out that the database role I was trying to add to a login required New-DbaDbUser to be called first. The function wasn't returning any errors, though it was pointed out to me later that if I was running in Verbose mode I would have seen a warning. 

### Approach
Change the verbose message to a warning instead. 

### Commands to test
User RABBIT\SQLTestUser has a login on localhost, but not on DBAToolsTest database:
```
Add-DbaDbRoleMember -SqlInstance localhost -Role db_backupoperator -User RABBIT\SQLTestUser -Database DBAToolsTest
```
Currently, when this is run no output is returned, implying that the role addition has succeeded. However no changes have been made by this function. If this pull request is applied, the following result is seen:
```
Add-DbaDbRoleMember -SqlInstance localhost -Role db_backupoperator -User RABBIT\SQLTestUser -Database DBAToolsTest
WARNING: [18:27:38][Add-DbaDbRoleMember] User RABBIT\SQLTestUser does not exist in [DBAToolsTest] on [RABBIT]
```
Again, no changes have made made by this function, but the user ismade aware that they can;t assume the role has been added to the login.

### Screenshots
![initial-redacted](https://user-images.githubusercontent.com/2443698/97092671-c347a280-163d-11eb-9334-6a8053f5bcb2.jpg)


### Learning
I'd written some code using this function to add database roles, and everything seemed to work OK. Then when I tried it later it wasnt working any more. In retrospect, I was probably removing only the roles while testing the code, so the database login was present in the test database and everything seemed OK. The next day I must have removed the database login instead of the roles and it all stopped working, and I spent too long trying to figure out what went wrong. Some posts on the #dbatools Slack channel associating the New-DbaDbUser with the Add-DbaDbRoleMember led me to the problem resolution.
![learning-opportunity-redacted](https://user-images.githubusercontent.com/2443698/97092682-d195be80-163d-11eb-9dc5-ac2587885ea7.jpg)
![is-it-my-ignorance-redacted](https://user-images.githubusercontent.com/2443698/97092688-d8243600-163d-11eb-8ca0-89f37b85a3f4.jpg)

