### PR TITLE
New-DbaDbMaskingConfig – update the regex for address

### DIFF
--- a/bin/datamasking/pii-knownnames.json
+++ b/bin/datamasking/pii-knownnames.json
@@ -123,7 +123,7 @@
         "Name": "Address",
         "Category": "Location",
         "Pattern": [
-            "(\\w*)(?i)address(\\w*)",
+            "(\\w*)(?i)^(?!ipaddress)(address)(\\w*)",
             "(?>(str(eet)?_?addre?s?s?\\|street))(?!\\w*(ID\\|type))",
             "(\\w*)(?i)adresse(\\w*)",
             "(\\w*)(?i)direccion(\\w*)",
@@ -222,7 +222,7 @@
         "MaskingSubType": "Url"
     },
     {
-        "Name": "IPAddres",
+        "Name": "IPAddress",
         "Category": "System",
         "Pattern": [
             "(\\w*)(?i)(ip|ipaddress|ipv4|ipv6)(\\w*)",

--- a/functions/New-DbaDbMaskingConfig.ps1
+++ b/functions/New-DbaDbMaskingConfig.ps1
@@ -408,7 +408,7 @@ function New-DbaDbMaskingConfig {
                             }
                         } else {
                             if ($knownNames.Count -ge 1) {
-                                # Go through the first check to see if any column is found with a known type
+                                # Go through the first check to see if any column is found with a known name
                                 foreach ($knownName in $knownNames) {
                                     foreach ($pattern in $knownName.Pattern) {
                                         if ($null -eq $result -and $columnobject.Name -match $pattern ) {

--- a/tests/New-DbaDbMaskingConfig.Tests.ps1
+++ b/tests/New-DbaDbMaskingConfig.Tests.ps1
@@ -8,7 +8,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Table', 'Column', 'Path', 'Locale', 'CharacterString', 'SampleCount', 'KnownNameFilePath', 'PatternFilePath', 'ExcludeDefaultKnownName', 'ExcludeDefaultPattern', 'Force', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
         }
     }
 }
@@ -26,6 +26,22 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $sql = "INSERT INTO people (fname, lname, dob) VALUES ('Joe','Schmoe','2/2/2000')
                 INSERT INTO people (fname, lname, dob) VALUES ('Jane','Schmee','2/2/1950')"
         $db.Query($sql)
+
+        # bug 6934
+        $db.Query("
+                CREATE TABLE dbo.DbConfigTest
+                (
+                    id              SMALLINT      NOT NULL,
+                    IPAddress       VARCHAR(100)  NOT NULL,
+                    Address         VARCHAR(100)  NOT NULL,
+                    StreetAddress   VARCHAR(100)  NOT NULL,
+                    Street          VARCHAR(100)  NOT NULL
+                );
+                INSERT INTO dbo.DbConfigTest (id, IPAddress, Address, StreetAddress, Street)
+                VALUES
+                (1, '127.0.0.1', '123 Fake Street', '123 Fake Street', '123 Fake Street'),
+                (2, '', '123 Fake Street', '123 Fake Street', '123 Fake Street'),
+                (3, 'fe80::7df3:7015:89e9:fbed%15', '123 Fake Street', '123 Fake Street', '123 Fake Street')")
     }
     AfterAll {
         Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
@@ -39,6 +55,27 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results.Directory.Name | Should -Be temp
             $results.FullName | Should -FileContentMatch $dbname
             $results.FullName | Should -FileContentMatch fname
+        }
+
+        It "Bug 6934: matching IPAddress, Address, and StreetAddress on known names" {
+            $results = New-DbaDbMaskingConfig -SqlInstance $script:instance1 -Database $dbname -Table DbConfigTest -Path C:\temp
+            $jsonOutput = Get-Content $results.FullName | ConvertFrom-Json
+
+            $jsonOutput.Tables.Columns[1].Name | Should -Be "IPAddress"
+            $jsonOutput.Tables.Columns[1].MaskingType | Should -Be "Internet"
+            $jsonOutput.Tables.Columns[1].SubType | Should -Be "Ip"
+
+            $jsonOutput.Tables.Columns[2].Name | Should -Be "Address"
+            $jsonOutput.Tables.Columns[2].MaskingType | Should -Be "Address"
+            $jsonOutput.Tables.Columns[2].SubType | Should -Be "StreetAddress"
+
+            $jsonOutput.Tables.Columns[3].Name | Should -Be "StreetAddress"
+            $jsonOutput.Tables.Columns[3].MaskingType | Should -Be "Address"
+            $jsonOutput.Tables.Columns[3].SubType | Should -Be "StreetAddress"
+
+            $jsonOutput.Tables.Columns[4].Name | Should -Be "Street"
+            $jsonOutput.Tables.Columns[4].MaskingType | Should -Be "Address"
+            $jsonOutput.Tables.Columns[4].SubType | Should -Be "StreetAddress"
         }
     }
 }


### PR DESCRIPTION
- Updated the regex to exclude ‘ipaddress’ from matching the ‘address’ known name.
- Added an integration test to check the regex for ‘ipaddress’, ‘address’, ‘streetaddress’, and ‘street’ to ensure this small change doesn’t introduce any regressions.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6934 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests.