### PR TITLE
Improve Export-DbaUser

### DIFF
--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -158,7 +158,7 @@ function Export-DbaUser {
     begin {
         $null = Test-ExportDirectory -Path $Path
 
-        $outsql = $script:pathcollection = @()
+        $outsql = $script:pathcollection = $instanceArray = @()
         $GenerateFilePerUser = $false
 
         $versions = @{
@@ -228,8 +228,6 @@ function Export-DbaUser {
             } else {
                 # Generate a new file name with passed/default path
                 $FilePath = Get-ExportFilePath -Path $PSBoundParameters.Path -FilePath $PSBoundParameters.FilePath -Type sql -ServerName $db.Parent.Name -Unique
-                # Force append to have everything on same file
-                $Append = $true
             }
 
             # Store roles between users so if we hit the same one we don't create it again
@@ -493,7 +491,14 @@ function Export-DbaUser {
                             Get-ChildItem -Path $FilePath
                         }
                     } else {
-                        $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
+                        $dbUserInstance = $dbuser.Parent.Parent.Name
+
+                        if ($instanceArray -notcontains $($dbUserInstance)) {
+                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
+                            $instanceArray += $dbUserInstance
+                        } else {
+                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append
+                        }
                     }
                     # Clear variables for next user
                     $outsql = @()

--- a/functions/Export-DbaUser.ps1
+++ b/functions/Export-DbaUser.ps1
@@ -28,6 +28,19 @@ function Export-DbaUser {
     .PARAMETER DestinationVersion
         To say to which version the script should be generated. If not specified will use database compatibility level
 
+    .PARAMETER Encoding
+        Specifies the file encoding. The default is UTF8.
+
+        Valid values are:
+        -- ASCII: Uses the encoding for the ASCII (7-bit) character set.
+        -- BigEndianUnicode: Encodes in UTF-16 format using the big-endian byte order.
+        -- Byte: Encodes a set of characters into a sequence of bytes.
+        -- String: Uses the encoding type for a string.
+        -- Unicode: Encodes in UTF-16 format using the little-endian byte order.
+        -- UTF7: Encodes in UTF-7 format.
+        -- UTF8: Encodes in UTF-8 format.
+        -- Unknown: The encoding type is unknown or invalid. The data can be treated as binary.
+
     .PARAMETER Path
         Specifies the directory where the file or files will be exported.
 
@@ -145,6 +158,8 @@ function Export-DbaUser {
         [string]$Path = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
         [Alias("OutFile", "FileName")]
         [string]$FilePath,
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'Byte', 'String', 'Unicode', 'UTF7', 'UTF8', 'Unknown')]
+        [string]$Encoding = 'UTF8',
         [Alias("NoOverwrite")]
         [switch]$NoClobber,
         [switch]$Append,
@@ -487,17 +502,17 @@ function Export-DbaUser {
                     # If generate a file per user, clean the collection to populate with next one
                     if ($GenerateFilePerUser) {
                         if (-not [string]::IsNullOrEmpty($sql)) {
-                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
+                            $sql | Out-File -Encoding:$Encoding -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
                             Get-ChildItem -Path $FilePath
                         }
                     } else {
                         $dbUserInstance = $dbuser.Parent.Parent.Name
 
                         if ($instanceArray -notcontains $($dbUserInstance)) {
-                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
+                            $sql | Out-File -Encoding:$Encoding -FilePath $FilePath -Append:$Append -NoClobber:$NoClobber
                             $instanceArray += $dbUserInstance
                         } else {
-                            $sql | Out-File -Encoding UTF8 -FilePath $FilePath -Append
+                            $sql | Out-File -Encoding:$Encoding -FilePath $FilePath -Append
                         }
                     }
                     # Clear variables for next user

--- a/tests/Export-DbaUser.Tests.ps1
+++ b/tests/Export-DbaUser.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'User', 'DestinationVersion', 'Path', 'FilePath', 'InputObject', 'NoClobber', 'Append', 'EnableException', 'ScriptingOptionsObject', 'ExcludeGoBatchSeparator', 'Passthru', 'Template'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'User', 'DestinationVersion', 'Encoding', 'Path', 'FilePath', 'InputObject', 'NoClobber', 'Append', 'EnableException', 'ScriptingOptionsObject', 'ExcludeGoBatchSeparator', 'Passthru', 'Template'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6710 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

- Fix default behaviour - Overwrite existing file (instead of append)
- Add missing `-Encoding` parameter.

### Approach
<!-- How does this change solve that purpose -->
I have fixed the wrong default behaviour (reported on #6710). With this version, it will overwrite by default as other `Export-Dba*` commands.

I took the opportunity and I have also added the `-Encoding` parameter because was missing. (we have it on `Export-Dba*` commands)