### PR TITLE
update constants to support devcontainer

### DIFF
--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -2,7 +2,7 @@
 if (Test-Path "$PSScriptRoot\constants.local.ps1") {
     Write-Verbose "tests\constants.local.ps1 found."
     . "$PSScriptRoot\constants.local.ps1"
-} elseif ($env:CODESPACES) {
+} elseif ($env:CODESPACES -and ($env:TERM_PROGRAM -eq 'vscode' -and $env:REMOTE_CONTAINERS)) {
     $script:instance1 = "dbatools1"
     $script:instance2 = "dbatools2"
     $script:instance3 = "dbatools3"

--- a/tests/constants.ps1
+++ b/tests/constants.ps1
@@ -2,6 +2,16 @@
 if (Test-Path "$PSScriptRoot\constants.local.ps1") {
     Write-Verbose "tests\constants.local.ps1 found."
     . "$PSScriptRoot\constants.local.ps1"
+} elseif ($env:CODESPACES) {
+    $script:instance1 = "dbatools1"
+    $script:instance2 = "dbatools2"
+    $script:instance3 = "dbatools3"
+    $script:instances = @($script:instance1, $script:instance2)
+
+    $SqlCred = [PSCredential]::new('sa',(ConvertTo-SecureString $env:SA_PASSWORD -AsPlainText -Force))
+    $PSDefaultParameterValues = @{
+        "*:SqlCredential" = $sqlCred
+    }
 } else {
     $script:dbatoolsci_computer = "localhost"
     $script:instance1 = "localhost\sql2008r2sp2"


### PR DESCRIPTION
Add support for our test framework to be used within devcontainers.

The environment variables within each option (GitHub CodeSpaces and VS Code Remote Container) offer the ability to detect whether we are running within that environment:

GitHub CodeSpaces: `$env:CODESPACES` (only one I think should be needed)
VS Code: `$env:REMOTE_CONTAINER` and `TERM_PROGRAM = vscode` 