### PR TITLE
Copy-DbaLogin - Dynamically changing default database if missing

### DIFF
--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -359,7 +359,8 @@ function Copy-DbaLogin {
                         LoginRenameHashtable = $LoginRenameHashtable
                     }
                     if ($Login.DefaultDatabase -notin $destServer.Databases.Name) {
-                        Write-Message -Level Warning -Message "Database $($Login.DefaultDatabase) does not exist on $destServer, switching DefaultDatabase to 'master' for $($Login.Name)"
+                        $copyLoginStatus.Notes = "Database $($Login.DefaultDatabase) does not exist on $destServer, switching DefaultDatabase to 'master' for $($Login.Name)"
+                        Write-Message -Level Warning -Message $copyLoginStatus.Notes
                         $splatNewLogin.DefaultDatabase = 'master'
                     }
                     $destLogin = New-DbaLogin @splatNewLogin -EnableException:$true

--- a/functions/Copy-DbaLogin.ps1
+++ b/functions/Copy-DbaLogin.ps1
@@ -352,7 +352,17 @@ function Copy-DbaLogin {
 
                 Write-Message -Level Verbose -Message "Attempting to add $newUserName to $destinstance."
                 try {
-                    $destLogin = New-DbaLogin -SqlInstance $destServer -InputObject $Login -NewSid:$NewSid -LoginRenameHashtable:$LoginRenameHashtable -EnableException:$true
+                    $splatNewLogin = @{
+                        SqlInstance          = $destServer
+                        InputObject          = $Login
+                        NewSid               = $NewSid
+                        LoginRenameHashtable = $LoginRenameHashtable
+                    }
+                    if ($Login.DefaultDatabase -notin $destServer.Databases.Name) {
+                        Write-Message -Level Warning -Message "Database $($Login.DefaultDatabase) does not exist on $destServer, switching DefaultDatabase to 'master' for $($Login.Name)"
+                        $splatNewLogin.DefaultDatabase = 'master'
+                    }
+                    $destLogin = New-DbaLogin @splatNewLogin -EnableException:$true
                     $copyLoginStatus.Status = "Successful"
                 } catch {
                     $copyLoginStatus.Status = "Failed"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6860 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow users to copy logins that have weird default databases

### Approach
Check for DB existence, replace with master if not found, display a warning.
