### PR TITLE
Add "PasswordMustChange" to New-DbaLogin command

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -160,6 +160,7 @@ function Get-DbaLogin {
         [switch]$HasAccess,
         [switch]$Locked,
         [switch]$Disabled,
+        [switch]$MustChangePassword,
         [switch]$Detailed,
         [switch]$EnableException
     )
@@ -239,6 +240,10 @@ function Get-DbaLogin {
 
             if ($Disabled) {
                 $serverLogins = $serverLogins | Where-Object IsDisabled
+            }
+
+            if ($MustChangePassword) {
+                $serverLogins = $serverLogins | Where-Object MustChangePassword
             }
 
             # There's no reliable method to get last login time with SQL Server 2000, so only show on 2005+

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -40,6 +40,9 @@ function Get-DbaLogin {
     .PARAMETER Disabled
         A Switch to return disabled Logins.
 
+    .PARAMETER MustChangePassword
+        A Switch to return Logins that need to change password.
+
     .PARAMETER SqlLogins
         Deprecated. Please use -Type SQL
 
@@ -143,6 +146,10 @@ function Get-DbaLogin {
 
         Get all user objects from server sql2016 that are SQL Logins. Get additional info for login available from LoginProperty function
 
+.EXAMPLE
+        PS C:\> 'sql2016', 'sql2014' | Get-DbaLogin -SqlCredential $sqlcred -MustChangePassword
+
+        Using Get-DbaLogin on the pipeline to get all logins that must change password on servers sql2016 and sql2014.
 #>
     [CmdletBinding()]
     param (

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -271,7 +271,7 @@ function Get-DbaLogin {
                     Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name PasswordHash -Value $loginProperties.PasswordHash
                     Add-Member -Force -InputObject $serverLogin -MemberType NoteProperty -Name PasswordLastSetTime -Value $loginProperties.PasswordLastSetTime
                 }
-                Select-DefaultView -InputObject $serverLogin -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled
+                Select-DefaultView -InputObject $serverLogin -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled, MustChangePassword
             }
         }
     }

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -533,11 +533,8 @@ function New-DbaLogin {
                             $server.Logins.Refresh()
                         }
 
-                        if ($loginType -eq 'SqlLogin') {
-                            Get-DbaLogin -SqlInstance $server -Login $loginName | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled, MustChangePassword
-                        } else {
-                            Get-DbaLogin -SqlInstance $server -Login $loginName
-                        }
+                        Get-DbaLogin -SqlInstance $server -Login $loginName
+
                     } catch {
                         Stop-Function -Message "Failed to create login $loginName on $instance." -Target $credential -InnerErrorRecord $_ -Continue
                     }

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -534,7 +534,7 @@ function New-DbaLogin {
                         }
 
                         if ($loginType -eq 'SqlLogin') {
-                            Get-DbaLogin -SqlInstance $server -Login $loginName | Select-Object ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled, MustChangePassword
+                            Get-DbaLogin -SqlInstance $server -Login $loginName | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, Name, LoginType, CreateDate, LastLogin, HasAccess, IsLocked, IsDisabled, MustChangePassword
                         } else {
                             Get-DbaLogin -SqlInstance $server -Login $loginName
                         }

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -212,6 +212,11 @@ function New-DbaLogin {
             Return
         }
 
