### PR TITLE
Fix 6864 for Get-DbaLastBackup

### DIFF
--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -59,6 +59,12 @@ function Get-DbaLastBackup {
         Returns a gridview displaying ComputerName, InstanceName, SqlInstance, Database, RecoveryModel, LastFullBackup, LastDiffBackup, LastLogBackup, SinceFull, SinceDiff, SinceLog, LastFullBackupIsCopyOnly, LastDiffBackupIsCopyOnly, LastLogBackupIsCopyOnly, DatabaseCreated, DaysSinceDbCreated, Status
 
     .EXAMPLE
+        PS C:\> $MyInstances | Get-DbaLastBackup | Where-Object -FilterScript { $_.LastFullBackup.Date -lt (Get-Date).AddDays(-3) } | Format-Table -Property SqlInstance, Database, LastFullBackup
+
+        Returns all databases on the given instances without a full backup in the last three days.
+        Note that the property LastFullBackup is a custom object, with the subproperty Date of type datetime and therefore suitable for comparison with dates.
+
+    .EXAMPLE
         PS C:\> Get-DbaLastBackup -SqlInstance ServerA\sql987 | Where-Object { $_.LastFullBackupIsCopyOnly -eq $true }
 
         Filters for the databases that had a copy_only full backup done as the last backup.

--- a/functions/Get-DbaLastBackup.ps1
+++ b/functions/Get-DbaLastBackup.ps1
@@ -56,8 +56,12 @@ function Get-DbaLastBackup {
     .EXAMPLE
         PS C:\> Get-DbaLastBackup -SqlInstance ServerA\sql987 | Select-Object * | Out-Gridview
 
-        Returns a gridview displaying Server, Database, RecoveryModel, LastFullBackup, LastDiffBackup, LastLogBackup, SinceFull, SinceDiff, SinceLog, Status, DatabaseCreated, DaysSinceDbCreated.
+        Returns a gridview displaying ComputerName, InstanceName, SqlInstance, Database, RecoveryModel, LastFullBackup, LastDiffBackup, LastLogBackup, SinceFull, SinceDiff, SinceLog, LastFullBackupIsCopyOnly, LastDiffBackupIsCopyOnly, LastLogBackupIsCopyOnly, DatabaseCreated, DaysSinceDbCreated, Status
 
+    .EXAMPLE
+        PS C:\> Get-DbaLastBackup -SqlInstance ServerA\sql987 | Where-Object { $_.LastFullBackupIsCopyOnly -eq $true }
+
+        Filters for the databases that had a copy_only full backup done as the last backup.
     #>
     [CmdletBinding()]
     param (
@@ -95,33 +99,41 @@ function Get-DbaLastBackup {
             if ($ExcludeDatabase) {
                 $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
             }
-            # Get-DbaDbBackupHistory -Last would make the job in one query but SMO's (and this) report the last backup of this type irregardless of the chain
+            # Get-DbaDbBackupHistory -Last would make the job in one query but SMO's (and this) report the last backup of this type regardless of the chain
             $FullHistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbs.Name -LastFull -IncludeCopyOnly -Raw
             $DiffHistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbs.Name -LastDiff -IncludeCopyOnly -Raw
-            $IncrHistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbs.Name -LastLog -IncludeCopyOnly -Raw
+            $LogHistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $dbs.Name -LastLog -IncludeCopyOnly -Raw
             foreach ($db in $dbs) {
                 Write-Message -Level Verbose -Message "Processing $db on $instance"
 
-                $LastFullBackup = ($FullHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
+                $LastFullBackup = ($FullHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
                 if ($null -ne $LastFullBackup) {
                     $SinceFull_ = [DbaTimeSpan](New-TimeSpan -Start $LastFullBackup)
                 } else {
                     $SinceFull_ = $StartOfTime
                 }
 
-                $LastDiffBackup = ($DiffHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
+                $LastFullBackupIsCopyOnly = ($FullHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).is_copy_only
+
+                $LastDiffBackup = ($DiffHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
                 if ($null -ne $LastDiffBackup) {
                     $SinceDiff_ = [DbaTimeSpan](New-TimeSpan -Start $LastDiffBackup)
                 } else {
                     $SinceDiff_ = $StartOfTime
                 }
 
-                $LastIncrBackup = ($IncrHistory | Where-Object Database -eq $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
-                if ($null -ne $LastIncrBackup) {
-                    $SinceLog_ = [DbaTimeSpan](New-TimeSpan -Start $LastIncrBackup)
+                # LastDiffBackupIsCopyOnly is always false because copy_only is not allowed with differential backups: https://docs.microsoft.com/en-us/sql/t-sql/statements/backup-transact-sql
+                # It is tempting to not include this property in the result object, however, it is low-cost to do so and makes the command more self-documenting.
+                $LastDiffBackupIsCopyOnly = ($DiffHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).is_copy_only
+
+                $LastLogBackup = ($LogHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).End
+                if ($null -ne $LastLogBackup) {
+                    $SinceLog_ = [DbaTimeSpan](New-TimeSpan -Start $LastLogBackup)
                 } else {
                     $SinceLog_ = $StartOfTime
                 }
+
+                $LastLogBackupIsCopyOnly = ($LogHistory | Where-Object Database -EQ $db.Name | Sort-Object -Property End -Descending | Select-Object -First 1).is_copy_only
 
                 $daysSinceDbCreated = (New-TimeSpan -Start $db.createDate).Days
 
@@ -136,22 +148,26 @@ function Get-DbaLastBackup {
                 }
 
                 $result = [PSCustomObject]@{
-                    ComputerName       = $server.ComputerName
-                    InstanceName       = $server.ServiceName
-                    SqlInstance        = $server.DomainInstanceName
-                    Database           = $db.Name
-                    RecoveryModel      = $db.RecoveryModel
-                    LastFullBackup     = [DbaDateTime]$LastFullBackup
-                    LastDiffBackup     = [DbaDateTime]$LastDiffBackup
-                    LastLogBackup      = [DbaDateTime]$LastIncrBackup
-                    SinceFull          = Get-DbaDateOrNull -TimeSpan $SinceFull_
-                    SinceDiff          = Get-DbaDateOrNull -TimeSpan $SinceDiff_
-                    SinceLog           = Get-DbaDateOrNull -TimeSpan $SinceLog_
-                    DatabaseCreated    = $db.createDate
-                    DaysSinceDbCreated = $daysSinceDbCreated
-                    Status             = $status
+                    ComputerName             = $server.ComputerName
+                    InstanceName             = $server.ServiceName
+                    SqlInstance              = $server.DomainInstanceName
+                    Database                 = $db.Name
+                    RecoveryModel            = $db.RecoveryModel
+                    LastFullBackup           = [DbaDateTime]$LastFullBackup
+                    LastDiffBackup           = [DbaDateTime]$LastDiffBackup
+                    LastLogBackup            = [DbaDateTime]$LastLogBackup
+                    SinceFull                = Get-DbaDateOrNull -TimeSpan $SinceFull_
+                    SinceDiff                = Get-DbaDateOrNull -TimeSpan $SinceDiff_
+                    SinceLog                 = Get-DbaDateOrNull -TimeSpan $SinceLog_
+                    LastFullBackupIsCopyOnly = $LastFullBackupIsCopyOnly
+                    LastDiffBackupIsCopyOnly = $LastDiffBackupIsCopyOnly # always false per https://docs.microsoft.com/en-us/sql/t-sql/statements/backup-transact-sql See comments above.
+                    LastLogBackupIsCopyOnly  = $LastLogBackupIsCopyOnly
+                    DatabaseCreated          = $db.createDate
+                    DaysSinceDbCreated       = $daysSinceDbCreated
+                    Status                   = $status
                 }
-                Select-DefaultView -InputObject $result -Property ComputerName, InstanceName, SqlInstance, Database, LastFullBackup, LastDiffBackup, LastLogBackup
+
+                Select-DefaultView -InputObject $result -Property ComputerName, InstanceName, SqlInstance, Database, LastFullBackup, LastDiffBackup, LastLogBackup, LastFullBackupIsCopyOnly, LastDiffBackupIsCopyOnly, LastLogBackupIsCopyOnly
             }
         }
     }

--- a/tests/Get-DbaLastBackup.Tests.ps1
+++ b/tests/Get-DbaLastBackup.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+            [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'EnableException'
+            $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -32,32 +32,32 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     }
 
     Context "Get null history for database" {
-        $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname
         It "doesn't have any values for last backups because none exist yet" {
-            $results.LastFullBackup | Should Be $null
-            $results.LastDiffBackup | Should Be $null
-            $results.LastLogBackup | Should Be $null
+            $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname
+            $results.LastFullBackup | Should -Be $null
+            $results.LastDiffBackup | Should -Be $null
+            $results.LastLogBackup  | Should -Be $null
         }
     }
 
-    $yesterday = (Get-Date).AddDays(-1)
-    $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir
-    $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir -Type Differential
-    $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir -Type Log
-
     Context "Get last history for single database" {
-        $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname
         It "returns a date within the proper range" {
-            [datetime]$results.LastFullBackup -gt $yesterday | Should Be $true
-            [datetime]$results.LastDiffBackup -gt $yesterday | Should Be $true
-            [datetime]$results.LastLogBackup -gt $yesterday | Should Be $true
+            $yesterday = (Get-Date).AddDays(-1)
+            $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir
+            $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir -Type Differential
+            $null = Get-DbaDatabase -SqlInstance $script:instance2 -Database $dbname | Backup-DbaDatabase -BackupDirectory $backupdir -Type Log
+            $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname
+            [datetime]$results.LastFullBackup -gt $yesterday    | Should -Be $true
+            [datetime]$results.LastDiffBackup -gt $yesterday    | Should -Be $true
+            [datetime]$results.LastLogBackup -gt $yesterday     | Should -Be $true
         }
     }
 
     Context "Get last history for all databases" {
-        $results = Get-DbaLastBackup -SqlInstance $script:instance2
         It "returns more than 3 databases" {
-            $results.count -gt 3 | Should Be $true
+            $results = Get-DbaLastBackup -SqlInstance $script:instance2
+            $results.count -gt 3                | Should -Be $true
+            $results.Database -contains $dbname | Should -Be $true
         }
     }
 
@@ -65,7 +65,30 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "supports multi-file backups" {
             $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -FileCount 4
             $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname | Select-Object -First 1
-            $results.LastFullBackup.GetType().Name | Should be "DbaDateTime"
+            $results.LastFullBackup.GetType().Name | Should -Be "DbaDateTime"
+        }
+    }
+
+    Context "Filter backups" {
+        It "by 'is_copy_only'" {
+            $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -BackupDirectory $backupdir -Type Full -CopyOnly
+            $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -BackupDirectory $backupdir -Type Log -CopyOnly
+
+            $results = Get-DbaLastBackup -SqlInstance $script:instance2
+            $copyOnlyFullBackup = ($results | Where-Object { $_.Database -eq $dbname -and $_.LastFullBackupIsCopyOnly -eq $true })
+            $copyOnlyLogBackup = ($results | Where-Object { $_.Database -eq $dbname -and $_.LastLogBackupIsCopyOnly -eq $true })
+
+            $copyOnlyFullBackup.Database   | Should -Be $dbname
+            $copyOnlyLogBackup.Database    | Should -Be $dbname
+
+
+            $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -BackupDirectory $backupdir -Type Full
+            $null = Backup-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -BackupDirectory $backupdir -Type Log
+
+            $results = Get-DbaLastBackup -SqlInstance $script:instance2 -Database $dbname
+
+            $results.LastFullBackupIsCopyOnly   | Should -Be $false
+            $results.LastLogBackupIsCopyOnly    | Should -Be $false
         }
     }
 }


### PR DESCRIPTION
Fixes #6864
- Added the is_copy_only to the default view of the result object.
- Changed 'Incr' to 'Log' in the variable names.
- Updated the documentation to show an accurate list of object properties and also an example of filtering on the copy only properties.
- Added a new integration test


<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number-->  )
 - [x] New feature (non-breaking change, adds functionality, fixes #6864 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Included new properties so that callers can filter or compare the value of 'is_copy_only' for the latest backup.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the help or integration tests.

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
