### PR TITLE
buildref, keep it fresh

### DIFF
--- a/bin/dbatools-buildref-index.json
+++ b/bin/dbatools-buildref-index.json
@@ -1,5 +1,5 @@
 {
-    "LastUpdated": "2020-11-23T00:00:00",
+    "LastUpdated": "2020-12-22T00:00:00",
     "Data": [
         {
             "Version": "8.0.47",


### PR DESCRIPTION
touched just the date at the top: given the "no new CUs till new year" no releases have been added by MS but we need to declare our index as "not stale" nonetheless.