### PR TITLE
Invoke-DbatoolsFormatter - remove tabs from code comments

### DIFF
--- a/functions/Invoke-DbatoolsFormatter.ps1
+++ b/functions/Invoke-DbatoolsFormatter.ps1
@@ -107,7 +107,7 @@ function Invoke-DbatoolsFormatter {
             $realContent = @()
             #trim whitespace lines
             foreach ($line in $content.Split("`n")) {
-                $realContent += $line.TrimEnd()
+                $realContent += $line.Replace("`t", "    ").TrimEnd()
             }
             [System.IO.File]::WriteAllText($realPath, ($realContent -Join "$OSEOL"), $Utf8NoBomEncoding)
         }


### PR DESCRIPTION
Invoke-DbatoolsFormatter - remove tabs from code comments

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7127 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Ensure that tabs are removed from code comments, since the dbatools style check will fail if there are tabs in the command documentation comments block.

### Approach
<!-- How does this change solve that purpose -->
The fix proposed here is to replace tabs with 4 spaces during the last step where the whitespace trim is being done.

