### PR TITLE
New-DbaDacProfile - add connection string to publish profile

### DIFF
--- a/functions/New-DbaDacProfile.ps1
+++ b/functions/New-DbaDacProfile.ps1
@@ -106,7 +106,9 @@ function New-DbaDacProfile {
             $return | Out-String
         }
 
-        function Get-Template ($db, $connString) {
+        function Get-Template {
+            Param ($db, $connString)
+
             "<?xml version=""1.0"" ?>
             <Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
               <PropertyGroup>
@@ -115,7 +117,7 @@ function New-DbaDacProfile {
                 <ProfileVersionNumber>1</ProfileVersionNumber>
                 {2}
               </PropertyGroup>
-            </Project>" -f $db[0], $connString, $(Convert-HashtableToXMLString($PublishOptions))
+            </Project>" -f $db, $connString, $(Convert-HashtableToXMLString($PublishOptions))
         }
 
         function Get-ServerName ($connString) {
@@ -149,7 +151,7 @@ function New-DbaDacProfile {
         foreach ($connString in $ConnectionString) {
             foreach ($db in $Database) {
                 if ($Pscmdlet.ShouldProcess($db, "Creating new DAC Profile")) {
-                    $profileTemplate = Get-Template $db, $connString
+                    $profileTemplate = Get-Template -db $db -connString $connString
                     $instanceName = Get-ServerName $connString
 
                     try {

--- a/functions/New-DbaDacProfile.ps1
+++ b/functions/New-DbaDacProfile.ps1
@@ -107,7 +107,10 @@ function New-DbaDacProfile {
         }
 
         function Get-Template {
-            Param ($db, $connString)
+            param (
+                $db,
+                $connString
+            )
 
             "<?xml version=""1.0"" ?>
             <Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix non-breaking change, fixes #7058 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fising #7058 

### Approach
Honestly, I am unsure but moving the param block and specifying the params when called works

### Commands to test
New-DbaDacProfile -SqlInstance $sql3 -Database FactoryIssue20201230 -Path c:\temp

### Screenshots
Broken pwsh
![image](https://user-images.githubusercontent.com/6729780/103354338-35f05680-4aa3-11eb-862a-94cd824b330b.png)
Fixed pwsh
![image](https://user-images.githubusercontent.com/6729780/103354665-14dc3580-4aa4-11eb-9505-da40b018e3c3.png)

broken Windows PowerShell
![image](https://user-images.githubusercontent.com/6729780/103354608-e6f6f100-4aa3-11eb-974d-5d8e9fed8986.png)
fixed Windows PowerShell
![image](https://user-images.githubusercontent.com/6729780/103354629-f2e2b300-4aa3-11eb-876c-cf6103763586.png)


