### PR TITLE
 Write-DbaDbTableData: Moving Connect to Server step to the beginning of the code.

### DIFF
--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -399,7 +399,7 @@ function Write-DbaDbTableData {
         $tableName = $fqtnObj.Name
 
         $quotedFQTN = New-Object System.Text.StringBuilder
-       
+
         if ($server.ServerType -ne 'SqlAzureDatabase') {
             <#
                 Skip adding database name to Fully Qualified Tablename for Azure SQL DB

--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -347,7 +347,16 @@ function Write-DbaDbTableData {
         }
 
         #endregion Utility Functions
-
+        
+        #region Connect to server
+        try {
+            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            return
+        }
+        #endregion Connect to server
+        
         #region Prepare type for bulk copy
         if (-not $Truncate) { $ConfirmPreference = "None" }
 
@@ -390,7 +399,7 @@ function Write-DbaDbTableData {
         $tableName = $fqtnObj.Name
 
         $quotedFQTN = New-Object System.Text.StringBuilder
-
+       
         if ($server.ServerType -ne 'SqlAzureDatabase') {
             <#
                 Skip adding database name to Fully Qualified Tablename for Azure SQL DB
@@ -425,14 +434,8 @@ function Write-DbaDbTableData {
         Write-Message -Level SomewhatVerbose -Message "FQTN processed: $fqtn"
         #endregion Resolve Full Qualified Table Name
 
-        #region Connect to server and get database
-        try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
-            return
-        }
 
+        #region Get database
         if ($server.ServerType -eq 'SqlAzureDatabase') {
             <#
                 For some reasons SMO wants an initial pull when talking to Azure Sql DB
@@ -447,7 +450,7 @@ function Write-DbaDbTableData {
         }
         try {
             $databaseObject = $server.Databases[$databaseName]
-            #endregion Connect to server and get database
+            #endregion Get database
 
             #region Prepare database and bulk operations
             if ($null -eq $databaseObject) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
I saw that in command Write-DbaDbTableData $server variable was called (line 394) before being initialised in line 430. So I moved the block of code where the connection is set to the beginning, as the first step of the command. 
### Approach
<!-- How does this change solve that purpose -->
Moving part of the code will make that the connection of the server is made before checking if it is an Azure SQL server or not.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Write-DbaDbTableData with an Azure SQL Server using a private enpoint.
