### PR TITLE
Test-DbaConnection - add note to Credential parameter

### DIFF
--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -40,7 +40,7 @@ function Test-DbaConnection {
 
     .EXAMPLE
         PS C:\> Test-DbaConnection SQL2016
-        ```
+
         ComputerName         : SQL2016
         InstanceName         : MSSQLSERVER
         SqlInstance          : sql2016
@@ -61,9 +61,38 @@ function Test-DbaConnection {
         LocalSMOVersion      : 13.0.0.0
         LocalDomainUser      : True
         LocalRunAsAdmin      : False
-        ```
+        LocalEdition         : Desktop
 
         Test connection to SQL2016 and outputs information collected
+
+    .EXAMPLE
+        PS C:\> $winCred = Get-Credential sql2017\Administrator
+        PS C:\> $sqlCred = Get-Credential sa
+        PS C:\> Test-DbaConnection SQL2017 -SqlCredential $sqlCred -Credential $winCred
+
+        ComputerName         : SQL2017
+        InstanceName         : MSSQLSERVER
+        SqlInstance          : sql2017
+        SqlVersion           : 14.0.3356
+        ConnectingAsUser     : sa
+        ConnectSuccess       : True
+        AuthType             : SQL Authentication
+        AuthScheme           : SQL
+        TcpPort              : 50164
+        IPAddress            : 10.10.10.15
+        NetBiosName          : sql2017.company.local
+        IsPingable           : True
+        PSRemotingAccessible : True
+        DomainName           : company.local
+        LocalWindows         : 10.0.15063.0
+        LocalPowerShell      : 5.1.19041.610
+        LocalCLR             : 4.0.30319.42000
+        LocalSMOVersion      : 15.100.0.0
+        LocalDomainUser      : True
+        LocalRunAsAdmin      : False
+        LocalEdition         : Desktop
+        
+        Test connection to SQL2017 instance and collecting information on SQL Server using the sa login, local Administrator account is used to collect port information
     #>
     [CmdletBinding()]
     param (

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -12,6 +12,8 @@ function Test-DbaConnection {
 
     .PARAMETER Credential
         Credential object used to connect to the Computer as a different user
+        
+        Utilized for gathering TCPPort information.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).


### PR DESCRIPTION
- Added additional note to the Credential parameter to make it more clear how it is used in the command
- Added example utilizing both `-SqlCredential` and `-Credential`

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6971 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 