### PR TITLE
Test-DbaLastBackup - Add MaxDop parameter

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -245,6 +245,7 @@ function Test-DbaLastBackup {
                     RestoreStart   = $null
                     RestoreEnd     = $null
                     RestoreElapsed = $null
+                    DbccMaxDop     = $null
                     DbccStart      = $null
                     DbccEnd        = $null
                     DbccElapsed    = $null
@@ -551,6 +552,7 @@ function Test-DbaLastBackup {
                     RestoreStart   = [dbadatetime]$startRestore
                     RestoreEnd     = [dbadatetime]$endRestore
                     RestoreElapsed = $restoreElapsed
+                    DbccMaxDop     = [int]$MaxDop
                     DbccStart      = [dbadatetime]$startDbcc
                     DbccEnd        = [dbadatetime]$endDbcc
                     DbccElapsed    = $dbccElapsed

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -65,6 +65,9 @@ function Test-DbaLastBackup {
     .PARAMETER MaxSize
         Max size in MB. Databases larger than this value will not be restored.
 
+    .PARAMETER MaxDop
+        Allows you to pass in a MAXDOP setting to the DBCC CheckDB command to limit the number of parallel processes used.
+
     .PARAMETER DeviceType
         Specifies a filter for backup sets based on DeviceTypes. Valid options are 'Disk','Permanent Disk Device', 'Tape', 'Permanent Tape Device','Pipe','Permanent Pipe Device','Virtual Device', in addition to custom integers for your own DeviceTypes.
 
@@ -106,8 +109,6 @@ function Test-DbaLastBackup {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
-    .PARAMETER MaxDop
-        Allows you to pass in a MAXDOP setting to the DBCC CheckDB command to limit the number of parallel processes used.
 
     .NOTES
         Tags: DisasterRecovery, Backup, Restore

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -106,6 +106,9 @@ function Test-DbaLastBackup {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+    .PARAMETER MaxDop
+        Allows you to pass in a MAXDOP setting to the DBCC CheckDB command to limit the number of parallel processes used.
+
     .NOTES
         Tags: DisasterRecovery, Backup, Restore
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -171,6 +174,11 @@ function Test-DbaLastBackup {
         Prior to running, you should check memory and server resources before configure it to run automatically.
         More information:
         https://www.mssqltips.com/sqlservertip/4935/optimize-sql-server-database-restore-performance/
+
+    .EXAMPLE
+        PS C:\> Test-DbaLastBackup -SqlInstance sql2016 -MaxDop 4
+
+        The use of the MaxDop parameter will limit the number of processors used during the DBCC command
     #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPlainTextForPassword", "", Justification = "For Parameters DestinationCredential and AzureCredential")]
@@ -199,6 +207,7 @@ function Test-DbaLastBackup {
         [int]$MaxTransferSize,
         [int]$BufferCount,
         [switch]$IgnoreDiffBackup,
+        [int]$MaxDop,
         [switch]$EnableException
     )
     process {
@@ -477,7 +486,7 @@ function Test-DbaLastBackup {
                                 Write-Message -Level Verbose -Message "Starting DBCC."
 
                                 $startDbcc = Get-Date
-                                $dbccresult = Start-DbccCheck -Server $destserver -DbName $dbName 3>$null
+                                $dbccresult = Start-DbccCheck -Server $destserver -DbName $dbName -MaxDop $MaxDop 3>$null
                                 $endDbcc = Get-Date
 
                                 $dbccts = New-TimeSpan -Start $startDbcc -End $endDbcc

--- a/internal/functions/Start-DbccCheck.ps1
+++ b/internal/functions/Start-DbccCheck.ps1
@@ -21,7 +21,6 @@ function Start-DbccCheck {
             } else {
                 if ($MaxDop) {
                     $null = $server.Query("DBCC CHECKDB ([$DbName]) WITH MAXDOP = $MaxDop")
-                    Write-Output $MaxDop
                     Write-Verbose "Dbcc CHECKDB finished successfully for $DbName on $servername"
                 } else {
                     $null = $server.Query("DBCC CHECKDB ([$DbName])")

--- a/internal/functions/Start-DbccCheck.ps1
+++ b/internal/functions/Start-DbccCheck.ps1
@@ -3,7 +3,8 @@ function Start-DbccCheck {
     param (
         [object]$server,
         [string]$DbName,
-        [switch]$table
+        [switch]$table,
+        [int]$MaxDop
     )
 
     $servername = $server.name
@@ -18,8 +19,14 @@ function Start-DbccCheck {
                 $null = $server.databases[$DbName].CheckTables('None')
                 Write-Verbose "Dbcc CheckTables finished successfully for $DbName on $servername"
             } else {
-                $null = $server.Query("DBCC CHECKDB ([$DbName])")
-                Write-Verbose "Dbcc CHECKDB finished successfully for $DbName on $servername"
+                if ($MaxDop) {
+                    $null = $server.Query("DBCC CHECKDB ([$DbName]) WITH MAXDOP = $MaxDop")
+                    Write-Output $MaxDop
+                    Write-Verbose "Dbcc CHECKDB finished successfully for $DbName on $servername"
+                } else {
+                    $null = $server.Query("DBCC CHECKDB ([$DbName])")
+                    Write-Verbose "Dbcc CHECKDB finished successfully for $DbName on $servername"
+                }
             }
             return "Success"
         } catch {

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType', 'MaxTransferSize', 'BufferCount', 'IgnoreDiffBackup'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'MaxDop', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType', 'MaxTransferSize', 'BufferCount', 'IgnoreDiffBackup'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add the ability to use the MAXDOP parameter on the DBCC CheckDB command to limit processing resources.

### Approach
<!-- How does this change solve that purpose -->
Parameter added to Test-DbaLastBackup and Start-DbccCheck which is called from the wrapper function.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Test-DbaLastBackup -SqlInstance "localhost\sql2017" -Destination "localhost\sql2017" -Verbose`
 `Test-DbaLastBackup -SqlInstance "localhost\sql2017" -Destination "localhost\sql2017" -MaxDop 2 -Verbose`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/169602/100468094-59397780-3099-11eb-99a7-1d4d965e96aa.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
