### PR TITLE
Get-DbaKbUpdate and Save-DbaKbUpdate - minor fixes

### DIFF
--- a/functions/Get-DbaKbUpdate.ps1
+++ b/functions/Get-DbaKbUpdate.ps1
@@ -134,7 +134,6 @@ function Get-DbaKbUpdate {
 
                 $guids = $results.Links |
                     Where-Object ID -match '_link' |
-                    Where-Object { $_.OuterHTML -match ( "(?=.*" + ( $Filter -join ")(?=.*" ) + ")" ) } |
                     ForEach-Object { $_.id.replace('_link', '') } |
                     Where-Object { $_ -in $kbids }
 

--- a/functions/Save-DbaKbUpdate.ps1
+++ b/functions/Save-DbaKbUpdate.ps1
@@ -67,7 +67,7 @@ function Save-DbaKbUpdate {
         [ValidateSet("x64", "x86", "ia64", "All")]
         [string]$Architecture = "x64",
         [parameter(ValueFromPipeline)]
-        [pscustomobject]$InputObject,
+        [object[]]$InputObject,
         [switch]$EnableException
     )
     process {

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -40,6 +40,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
 
     It "Call with multiple KBs" {
         $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+
+        # basic retry logic in case the first download didn't get all of the files
+        if ($null -eq $results -or $results.Count -ne 3) {
+            Write-Message -Level Warning -Message "Retrying..."
+            Start-Sleep -s 30
+            $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+        }
+
         $results.KBLevel | Should -Contain 4057119
         $results.KBLevel | Should -Contain 4577194
         $results.KBLevel | Should -Contain 4564903

--- a/tests/Get-DbaKbUpdate.Tests.ps1
+++ b/tests/Get-DbaKbUpdate.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'Name', 'Simple', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -18,5 +18,30 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $results = Get-DbaKbUpdate -Name KB4057119
         $results.Link -match 'download.windowsupdate.com'
         $results.Title -match 'Cumulative Update'
+        $results.KBLevel | Should -Be 4057119
+    }
+
+    It "test with the -Simple param" {
+        $results = Get-DbaKbUpdate -Name KB4577194 -Simple
+        $results.Link -match 'download.windowsupdate.com'
+        $results.Title -match 'Cumulative Update'
+        $results.KBLevel | Should -Be 4577194
+    }
+
+    # see https://github.com/sqlcollaborative/dbatools/issues/6745
+    It "Calling script uses a variable named filter" {
+        $filter = "SQLServer*-KB-*x64*.exe"
+
+        $results = Get-DbaKbUpdate -Name KB4564903
+        $results.KBLevel | Should -Be 4564903
+        $results.Link -match 'download.windowsupdate.com'
+        $results.Title -match 'Cumulative Update'
+    }
+
+    It "Call with multiple KBs" {
+        $results = Get-DbaKbUpdate -Name KB4057119, KB4577194, KB4564903
+        $results.KBLevel | Should -Contain 4057119
+        $results.KBLevel | Should -Contain 4577194
+        $results.KBLevel | Should -Contain 4564903
     }
 }

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'Name', 'Path', 'FilePath', 'InputObject', 'Architecture', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -20,8 +20,26 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $results | Remove-Item -Confirm:$false
     }
     It "supports piping" {
-        $results = Get-DbaKbUpdate -Name KB2992080 | Select -First 1 | Save-DbaKbUpdate -Path C:\temp
+        $results = Get-DbaKbUpdate -Name KB2992080 | select -First 1 | Save-DbaKbUpdate -Path C:\temp
         $results.Name -match 'aspnet'
+        $results | Remove-Item -Confirm:$false
+    }
+    It "Download multiple updates" {
+        $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Path C:\temp
+        $results.Count | Should -Be 2
+        $results | Remove-Item -Confirm:$false
+
+        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Path C:\temp
+        $results.Count | Should -Be 2
+        $results | Remove-Item -Confirm:$false
+    }
+
+    # see https://github.com/sqlcollaborative/dbatools/issues/6745
+    It "Ensuring that variable scope doesn't impact the command negatively" {
+        $filter = "SQLServer*-KB-*x64*.exe"
+
+        $results = Save-DbaKbUpdate -Name KB4513696 -Path C:\temp
+        $results.Count | Should -Be 1
         $results | Remove-Item -Confirm:$false
     }
 }

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -26,10 +26,33 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
     It "Download multiple updates" {
         $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Path C:\temp
+
+        # basic retry logic in case the first download didn't get all of the files
+        if ($null -eq $results -or $results.Count -ne 2) {
+            Write-Message -Level Warning -Message "Retrying..."
+            if ($results.Count -gt 0) {
+                $results | Remove-Item -Confirm:$false
+            }
+            Start-Sleep -s 30
+            $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Path C:\temp
+        }
+
         $results.Count | Should -Be 2
         $results | Remove-Item -Confirm:$false
 
+        # download multiple updates via piping
         $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Path C:\temp
+
+        # basic retry logic in case the first download didn't get all of the files
+        if ($null -eq $results -or $results.Count -ne 2) {
+            Write-Message -Level Warning -Message "Retrying..."
+            if ($results.Count -gt 0) {
+                $results | Remove-Item -Confirm:$false
+            }
+            Start-Sleep -s 30
+            $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Path C:\temp
+        }
+
         $results.Count | Should -Be 2
         $results | Remove-Item -Confirm:$false
     }


### PR DESCRIPTION
- Removed the where-object clause with the $Filter variable mentioned in #6745 since it was not being used.
- Fixed bug that occurred in Save-DbaKbUpdate when multiple KBs were passed in.
- Added more integration tests.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6745 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Minor fix for the issue described in #6745 and one additional bug encountered along the way.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests.

### Learning
The $Filter variable was originally part of the code at https://keithga.wordpress.com/2017/05/21/new-tool-get-the-latest-windows-10-cumulative-updates/ 
