### PR TITLE
New-DbaDatabase - Ensure Autogrowth is set in all cases (#6780)

### DIFF
--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -76,6 +76,12 @@ function New-DbaDatabase {
     .PARAMETER DefaultFileGroup
         Sets the default file group. Either primary or secondary.
 
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -6,7 +6,13 @@ function New-DbaDatabase {
     .DESCRIPTION
         This command creates a new database.
 
-        It allows creation with multiple files, and sets all growth settings to be fixed size rather than percentage growth.
+        It allows creation with multiple files, and sets all growth settings to be fixed size rather than percentage growth. The autogrowth settings are obtained from the modeldev file in the model database when not supplied as command line arguments.
+
+        The generated database filenames take the form:
+
+        <db name>_PRIMARY
+        <db name>_Log
+        <db name>_MainData_1  (Secondary filegroup files)
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -30,7 +36,7 @@ function New-DbaDatabase {
     .PARAMETER Collation
         The database collation, if not supplied the default server collation will be used.
 
-    .PARAMETER Recoverymodel
+    .PARAMETER RecoveryModel
         The recovery model for the database, if not supplied the recovery model from the model database will be used.
         Valid options are: Simple, Full, BulkLogged.
 
@@ -44,13 +50,16 @@ function New-DbaDatabase {
         The size in MB that the Primary file will autogrow by.
 
     .PARAMETER PrimaryFileMaxSize
-        The maximum permitted size in MB for the Primary File. If this is less the primary file size for the model database, then the model size will be used instead.
+        The maximum permitted size in MB for the Primary File. If this is less than the primary file size for the model database, then the model size will be used instead.
 
     .PARAMETER LogSize
         The size in MB that the Transaction log will be created.
 
     .PARAMETER LogGrowth
         The amount in MB that the log file will be set to autogrow by.
+
+    .PARAMETER LogMaxSize
+        The maximum permitted size in MB. If this is less than the log file size for the model database, then the model log size will be used instead.
 
     .PARAMETER SecondaryFileCount
         The number of files to create in the Secondary filegroup for the database.
@@ -66,12 +75,6 @@ function New-DbaDatabase {
 
     .PARAMETER DefaultFileGroup
         Sets the default file group. Either primary or secondary.
-
-    .PARAMETER WhatIf
-        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
-
-    .PARAMETER Confirm
-        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -111,6 +114,15 @@ function New-DbaDatabase {
 
         Creates a secondary group with 2 files in the Secondary filegroup.
 
+    .EXAMPLE
+        New-DbaDatabase -SqlInstance sql1 -Name newDb -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64
+
+        Creates a new database named newDb on the sql1 instance and sets the file sizes, max sizes, and growth as specified. The resulting filenames will take the form:
+
+        newDb_PRIMARY
+        newDb_Log
+        newDb_MainData_1  (Secondary filegroup files)
+
     #>
     [Cmdletbinding(SupportsShouldProcess, ConfirmImpact = "Low")]
     param
@@ -122,7 +134,7 @@ function New-DbaDatabase {
         [string[]]$Name,
         [string]$Collation,
         [ValidateSet('Simple', 'Full', 'BulkLogged')]
-        [string]$Recoverymodel,
+        [string]$RecoveryModel,
         [string]$Owner,
         [string]$DataFilePath,
         [string]$LogFilePath,
@@ -131,6 +143,7 @@ function New-DbaDatabase {
         [int32]$PrimaryFileMaxSize,
         [int32]$LogSize,
         [int32]$LogGrowth,
+        [int32]$LogMaxSize,
         [int32]$SecondaryFilesize,
         [int32]$SecondaryFileGrowth,
         [int32]$SecondaryFileMaxSize,
@@ -142,23 +155,8 @@ function New-DbaDatabase {
 
     begin {
         # do some checks to see if the advanced config settings will be invoked
-        if (Test-Bound -ParameterName DataFilePath, LogFilePath, DefaultFileGroup) {
+        if (Test-Bound -ParameterName DataFilePath, DefaultFileGroup, LogFilePath, LogGrowth, LogMaxSize, LogSize, PrimaryFileGrowth, PrimaryFileMaxSize, PrimaryFilesize, SecondaryFileCount, SecondaryFileGrowth, SecondaryFileMaxSize, SecondaryFilesize) {
             $advancedconfig = $true
-        }
-
-        if (Test-Bound -ParameterName PrimaryFilesize, PrimaryFileGrowth, PrimaryFileMaxSize) {
-            $advancedconfig = $true
-        }
-
-        if (Test-Bound -ParameterName LogSize, LogGrowth) {
-            $advancedconfig = $true
-        }
-
-        if (Test-Bound -ParameterName SecondaryFilesize, SecondaryFileMaxSize, SecondaryFileGrowth, SecondaryFileCount) {
-            $advancedconfig = $true
-        }
-
-        if ($advancedconfig) {
             Write-Message -Message "Advanced data file configuration will be invoked" -Level Verbose
         }
     }
@@ -177,6 +175,15 @@ function New-DbaDatabase {
 
             if ($advancedconfig -and $server.VersionMajor -eq 8) {
                 Stop-Function -Message "Advanced configuration options are not available to SQL Server 2000. Aborting creation of database on $instance" -Target $instance -Continue
+            }
+
+            # validate the collation
+            if ($Collation) {
+                $collations = Get-DbaAvailableCollation -SqlInstance $instance
+
+                if ($collations.Name -notcontains $Collation) {
+                    Stop-Function -Message "$Collation is not a valid collation on $instance" -Target $instance -Continue
+                }
             }
 
             if (-not (Test-Bound -ParameterName Name)) {
@@ -228,9 +235,9 @@ function New-DbaDatabase {
                     $newdb.Collation = $Collation
                 }
 
-                if ($Recoverymodel) {
-                    Write-Message -Message "Setting recovery model to $Recoverymodel" -Level Verbose
-                    $newdb.Recoverymodel = $Recoverymodel
+                if ($RecoveryModel) {
+                    Write-Message -Message "Setting recovery model to $RecoveryModel" -Level Verbose
+                    $newdb.RecoveryModel = $RecoveryModel
                 }
 
                 if ($advancedconfig) {
@@ -247,7 +254,7 @@ function New-DbaDatabase {
                         $primaryfilename = $dbName + "_PRIMARY"
                         Write-Message -Message "Creating file name $primaryfilename in filegroup PRIMARY" -Level Verbose
 
-                        #check the size of the modeldev file; if larger than our $PrimaryFilesize setting use that instead
+                        # if PrimaryFilesize and PrimaryFileMaxSize were passed in then check the size of the modeldev file; if larger than our $PrimaryFilesize setting use that instead
                         if ($server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size -gt ($PrimaryFilesize * 1024)) {
                             Write-Message -Message "model database modeldev larger than our the PrimaryFilesize so using modeldev size for Primary file" -Level Verbose
                             $PrimaryFilesize = ($server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size / 1024)
@@ -257,20 +264,27 @@ function New-DbaDatabase {
                             }
                         }
 
-                        #create the filegroup object
+                        #create the primary file
                         $primaryfile = New-Object Microsoft.SqlServer.Management.Smo.DataFile($primaryfg, $primaryfilename)
                         $primaryfile.FileName = $DataFilePath + "\" + $primaryfilename + ".mdf"
                         $primaryfile.IsPrimaryFile = $true
 
                         if (Test-Bound -ParameterName PrimaryFilesize) {
                             $primaryfile.Size = ($PrimaryFilesize * 1024)
+                        } else {
+                            $primaryfile.Size = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
                         }
                         if (Test-Bound -ParameterName PrimaryFileGrowth) {
                             $primaryfile.Growth = ($PrimaryFileGrowth * 1024)
                             $primaryfile.GrowthType = "KB"
+                        } else {
+                            $primaryfile.Growth = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+                            $primaryfile.GrowthType = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
                         }
                         if (Test-Bound -ParameterName PrimaryFileMaxSize) {
                             $primaryfile.MaxSize = ($PrimaryFileMaxSize * 1024)
+                        } else {
+                            $primaryfile.MaxSize = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].MaxSize
                         }
 
                         #add the file to the filegroup
@@ -283,10 +297,14 @@ function New-DbaDatabase {
                         $logname = $dbName + "_Log"
                         Write-Message -Message "Creating log $logname" -Level Verbose
 
-                        #check the size of the modellog file; if larger than our $LogSize setting use that instead
+                        # if LogSize and LogMaxSize were passed in then check the size of the modellog file; if larger than our $LogSize setting use that instead
                         if ($server.Databases["model"].LogFiles["modellog"].Size -gt ($LogSize * 1024)) {
                             Write-Message -Message "model database modellog larger than our the LogSize so using modellog size for Log file size" -Level Verbose
                             $LogSize = ($server.Databases["model"].LogFiles["modellog"].Size / 1024)
+                            if ($LogSize -gt $LogMaxSize) {
+                                Write-Message -Message "Resetting Log File Max size to be the new Log File Size setting" -Level Verbose
+                                $LogMaxSize = $LogSize
+                            }
                         }
 
                         $tlog = New-Object Microsoft.SqlServer.Management.Smo.LogFile($newdb, $logname)
@@ -294,10 +312,20 @@ function New-DbaDatabase {
 
                         if (Test-Bound -ParameterName LogSize) {
                             $tlog.Size = ($LogSize * 1024)
+                        } else {
+                            $tlog.Size = $server.Databases["model"].LogFiles["modellog"].Size
                         }
                         if (Test-Bound -ParameterName LogGrowth) {
                             $tlog.Growth = ($LogGrowth * 1024)
                             $tlog.GrowthType = "KB"
+                        } else {
+                            $tlog.Growth = $server.Databases["model"].LogFiles["modellog"].Growth
+                            $tlog.GrowthType = $server.Databases["model"].LogFiles["modellog"].GrowthType
+                        }
+                        if (Test-Bound -ParameterName LogMaxSize) {
+                            $tlog.MaxSize = ($LogMaxSize * 1024)
+                        } else {
+                            $tlog.MaxSize = $server.Databases["model"].LogFiles["modellog"].MaxSize
                         }
 
                         #add the log to the db
@@ -306,7 +334,7 @@ function New-DbaDatabase {
                         Stop-Function -Message "Error adding log file to database." -ErrorRecord $_ -Target $instance -Continue
                     }
 
-                    if (Test-Bound -ParameterName SecondaryFileMaxSize, SecondaryFileGrowth, SecondaryFilesize) {
+                    if ($DefaultFileGroup -eq "Secondary" -or (Test-Bound -ParameterName SecondaryFileMaxSize, SecondaryFileGrowth, SecondaryFilesize, SecondaryFileCount)) {
                         #add the Secondary data file group
                         try {
                             $secondaryfilegroupname = $dbName + "_MainData"
@@ -316,6 +344,16 @@ function New-DbaDatabase {
                             $newdb.Filegroups.Add($secondaryfg)
                         } catch {
                             Stop-Function -Message "Error creating Secondary filegroup" -ErrorRecord $_ -Target $instance -Continue
+                        }
+
+                        # if SecondaryFilesize and SecondaryFileMaxSize were passed in then check the size of the modeldev file; if larger than our $SecondaryFilesize setting use that instead
+                        if ($server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size -gt ($SecondaryFilesize * 1024)) {
+                            Write-Message -Message "model database modeldev larger than our the SecondaryFilesize so using modeldev size for the Secondary file" -Level Verbose
+                            $SecondaryFilesize = ($server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size / 1024)
+                            if ($SecondaryFilesize -gt $SecondaryFileMaxSize) {
+                                Write-Message -Message "Resetting Secondary File Max size to be the new Secondary File Size setting" -Level Verbose
+                                $SecondaryFileMaxSize = $SecondaryFilesize
+                            }
                         }
 
                         # add the required number of files to the filegroup in a loop
@@ -332,13 +370,20 @@ function New-DbaDatabase {
 
                                 if (Test-Bound -ParameterName SecondaryFilesize) {
                                     $secondaryfile.Size = ($SecondaryFilesize * 1024)
+                                } else {
+                                    $secondaryfile.Size = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
                                 }
                                 if (Test-Bound -ParameterName SecondaryFileGrowth) {
                                     $secondaryfile.Growth = ($SecondaryFileGrowth * 1024)
                                     $secondaryfile.GrowthType = "KB"
+                                } else {
+                                    $secondaryfile.Growth = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+                                    $secondaryfile.GrowthType = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
                                 }
                                 if (Test-Bound -ParameterName SecondaryFileMaxSize) {
                                     $secondaryfile.MaxSize = ($SecondaryFileMaxSize * 1024)
+                                } else {
+                                    $secondaryfile.MaxSize = $server.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].MaxSize
                                 }
 
                                 $secondaryfg.Files.Add($secondaryfile)
@@ -347,7 +392,7 @@ function New-DbaDatabase {
                                 Stop-Function -Message "Error adding file $secondaryfg to $secondaryfilegroupname" -ErrorRecord $_ -Target $instance
                                 return
                             }
-                        } while ($secondaryfgcount -le $SecondaryFileCount -or $bail)
+                        } while ($secondaryfgcount -lt $SecondaryFileCount -or $bail)
                     }
                 }
 
@@ -374,7 +419,7 @@ function New-DbaDatabase {
                         try {
                             $newdb.SetDefaultFileGroup($secondaryfilegroupname)
                         } catch {
-                            Stop-Function -Message "Error setting default filegorup to $secondaryfilegroupname" -ErrorRecord $_ -Target $instance -Continue
+                            Stop-Function -Message "Error setting default filegroup to $secondaryfilegroupname" -ErrorRecord $_ -Target $instance -Continue
                         }
                     }
 

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -4,38 +4,147 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Collation', 'Recoverymodel', 'Owner', 'DataFilePath', 'LogFilePath', 'PrimaryFilesize', 'PrimaryFileGrowth', 'PrimaryFileMaxSize', 'LogSize', 'LogGrowth', 'SecondaryFilesize', 'SecondaryFileGrowth', 'SecondaryFileMaxSize', 'SecondaryFileCount', 'DefaultFileGroup', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Name', 'Collation', 'Recoverymodel', 'Owner', 'DataFilePath', 'LogFilePath', 'PrimaryFilesize', 'PrimaryFileGrowth', 'PrimaryFileMaxSize', 'LogSize', 'LogGrowth', 'LogMaxSize', 'SecondaryFilesize', 'SecondaryFileGrowth', 'SecondaryFileMaxSize', 'SecondaryFileCount', 'DefaultFileGroup', 'EnableException'
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
     }
 }
 
 Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
+        $null = Get-DbaProcess -SqlInstance $instance2, $instance3 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $randomDb = New-DbaDatabase -SqlInstance $instance2
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb1Name = "dbatoolsci_newdb1_$random"
+        $newDb2Name = "dbatoolsci_newdb2_$random"
+        $bug6780DbName = "dbatoolsci_6780_$random"
+        $collationDbName = "dbatoolsci_collation_$random"
+        $secondaryFileTestDbName = "dbatoolsci_secondaryfiletest_$random"
+        $secondaryFileCountTestDbName = "dbatoolsci_secondaryfilecounttest_$random"
+        $simpleRecoveryModelDbName = "dbatoolsci_simple_$random"
+        $fullRecoveryModelDbName = "dbatoolsci_full_$random"
+        $bulkLoggedRecoveryModelDbName = "dbatoolsci_bulklogged_$random"
+        $primaryFileGroupDbName = "dbatoolsci_primary_filegroup_$random"
+        $secondaryFileGroupDbName = "dbatoolsci_secondary_filegroup_$random"
+    }
+
+    AfterAll {
+        $null = Remove-DbaDatabase -SqlInstance $instance2 -Database $randomDb.Name, $newDbName, $newDb1Name, $newDb2Name, $bug6780DbName, $collationDbName, $simpleRecoveryModelDbName, $fullRecoveryModelDbName, $bulkLoggedRecoveryModelDbName -Confirm:$false
+        $null = Remove-DbaDatabase -SqlInstance $instance3 -Database $newDbName, $newDb1Name, $newDb2Name, $secondaryFileTestDbName, $secondaryFileCountTestDbName, $primaryFileGroupDbName, $secondaryFileGroupDbName -Confirm:$false
+    }
+
     Context "commands work as expected" {
-        $null = Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
-        $results = New-DbaDatabase -SqlInstance $script:instance2
+
         It "creates one new randomly named database" {
-            $results.Name | Should -Match random
-            $results | Remove-DbaDatabase -Confirm:$false
+            $randomDb.Name | Should -Match random
         }
 
-        $null = Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
-        $results = New-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Name dbatoolsci_newdb
         It "creates one new database on two servers" {
-            $results.Name | Should -Be 'dbatoolsci_newdb', 'dbatoolsci_newdb'
-            $results | Remove-DbaDatabase -Confirm:$false
+            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64
+            $newDbOnTwoServers.Count | Should -Be 2
+            $newDbOnTwoServers[0].Name | Should -Be $newDbName
+            $newDbOnTwoServers[1].Name | Should -Be $newDbName
+
+            $instance2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
+            $instance2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
+            $instance2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
+            $instance2.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be 'KB'
+
+            $instance2.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
+            $instance2.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
+            $instance2.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
+            $instance2.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be 'KB'
+
+            $instance2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
+            $instance2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
+            $instance2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
+            $instance2.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be 'KB'
+
+            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Size | Should -Be 65536
+            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].MaxSize | Should -Be 524288
+            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].Growth | Should -Be 65536
+            $instance3.Databases[$newDbName].FileGroups["PRIMARY"].Files["$($newDbName)_PRIMARY"].GrowthType | Should -Be 'KB'
+
+            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].Size | Should -Be 32768
+            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].MaxSize | Should -Be 524288
+            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].Growth | Should -Be 32768
+            $instance3.Databases[$newDbName].LogFiles["$($newDbName)_log"].GrowthType | Should -Be 'KB'
+
+            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Size | Should -Be 65536
+            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].MaxSize | Should -Be 524288
+            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].Growth | Should -Be 65536
+            $instance3.Databases[$newDbName].FileGroups["$($newDbName)_MainData"].Files[0].GrowthType | Should -Be 'KB'
         }
 
-        $null = Get-DbaProcess -SqlInstance $script:instance2, $script:instance3 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
-        $results = New-DbaDatabase -SqlInstance $script:instance2, $script:instance3 -Name dbatoolsci_newdb1, dbatoolsci_newdb2
         It "creates two new databases on two servers" {
-            $results.Name | Should -Contain dbatoolsci_newdb1
-            $results.Name | Should -Contain dbatoolsci_newdb2
-            $results.Count | Should -Be 4
-            $results | Remove-DbaDatabase -Confirm:$false
+            $multipleDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDb1Name, $newDb2Name
+            $multipleDbOnTwoServers.Count | Should -Be 4
+            $multipleDbOnTwoServers[0].Name | Should -Be $newDb1Name
+            $multipleDbOnTwoServers[1].Name | Should -Be $newDb2Name
+        }
+
+        It "bug 6780 autogrowth params" {
+            $db6780 = New-DbaDatabase -SqlInstance $instance2 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1
+            $db6780.Count | Should -Be 1
+
+            $instance2.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].Growth | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+            $instance2.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].GrowthType | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
+
+            $instance2.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].Growth | Should -Be $instance2.Databases["model"].LogFiles["modellog"].Growth
+            $instance2.Databases[$bug6780DbName].LogFiles["$($bug6780DbName)_log"].GrowthType | Should -Be $instance2.Databases["model"].LogFiles["modellog"].GrowthType
+
+            # also check the randomDb since it was created without any additional params
+            $instance2.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].Growth | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
+            $instance2.Databases[$($randomDb.Name)].FileGroups["PRIMARY"].Files["$($randomDb.Name)"].GrowthType | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].GrowthType
+
+            $instance2.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].Growth | Should -Be $instance2.Databases["model"].LogFiles["modellog"].Growth
+            $instance2.Databases[$($randomDb.Name)].LogFiles["$($randomDb.Name)_log"].GrowthType | Should -Be $instance2.Databases["model"].LogFiles["modellog"].GrowthType
+        }
+
+        It "collation is validated" {
+            $collationDb = New-DbaDatabase -SqlInstance $instance2 -Name $collationDbName -Collation "invalid_collation"
+            $collationDb | Should -BeNull
+
+            $collationDb = New-DbaDatabase -SqlInstance $instance2 -Name $collationDbName -Collation $instance2.Databases["model"].Collation
+            $instance2.Databases[$collationDbName].Collation | Should -Be $instance2.Databases["model"].Collation
+        }
+
+        It "SecondaryFilesize is specified but not the SecondaryFileCount" {
+            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10
+            $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files.Count | Should -Be 1
+            $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files[0].Size | Should -Be 10240
+        }
+
+        It "SecondaryFileCount is specified but not the other secondary file params" {
+            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2
+            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files.Count | Should -Be 2
+            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[0].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
+            $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[1].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
+        }
+
+        It "RecoveryModel" {
+            $simpleRecoveryModelDb = New-DbaDatabase -SqlInstance $instance2 -Name $simpleRecoveryModelDbName -RecoveryModel Simple
+            $simpleRecoveryModelDb.RecoveryModel | Should -Be "Simple"
+
+            $fullRecoveryModelDb = New-DbaDatabase -SqlInstance $instance2 -Name $fullRecoveryModelDbName -RecoveryModel Full
+            $fullRecoveryModelDb.RecoveryModel | Should -Be "Full"
+
+            $bulkLoggedRecoveryModelDb = New-DbaDatabase -SqlInstance $instance2 -Name $bulkLoggedRecoveryModelDbName -RecoveryModel BulkLogged
+            $bulkLoggedRecoveryModelDb.RecoveryModel | Should -Be "BulkLogged"
+        }
+
+        It "DefaultFileGroup" {
+            $primaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $primaryFileGroupDbName -DefaultFileGroup "Primary"
+            $primaryFileGroupDb.DefaultFileGroup | Should -Be "PRIMARY"
+
+            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary"
+            $secondaryFileGroupDb.DefaultFileGroup | Should -Be "$($secondaryFileGroupDbName)_MainData"
         }
     }
 }


### PR DESCRIPTION
- Updated to set the autogrowth based on the model db when the caller has not specified the growth parameters
- Consolidated the parameter validation for the 'advanced config' workflow
- Fixed bug with "-SecondaryFileCount 1" resulting in two secondary files because of the do-while comparison operator
- Added a parameter for LogMaxSize
- Added validation for the db collation
- Updated the SecondaryFileSize and SecondaryFileMaxSize to be modified based on the model db similar to how it is done for the PrimaryFileSize and PrimaryFileMaxSize
- Added logic to create one secondary data file if the user has passed in "-DefaultFileGroup Secondary"
- Updated the unit test that checks the command params to use the modern approach
- Added more integration tests to increase test coverage
- Updated the examples to show what the resulting filenames would be
- Updated the documentation to describe the format of the db filenames

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6780  )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
This PR resolves the issue with the AutoGrowth settings for new databases. Other minor issues encountered along the way were also addressed, see the notes above.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
The examples in the command description and the integration tests can be used.

