### PR TITLE
Get-DbaPermission.Tests - reorder the integration tests and add debug messages

### DIFF
--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -66,7 +66,9 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $table2 = New-DbaDbTable -SqlInstance $server -Database $dbName -Name $tableName2 -Schema $schemaNameForTable2 -ColumnMap $tableSpec2
 
         # debugging errors seen only in AppVeyor
-        Write-Message -Level Verbose -Message "Get-DbaPermission: Server=$server, dbName=$dbName, loginDBO=$($loginDBO.Name), loginDBOwner=$($loginDBOwner.Name), loginUser1=$($loginUser1.Name), newUserDBOwner=$($newUserDBOwner.Name), newUser1=$($newUser1.Name), table1=$($table1.Name), loginUser2=$($loginUser2.Name), newUser2=$($newUser2.Name), table2=$($table2.Name), table2Schema=$($table2.Schema)"
+        Write-Message -Level Warning -Message "Get-DbaPermission: Server=$server, dbName=$dbName, loginDBO=$($loginDBO.Name), loginDBOwner=$($loginDBOwner.Name), loginUser1=$($loginUser1.Name), newUserDBOwner=$($newUserDBOwner.Name), newUser1=$($newUser1.Name), table1=$($table1.Name), loginUser2=$($loginUser2.Name), newUser2=$($newUser2.Name), table2=$($table2.Name), table2Schema=$($table2.Schema)"
+
+        Write-Host "Get-DbaPermission: Server=$server, dbName=$dbName, loginDBO=$($loginDBO.Name), loginDBOwner=$($loginDBOwner.Name), loginUser1=$($loginUser1.Name), newUserDBOwner=$($newUserDBOwner.Name), newUser1=$($newUser1.Name), table1=$($table1.Name), loginUser2=$($loginUser2.Name), newUser2=$($newUser2.Name), table2=$($table2.Name), table2Schema=$($table2.Schema)"
     }
 
     AfterAll {
@@ -101,12 +103,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results.where( { $_.Securable -eq "dbo.$tableName1" -and $_.PermState -eq 'GRANT' -and $_.PermissionName -eq 'SELECT' }).count | Should -Be 1
         }
     }
-    Context "Validate input" {
-        It "Cannot resolve hostname of computer" {
-            Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaComputerSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null } | Should Throw
-        }
-    }
 
     # See https://github.com/sqlcollaborative/dbatools/issues/6744
     Context "Ensure implicit permissions are included in the result set" {
@@ -123,6 +119,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results.where( { $_.Securable -eq "$schemaNameForTable2" -and $_.PermissionName -eq "CONTROL" -and $_.Grantee -eq $loginNameUser1 -and $_.GranteeType -eq "SCHEMA OWNER" }).count | Should -Be 1
             $results.where( { $_.Securable -eq "$schemaNameForTable2" -and $_.PermissionName -eq "CONTROL" -and $_.Grantee -eq $loginNameUser2 -and $_.GranteeType -eq "SQL_USER" }).count | Should -Be 1
 
+        }
+    }
+
+    Context "Validate input" {
+        It "Cannot resolve hostname of computer" {
+            Mock Resolve-DbaNetworkName { $null }
+            { Get-DbaComputerSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null } | Should Throw
         }
     }
 }

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -66,8 +66,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         $table2 = New-DbaDbTable -SqlInstance $server -Database $dbName -Name $tableName2 -Schema $schemaNameForTable2 -ColumnMap $tableSpec2
 
         # debugging errors seen only in AppVeyor
-        Write-Message -Level Warning -Message "Get-DbaPermission: Server=$server, dbName=$dbName, loginDBO=$($loginDBO.Name), loginDBOwner=$($loginDBOwner.Name), loginUser1=$($loginUser1.Name), newUserDBOwner=$($newUserDBOwner.Name), newUser1=$($newUser1.Name), table1=$($table1.Name), loginUser2=$($loginUser2.Name), newUser2=$($newUser2.Name), table2=$($table2.Name), table2Schema=$($table2.Schema)"
-
         Write-Host "Get-DbaPermission: Server=$server, dbName=$dbName, loginDBO=$($loginDBO.Name), loginDBOwner=$($loginDBOwner.Name), loginUser1=$($loginUser1.Name), newUserDBOwner=$($newUserDBOwner.Name), newUser1=$($newUser1.Name), table1=$($table1.Name), loginUser2=$($loginUser2.Name), newUser2=$($newUser2.Name), table2=$($table2.Name), table2Schema=$($table2.Schema)"
     }
 

--- a/tests/Get-DbaPermission.Tests.ps1
+++ b/tests/Get-DbaPermission.Tests.ps1
@@ -119,11 +119,4 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
         }
     }
-
-    Context "Validate input" {
-        It "Cannot resolve hostname of computer" {
-            Mock Resolve-DbaNetworkName { $null }
-            { Get-DbaComputerSystem -ComputerName 'DoesNotExist142' -WarningAction Stop 3> $null } | Should Throw
-        }
-    }
 }


### PR DESCRIPTION
Get-DbaPermission.Tests - reorder the integration tests and add debug messages

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7101 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Debugging the integration test in appveyor. The tests are working fine on my local machine with SQL 2019, 2017, and 2016. 

### Approach
There is one test that uses a mock method for resolving the network name, so I've put that test last in the file in case there is some unexpected side effect from that test.

