### PR TITLE
Fix 6875 for Get-DbaDependency

### DIFF
--- a/functions/Get-DbaDependency.ps1
+++ b/functions/Get-DbaDependency.ps1
@@ -31,9 +31,6 @@ function Get-DbaDependency {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-    .PARAMETER IncludeScript
-        Setting this switch will cause the function to also retrieve the creation script of the dependency.
-
     .NOTES
         Tags: Database, Dependent, Dependency, Object
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -228,7 +225,7 @@ function Get-DbaDependency {
             $limitCount = 2
             if ($IncludeSelf) { $limitCount = 1 }
             if ($tree.Count -lt $limitCount) {
-                Write-Message -Message "No dependencies detected for $($Item)" -Level Host
+                Write-Message -Message "No dependencies detected for $($Item)" -Level Important
                 continue
             }
 

--- a/tests/Get-DbaDependency.Tests.ps1
+++ b/tests/Get-DbaDependency.Tests.ps1
@@ -4,16 +4,92 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'InputObject', 'AllowSystemObjects', 'Parents', 'IncludeSelf', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'InputObject', 'AllowSystemObjects', 'Parents', 'IncludeSelf', 'EnableException'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidance.
-#>
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    BeforeAll {
+        $dbname = "dbatoolsscidb_$(Get-Random)"
+        $null = New-DbaDatabase -SqlInstance $script:instance1 -Name $dbname
+
+        $createTableScript = "IF OBJECT_ID('dbo.dbatoolsci_nodependencies') IS NOT NULL
+                            BEGIN
+                                DROP TABLE dbo.dbatoolsci_nodependencies;
+                            END
+
+                            IF OBJECT_ID('dbo.dbatoolsci3') IS NOT NULL
+                            BEGIN
+                                DROP TABLE dbo.dbatoolsci3;
+                            END
+
+                            IF OBJECT_ID('dbo.dbatoolsci2') IS NOT NULL
+                            BEGIN
+                                DROP TABLE dbo.dbatoolsci2;
+                            END
+
+                            IF OBJECT_ID('dbo.dbatoolsci1') IS NOT NULL
+                            BEGIN
+                                DROP TABLE dbo.dbatoolsci1;
+                            END
+
+                            CREATE TABLE dbo.dbatoolsci_nodependencies
+                            (
+                                ID INTEGER
+                            );
+
+                            CREATE TABLE dbo.dbatoolsci1
+                            (
+                                ID INTEGER PRIMARY KEY
+                            );
+
+                            CREATE TABLE dbo.dbatoolsci2
+                            (
+                                ID INTEGER PRIMARY KEY
+                            ,	ParentID INTEGER FOREIGN KEY REFERENCES dbo.dbatoolsci1(ID)
+                            );
+
+                            CREATE TABLE dbo.dbatoolsci3
+                            (
+                                ID INTEGER
+                            ,	ParentID INTEGER FOREIGN KEY REFERENCES dbo.dbatoolsci2(ID)
+                            );"
+
+
+        $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database $dbname -Query $createTableScript
+    }
+    AfterAll {
+        $null = Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
+    }
+
+    It "Test with a table that has no dependencies" {
+        $results = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table dbo.dbatoolsci_nodependencies | Get-DbaDependency -Parents
+        $results.length | Should -Be 0
+    }
+
+    It "Test with a table that has parent dependencies" {
+        $results = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table dbo.dbatoolsci2 | Get-DbaDependency -Parents
+        $results.length         | Should -Be 1
+        $results[0].Dependent   | Should -Be "dbatoolsci1"
+        $results[0].Tier        | Should -Be -1
+    }
+
+    It "Test with a table that has child dependencies" {
+        $results = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table dbo.dbatoolsci2 | Get-DbaDependency -IncludeSelf
+        $results.length | Should -Be 2
+        $results[1].Dependent   | Should -Be "dbatoolsci3"
+        $results[1].Tier        | Should -Be 1
+    }
+
+    It "Test with a table that has multiple levels of dependencies and use -IncludeSelf" {
+        $results = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table dbo.dbatoolsci3 | Get-DbaDependency -IncludeSelf -Parents
+        $results.length         | Should -Be 3
+        $results[0].Dependent   | Should -Be "dbatoolsci1"
+        $results[0].Tier        | Should -Be -2
+    }
+}


### PR DESCRIPTION
- Fixes #6875 by changing the log level to 'Important' since 'Host' is not a valid level. ‘Important’ has the same numeric value that was intended by Host (level 2).
- Added basic integration tests.
- Removed the documentation for the switch param 'IncludeScript' since it is not implemented in the command.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6875 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Minor change to update the log level.
