### PR TITLE
Get-DbaLogin, Set-DbaLogin, Connect-SqlInstance - block use with Azure via AzureUnsupported param

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -1,7 +1,8 @@
 function Get-DbaLogin {
     <#
     .SYNOPSIS
-        Function to get an SMO login object of the logins for a given SQL Server instance. Takes a server object from the pipeline. SQL Azure DB is not supported.
+        Function to get an SMO login object of the logins for a given SQL Server instance. Takes a server object from the pipeline.
+        SQL Azure DB is not supported.
 
     .DESCRIPTION
         The Get-DbaLogin function returns an SMO Login object for the logins passed, if there are no users passed it will return all logins.
@@ -20,7 +21,7 @@ function Get-DbaLogin {
         The login(s) to process - this list is auto-populated from the server. If unspecified, all logins will be processed.
 
     .PARAMETER ExcludeLogin
-        The login(s) to exclude from an auto-populated list of logins from the server.
+        The login(s) to exclude. Options for this list are auto-populated from the server.
 
     .PARAMETER IncludeFilter
         A list of logins to include - accepts wildcard patterns

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -1,7 +1,7 @@
 function Get-DbaLogin {
     <#
     .SYNOPSIS
-        Function to get an SMO login object of the logins for a given SQL Server instance. Takes a server object from the pipeline.
+        Function to get an SMO login object of the logins for a given SQL Server instance. Takes a server object from the pipeline. SQL Azure DB is not supported.
 
     .DESCRIPTION
         The Get-DbaLogin function returns an SMO Login object for the logins passed, if there are no users passed it will return all logins.
@@ -20,7 +20,7 @@ function Get-DbaLogin {
         The login(s) to process - this list is auto-populated from the server. If unspecified, all logins will be processed.
 
     .PARAMETER ExcludeLogin
-        The login(s) to exclude - this list is auto-populated from the server
+        The login(s) to exclude
 
     .PARAMETER IncludeFilter
         A list of logins to include - accepts wildcard patterns
@@ -194,7 +194,7 @@ function Get-DbaLogin {
         foreach ($instance in $SqlInstance) {
 
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }

--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -20,7 +20,7 @@ function Get-DbaLogin {
         The login(s) to process - this list is auto-populated from the server. If unspecified, all logins will be processed.
 
     .PARAMETER ExcludeLogin
-        The login(s) to exclude
+        The login(s) to exclude from an auto-populated list of logins from the server.
 
     .PARAMETER IncludeFilter
         A list of logins to include - accepts wildcard patterns

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -51,6 +51,9 @@ function Set-DbaLogin {
     .PARAMETER PasswordPolicyEnforced
         Should the password policy be enforced.
 
+    .PARAMETER PasswordExpirationEnabled
+        Should the password expiration check be enforced.
+
     .PARAMETER AddRole
         Add one or more server roles to the login
         The following roles can be used "bulkadmin", "dbcreator", "diskadmin", "processadmin", "public", "securityadmin", "serveradmin", "setupadmin", "sysadmin".

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -51,9 +51,6 @@ function Set-DbaLogin {
     .PARAMETER PasswordPolicyEnforced
         Should the password policy be enforced.
 
-    .PARAMETER PasswordExpirationEnabled
-        Should the password expiration check be enforced.
-
     .PARAMETER AddRole
         Add one or more server roles to the login
         The following roles can be used "bulkadmin", "dbcreator", "diskadmin", "processadmin", "public", "securityadmin", "serveradmin", "setupadmin", "sysadmin".
@@ -176,7 +173,6 @@ function Set-DbaLogin {
         [switch]$DenyLogin,
         [switch]$GrantLogin,
         [switch]$PasswordPolicyEnforced,
-        [switch]$PasswordExpirationEnabled,
         [ValidateSet('bulkadmin', 'dbcreator', 'diskadmin', 'processadmin', 'public', 'securityadmin', 'serveradmin', 'setupadmin', 'sysadmin')]
         [string[]]$AddRole,
         [ValidateSet('bulkadmin', 'dbcreator', 'diskadmin', 'processadmin', 'public', 'securityadmin', 'serveradmin', 'setupadmin', 'sysadmin')]
@@ -212,19 +208,6 @@ function Set-DbaLogin {
                     Stop-Function -Message 'Password must be a PSCredential or SecureString' -Target $Login
                 }
             }
-        }
-
-        if ((Test-Bound Unlock) -and (Test-Bound SecurePassword -Not)) {
-            Stop-Function -Message 'You must specify a password when using the -Unlock parameter'
-        }
-
-        if ((Test-Bound MustChange) -and (Test-Bound SecurePassword -Not)) {
-            Stop-Function -Message 'You must specify a password when using the -MustChange parameter'
-        }
-
-        # check_expiration and check_policy are required for must_change
-        if ((Test-Bound MustChange) -and ((Test-Bound PasswordPolicyEnforced -Not) -or (Test-Bound PasswordExpirationEnabled -Not))) {
-            Stop-Function -Message 'The -MustChange parameter must be used with -PasswordPolicyEnforced and -PasswordExpirationEnabled'
         }
     }
 
@@ -270,20 +253,8 @@ function Set-DbaLogin {
                 # Change the password
                 if (Test-bound -ParameterName 'SecurePassword') {
                     try {
-                        # these settings are required for must_change and are validated above
-                        if (Test-Bound MustChange) {
-                            Write-Message -Message "Setting check_policy and check_expiration to true for $l because the must_change option requires it." -Level Warning
-                            $l.PasswordPolicyEnforced = $PasswordPolicyEnforced
-                            $l.PasswordExpirationEnabled = $PasswordExpirationEnabled
-                            $l.Alter()
-                        }
-
                         $l.ChangePassword($NewSecurePassword, $Unlock, $MustChange)
                         $passwordChanged = $true
-
-                        if (Test-Bound MustChange) {
-                            $l.Refresh()  # necessary so that the read only property MustChangePassword is updated
-                        }
                     } catch {
                         $notes += "Couldn't change password"
                         $passwordChanged = $false
@@ -343,15 +314,6 @@ function Set-DbaLogin {
                         Write-Message -Message "Login $l password policy is already set to $($l.PasswordPolicyEnforced)" -Level Verbose
                     } else {
                         $l.PasswordPolicyEnforced = $PasswordPolicyEnforced
-                    }
-                }
-
-                # Enforce password expiration
-                if (Test-Bound -ParameterName 'PasswordExpirationEnabled') {
-                    if ($l.PasswordExpirationEnabled -eq $PasswordExpirationEnabled) {
-                        Write-Message -Message "Login $l password expiration check is already set to $($l.PasswordExpirationEnabled)" -Level Verbose
-                    } else {
-                        $l.PasswordExpirationEnabled = $PasswordExpirationEnabled
                     }
                 }
 
@@ -417,7 +379,7 @@ function Set-DbaLogin {
                 Add-Member -Force -InputObject $l -MemberType NoteProperty -Name DenyLogin -Value $l.DenyWindowsLogin
 
                 $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'LoginName', 'DenyLogin', 'IsDisabled', 'IsLocked',
-                'PasswordPolicyEnforced', 'PasswordExpirationEnabled', 'MustChangePassword', 'PasswordChanged', 'ServerRole', 'Notes'
+                'PasswordPolicyEnforced', 'MustChangePassword', 'PasswordChanged', 'ServerRole', 'Notes'
 
                 Select-DefaultView -InputObject $l -Property $defaults
             }

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -1,7 +1,8 @@
 function Set-DbaLogin {
     <#
     .SYNOPSIS
-        Set-DbaLogin makes it possible to make changes to one or more logins. SQL Azure DB is not supported.
+        Set-DbaLogin makes it possible to make changes to one or more logins.
+        SQL Azure DB is not supported.
 
     .DESCRIPTION
         Set-DbaLogin will enable you to change the password, unlock, rename, disable or enable, deny or grant login privileges to the login. It's also possible to add or remove server roles from the login.

--- a/internal/functions/Connect-SqlInstance.ps1
+++ b/internal/functions/Connect-SqlInstance.ps1
@@ -66,7 +66,7 @@ function Connect-SqlInstance {
         [switch]$NonPooled
     )
     if ($SqlInstance.InputObject.GetType().Name -eq 'Server') {
-        if ($AzureUnsupported -and $server.DatabaseEngineType -eq "SqlAzureDatabase") {
+        if ($AzureUnsupported -and $SqlInstance.InputObject.DatabaseEngineType -eq "SqlAzureDatabase") {
             throw "Azure SQL Database is not supported by this command"
         }
         return $SqlInstance.InputObject

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -102,14 +102,8 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $invalidPassword = ConvertTo-SecureString -String 'invalid' -AsPlainText -Force
             $invalidSqlCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "testlogin1_$random", $invalidPassword
 
-            # Get the lockout threshold for the local server (assumption: the tests are running on the server itself) https://stackoverflow.com/questions/60117943/powershell-script-to-report-account-lockout-policy-settings
-            $lockoutObj = net accounts | Select-String threshold
-            $lockoutStr = $lockoutObj.ToString()
-            $lockoutStr -match '\d{1,3}' | Out-Null
-            $lockoutThreshold = $matches[0]
-
             # exceed the lockout count
-            for (($i = 0); $i -le $lockoutThreshold; $i++) {
+            for (($i = 0); $i -le 5; $i++) {
                 try {
                     Connect-DbaInstance -SqlInstance $script:instance1 -SqlCredential $invalidSqlCredential
                 } catch {

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -4,16 +4,28 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'IncludeFilter', 'ExcludeLogin', 'ExcludeFilter', 'ExcludeSystemLogin', 'Type', 'HasAccess', 'Locked', 'Disabled', , 'MustChangePassword', 'Detailed', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $random = Get-Random
+
+        $password = ConvertTo-SecureString -String "password1A@" -AsPlainText -Force
+        New-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -Password $password
+        New-DbaLogin -SqlInstance $script:instance1 -Login "testlogin2_$random" -Password $password
+    }
+
+    AfterAll {
+        Remove-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random", "testlogin2_$random" -Confirm:$false -Force
+    }
+
     Context "Does sql instance have a SA account" {
         $results = Get-DbaLogin -SqlInstance $script:instance1 -Login sa
         It "Should report that one account named SA exists" {
@@ -36,6 +48,111 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         It "Should get LoginProperties via Detailed switch" {
             $results.BadPasswordCount | Should Not Be $null
             $results.PasswordHash | Should Not Be $null
+        }
+    }
+
+    Context "Validate params" {
+
+        It "Multiple logins" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random", "testlogin2_$random" -Type SQL
+            $results.Count | Should -Be 2
+            $results.Name | Should -Contain "testlogin1_$random"
+            $results.Name | Should -Contain "testlogin2_$random"
+        }
+
+        It "ExcludeLogin" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -ExcludeLogin "testlogin2_$random" -Type SQL
+            $results.Name | Should -Not -Contain "testlogin2_$random"
+            $results.Name | Should -Contain "testlogin1_$random"
+
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -ExcludeLogin "testlogin1_$random", "testlogin2_$random" -Type SQL
+            $results.Name | Should -Not -Contain "testlogin2_$random"
+            $results.Name | Should -Not -Contain "testlogin1_$random"
+        }
+
+        It "IncludeFilter" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -IncludeFilter "*$random" -Type SQL
+            $results.Count | Should -Be 2
+            $results.Name | Should -Contain "testlogin1_$random"
+            $results.Name | Should -Contain "testlogin2_$random"
+        }
+
+        It "ExcludeFilter" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -ExcludeFilter "*$random" -Type SQL
+            $results.Name | Should -Not -Contain "testlogin1_$random"
+            $results.Name | Should -Not -Contain "testlogin2_$random"
+        }
+
+        It "ExcludeSystemLogin" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -ExcludeSystemLogin -Type SQL
+            $results.Name | Should -Not -Contain "sa"
+        }
+
+        It "HasAccess" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -HasAccess -Type SQL
+            $results.Name | Should -Contain "testlogin1_$random"
+            $results.Name | Should -Contain "testlogin2_$random"
+        }
+
+        It "Locked" {
+            $result = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
+            $result.PasswordPolicyEnforced | Should -Be $true
+
+            # simulate a lockout
+            $invalidPassword = ConvertTo-SecureString -String 'invalid' -AsPlainText -Force
+            $invalidSqlCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "testlogin1_$random", $invalidPassword
+
+            # Get the lockout threshold for the local server (assumption: the tests are running on the server itself) https://stackoverflow.com/questions/60117943/powershell-script-to-report-account-lockout-policy-settings
+            $lockoutObj = net accounts | Select-String threshold
+            $lockoutStr = $lockoutObj.ToString()
+            $lockoutStr -match '\d{1,3}' | Out-Null
+            $lockoutThreshold = $matches[0]
+
+            # exceed the lockout count
+            for (($i = 0); $i -le $lockoutThreshold; $i++) {
+                try {
+                    Connect-DbaInstance -SqlInstance $script:instance1 -SqlCredential $invalidSqlCredential
+                } catch {
+                    Write-Message -Level Warning -Message "invalid login credentials used on purpose to lock out account"
+                    Start-Sleep -s 5
+                }
+            }
+
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -Locked
+            $results.Name | Should -Contain "testlogin1_$random"
+
+            $results = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -Unlock -SecurePassword $password
+            $results.IsLocked | Should -Be $false
+        }
+
+        It "Disabled" {
+            $null = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -Disable
+            $result = Get-DbaLogin -SqlInstance $script:instance1 -Disabled
+            $result.Name | Should -Contain "testlogin1_$random"
+            $null = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -Enable
+        }
+
+        It "MustChangePassword" {
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -MustChange -Password $password -PasswordPolicyEnforced -PasswordExpirationEnabled
+            $changeResult.MustChangePassword | Should -Be $true
+
+            $result = Get-DbaLogin -SqlInstance $script:instance1 -MustChangePassword
+            $result.Name | Should -Contain "testlogin1_$random"
+        }
+
+        It "Detailed" {
+            $results = Get-DbaLogin -SqlInstance $script:instance1 -Detailed -Type SQL
+
+            $results.Count | Should -BeGreaterOrEqual 2
+
+            ($results[0].PSobject.Properties.Name -contains "BadPasswordCount") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "BadPasswordTime") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "DaysUntilExpiration") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "HistoryLength") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "IsMustChange") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "LockoutTime") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "PasswordHash") | Should -Be $true
+            ($results[0].PSobject.Properties.Name -contains "PasswordLastSetTime") | Should -Be $true
         }
     }
 }

--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -15,6 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
+        $SkipLocalTest = $true # Change to $false to run the local-only tests on a local instance.
         $random = Get-Random
 
         $password = ConvertTo-SecureString -String "password1A@" -AsPlainText -Force
@@ -94,7 +95,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results.Name | Should -Contain "testlogin2_$random"
         }
 
