### PR TITLE
New-DbaDbTable - Add support for adding identity column

### DIFF
--- a/functions/New-DbaDbTable.ps1
+++ b/functions/New-DbaDbTable.ps1
@@ -219,6 +219,11 @@ function New-DbaDbTable {
 
         >> # Add columns to collection
         >> $cols += @{
+        >>     Name      = 'testId'
+        >>     Type      = 'int'
+        >>     Identity  = $true
+        >> }
+        >> $cols += @{
         >>     Name      = 'test'
         >>     Type      = 'varchar'
         >>     MaxLength = 20
@@ -419,8 +424,8 @@ function New-DbaDbTable {
                         } else {
                             $dataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $sqlDbType
                         }
-                        $sqlcolumn = New-Object Microsoft.SqlServer.Management.Smo.Column $object, $column.Name, $dataType
-                        $sqlcolumn.Nullable = $column.Nullable
+                        $sqlColumn = New-Object Microsoft.SqlServer.Management.Smo.Column $object, $column.Name, $dataType
+                        $sqlColumn.Nullable = $column.Nullable
 
                         if ($column.Default) {
                             if ($column.DefaultName) {
@@ -430,15 +435,24 @@ function New-DbaDbTable {
                             }
 
                             if ($sqlDbType -in @('NVarchar', 'NChar', 'NVarcharMax', 'NCharMax')) {
-                                $sqlcolumn.AddDefaultConstraint($dfName).Text = "N'$($column.Default)'"
+                                $sqlColumn.AddDefaultConstraint($dfName).Text = "N'$($column.Default)'"
                             } elseif ($sqlDbType -in @('Varchar', 'Char', 'VarcharMax', 'CharMax')) {
-                                $sqlcolumn.AddDefaultConstraint($dfName).Text = "'$($column.Default)'"
+                                $sqlColumn.AddDefaultConstraint($dfName).Text = "'$($column.Default)'"
                             } else {
-                                $sqlcolumn.AddDefaultConstraint($dfName).Text = $column.Default
+                                $sqlColumn.AddDefaultConstraint($dfName).Text = $column.Default
                             }
                         }
 
-                        $object.Columns.Add($sqlcolumn)
+                        if ($column.Identity) {
+                            $sqlColumn.Identity = $true
+                            if ($column.IdentitySeed) {
+                                $sqlColumn.IdentitySeed = $column.IdentitySeed
+                            }
+                            if ($column.IdentityIncrement) {
+                                $sqlColumn.IdentityIncrement = $column.IdentityIncrement
+                            }
+                        }
+                        $object.Columns.Add($sqlColumn)
                     }
 
                     if ($Passthru) {

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'ColumnMap', 'ColumnObject', 'AnsiNullsStatus', 'ChangeTrackingEnabled', 'DataSourceName', 'Durability', 'ExternalTableDistribution', 'FileFormatName', 'FileGroup', 'FileStreamFileGroup', 'FileStreamPartitionScheme', 'FileTableDirectoryName', 'FileTableNameColumnCollation', 'FileTableNamespaceEnabled', 'HistoryTableName', 'HistoryTableSchema', 'IsExternal', 'IsFileTable', 'IsMemoryOptimized', 'IsSystemVersioned', 'Location', 'LockEscalation', 'Owner', 'PartitionScheme', 'QuotedIdentifierStatus', 'RejectSampleValue', 'RejectType', 'RejectValue', 'RemoteDataArchiveDataMigrationState', 'RemoteDataArchiveEnabled', 'RemoteDataArchiveFilterPredicate', 'RemoteObjectName', 'RemoteSchemaName', 'RemoteTableName', 'RemoteTableProvisioned', 'ShardingColumnName', 'TextFileGroup', 'TrackColumnsUpdatedEnabled', 'HistoryRetentionPeriod', 'HistoryRetentionPeriodUnit', 'DwTableDistribution', 'RejectedRowLocation', 'OnlineHeapOperation', 'LowPriorityMaxDuration', 'DataConsistencyCheck', 'LowPriorityAbortAfterWait', 'MaximumDegreeOfParallelism', 'IsNode', 'IsEdge', 'IsVarDecimalStorageFormatEnabled', 'Passthru', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -19,6 +19,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $null = New-DbaDatabase -SqlInstance $script:instance1 -Name $dbname
         $tablename = "dbatoolssci_$(Get-Random)"
         $tablename2 = "dbatoolssci2_$(Get-Random)"
+        $tablename3 = "dbatoolssci2_$(Get-Random)"
     }
     AfterAll {
         $null = Invoke-DbaQuery -SqlInstance $script:instance1 -Database $dbname -Query "drop table $tablename, $tablename2"
@@ -41,11 +42,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "Should create the table with constraint on column" {
         It "Creates the table" {
             $map = @{
-                Name      = 'test'
-                Type      = 'nvarchar'
-                MaxLength = 20
-                Nullable  = $true
-                Default  =  'MyTest'
+                Name        = 'test'
+                Type        = 'nvarchar'
+                MaxLength   = 20
+                Nullable    = $true
+                Default     = 'MyTest'
                 DefaultName = 'DF_MyTest'
             }
             (New-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Name $tablename2 -ColumnMap $map).Name | Should -Contain $tablename2
@@ -54,6 +55,25 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $table = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table $tablename2
             $table.Name | Should -Contain $tablename2
             $table.Columns.DefaultConstraint.Name | Should -Contain "DF_MyTest"
+        }
+    }
+    Context "Should create the table with an identity column" {
+        It "Creates the table" {
+            $map = @{
+                Name              = 'testId'
+                Type              = 'int'
+                Identity          = $true
+                IdentitySeed      = 10
+                IdentityIncrement = 2
+            }
+            (New-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Name $tablename3 -ColumnMap $map).Name | Should -Contain $tablename3
+        }
+        It "Has an identity column" {
+            $table = Get-DbaDbTable -SqlInstance $script:instance1 -Database $dbname -Table $tablename3
+            $table.Name | Should -Be $tablename3
+            $table.Columns.Identity | Should -Be $true
+            $table.Columns.IdentitySeed | Should -Be $map.IdentitySeed
+            $table.Columns.IdentityIncrement | Should -Be $map.IdentityIncrement
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [X] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
- add ability to specify identity, identityseed and identityincrememt for the ColumnMap

### Approach
- if ColumnMap contains a column with these properties add them to the SqlColumn object

### Commands to test
```PowerShell
$cols = @()
$cols += @{
    Name              = 'testId'
    Type              = 'int'
    Identity          = $true
    IdentitySeed      = 10
    IdentityIncrement = 2
}
New-DbaDbTable -SqlInstance mssql1 -Database tempdb -Name TestTable -ColumnMap $cols
```
### Screenshots
![image](https://user-images.githubusercontent.com/981370/103460655-ec587380-4d0f-11eb-918c-87a621e09cc3.png)