### PR TITLE
Get-DbaPbmCondition - add integration test

### DIFF
--- a/tests/Get-DbaPbmCondition.Tests.ps1
+++ b/tests/Get-DbaPbmCondition.Tests.ps1
@@ -17,3 +17,55 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
     for more guidence.
 #>
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $conditionName = "dbatoolsCondition_$(get-random)"
+        $conditionQuery = "
+            Declare @condition_id int
+            EXEC msdb.dbo.sp_syspolicy_add_condition @name=N'$conditionName', @description=N'', @facet=N'Database', @expression=N'<Operator>
+            <TypeClass>Bool</TypeClass>
+            <OpType>EQ</OpType>
+            <Count>2</Count>
+            <Attribute>
+                <TypeClass>String</TypeClass>
+                <Name>Name</Name>
+            </Attribute>
+            <Constant>
+                <TypeClass>String</TypeClass>
+                <ObjType>System.String</ObjType>
+                <Value>test</Value>
+            </Constant>
+            </Operator>', @is_name_condition=1, @obj_name=N'test', @condition_id=@condition_id OUTPUT
+            Select @condition_id as conditionId"
+
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $conditionId = $server.Query($conditionQuery) | Select-Object -expand conditionId
+    }
+    AfterAll {
+        $dropQuery = "EXEC msdb.dbo.sp_syspolicy_delete_condition @condition_id=$conditionId"
+        $null = $server.Query($dropQuery)
+    }
+
+    Context "Command returns results" {
+        $results = Get-DbaPbmCondition -SqlInstance $script:instance2
+        It "Should get results" {
+            $results | Should Not Be $null
+        }
+
+        It "Should have name property '$conditionName'" {
+            $results.Name | Should Be $conditionName
+        }
+    }
+
+    Context "Command actually works by condition name" {
+        $results = Get-DbaPbmCondition -SqlInstance $script:instance2 -Condition $conditionName
+        It "Should get results" {
+            $results | Should Not Be $null
+        }
+
+        It "Should have name property '$conditionName'" {
+            $results.Name | Should Be $conditionName
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [X] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Noticed that this function didn't have any integration tests.

### Approach
Added simple test to ensure the command returns results when used with or without the `-Condition` parameter

### Commands to test
```
.\tests\manual.pester.ps1 -Path .\tests\Get-DbaPbmCondition.Tests.ps1 -TestIntegration -Coverage
```
![image](https://user-images.githubusercontent.com/981370/97274920-306d5a80-182d-11eb-8c47-cc4430fe9e1f.png)
