### PR TITLE
Add config item to bypass CredSSP initialization

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -24,6 +24,10 @@ function Install-DbaInstance {
         Note that the dowloaded installation media must be extracted and available to the server where the installation runs.
         NOTE: If no ProductID (PID) is found in the configuration files/parameters, Evaluation version is going to be installed.
 
+        When using CredSSP authentication, this function will configure CredSSP authentication for PowerShell Remoting sessions.
+        If this is not desired (e.g.: CredSSP authentication is managed externally, or is already configured appropriately,)
+        it can be disabled by setting the dbatools configuration option 'commands.initialize-credssp.bypass' value to $true.
+
     .PARAMETER SqlInstance
         The target computer and, optionally, a new instance name and a port number.
         Use one of the following generic formats:

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -25,6 +25,10 @@ function Update-DbaInstance {
         CVE-2018-0886 security update is required for both local and remote hosts. If CredSSP connections are failing, make sure to
         apply recent security updates prior to doing anything else.
 
+        When using CredSSP authentication, this function will configure CredSSP authentication for PowerShell Remoting sessions.
+        If this is not desired (e.g.: CredSSP authentication is managed externally, or is already configured appropriately,)
+        it can be disabled by setting the dbatools configuration option 'commands.initialize-credssp.bypass' value to $true.
+
         Always backup databases and configurations prior to upgrade.
 
     .PARAMETER ComputerName

--- a/internal/configurations/settings/commands.ps1
+++ b/internal/configurations/settings/commands.ps1
@@ -10,3 +10,6 @@ Set-DbatoolsConfig -FullName 'commands.resolve-dbanetworkname.bypass' -Value $fa
 # Get-DbaRegServer
 Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.defaultcms' -Value $null -Initialize -Validation string -Description "Use a default Central Management Server"
 Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.includelocal' -Value $false -Initialize -Validation bool -Description "Include local servers by default"
+
+# Initialize-CredSSP
+Set-DbatoolsConfig -FullName 'commands.initialize-credssp.bypass' -Value $false -Initialize -Validation bool -Description "Do not attempt to configure CredSSP authentication, use existing configuration as-is"

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -38,7 +38,7 @@ function Initialize-CredSSP {
     )
 
     #Check to see if this function is bypassed
-    if ( ( Get-DbatoolsConfigValue -FullName 'commands.initialize-credssp.bypass')  -eq $true ) {
+    if ( ( Get-DbatoolsConfigValue -FullName 'commands.initialize-credssp.bypass') -eq $true ) {
         Write-Message -Level Verbose -Message "CredSSP initialization bypass (commands.initialize-credssp.bypass) is set to $true";
         return;
     }

--- a/internal/functions/Initialize-CredSSP.ps1
+++ b/internal/functions/Initialize-CredSSP.ps1
@@ -8,6 +8,8 @@ function Initialize-CredSSP {
         Local computer will be told to trust the Delegate (remote) computer.
         Remote computer will be configured to act as a server and accept client connections from local computer.
 
+        This function can be disabled by setting the value of configuration item "commands.initialize-credssp.bypass" to $true.
+
     .PARAMETER ComputerName
         Remote computer name
 
@@ -34,6 +36,12 @@ function Initialize-CredSSP {
         [pscredential]$Credential,
         [bool]$EnableException
     )
+
+    #Check to see if this function is bypassed
+    if ( ( Get-DbatoolsConfigValue -FullName 'commands.initialize-credssp.bypass')  -eq $true ) {
+        Write-Message -Level Verbose -Message "CredSSP initialization bypass (commands.initialize-credssp.bypass) is set to $true";
+        return;
+    }
 
     #Configure local machine
     #Start local WinRM service


### PR DESCRIPTION
* add configuration setting "commands.initialize-credssp.bypass"
* add check for configuration item value in Initialize-CredSSP function,
  log message and return if true

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #7148 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add a configuration item to bypass initialization of CredSSP configuration. This can be useful in cases where the user is not allowed to configure CredSSP on their computer or servers, or where a user already has CredSSP configured and does not want the existing configuration to be altered.

### Approach
Add a configuration item "commands.initialize-credssp.bypass" with a default value of $false to internal/configurations/settings/commands.ps1 

In internal/functions/Initialize-CredSSP.ps1, add a check for this configuration value.
If true, log a message indicating CredSSP initialization is bypassed, and return from the function with no further action.
