### PR TITLE
Export-DbaDacPackage - add the database name to the generated filename

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -75,7 +75,7 @@ function Export-DbaDacPackage {
         PS C:\> $options = New-DbaDacOption -Type Dacpac -Action Export
         PS C:\> $options.ExtractAllTableData = $true
         PS C:\> $options.CommandTimeout = 0
-        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options $options
+        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -DacOption $options
 
         Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to C:\Users\username\Documents\DbatoolsExport\sql2016-DB1-20201227140759-dacpackage.dacpac including all table data. As noted the generated filename will contain the server name, database name, and the current timestamp in the "%Y%m%d%H%M%S" format.
 
@@ -171,7 +171,7 @@ function Export-DbaDacPackage {
                     $tblName = [string]$tableSplit
                     $schemaName = 'dbo'
                 }
-                $tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName, $tblName))
+                $tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName,$tblName))
             }
         } else {
             $tblList = $null
@@ -181,7 +181,7 @@ function Export-DbaDacPackage {
             try {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Error occurred while establishing connection to $instance"-Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if ($Database) {
                 $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -Database $Database -ExcludeDatabase $ExcludeDatabase
@@ -190,7 +190,7 @@ function Export-DbaDacPackage {
                 $dbs = Get-DbaDatabase -SqlInstance $server -OnlyAccessible -ExcludeSystem -ExcludeDatabase $ExcludeDatabase
             }
             if (-not $dbs) {
-                Stop-Function -Message "Databases not found on $instance" -Target $instance -Continue
+                Stop-Function -Message "Databases not found on $instance"-Target $instance -Continue
             }
 
             foreach ($db in $dbs) {
@@ -216,7 +216,7 @@ function Export-DbaDacPackage {
                     try {
                         $dacSvc = New-Object -TypeName Microsoft.SqlServer.Dac.DacServices -ArgumentList $connstring -ErrorAction Stop
                     } catch {
-                        Stop-Function -Message "Could not connect to the connection string $connstring" -Target $instance -Continue
+                        Stop-Function -Message "Could not connect to the connection string $connstring"-Target $instance -Continue
                     }
                     if (-not $DacOption) {
                         $opts = New-DbaDacOption -Type $Type -Action Export
@@ -276,7 +276,7 @@ function Export-DbaDacPackage {
                     }
 
                     if ($process.ExitCode -ne 0) {
-                        Stop-Function -Message "Standard output - $stderr" -Continue
+                        Stop-Function -Message "Standard output - $stderr"-Continue
                     }
                 }
                 [pscustomobject]@{
@@ -287,7 +287,7 @@ function Export-DbaDacPackage {
                     Path         = $FilePath
                     Elapsed      = [prettytimespan]($resultstime.Elapsed)
                     Result       = $finalResult
-                } | Select-DefaultView -ExcludeProperty ComputerName, InstanceName
+                } | Select-DefaultView -ExcludeProperty ComputerName,InstanceName
             }
         }
     }

--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -77,17 +77,17 @@ function Export-DbaDacPackage {
         PS C:\> $options.CommandTimeout = 0
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options $options
 
-        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to C:\Users\username\Documents\DbatoolsExport\ including all table data. The generated filename will contain the server name, database name, and a timestamp.
+        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to C:\Users\username\Documents\DbatoolsExport\sql2016-DB1-20201227140759-dacpackage.dacpac including all table data. As noted the generated filename will contain the server name, database name, and the current timestamp in the "%Y%m%d%H%M%S" format.
 
     .EXAMPLE
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -AllUserDatabases -ExcludeDatabase "DBMaintenance","DBMonitoring" -Path "C:\temp"
-        Exports dacpac packages for all USER databases, excluding "DBMaintenance" & "DBMonitoring", on sql2016 and saves them to C:\temp. The generated filename(s) will contain the server name, database name, and a timestamp.
+        Exports dacpac packages for all USER databases, excluding "DBMaintenance" & "DBMonitoring", on sql2016 and saves them to C:\temp. The generated filename(s) will contain the server name, database name, and the current timestamp in the "%Y%m%d%H%M%S" format.
 
     .EXAMPLE
         PS C:\> $moreparams = "/OverwriteFiles:$true /Quiet:$true"
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config -Path C:\temp -ExtendedParameters $moreparams
 
-        Using extended parameters to over-write the files and performs the extraction in quiet mode. Uses command line instead of SMO behind the scenes. The generated filename will contain the server name, database name, and a timestamp.
+        Using extended parameters to over-write the files and performs the extraction in quiet mode to C:\temp\sql2016-SharePoint_Config-20201227140759-dacpackage.dacpac. Uses command line instead of SMO behind the scenes. As noted the generated filename will contain the server name, database name, and the current timestamp in the "%Y%m%d%H%M%S" format.
     #>
     [CmdletBinding(DefaultParameterSetName = 'SMO')]
     param

--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -209,7 +209,7 @@ function Export-DbaDacPackage {
                     $ext = 'bacpac'
                 }
 
-                $FilePath = Get-ExportFilePath -Path $PSBoundParameters.Path -FilePath $PSBoundParameters.FilePath -Type $ext -ServerName $instance
+                $FilePath = Get-ExportFilePath -Path $PSBoundParameters.Path -FilePath $PSBoundParameters.FilePath -Type $ext -ServerName $instance -DatabaseName $dbName
 
                 #using SMO by default
                 if ($PsCmdlet.ParameterSetName -eq 'SMO') {

--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -67,9 +67,9 @@ function Export-DbaDacPackage {
         https://dbatools.io/Export-DbaDacPackage
 
     .EXAMPLE
-        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config
+        PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config -FilePath C:\SharePoint_Config.dacpac
 
-        Exports the dacpac for SharePoint_Config on sql2016 to $home\Documents\SharePoint_Config.dacpac
+        Exports the dacpac for SharePoint_Config on sql2016 to C:\SharePoint_Config.dacpac
 
     .EXAMPLE
         PS C:\> $options = New-DbaDacOption -Type Dacpac -Action Export
@@ -77,17 +77,17 @@ function Export-DbaDacPackage {
         PS C:\> $options.CommandTimeout = 0
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database DB1 -Options $options
 
-        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to $home\Documents\DB1.dacpac including all table data.
+        Uses DacOption object to set the CommandTimeout to 0 then extracts the dacpac for DB1 on sql2016 to C:\Users\username\Documents\DbatoolsExport\ including all table data. The generated filename will contain the server name, database name, and a timestamp.
 
     .EXAMPLE
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -AllUserDatabases -ExcludeDatabase "DBMaintenance","DBMonitoring" -Path "C:\temp"
-        Exports dacpac packages for all USER databases, excluding "DBMaintenance" & "DBMonitoring", on sql2016 and saves them to C:\temp
+        Exports dacpac packages for all USER databases, excluding "DBMaintenance" & "DBMonitoring", on sql2016 and saves them to C:\temp. The generated filename(s) will contain the server name, database name, and a timestamp.
 
     .EXAMPLE
         PS C:\> $moreparams = "/OverwriteFiles:$true /Quiet:$true"
         PS C:\> Export-DbaDacPackage -SqlInstance sql2016 -Database SharePoint_Config -Path C:\temp -ExtendedParameters $moreparams
 
-        Using extended parameters to over-write the files and performs the extraction in quiet mode. Uses command line instead of SMO behind the scenes.
+        Using extended parameters to over-write the files and performs the extraction in quiet mode. Uses command line instead of SMO behind the scenes. The generated filename will contain the server name, database name, and a timestamp.
     #>
     [CmdletBinding(DefaultParameterSetName = 'SMO')]
     param

--- a/internal/configurations/settings/formatting.ps1
+++ b/internal/configurations/settings/formatting.ps1
@@ -20,4 +20,4 @@ Set-DbatoolsConfig -FullName 'Formatting.size.digits' -Value 2 -Initialize -Vali
 Set-DbatoolsConfig -FullName 'Formatting.BatchSeparator' -Value "GO" -Initialize -Validation string -Handler { [Sqlcollaborative.Dbatools.Utility.UtilityHost]::FormatDate = $args[0] } -Description "The default batch separator used in export of scripts"
 
 # The default uformat style for formatting dates in scripts
-Set-DbatoolsConfig -FullName 'Formatting.UFormat' -Value "%Y%m%d%H%M%S" -Initialize -Validation string -Handler { [Sqlcollaborative.Dbatools.Utility.UtilityHost]::FormatDate = $args[0] } -Description "The default batch separator used in export of scripts"
+Set-DbatoolsConfig -FullName 'Formatting.UFormat' -Value "%Y%m%d%H%M%S" -Initialize -Validation string -Handler { [Sqlcollaborative.Dbatools.Utility.UtilityHost]::FormatDate = $args[0] } -Description "The default uformat style for formatting dates in scripts"

--- a/tests/Export-DbaDacPackage.Tests.ps1
+++ b/tests/Export-DbaDacPackage.Tests.ps1
@@ -4,22 +4,23 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'AllUserDatabases', 'Path', 'FilePath', 'DacOption', 'ExtendedParameters', 'ExtendedProperties', 'Type', 'Table', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
+        $server = $script:instance1
         $dbname = "dbatoolsci_exportdacpac"
         try {
-            $server = Connect-DbaInstance -SqlInstance $script:instance1
+            $server = Connect-DbaInstance -SqlInstance $server
             $null = $server.Query("Create Database [$dbname]")
-            $db = Get-DbaDatabase -SqlInstance $script:instance1 -Database $dbname
+            $db = Get-DbaDatabase -SqlInstance $server -Database $dbname
             $null = $db.Query("CREATE TABLE dbo.example (id int, PRIMARY KEY (id));
             INSERT dbo.example
             SELECT top 100 object_id
@@ -27,9 +28,28 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         } catch { } # No idea why appveyor can't handle this
 
         $testFolder = 'C:\Temp\dacpacs'
+
+        $dbName2 = "dbatoolsci:2"
+        $dbName2Escaped = "dbatoolsci$2"
+
+        $null = New-DbaDatabase -SqlInstance $server -Name $dbName2
     }
     AfterAll {
-        Remove-DbaDatabase -SqlInstance $script:instance1 -Database $dbname -Confirm:$false
+        Remove-DbaDatabase -SqlInstance $server -Database $dbname, $dbName2 -Confirm:$false
+    }
+
+    Context "Bug 7038" {
+        It "Database name is included in the output filename" {
+            $result = Export-DbaDacPackage -SqlInstance $server -Database $dbname
+            $result.Path | Should -BeLike "*$($dbName)*"
+        }
+
+        It "Database names with invalid filesystem chars are successfully exported" {
+            $result = Export-DbaDacPackage -SqlInstance $server -Database $dbname, $dbName2
+            $result.Path.Count | Should -Be 2
+            $result.Path[0] | Should -BeLike "*$($dbName)*"
+            $result.Path[1] | Should -BeLike "*$($dbName2Escaped)*"
+        }
     }
     Context "Extract dacpac" {
         BeforeEach {
@@ -40,10 +60,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             Pop-Location
             Remove-Item $testFolder -Force -Recurse
         }
-        if ((Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table example)) {
+        if ((Get-DbaDbTable -SqlInstance $server -Database $dbname -Table example)) {
             # Sometimes appveyor bombs
             It "exports a dacpac" {
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname
                 $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
@@ -53,14 +73,14 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             It "exports to the correct directory" {
                 $relativePath = '.\'
                 $expectedPath = (Resolve-Path $relativePath).Path
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Path $relativePath
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -Path $relativePath
                 $results.Path | Split-Path | Should -Be $expectedPath
                 Test-Path $results.Path | Should -Be $true
             }
             It "exports dacpac with a table list" {
                 $relativePath = '.\extract.dacpac'
                 $expectedPath = Join-Path (Get-Item .) 'extract.dacpac'
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -FilePath $relativePath -Table example
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -FilePath $relativePath -Table example
                 $results.Path | Should -Be $expectedPath
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
@@ -69,7 +89,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             }
             It "uses EXE to extract dacpac" {
                 $exportProperties = "/p:ExtractAllTableData=True"
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -ExtendedProperties $exportProperties
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -ExtendedProperties $exportProperties
                 $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
@@ -87,10 +107,10 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             Pop-Location
             Remove-Item $testFolder -Force -Recurse
         }
-        if ((Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table example)) {
+        if ((Get-DbaDbTable -SqlInstance $server -Database $dbname -Table example)) {
             # Sometimes appveyor bombs
             It "exports a bacpac" {
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -Type Bacpac
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -Type Bacpac
                 $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
@@ -100,7 +120,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             It "exports bacpac with a table list" {
                 $relativePath = '.\extract.bacpac'
                 $expectedPath = Join-Path (Get-Item .) 'extract.bacpac'
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -FilePath $relativePath -Table example -Type Bacpac
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -FilePath $relativePath -Table example -Type Bacpac
                 $results.Path | Should -Be $expectedPath
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {
@@ -109,7 +129,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             }
             It "uses EXE to extract bacpac" {
                 $exportProperties = "/p:TargetEngineVersion=Default"
-                $results = Export-DbaDacPackage -SqlInstance $script:instance1 -Database $dbname -ExtendedProperties $exportProperties -Type Bacpac
+                $results = Export-DbaDacPackage -SqlInstance $server -Database $dbname -ExtendedProperties $exportProperties -Type Bacpac
                 $results.Path | Should -Not -BeNullOrEmpty
                 Test-Path $results.Path | Should -Be $true
                 if (($results).Path) {


### PR DESCRIPTION
- Updated the Get-ExportFilePath to support -DatabaseName
- Updated Export-DbaDacPackage to include the db name in the filename
- Added integration tests to cover the code changes

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7038 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure that the generated filenames will contain the db name (when -FilePath is not used).

### Approach
<!-- How does this change solve that purpose -->
Added -DatabaseName to Get-ExportFilePath to solve the issue here and also to make it available for other export commands.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the examples and integration tests.
