### PR TITLE
Set-DbaMaxDop - Added Min and Max to Test-Bound to correct test for parameters

### DIFF
--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -104,7 +104,7 @@ function Set-DbaMaxDop {
     }
 
     process {
-        if (Test-Bound -ParameterName Database, AllDatabases, ExcludeDatabase) {
+        if (Test-Bound -Not -Min 0 -Max 1 -ParameterName Database, AllDatabases, ExcludeDatabase) {
             Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one."
             return
         }

--- a/functions/Set-DbaMaxDop.ps1
+++ b/functions/Set-DbaMaxDop.ps1
@@ -104,7 +104,7 @@ function Set-DbaMaxDop {
     }
 
     process {
-        if (Test-Bound -Not -Min 0 -Max 1 -ParameterName Database, AllDatabases, ExcludeDatabase) {
+        if (Test-Bound -Min 2 -ParameterName Database, AllDatabases, ExcludeDatabase) {
             Stop-Function -Category InvalidArgument -Message "-Database, -AllDatabases and -ExcludeDatabase are mutually exclusive. Please choose only one."
             return
         }

--- a/internal/functions/flowcontrol/Test-Bound.ps1
+++ b/internal/functions/flowcontrol/Test-Bound.ps1
@@ -16,6 +16,12 @@ function Test-Bound {
     .PARAMETER And
         All specified parameters must be present, rather than at least one of them.
 
+    .PARAMETER Min
+        At least the specified number of parameters out of the specified parameters must be present. Default is 1.
+
+    .PARAMETER Max
+        A maximum of the specified number of parameters out of the specified parameters may be present. Default is the length of ParameterName.
+
     .PARAMETER BoundParameters
         The hashtable of bound parameters. Is automatically inherited from the calling function via default value. Needs not be bound explicitly.
 
@@ -35,7 +41,17 @@ function Test-Bound {
     .EXAMPLE
         Test-Bound -And 'Login', 'Spid', 'ExcludeSpid', 'Host', 'Program', 'Database'
 
-        Returns whether any of the specified parameters was not bound
+        Returns whether any of the specified parameters was not bound.
+
+    .EXAMPLE
+        Test-Bound -ParameterName 'MinimumBuild', 'MaxBehind', 'Latest' -Max 1
+
+        Tests for mutually exclusive but necessary parameters.
+
+    .EXAMPLE
+        Test-Bound -ParameterName 'Database', 'AllDatabases', 'ExcludeDatabase' -Min 0 -Max 1
+
+        Tests for mutually exclusive but optional parameters.
     #>
     # Do not be tempted to use [CmdletBinding()] here, this will subtly change the way this function's parameters are bound, and break it.
     param (
@@ -49,6 +65,11 @@ function Test-Bound {
         [switch]
         $And,
 
+        [int]
+        $Min = 1,
+        [int]
+        $Max = $ParameterName.Length,
+
         [object]
         $BoundParameters = $($ExecutionContext.SessionState.PSVariable.Get('psboundparameters').Value)
     )
@@ -57,17 +78,20 @@ function Test-Bound {
     if (-not $BoundParameters) { return $false }
 
     if ($And) {
+        $Min = $ParameterName.Length
+    }
+
+    $usedParameters = 0
+    foreach ($name in $ParameterName) {
+        if ($BoundParameters.ContainsKey($name)) {
+            $usedParameters++
+        }
+    }
+
+    if ($usedParameters -ge $Min -and $usedParameters -le $Max) {
         $test = $true
     } else {
         $test = $false
-    }
-
-    foreach ($name in $ParameterName) {
-        if ($And) {
-            if (-not $BoundParameters.ContainsKey($name)) { $test = $false }
-        } else {
-            if ($BoundParameters.ContainsKey($name)) { $test = $true }
-        }
     }
 
     return ((-not $Not) -eq $test)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6965 )
 - [x] New feature (non-breaking change, adds functionality, fixes #6965 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Be able to have a simple test for mutually exclusive parameters.

### Approach
Added Min and Max to Test-Bound

### Commands to test
Should work:
```
Set-DbaMaxDop -SqlInstance SRV1\SQL2016
Set-DbaMaxDop -SqlInstance SRV1\SQL2016 -AllDatabases
```
Should fail:
```
Set-DbaMaxDop -SqlInstance SRV1\SQL2016 -AllDatabases -Database xy
```