-        It "Locked" {
+        It -Skip:$SkipLocalTest "Locked" {
             $result = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
             $result.PasswordPolicyEnforced | Should -Be $true
 

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('WhatIf', 'Confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'SecurePassword', 'DefaultDatabase', 'Unlock', 'MustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'PasswordPolicyEnforced', 'AddRole', 'RemoveRole', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'SecurePassword', 'DefaultDatabase', 'Unlock', 'MustChange', 'NewName', 'Disable', 'Enable', 'DenyLogin', 'GrantLogin', 'PasswordPolicyEnforced', 'PasswordExpirationEnabled', 'AddRole', 'RemoveRole', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -58,141 +58,187 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
-    Context "Change login" {
+    Context "verify command functions" {
         BeforeAll {
+            $random = Get-Random
+
             # Create the new password
-            $password1 = ConvertTo-SecureString -String "password1" -AsPlainText -Force
-            $password2 = ConvertTo-SecureString -String "password2" -AsPlainText -Force
+            $password1 = ConvertTo-SecureString -String "password1A@" -AsPlainText -Force
+            $password2 = ConvertTo-SecureString -String "password2A@" -AsPlainText -Force
 
             # Create the login
-            New-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Password $password1
+            New-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random", "testlogin2_$random" -Password $password1
+
+            New-DbaDatabase -SqlInstance $script:instance2 -Name "testdb1_$random" -Confirm:$false
+        }
+
+        AfterAll {
+            Remove-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random", "testlogin2_$random" -Confirm:$false -Force
+            Remove-DbaDatabase -SqlInstance $script:instance2 -Database "testdb1_$random" -Confirm:$false
         }
 
         It "Does test login exist" {
-            $logins = Get-DbaLogin -SqlInstance $script:instance2 | Where-Object { $_.Name -eq "testlogin" } | Select-Object Name
-            $logins.Name | Should -Be "testlogin"
+            $logins = Get-DbaLogin -SqlInstance $script:instance2 | Where-Object { $_.Name -eq "testlogin1_$random" } | Select-Object Name
+            $logins.Name | Should -Be "testlogin1_$random"
         }
 
         It "Verifies -NewName doesn't already exist when renaming a login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login 'testLogin' -NewName 'sa' -EnableException
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -NewName 'sa' -EnableException
 
             $result.Notes | Should -Be 'New login name already exists'
         }
 
         It 'Change the password from a SecureString' {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Password $password2
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Password $password2
 
             $result.PasswordChanged | Should -Be $true
         }
 
         It 'Changes the password from a PSCredential' {
-            $cred = New-Object System.Management.Automation.PSCredential ('testLogin', $password2)
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login 'testLogin' -Password $cred
+            $cred = New-Object System.Management.Automation.PSCredential ("testlogin1_$random", $password2)
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Password $cred
 
             $result.PasswordChanged | Should -Be $true
         }
 
         It "Change the password from piped Login" {
-            $login = Get-DbaLogin -Sqlinstance $script:instance2 -Login testLogin
+            $login = Get-DbaLogin -Sqlinstance $script:instance2 -Login "testlogin1_$random"
 
             $result = $login | Set-DbaLogin -Password $password2
             $result.PasswordChanged | Should -Be $true
         }
 
         It "Change the password from InputObject" {
-            $login = Get-DbaLogin -Sqlinstance $script:instance2 -Login testLogin
+            $login = Get-DbaLogin -Sqlinstance $script:instance2 -Login "testlogin1_$random"
 
             $result = Set-DbaLogin -InputObject $login -Password $password2
             $result.PasswordChanged | Should -Be $true
         }
 
         It "Disable the login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Disable
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Disable
             $result.IsDisabled | Should -Be $true
         }
 
         It "Enable the login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -Enable
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Enable
             $result.IsDisabled | Should -Be $false
         }
 
         It "Deny access to login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -DenyLogin
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -DenyLogin
 
             $result.DenyLogin | Should -Be $true
         }
 
         It "Grant access to login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -GrantLogin
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -GrantLogin
 
             $result.DenyLogin | Should -Be $false
         }
 
         It "Enforces password policy on login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced
 
             $result.PasswordPolicyEnforced | Should Be $true
         }
 
         It "Catches errors when password can't be changed" {
             # enforce password policy
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login 'testLogin' -PasswordPolicyEnforced -EnableException
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
             $result.PasswordPolicyEnforced | Should -Be $true
 
             # violate policy
             $invalidPassword = ConvertTo-SecureString -String "password1" -AsPlainText -Force
 
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login 'testLogin' -Password $invalidPassword -WarningAction 'SilentlyContinue'
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Password $invalidPassword -WarningAction 'SilentlyContinue'
             $result | Should -Be $null
 
-            { Set-DbaLogin -SqlInstance $script:instance2 -Login 'testLogin' -Password $invalidPassword -EnableException } | Should -Throw
+            { Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Password $invalidPassword -EnableException } | Should -Throw
         }
 
         It "Disables enforcing password policy on login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -PasswordPolicyEnforced:$false
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced:$false
 
             $result.PasswordPolicyEnforced | Should Be $false
         }
 
         It "Add roles to login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -AddRole serveradmin, processadmin
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -AddRole serveradmin, processadmin
 
             $result.ServerRole | Should -Be "processadmin, serveradmin"
         }
 
         It "Remove roles from login" {
-            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin -RemoveRole serveradmin
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -RemoveRole serveradmin
 
             $result.ServerRole | Should -Be "processadmin"
         }
 