+        if ($PasswordMustChange -and (-not $SecurePassword)) {
+            Stop-Function -Message "You need to specified -SecurePassword when using -PasswordMustChange parameter." -Category InvalidArgument -EnableException $EnableException
+            Return
+        }
+
         $loginCollection = @()
         if ($InputObject) {
             $loginCollection += $InputObject

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'IncludeFilter', 'ExcludeLogin', 'ExcludeFilter', 'ExcludeSystemLogin', 'Type', 'HasAccess', 'Locked', 'Disabled', 'Detailed', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'IncludeFilter', 'ExcludeLogin', 'ExcludeFilter', 'ExcludeSystemLogin', 'Type', 'HasAccess', 'Locked', 'Disabled', , 'MustChangePassword', 'Detailed', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/New-DbaLogin.Tests.ps1
+++ b/tests/New-DbaLogin.Tests.ps1
@@ -8,7 +8,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'InputObject', 'LoginRenameHashtable', 'SecurePassword', 'HashedPassword', 'MapToCertificate', 'MapToAsymmetricKey', 'MapToCredential', 'Sid', 'DefaultDatabase', 'Language', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced', 'Disabled', 'DenyWindowsLogin', 'NewSid', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'InputObject', 'LoginRenameHashtable', 'SecurePassword', 'HashedPassword', 'MapToCertificate', 'MapToAsymmetricKey', 'MapToCredential', 'Sid', 'DefaultDatabase', 'Language', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced', 'PasswordMustChange', 'Disabled', 'DenyWindowsLogin', 'NewSid', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -28,7 +28,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     $servers = @($server1, $server2)
     $computerName = $server1.NetName
     $winLogin = "$computerName\$credLogin"
-    $logins = "claudio", "port", "tester", "certifico", $winLogin
+    $logins = "claudio", "port", "tester", "certifico", $winLogin, "withMustChange", "mustChange"
 
     #cleanup
     try {
@@ -87,6 +87,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsDisabled | Should be $false
             $results.PasswordExpirationEnabled | Should be $false
             $results.PasswordPolicyEnforced | Should be $false
+            $results.MustChangePassword | Should be $false
             $results.LoginType | Should be 'SqlLogin'
         }
         It "Should be created successfully - password, credential and a custom sid " {
@@ -97,10 +98,11 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsDisabled | Should be $false
             $results.PasswordExpirationEnabled | Should be $false
             $results.PasswordPolicyEnforced | Should be $false
+            $results.MustChangePassword | Should be $false
             $results.Sid | Should be (Convert-HexStringToByte $sid)
             $results.LoginType | Should be 'SqlLogin'
         }
-        It "Should be created successfully - password and all the flags" {
+        It "Should be created successfully - password and all the flags (exclude -PasswordMustChange)" {
             $results = New-DbaLogin -SqlInstance $server1 -Login port -Password $securePassword -PasswordPolicy -PasswordExpiration -DefaultDatabase tempdb -Disabled -Language Nederlands -DenyWindowsLogin
             $results.Name | Should Be "port"
             $results.Language | Should Be 'Nederlands'
@@ -109,6 +111,33 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsDisabled | Should be $true
             $results.PasswordExpirationEnabled | Should be $true
             $results.PasswordPolicyEnforced | Should be $true
+            $results.MustChangePassword | Should be $false
+            $results.LoginType | Should be 'SqlLogin'
+            $results.DenyWindowsLogin | Should Be $true
+        }
+        It "Should be created successfully - password and all the flags (include -PasswordMustChange)" {
+            $results = New-DbaLogin -SqlInstance $server1 -Login withMustChange -Password $securePassword -PasswordPolicy -PasswordExpiration -PasswordMustChange -DefaultDatabase tempdb -Disabled -Language Nederlands -DenyWindowsLogin
+            $results.Name | Should Be "withMustChange"
+            $results.Language | Should Be 'Nederlands'
+            $results.EnumCredentials() | Should be $null
+            $results.DefaultDatabase | Should be 'tempdb'
+            $results.IsDisabled | Should be $true
+            $results.PasswordExpirationEnabled | Should be $true
+            $results.PasswordPolicyEnforced | Should be $true
+            $results.MustChangePassword | Should be $true
+            $results.LoginType | Should be 'SqlLogin'
+            $results.DenyWindowsLogin | Should Be $true
+        }
+        It "Should be created successfully - password and just -PasswordMustChange" {
+            $results = New-DbaLogin -SqlInstance $server1 -Login MustChange -Password $securePassword -PasswordMustChange -DefaultDatabase tempdb -Disabled -Language Nederlands -DenyWindowsLogin
+            $results.Name | Should Be "MustChange"
+            $results.Language | Should Be 'Nederlands'
+            $results.EnumCredentials() | Should be $null
+            $results.DefaultDatabase | Should be 'tempdb'
+            $results.IsDisabled | Should be $true
+            $results.PasswordExpirationEnabled | Should be $true
+            $results.PasswordPolicyEnforced | Should be $true
+            $results.MustChangePassword | Should be $true
             $results.LoginType | Should be 'SqlLogin'
             $results.DenyWindowsLogin | Should Be $true
         }
@@ -155,13 +184,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $login1.IsDisabled | Should be $login2.IsDisabled
             $login1.PasswordExpirationEnabled | Should be $login2.PasswordExpirationEnabled
             $login1.PasswordPolicyEnforced | Should be $login2.PasswordPolicyEnforced
+            $login1.MustChangePassword | Should be $login2.MustChangePassword
             $login1.Sid | Should be $login2.Sid
         }
 
         It "Should not have same properties because of the overrides" {
 
             $login1 = Get-DbaLogin -SqlInstance $script:instance1 -login claudio
-            $login2 = Get-DbaLogin -SqlInstance $script:instance2 -login port
+            $login2 = Get-DbaLogin -SqlInstance $script:instance2 -login withMustChange
 
             $login2 | Should Not BeNullOrEmpty
 
@@ -172,6 +202,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $login1.IsDisabled | Should Not be $login2.IsDisabled
             $login1.PasswordExpirationEnabled | Should Not be $login2.PasswordExpirationEnabled
             $login1.PasswordPolicyEnforced | Should Not be $login2.PasswordPolicyEnforced
+            $login1.MustChangePassword | Should Not be $login2.MustChangePassword
             $login1.Sid | Should Not be $login2.Sid
         }
         if ($IsWindows -ne $false) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Make possible to specify that login being created need to change password at next login

### Approach
<!-- How does this change solve that purpose -->
When `-PasswordMustChange` is specified, we will enforce the `PasswordExpirationEnabled` and `PasswordPolicyEnforced` to true as they are required for the must change flag be turn on.

### Commands to test
New-DbaLogin with `-PasswordMustChange`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/19521315/99794035-79a98500-2b21-11eb-8c9b-85aa8e933b98.png)


### Learning
As `MustChangePassword` property of the login is just a `get`, we need to use the [ChangePassword](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.login.changepassword?view=sql-smo-160#Microsoft_SqlServer_Management_Smo_Login_ChangePassword_System_Security_SecureString_System_Boolean_System_Boolean_) method

