### PR TITLE
Remove-DbaDbOrphanUser - ensure 'drop user' command syntax is valid

### DIFF
--- a/functions/Remove-DbaDbOrphanUser.ps1
+++ b/functions/Remove-DbaDbOrphanUser.ps1
@@ -274,7 +274,13 @@ function Remove-DbaDbOrphanUser {
                                         Write-Message -Level Verbose -Message "User $dbuser does not own any schema. Will be dropped."
                                     }
 
-                                    $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbuser
+                                    # https://github.com/sqlcollaborative/dbatools/issues/7130
+                                    $dbUserName = $dbuser.ToString()
+                                    if (-not ($dbUserName.StartsWith("[") -and $dbUserName.EndsWith("]"))) {
+                                        $dbUserName = "[" + $dbUserName + "]"
+                                    }
+
+                                    $query = "$AlterSchemaOwner `r`n$DropSchema `r`nDROP USER " + $dbUserName
 
                                     Write-Message -Level Debug -Message $query
                                 } else {

--- a/tests/Remove-DbaDbOrphanUser.Tests.ps1
+++ b/tests/Remove-DbaDbOrphanUser.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'User', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -16,24 +16,33 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $server = Connect-DbaInstance -SqlInstance $script:instance2
-        $dbname = "dbatoolsci_$(Get-Random)"
-        $login1 = "dbatoolssci_user1_$(Get-Random)"
-        $login2 = "dbatoolssci_user2_$(Get-Random)"
-        $schema = "dbatoolssci_Schema_$(Get-Random)"
+        $random = Get-Random
+        $dbname = "dbatoolsci_$random"
+        $login1 = "dbatoolssci_user1_$random"
+        $login2 = "dbatoolssci_user2_$random"
+        $schema = "dbatoolssci_Schema_$random"
         $securePassword = ConvertTo-SecureString 'MyV3ry$ecur3P@ssw0rd' -AsPlainText -Force
+        $plaintext = 'BigOlPassword!'
 
         $null = New-DbaDatabase -SqlInstance $server -Name $dbname -Owner sa
+
+        $loginWindows = "db$random"
+
+        $null = Invoke-Command2 -ScriptBlock { net user $args[0] $args[1] /add *>&1 } -ArgumentList $loginWindows, $plaintext -ComputerName $script:instance2
     }
     BeforeEach {
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Password $securePassword -Force
         $null = New-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Password $securePassword -Force
+        $null = New-DbaLogin -SqlInstance $script:instance2 -Login "$($script:instance2)\$loginWindows" -Force
 
         $null = New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Login $login1 -Username $login1
         $null = New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Login $login2 -Username $login2
+        $null = New-DbaDbUser -SqlInstance $script:instance2 -Database $dbname -Login "$($script:instance2)\$loginWindows" -Username "$($script:instance2)\$loginWindows"
         $null = New-DbaDbUser -SqlInstance $script:instance2 -Database msdb -Login $login1 -Username $login1 -IncludeSystem
         $null = New-DbaDbUser -SqlInstance $script:instance2 -Database msdb -Login $login2 -Username $login2 -IncludeSystem
         $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Confirm:$false
+        $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login "$($script:instance2)\$loginWindows" -Confirm:$false
     }
     AfterEach {
         $users = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
@@ -43,22 +52,19 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         if ($users.Name -contains $login2) {
             $null = Remove-DbaDbUser $script:instance2 -Database $dbname, msdb -User $login2
         }
-        #$null = Remove-DbaDbUser -SqlInstance -SqlInstance $script:instance2 -Database $dbname, tempdb -User $login1, $login2 -Force -Confirm:$false
     }
     AfterAll {
         $null = Remove-DbaDatabase -SqlInstance $script:instance2 -Database $dbname -confirm:$false
+        $null = Invoke-Command2 -ScriptBlock { net user $args /delete *>&1 } -ArgumentList $loginWindows -ComputerName $script:instance2
     }
 
     It "Removes Orphan Users" {
         $results0 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2
-        $results1 = Get-DbaDbUser -SqlInstance lensmansb -Database $dbname, msdb
 
-        $results0.Name -contains $login1  | Should Be $true
-        $results0.Name -contains $login2  | Should Be $true
+        $results0.Name -contains $login1 | Should Be $true
+        $results0.Name -contains $login2 | Should Be $true
         $results0.Count | Should BeGreaterThan $results1.Count
-        $results1.Name -contains $login1  | Should Be $false
-        $results1.Name -contains $login2  | Should Be $false
     }
 
     It "Removes selected Orphan Users" {
@@ -68,31 +74,31 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
 
         $results0.Count | Should BeGreaterThan $results1.Count
-        $results1.Name -contains $login1  | Should Be $false
-        $results1.Name -contains $login2  | Should Be $true
+        $results1.Name -contains $login1 | Should Be $false
+        $results1.Name -contains $login2 | Should Be $true
     }
 
     It "Removes Orphan Users for Database" {
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -Database msdb -User $login1, $login2
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
-        $results1 = $results1 | Where-Object {$_.Name -eq $login1 -or $_.Name -eq $login2}
+        $results1 = $results1 | Where-Object { $_.Name -eq $login1 -or $_.Name -eq $login2 }
 
-        $results1.Name -contains $login1  | Should Be $true
-        $results1.Name -contains $login2  | Should Be $true
-        $results1.Database -contains 'msdb'  | Should Be $false
-        $results1.Database -contains $dbname  | Should Be $true
+        $results1.Name -contains $login1 | Should Be $true
+        $results1.Name -contains $login2 | Should Be $true
+        $results1.Database -contains 'msdb' | Should Be $false
+        $results1.Database -contains $dbname | Should Be $true
 
     }
 
     It "Removes Orphan Users except for excluded databases" {
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -ExcludeDatabase msdb -User $login1, $login2
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
-        $results1 = $results1 | Where-Object {$_.Name -eq $login1 -or $_.Name -eq $login2}
+        $results1 = $results1 | Where-Object { $_.Name -eq $login1 -or $_.Name -eq $login2 }
 
-        $results1.Name -contains $login1  | Should Be $true
-        $results1.Name -contains $login2  | Should Be $true
-        $results1.Database -contains 'msdb'  | Should Be $true
-        $results1.Database -contains $dbname  | Should Be $false
+        $results1.Name -contains $login1 | Should Be $true
+        $results1.Name -contains $login2 | Should Be $true
+        $results1.Database -contains 'msdb' | Should Be $true
+        $results1.Database -contains $dbname | Should Be $false
     }
 
     It "Removes Orphan Users with unmapped logins if force specified" {
@@ -103,8 +109,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -User $login2
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
 
-        $results1.Name -contains $login1  | Should Be $false
-        $results1.Name -contains $login2  | Should Be $true
+        $results1.Name -contains $login1 | Should Be $false
+        $results1.Name -contains $login2 | Should Be $true
 
         $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Confirm:$false
         $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Confirm:$false
@@ -118,8 +124,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -Database $dbname, msdb -User $login1, $login2 -Force
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname, msdb
 
-        $results1.Name -contains $login1  | Should Be $false
-        $results1.Name -contains $login2  | Should Be $false
+        $results1.Name -contains $login1 | Should Be $false
+        $results1.Name -contains $login2 | Should Be $false
 
         $sql = "DROP SCHEMA $schema"
         $server.Query($sql, $dbname)
@@ -139,12 +145,16 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -Database $dbname -User $login2 -Force
         $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname
 
-        $results1.Name -contains $login1  | Should Be $true
-        $results1.Name -contains $login2  | Should Be $false
+        $results1.Name -contains $login1 | Should Be $true
+        $results1.Name -contains $login2 | Should Be $false
 
         $sql = "DROP TABLE $schema.test1;DROP TABLE [$login2].test2;DROP SCHEMA $schema;DROP SCHEMA [$login2];"
         $server.Query($sql, $dbname)
     }
 
-
+    It "Removes the orphaned windows login" {
+        $null = Remove-DbaDbOrphanUser -SqlInstance $script:instance2 -Database $dbname -User "$($script:instance2)\$loginWindows"
+        $results1 = Get-DbaDbUser -SqlInstance $script:instance2 -Database $dbname
+        $results1.Name -contains $loginWindows | Should -Be $false
+    }
 }


### PR DESCRIPTION
Remove-DbaDbOrphanUser - ensure dynamic sql for 'drop user' is valid when a windows user is being removed.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7130 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensuring that the drop user command completes successfully.

### Approach
<!-- How does this change solve that purpose -->
Added a check for the square brackets and if not found they are added before the drop user statement is run.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new integration test and the report from #7130