### PR TITLE
Publish-DbaDacPackage - auto detect bacpac files and minor refactoring

### DIFF
--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -1,10 +1,10 @@
 function Publish-DbaDacPackage {
     <#
     .SYNOPSIS
-        The Publish-DbaDacPackage command takes a dacpac and publishes it to a database.
+        The Publish-DbaDacPackage command takes a dacpac or bacpac and publishes it to a database.
 
     .DESCRIPTION
-        Publishes the dacpac taken from SSDT project or Export-DbaDacPackage. Changing the schema to match the dacpac and also to run any scripts in the dacpac (pre/post deploy scripts).
+        Publishes the dacpac taken from SSDT project or Export-DbaDacPackage. Changing the schema to match the dacpac and also to run any scripts in the dacpac (pre/post deploy scripts) or bacpac.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -26,9 +26,6 @@ function Publish-DbaDacPackage {
     .PARAMETER ConnectionString
         Specifies the connection string to the database you are upgrading. This is not required if SqlInstance is specified.
 
-    .PARAMETER GenerateDeploymentScript
-        If this switch is enabled, the publish script will be generated.
-
     .PARAMETER GenerateDeploymentReport
         If this switch is enabled, the publish XML report  will be generated.
 
@@ -42,7 +39,7 @@ function Publish-DbaDacPackage {
         Specifies the filesystem path (directory) where output files will be generated.
 
     .PARAMETER ScriptOnly
-        If this switch is enabled, only the change scripts will be generated.
+        If this switch is enabled the publish script will be generated.
 
     .PARAMETER IncludeSqlCmdVars
         If this switch is enabled, SqlCmdVars in publish.xml will have their values overwritten.
@@ -62,7 +59,7 @@ function Publish-DbaDacPackage {
         Path to the dac dll. If this is omitted, then the version of dac dll which is packaged with dbatools is used.
 
     .NOTES
-        Tags: Migration, Database, Dacpac
+        Tags: Migration, Database, Dacpac, Bacpac
         Author: Richie lee (@richiebzzzt)
 
         Website: https://dbatools.io
@@ -100,7 +97,7 @@ function Publish-DbaDacPackage {
         Publishes the dacpac using a specific dacfx library. Prompts for confirmation.
 
     .EXAMPLE
-        PS C:\> Publish-DbaDacPackage -SqlInstance sql2017 -Database WideWorldImporters -Path C:\temp\sql2016-WideWorldImporters.dacpac -PublishXml C:\temp\sql2016-WideWorldImporters-publish.xml -GenerateDeploymentScript -ScriptOnly
+        PS C:\> Publish-DbaDacPackage -SqlInstance sql2017 -Database WideWorldImporters -Path C:\temp\sql2016-WideWorldImporters.dacpac -PublishXml C:\temp\sql2016-WideWorldImporters-publish.xml -ScriptOnly
 
         Does not deploy the changes, but will generate the deployment script that would be executed against WideWorldImporters.
     #>
@@ -110,19 +107,16 @@ function Publish-DbaDacPackage {
         [PSCredential]$SqlCredential,
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [string]$Path,
-        [Parameter(Mandatory, ParameterSetName = 'Xml')]
+        [Parameter(ParameterSetName = 'Xml')]
         [string]$PublishXml,
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [string[]]$Database,
         [string[]]$ConnectionString,
-        [parameter(ParameterSetName = 'Xml')]
-        [switch]$GenerateDeploymentScript,
-        [parameter(ParameterSetName = 'Xml')]
         [switch]$GenerateDeploymentReport,
         [Switch]$ScriptOnly,
         [ValidateSet('Dacpac', 'Bacpac')]
         [string]$Type = 'Dacpac',
-        [string]$OutputPath = "$home\Documents",
+        [string]$OutputPath = (Get-DbatoolsConfigValue -FullName 'Path.DbatoolsExport'),
         [switch]$IncludeSqlCmdVars,
         [Parameter(ParameterSetName = 'Obj')]
         [Alias("Option")]
@@ -137,22 +131,17 @@ function Publish-DbaDacPackage {
             return
         }
         if ($Type -eq 'Dacpac') {
-            if ((Test-Bound -ParameterName GenerateDeploymentScript) -or (Test-Bound -ParameterName GenerateDeploymentReport)) {
+            if ((Test-Bound -ParameterName ScriptOnly) -or (Test-Bound -ParameterName GenerateDeploymentReport)) {
                 $defaultColumns = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Dacpac', 'PublishXml', 'Result', 'DatabaseScriptPath', 'MasterDbScriptPath', 'DeploymentReport', 'DeployOptions', 'SqlCmdVariableValues'
             } else {
                 $defaultColumns = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Dacpac', 'PublishXml', 'Result', 'DeployOptions', 'SqlCmdVariableValues'
             }
         } elseif ($Type -eq 'Bacpac') {
-            if ($ScriptOnly -or $GenerateDeploymentReport -or $GenerateDeploymentScript) {
-                Stop-Function -Message "ScriptOnly, GenerateDeploymentScript, and GenerateDeploymentReport cannot be used in a Bacpac scenario." -ErrorRecord $_
+            if ($ScriptOnly -or $GenerateDeploymentReport) {
+                Stop-Function -Message "ScriptOnly and GenerateDeploymentReport cannot be used in a Bacpac scenario." -ErrorRecord $_
                 return
             }
             $defaultColumns = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database', 'Bacpac', 'Result', 'DeployOptions'
-        }
-
-        if ((Test-Bound -ParameterName ScriptOnly) -and (Test-Bound -Not -ParameterName GenerateDeploymentScript) -and (Test-Bound -Not -ParameterName GenerateDeploymentScript)) {
-            Stop-Function -Message "You must at least one of GenerateDeploymentScript or GenerateDeploymentReport when using ScriptOnly"
-            return
         }
 
         function Get-ServerName ($connString) {
@@ -182,19 +171,6 @@ function Publish-DbaDacPackage {
                 }
             }
         }
-
-        #Check Option object types - should have a specific type
-        if ($Type -eq 'Dacpac') {
-            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.PublishOptions]) {
-                Stop-Function -Message "Microsoft.SqlServer.Dac.PublishOptions object type is expected - got $($DacOption.GetType())."
-                return
-            }
-        } elseif ($Type -eq 'Bacpac') {
-            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.DacImportOptions]) {
-                Stop-Function -Message "Microsoft.SqlServer.Dac.DacImportOptions object type is expected - got $($DacOption.GetType())."
-                return
-            }
-        }
     }
 
     process {
@@ -207,7 +183,25 @@ function Publish-DbaDacPackage {
             return
         }
 
-        if ($PsCmdlet.ParameterSetName -eq 'Xml') {
+        # auto detect if a .bacpac was passed in, just in case the -Type param was not specified
+        if (-not (Test-Bound Type) -and [IO.Path]::GetExtension($Path) -eq '.bacpac') {
+            $Type = 'Bacpac'
+        }
+
+        #Check Option object types - should have a specific type
+        if ($Type -eq 'Dacpac') {
+            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.PublishOptions]) {
+                Stop-Function -Message "Microsoft.SqlServer.Dac.PublishOptions object type is expected for `"-Type Dacpac`" but $($DacOption.GetType()) was passed in."
+                return
+            }
+        } elseif ($Type -eq 'Bacpac') {
+            if ($DacOption -and $DacOption -isnot [Microsoft.SqlServer.Dac.DacImportOptions]) {
+                Stop-Function -Message "Microsoft.SqlServer.Dac.DacImportOptions object type is expected for `"-Type Bacpac`" but $($DacOption.GetType()) was passed in."
+                return
+            }
+        }
+
+        if (Test-Bound PublishXml) {
             if (-not (Test-Path -Path $PublishXml)) {
                 Stop-Function -Message "$PublishXml not found."
                 return
@@ -240,7 +234,7 @@ function Publish-DbaDacPackage {
             }
         }
         #Load XML profile when used
-        if ($PsCmdlet.ParameterSetName -eq 'Xml') {
+        if (Test-Bound PublishXml) {
             try {
                 $options = New-DbaDacOption -Type $Type -Action Publish -PublishXml $PublishXml -EnableException
             } catch {
@@ -249,8 +243,8 @@ function Publish-DbaDacPackage {
             }
         }
         #Create/re-use deployment options object
-        elseif ($PsCmdlet.ParameterSetName -eq 'Obj') {
-            if (!$DacOption) {
+        else {
+            if (-not (Test-Bound DacOption)) {
                 $options = New-DbaDacOption -Type $Type -Action Publish
             } else {
                 $options = $DacOption
@@ -267,15 +261,15 @@ function Publish-DbaDacPackage {
 
             foreach ($dbName in $Database) {
                 #Set deployment properties when specified
-                if (Test-Bound -ParameterName GenerateDeploymentScript) {
-                    $options.GenerateDeploymentScript = $GenerateDeploymentScript
+                if (Test-Bound -ParameterName ScriptOnly) {
+                    $options.GenerateDeploymentScript = $true
                 }
                 if (Test-Bound -ParameterName GenerateDeploymentReport) {
                     $options.GenerateDeploymentReport = $GenerateDeploymentReport
                 }
                 #Set output file paths when needed
                 $timeStamp = (Get-Date).ToString("yyMMdd_HHmmss_f")
-                if ($GenerateDeploymentScript) {
+                if ($options.GenerateDeploymentScript) {
                     $options.DatabaseScriptPath = Join-Path $OutputPath "$cleaninstance-$dbName`_DeployScript_$timeStamp.sql"
                     $options.MasterDbScriptPath = Join-Path $OutputPath "$cleaninstance-$dbName`_Master.DeployScript_$timeStamp.sql"
                 }
@@ -296,10 +290,8 @@ function Publish-DbaDacPackage {
                     }
                     #Perform proper action depending on the Type
                     if ($Type -eq 'Dacpac') {
-                        if ($ScriptOnly) {
-                            if (!$options.GenerateDeploymentScript) {
-                                Stop-Function -Message "GenerateDeploymentScript option should be specified when running with -ScriptOnly" -EnableException $true
-                            }
+                        if ($options.GenerateDeploymentScript) {
+                            Write-Message -Level Verbose -Message "Generating the deployment script as requested by the caller."
                             if (!$options.DatabaseScriptPath) {
                                 Stop-Function -Message "DatabaseScriptPath option should be specified when running with -ScriptOnly" -EnableException $true
                             }


### PR DESCRIPTION
- Added logic to auto detect the bacpac file
- Changed the OutputPath to have the default config value.
- Adjusted the parameter sets to reflect the allowable combinations of params based on how the command was originally written.
- Removed the GenerateDeploymentScript param to simplify the command. Now the -ScriptOnly param implies that the deployment script will be generated (which reflects how the code was written originally).
- Updated the integration tests

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6839 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Added the auto detection logic as requested in #6839 and also did some minor refactoring to simplify the command for both the callers and maintainers.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests for example commands.