-        AfterAll {
-            Remove-DbaLogin -SqlInstance $script:instance2 -Login testlogin,testlogin1,testlogin2 -Confirm:$false -Force
-        }
-    }
-    Context "Can handle multiple Logins" {
-        BeforeAll {
-            # Create the new password
-            $password = ConvertTo-SecureString -String "password1" -AsPlainText -Force
-
-            # Create two logins
-            New-DbaLogin -SqlInstance $script:instance2 -Login testlogin1, testlogin2 -Password $password
-        }
-        $results = Set-DbaLogin -SqlInstance $script:instance2 -Login testlogin1, testlogin2 -DenyLogin
-
-        It "Results include multiple objects" {
+        It "Results include multiple changed objects" {
+            $results = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random", "testlogin2_$random" -DenyLogin
             $results.Count | Should -Be 2
-        }
-        if ($results.Count -eq 2) {
-            It "Applies change to multiple logins" {
-                foreach ($r in $results) {
-                    $r.DenyLogin | Should -Be $true
-                }
+            foreach ($r in $results) {
+                $r.DenyLogin | Should -Be $true
             }
         }
 
-        AfterAll {
-            Remove-DbaLogin -SqlInstance $script:instance2 -Login testlogin1,testlogin2 -Confirm:$false -Force
+        It "DefaultDatabase" {
+            $results = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -DefaultDatabase "testdb1_$random"
+            $results.DefaultDatabase | Should -Be "testdb1_$random"
+        }
+
+        It "Unlock" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
+            $result.PasswordPolicyEnforced | Should -Be $true
+
+            # simulate a lockout
+            $invalidPassword = ConvertTo-SecureString -String 'invalid' -AsPlainText -Force
+            $invalidSqlCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "testlogin1_$random", $invalidPassword
+
+            # Get the lockout threshold for the local server (assumption: the tests are running on the server itself) https://stackoverflow.com/questions/60117943/powershell-script-to-report-account-lockout-policy-settings
+            $lockoutObj = net accounts | Select-String threshold
+            $lockoutStr = $lockoutObj.ToString()
+            $lockoutStr -match '\d{1,3}' | Out-Null
+            $lockoutThreshold = $matches[0]
+
+            # exceed the lockout count
+            for (($i = 0); $i -le $lockoutThreshold; $i++) {
+                try {
+                    Connect-DbaInstance -SqlInstance $script:instance2 -SqlCredential $invalidSqlCredential
+                } catch {
+                    Write-Message -Level Warning -Message "invalid login credentials used on purpose to lock out account"
+                    Start-Sleep -s 5
+                }
+            }
+
+            $results = Get-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random"
+            $results.IsLocked | Should -Be $true
+
+            $results = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Unlock
+            $results | Should -BeNullOrEmpty
+
+            $results = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -Unlock -SecurePassword $password1
+            $results.IsLocked | Should -Be $false
+        }
+
+        It "MustChange" {
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -MustChange
+            $changeResult | Should -BeNullOrEmpty
+
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -MustChange -Password $password1
+            $changeResult | Should -BeNullOrEmpty
+
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -MustChange -Password $password1 -PasswordPolicyEnforced -PasswordExpirationEnabled
+            $changeResult.MustChangePassword | Should -Be $true
+
+            $result = Get-DbaLogin -SqlInstance $script:instance2 -MustChangePassword
+            $result.Name | Should -Contain "testlogin1_$random"
+        }
+
+        It "PasswordExpirationEnabled" {
+            $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordExpirationEnabled
+            $result.PasswordExpirationEnabled | Should Be $true
         }
     }
 }

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -60,6 +60,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
     Context "verify command functions" {
         BeforeAll {
+            $SkipLocalTest = $true # Change to $false to run the local-only tests on a local instance.
             $random = Get-Random
 
             # Create the new password
@@ -188,7 +189,7 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $results.DefaultDatabase | Should -Be "testdb1_$random"
         }
 
-        It "Unlock" {
+        It -Skip:$SkipLocalTest "Unlock" {
             $result = Set-DbaLogin -SqlInstance $script:instance2 -Login "testlogin1_$random" -PasswordPolicyEnforced -EnableException
             $result.PasswordPolicyEnforced | Should -Be $true
 

--- a/tests/Set-DbaLogin.Tests.ps1
+++ b/tests/Set-DbaLogin.Tests.ps1
@@ -196,14 +196,8 @@ Describe "$CommandName Integration Tests" -Tag 'IntegrationTests' {
             $invalidPassword = ConvertTo-SecureString -String 'invalid' -AsPlainText -Force
             $invalidSqlCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "testlogin1_$random", $invalidPassword
 
-            # Get the lockout threshold for the local server (assumption: the tests are running on the server itself) https://stackoverflow.com/questions/60117943/powershell-script-to-report-account-lockout-policy-settings
-            $lockoutObj = net accounts | Select-String threshold
-            $lockoutStr = $lockoutObj.ToString()
-            $lockoutStr -match '\d{1,3}' | Out-Null
-            $lockoutThreshold = $matches[0]
-
             # exceed the lockout count
-            for (($i = 0); $i -le $lockoutThreshold; $i++) {
+            for (($i = 0); $i -le 5; $i++) {
                 try {
                     Connect-DbaInstance -SqlInstance $script:instance2 -SqlCredential $invalidSqlCredential
                 } catch {


### PR DESCRIPTION
Get-DbaLogin, Set-DbaLogin, Connect-SqlInstance - add the -AzureUnsupported and more integration tests

- Added the -AzureUnsupported to Set-DbaLogin and Get-DbaLogin
- Updated Connect-SqlInstance to check the $SqlInstance.InputObject
- ~~Added param validation for Unlock in Set-DbaLogin~~ (moved to #7088)
- ~~Added logic to ensure the MustChange takes effect in Set-DbaLogin~~ (moved to #7089)
- ~~Added a new param to Set-DbaLogin for the check_expiration~~ (moved to #7090)
- Added integration tests

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7004 )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Added the -AzureUnsupported to the commands and backfilled the integration tests.  ~~, and fixed some minor issues found by the integration tests.~~

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests

### Learning
https://stackoverflow.com/questions/60117943/powershell-script-to-report-account-lockout-policy-settings
