### PR TITLE
Fix 5856 for Export-DbaRegServer

### DIFF
--- a/functions/Add-DbaRegServerGroup.ps1
+++ b/functions/Add-DbaRegServerGroup.ps1
@@ -129,8 +129,8 @@ function Add-DbaRegServerGroup {
                     $newgroup.Alter()
 
                     Get-DbaRegServerGroup -SqlInstance $currentInstance -Group (Get-RegServerGroupReverseParse -object $newgroup)
-                    if ($parentserver.ServerConnection) {
-                        $parentserver.ServerConnection.Disconnect()
+                    if ($currentInstance.ConnectionContext) {
+                        $currentInstance.ConnectionContext.Disconnect()
                     }
                 } catch {
                     Stop-Function -Message "Failed to add $reggroup" -ErrorRecord $_ -Continue

--- a/functions/Export-DbaRegServer.ps1
+++ b/functions/Export-DbaRegServer.ps1
@@ -23,12 +23,21 @@ function Export-DbaRegServer {
         Specifies the directory where the file or files will be exported.
 
     .PARAMETER FilePath
-        Specifies the full file path of the output file.
+        Specifies the full file path of the output file. The file must end with .xml or .regsrvr
 
     .PARAMETER InputObject
         Enables piping from Get-DbaRegServer, Get-DbaRegServerGroup, CSVs and other objects.
 
         If importing from CSV or other object, a column named ServerName is required. Optional columns include Name, Description and Group.
+
+    .PARAMETER Group
+        Specifies one or more groups to include.
+
+    .PARAMETER ExcludeGroup
+        Specifies one or more groups to exclude.
+
+    .PARAMETER Overwrite
+        Specifies to overwrite the output file (FilePath) if it already exists.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -73,47 +82,96 @@ function Export-DbaRegServer {
         [object[]]$InputObject,
         [string]$Path = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
         [Alias("OutFile", "FileName")]
-        [string]$FilePath,
+        [ValidateScript( {
+                if ($_.FullName -notmatch "\.xml$|\.regsrvr$") {
+                    throw "The FilePath specified must end with either .xml or .regsrvr"
+                }
+                return $true
+            })]
+        [System.IO.FileInfo]$FilePath,
         [ValidateSet("None", "PersistLoginName", "PersistLoginNameAndPassword")]
         [string]$CredentialPersistenceType = "None",
+        [object[]]$Group,
+        [object[]]$ExcludeGroup,
+        [switch]$Overwrite,
         [switch]$EnableException
     )
     begin {
         $null = Test-ExportDirectory -Path $Path
-        $timeNow = (Get-Date -uformat "%m%d%Y%H%M%S")
+        $timeNow = (Get-Date -UFormat "%m%d%Y%H%M%S")
+
+        # ValidateScript in the above param block relies on the order of the params specified by the user,
+        # so the creation of the file path and $Overwrite are evaluated here
+        if ($PSBoundParameters.ContainsKey("FilePath")) {
+            if (-not (Test-Path $FilePath) ) {
+                New-Item -Path $FilePath.DirectoryName -ItemType "directory" -Force | Out-Null # make sure the parent dir exists
+            } elseif (-not $Overwrite.IsPresent) {
+                throw [System.Management.Automation.RuntimeException] "Use the -Overwrite parameter if the file $FilePath should be overwritten."
+            }
+        }
     }
     process {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -Id 1
+            if ($PSBoundParameters.ContainsKey("Group")) {
+                if ($PSBoundParameters.ContainsKey("ExcludeGroup")) {
+                    $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -Group $Group -ExcludeGroup $ExcludeGroup
+                } else {
+                    $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -Group $Group
+                }
+            } elseif ($PSBoundParameters.ContainsKey("ExcludeGroup")) {
+                $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -ExcludeGroup $ExcludeGroup
+            } else {
+                $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -Id 1 # legacy behavior to return -Id 1 which means return everything
+            }
         }
 
         foreach ($object in $InputObject) {
             try {
                 if ($object -is [Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore]) {
-                    $object = Get-DbaRegServerGroup -SqlInstance $object.ParentServer -Id 1
+                    if ($PSBoundParameters.ContainsKey("Group")) {
+                        if ($PSBoundParameters.ContainsKey("ExcludeGroup")) {
+                            $object = Get-DbaRegServerGroup -SqlInstance $object.ParentServer -Group $Group -ExcludeGroup $ExcludeGroup
+                        } else {
+                            $object = Get-DbaRegServerGroup -SqlInstance $object.ParentServer -Group $Group
+                        }
+                    } elseif ($PSBoundParameters.ContainsKey("ExcludeGroup")) {
+                        $InputObject += Get-DbaRegServerGroup -SqlInstance $instance -SqlCredential $SqlCredential -ExcludeGroup $ExcludeGroup
+                    } else {
+                        $object = Get-DbaRegServerGroup -SqlInstance $object.ParentServer -Id 1 # legacy behavior to return -Id 1 which means return everything
+                    }
                 }
-                if ($object -is [Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer]) {
-                    if (-not $FilePath) {
+
+                if (($object -is [Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer]) -or ($object -is [Microsoft.SqlServer.Management.RegisteredServers.ServerGroup])) {
+                    $regname = $object.Name.Replace('\', '$')
+                    $OutputFilePath = $null
+
+                    if (-not $PSBoundParameters.ContainsKey("FilePath")) {
+                        $ExportFileName = $null
                         $serverName = $object.SqlInstance.Replace('\', '$');
-                        $regservername = $object.Name.Replace('\', '$')
-                        $ExportFileName = "$serverName-regserver-$regservername-$timeNow.xml"
-                        $FilePath = Join-DbaPath -Path $Path -Child $ExportFileName
-                        $object.Export($FilePath, $CredentialPersistenceType)
+
+                        if ($object -is [Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer]) {
+                            $ExportFileName = "$serverName-regserver-$regname-$timeNow.xml"
+                        } elseif ($object -is [Microsoft.SqlServer.Management.RegisteredServers.ServerGroup]) {
+                            $ExportFileName = "$serverName-reggroup-$regname-$timeNow.xml"
+                        }
+
+                        $OutputFilePath = Join-DbaPath -Path $Path -Child $ExportFileName
+                    } elseif ($InputObject.length -gt 1) {
+                        # more than one group was passed in, so we need to add the group name to the FilePath because there will be multiple files generated.
+                        $extension = [IO.Path]::GetExtension($FilePath.FullName)
+                        $OutputFilePath = $FilePath.FullName.Replace($extension, "-" + $regname + $extension)
+                    } else {
+                        $OutputFilePath = $FilePath.FullName
                     }
-                } elseif ($object -is [Microsoft.SqlServer.Management.RegisteredServers.ServerGroup]) {
-                    if (-not $FilePath) {
-                        $servername = $object.SqlInstance.Replace('\', '$')
-                        $regservergroup = $object.Name.Replace('\', '$')
-                        $ExportFileName = "$serverName-reggroup-$regservergroup-$timeNow.xml"
-                        $FilePath = Join-DbaPath -Path $Path -Child $ExportFileName
-                        $object.Export($FilePath, $CredentialPersistenceType)
-                    }
+
+                    $object.Export($OutputFilePath, $CredentialPersistenceType)
+
+                    Get-ChildItem $OutputFilePath -ErrorAction Stop
                 } else {
                     Stop-Function -Message "InputObject is not a registered server or server group" -Continue
                 }
-                Get-ChildItem $FilePath -ErrorAction Stop
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_
             }

--- a/functions/Export-DbaRegServer.ps1
+++ b/functions/Export-DbaRegServer.ps1
@@ -82,12 +82,6 @@ function Export-DbaRegServer {
         [object[]]$InputObject,
         [string]$Path = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
         [Alias("OutFile", "FileName")]
-        [ValidateScript( {
-                if ($_.FullName -notmatch "\.xml$|\.regsrvr$") {
-                    throw "The FilePath specified must end with either .xml or .regsrvr"
-                }
-                return $true
-            })]
         [System.IO.FileInfo]$FilePath,
         [ValidateSet("None", "PersistLoginName", "PersistLoginNameAndPassword")]
         [string]$CredentialPersistenceType = "None",
@@ -103,10 +97,16 @@ function Export-DbaRegServer {
         # ValidateScript in the above param block relies on the order of the params specified by the user,
         # so the creation of the file path and $Overwrite are evaluated here
         if ($PSBoundParameters.ContainsKey("FilePath")) {
+            if ($FilePath.FullName -notmatch "\.xml$|\.regsrvr$") {
+                Stop-Function -Message "The FilePath specified must end with either .xml or .regsrvr"
+                return
+            }
+
             if (-not (Test-Path $FilePath) ) {
                 New-Item -Path $FilePath.DirectoryName -ItemType "directory" -Force | Out-Null # make sure the parent dir exists
             } elseif (-not $Overwrite.IsPresent) {
-                throw [System.Management.Automation.RuntimeException] "Use the -Overwrite parameter if the file $FilePath should be overwritten."
+                Stop-Function -Message "Use the -Overwrite parameter if the file $FilePath should be overwritten."
+                return
             }
         }
     }

--- a/functions/Get-DbaRegServerGroup.ps1
+++ b/functions/Get-DbaRegServerGroup.ps1
@@ -140,7 +140,7 @@ function Get-DbaRegServerGroup {
             }
 
             if ($ExcludeGroup) {
-                $excluded = Get-DbaRegServer -SqlInstance $serverstore.ParentServer -Group $ExcludeGroup
+                $excluded = Get-DbaRegServerGroup -SqlInstance $serverstore.ParentServer -SqlCredential $SqlCredential -Group $ExcludeGroup
                 Write-Message -Level Verbose -Message "Excluding $ExcludeGroup"
                 $groups = $groups | Where-Object { $_.Urn.Value -notin $excluded.Urn.Value }
             }
@@ -150,7 +150,7 @@ function Get-DbaRegServerGroup {
                 if ($Id -eq 1) {
                     $groups = $serverstore.DatabaseEngineServerGroup
                 } else {
-                    $groups = $serverstore.DatabaseEngineServerGroup.GetDescendantRegisteredServers().Parent | Where-Object Id -in $Id
+                    $groups = $serverstore.DatabaseEngineServerGroup.GetDescendantRegisteredServers().Parent | Where-Object Id -In $Id
                 }
             }
             if ($serverstore.ServerConnection) {
@@ -158,10 +158,10 @@ function Get-DbaRegServerGroup {
             }
 
             foreach ($groupobject in $groups) {
-                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ComputerName -value $serverstore.ComputerName
-                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name InstanceName -value $serverstore.InstanceName
-                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name SqlInstance -value $serverstore.SqlInstance
-                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ParentServer -value $serverstore.ParentServer
+                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ComputerName -Value $serverstore.ComputerName
+                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name InstanceName -Value $serverstore.InstanceName
+                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name SqlInstance -Value $serverstore.SqlInstance
+                Add-Member -Force -InputObject $groupobject -MemberType NoteProperty -Name ParentServer -Value $serverstore.ParentServer
 
                 if ($groupobject.ComputerName) {
                     Select-DefaultView -InputObject $groupobject -Property ComputerName, InstanceName, SqlInstance, Name, DisplayName, Description, ServerGroups, RegisteredServers

--- a/tests/Export-DbaRegServer.Tests.ps1
+++ b/tests/Export-DbaRegServer.Tests.ps1
@@ -86,7 +86,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     It "Try to create an invalid file using FilePath" {
         $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.txt"
-        { Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName } | Should -Throw -ErrorId "ParameterArgumentValidationError,Export-DbaRegServer"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName
+        $results.length | Should -Be 0
     }
 
     It "Create an xml file using the FilePath alias FileName in a directory that does not yet exist" {
@@ -103,7 +104,8 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $results.FullName | Should -Be $outputFileName
 
         # test without -Overwrite
-        { Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName } | Should -Throw -ErrorId "RuntimeException"
+        $invalidResults = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName
+        $invalidResults.length | Should -Be 0
 
         # test with -Overwrite
         $resultsOverwrite = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName -Overwrite

--- a/tests/Export-DbaRegServer.Tests.ps1
+++ b/tests/Export-DbaRegServer.Tests.ps1
@@ -4,17 +4,17 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tags "UnitTests" {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'Path', 'FilePath', 'CredentialPersistenceType', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'Path', 'FilePath', 'CredentialPersistenceType', 'EnableException', 'Group', 'ExcludeGroup', 'Overwrite'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
-    BeforeAll {
+    BeforeEach {
         $srvName = "dbatoolsci-server1"
         $group = "dbatoolsci-group1"
         $regSrvName = "dbatoolsci-server12"
@@ -24,7 +24,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $newServer = Add-DbaRegServer -SqlInstance $script:instance2 -ServerName $srvName -Name $regSrvName -Description $regSrvDesc
 
         $srvName2 = "dbatoolsci-server2"
-        $group2 = "dbatoolsci-group1a"
+        $group2 = "dbatoolsci-group2"
         $regSrvName2 = "dbatoolsci-server21"
         $regSrvDesc2 = "dbatoolsci-server321"
 
@@ -36,14 +36,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $regSrvDesc3 = "dbatoolsci-server3desc"
 
         $newServer3 = Add-DbaRegServer -SqlInstance $script:instance2 -ServerName $srvName3 -Name $regSrvName3 -Description $regSrvDesc3
+
+        $random = Get-Random
+        $newDirectory = "C:\temp-$random"
     }
     AfterEach {
-        Get-DbaRegServer -SqlInstance $script:instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false
-        Get-DbaRegServerGroup -SqlInstance $script:instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
+        Get-DbaRegServer -SqlInstance $script:instance2 | Where-Object Name -Match dbatoolsci | Remove-DbaRegServer -Confirm:$false
+        Get-DbaRegServerGroup -SqlInstance $script:instance2 | Where-Object Name -Match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
         $results, $results2, $results3 | Remove-Item -ErrorAction Ignore
+
+        Remove-Item $newDirectory -ErrorAction Ignore -Recurse -Force
     }
 
-    It -Skip "should create an xml file" {
+    It "should create an xml file" {
         $results = $newServer | Export-DbaRegServer
         $results -is [System.IO.FileInfo] | Should -Be $true
         $results.Extension -eq '.xml' | Should -Be $true
@@ -53,15 +58,94 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $results2 = $newGroup2 | Export-DbaRegServer -Path C:\temp
         $results2 -is [System.IO.FileInfo] | Should -Be $true
         $results2.FullName | Should -match 'C\:\\temp'
-        Get-Content -Path $results2 -Raw | Should -Match dbatoolsci-group1a
+        Get-Content -Path $results2 -Raw | Should -Match $group2
     }
 
     It "creates an importable xml file" {
         $results3 = $newServer3 | Export-DbaRegServer -Path C:\temp
-        Get-DbaRegServer -SqlInstance $script:instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServer -Confirm:$false
-        Get-DbaRegServerGroup -SqlInstance $script:instance2 | Where-Object Name -match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
+        Get-DbaRegServer -SqlInstance $script:instance2 | Where-Object Name -Match dbatoolsci | Remove-DbaRegServer -Confirm:$false
+        Get-DbaRegServerGroup -SqlInstance $script:instance2 | Where-Object Name -Match dbatoolsci | Remove-DbaRegServerGroup -Confirm:$false
         $results4 = Import-DbaRegServer -SqlInstance $script:instance2 -Path $results3
         $newServer3.ServerName | Should -BeIn $results4.ServerName
         $newServer3.Description | Should -BeIn $results4.Description
+    }
+
+    It "Create an xml file using FilePath" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.xml"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName
+        $results -is [System.IO.FileInfo] | Should -Be $true
+        $results.FullName | Should -Be $outputFileName
+    }
+
+    It "Create a regsrvr file using the FilePath alias OutFile" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.regsrvr"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -OutFile $outputFileName
+        $results -is [System.IO.FileInfo] | Should -Be $true
+        $results.FullName | Should -Be $outputFileName
+    }
+
+    It "Try to create an invalid file using FilePath" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.txt"
+        { Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName } | Should -Throw -ErrorId "ParameterArgumentValidationError,Export-DbaRegServer"
+    }
+
+    It "Create an xml file using the FilePath alias FileName in a directory that does not yet exist" {
+        $outputFileName = "$newDirectory\dbatoolsci-regsrvr-export-$random.xml"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FileName $outputFileName
+        $results -is [System.IO.FileInfo] | Should -Be $true
+        $results.FullName | Should -Be $outputFileName
+    }
+
+    It "Ensure the Overwrite param is working" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.xml"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName
+        $results -is [System.IO.FileInfo] | Should -Be $true
+        $results.FullName | Should -Be $outputFileName
+
+        # test without -Overwrite
+        { Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName } | Should -Throw -ErrorId "RuntimeException"
+
+        # test with -Overwrite
+        $resultsOverwrite = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName -Overwrite
+        $resultsOverwrite -is [System.IO.FileInfo] | Should -Be $true
+        $resultsOverwrite.FullName | Should -Be $outputFileName
+    }
+
+    It "Test with the Group param" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.xml"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName -Group $group
+        $results -is [System.IO.FileInfo] | Should -Be $true
+        $results.FullName | Should -Be $outputFileName
+
+        $fileText = Get-Content -Path $results -Raw
+
+        $fileText | Should -Match $group
+        $fileText | Should -Not -Match $group2
+    }
+
+    It "Test with the Group param and multiple group names" {
+        $outputFileName = "C:\temp\dbatoolsci-regsrvr-export-$random.xml"
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -FilePath $outputFileName -Group @($group, $group2)
+        $results.length | Should -Be 2
+
+        $fileText = Get-Content -Path $results[0] -Raw
+
+        $fileText | Should -Match $group
+        $fileText | Should -Not -Match $group2
+
+        $fileText = Get-Content -Path $results[1] -Raw
+
+        $fileText | Should -Not -Match $group
+        $fileText | Should -Match $group2
+    }
+
+    It "Test with the ExcludeGroup param" {
+        $results = Export-DbaRegServer -SqlInstance $script:instance2 -ExcludeGroup $group2
+        $results -is [System.IO.FileInfo] | Should -Be $true
+
+        $fileText = Get-Content -Path $results -Raw
+
+        $fileText | Should -Match $group
+        $fileText | Should -Not -Match $group2
     }
 }


### PR DESCRIPTION
- Fixes #5856 by ensuring -FilePath is implemented
- Added -Group and -ExcludeGroup params
- Changed the command to allow for either .xml or .regsrvr file extensions
- Updated documentation for the new params
- Added more integration tests
- Fixed the implementation of -ExcludeGroup in Get-DbaRegServerGroup
- Fixed the Disconnect call in Add-DbaRegServerGroup

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #5856  )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
See comments above.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the pester test files.

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
Helpful resource:
https://4sysops.com/archives/validating-file-and-folder-paths-in-powershell-parameters/

