### PR TITLE
Backup-DbaDatabase - Allow CompressBackup to be used with TDE

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -456,9 +456,9 @@ function Backup-DbaDatabase {
                     $minVerForTDECompression = [version]'13.0.4446.0' # SQL Server 2016 CU 4
                     $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
                     $flagTestBoundMaxTransferSize = test-bound 'MaxTransferSize'
-                    $flag_correct_MaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 65536)
-                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flag_correct_MaxTransferSize) {
-                        write-message -Level Verbose "$dbName is enabled for encryption but will compress"
+                    $flagVcorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)
+                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flagVcorrectMaxTransferSize) {
+                        Write-Message -Level Verbose "$dbName is enabled for encryption but will compress"
                         $backup.CompressionOption = 1
                     } else {
                         Write-Message -Level Output -Message "$dbName is enabled for encryption, will not compress"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -456,8 +456,8 @@ function Backup-DbaDatabase {
                     $minVerForTDECompression = [version]'13.0.4446.0' # SQL Server 2016 CU 4
                     $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
                     $flagTestBoundMaxTransferSize = test-bound 'MaxTransferSize'
-                    $flagVcorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)
-                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flagVcorrectMaxTransferSize) {
+                    $flagCorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)
+                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flagCorrectMaxTransferSize) {
                         Write-Message -Level Verbose "$dbName is enabled for encryption but will compress"
                         $backup.CompressionOption = 1
                     } else {

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -461,7 +461,7 @@ function Backup-DbaDatabase {
                         Write-Message -Level Verbose "$dbName is enabled for encryption but will compress"
                         $backup.CompressionOption = 1
                     } else {
-                        Write-Message -Level Output -Message "$dbName is enabled for encryption, will not compress"
+                        Write-Message -Level Warning -Message "$dbName is enabled for encryption, will not compress"
                         $backup.CompressionOption = 2
                     }
                 } elseif ($server.Edition -like 'Express*' -or ($server.VersionMajor -eq 10 -and $server.VersionMinor -eq 0 -and $server.Edition -notlike '*enterprise*') -or $server.VersionMajor -lt 10) {

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -453,7 +453,7 @@ function Backup-DbaDatabase {
 
             if ($CompressBackup) {
                 if ($db.EncryptionEnabled) {
-                    $minVerForTDECompression = [version]'13.0.4446.0' # SQL Server 2016 CU 4
+                    $minVerForTDECompression = [version]'13.0.4446.0' #SQL Server 2016 CU 4
                     $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
                     $flagTestBoundMaxTransferSize = test-bound 'MaxTransferSize'
                     $flagCorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -453,14 +453,14 @@ function Backup-DbaDatabase {
 
             if ($CompressBackup) {
                 if ($db.EncryptionEnabled) {
-                    $minVerForTDECompression=[version]'13.0.4446.0' # SQL Server 2016 CU 4
-                    $flagTDESQLVersion= $minVerForTDECompression -le  $Server.version
-                    $flagTestBoundMaxTransferSize=test-bound 'MaxTransferSize'
-                    $flag_correct_MaxTransferSize= $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 65536)
-                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flag_correct_MaxTransferSize){
+                    $minVerForTDECompression = [version]'13.0.4446.0' # SQL Server 2016 CU 4
+                    $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
+                    $flagTestBoundMaxTransferSize = test-bound 'MaxTransferSize'
+                    $flag_correct_MaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 65536)
+                    if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flag_correct_MaxTransferSize) {
                         write-message -Level Verbose "$dbName is enabled for encryption but will compress"
                         $backup.CompressionOption = 1
-                    }else{
+                    } else {
                         Write-Message -Level Output -Message "$dbName is enabled for encryption, will not compress"
                         $backup.CompressionOption = 2
                     }

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -455,7 +455,7 @@ function Backup-DbaDatabase {
                 if ($db.EncryptionEnabled) {
                     $minVerForTDECompression = [version]'13.0.4446.0' #SQL Server 2016 CU 4
                     $flagTDESQLVersion = $minVerForTDECompression -le $Server.version
-                    $flagTestBoundMaxTransferSize = test-bound 'MaxTransferSize'
+                    $flagTestBoundMaxTransferSize = Test-Bound 'MaxTransferSize'
                     $flagCorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)
                     if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flagCorrectMaxTransferSize) {
                         Write-Message -Level Verbose "$dbName is enabled for encryption but will compress"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -458,7 +458,7 @@ function Backup-DbaDatabase {
                     $flagTestBoundMaxTransferSize = Test-Bound 'MaxTransferSize'
                     $flagCorrectMaxTransferSize = $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 64kb)
                     if ($flagTDESQLVersion -and $flagTestBoundMaxTransferSize -and $flagCorrectMaxTransferSize) {
-                        Write-Message -Level Verbose "$dbName is enabled for encryption but will compress"
+                        Write-Message -Level Verbose -Message "$dbName is enabled for encryption but will compress"
                         $backup.CompressionOption = 1
                     } else {
                         Write-Message -Level Warning -Message "$dbName is enabled for encryption, will not compress"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -453,7 +453,7 @@ function Backup-DbaDatabase {
 
             if ($CompressBackup) {
                 if ($db.EncryptionEnabled) {
-                    $minVerForTDECompression=[version]'13.0.4446.0' # SQL Server 2016 CU 4 
+                    $minVerForTDECompression=[version]'13.0.4446.0' # SQL Server 2016 CU 4
                     $flagTDESQLVersion= $minVerForTDECompression -le  $Server.version
                     $flagTestBoundMaxTransferSize=test-bound 'MaxTransferSize'
                     $flag_correct_MaxTransferSize= $flagTestBoundMaxTransferSize -and ($MaxTransferSize -gt 65536)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6963 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
This PR corrects the behavior in the backup of an encrypted database. In the dbatools' current version, if a user requires a compressed backup of an encrypted database, the compression is disabled. Based on the the blog posts I attached, the backup compression of an encrypted database is supported without bug since SQL 2016 CU 7 or SQL 2016 SP1 CU 4 it some condition are met. The conditions are that *MAXTRANSFERSIZE* is specified in the *BACKUP* command and its value is greater than 65536.

### Approach
I added some lines that calculate the conditions:
 - SQL Server version is greater than 13.0.4446.0, SQL Server 2016 CU 4
 - MAXTRANSFERSIZE is a specified as parameter 
 - MAXTRANSFERSIZE value is greater than 65536
if the logical AND of these conditions is true, the backup compression is not disabled. If these conditions are not met, the compression is disabled.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
```powershell
Backup-DbaDatabase -SqlInstance $target_instance -Database $mydb -FilePath $backup_filename -Type $backup_type -CreateFolder -CompressBackup -FileCount 1 -WithFormat -EnableException -WhatIf:$false -Verbose:$true -MaxTransferSize 1048576 -OutputScriptOnly
```


### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
 - https://www.brentozar.com/archive/2016/07/tde-backup-compression-together-last/
 - https://docs.microsoft.com/en-us/archive/blogs/sql_server_team/backup-compression-for-tde-enabled-databases-important-fixes-in-sql-2016-sp1-cu4-and-sql-2016-rtm-cu7
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
