### PR TITLE
Export-DbaLogin -  ensure the ScriptingOptions object with IncludeIfNotExists set to true is used when scripting the db users

### DIFF
--- a/functions/Export-DbaLogin.ps1
+++ b/functions/Export-DbaLogin.ps1
@@ -461,16 +461,17 @@ function Export-DbaLogin {
 
                         $outsql += "`r`nUSE [$dbName]`r`n"
 
+                        $scriptOptions = New-DbaScriptingOption
+                        $scriptVersion = $sourceDb.CompatibilityLevel
+                        $scriptOptions.TargetServerVersion = [Microsoft.SqlServer.Management.Smo.SqlServerVersion]::$scriptVersion
+                        $scriptOptions.ContinueScriptingOnError = $false
+                        $scriptOptions.IncludeDatabaseContext = $false
+                        $scriptOptions.IncludeIfNotExists = $true
+
                         if ($ObjectLevel) {
                             # Exporting all permissions
-                            $scriptOptions = New-DbaScriptingOption
-                            $scriptVersion = $sourceDb.CompatibilityLevel
-                            $scriptOptions.TargetServerVersion = [Microsoft.SqlServer.Management.Smo.SqlServerVersion]::$scriptVersion
                             $scriptOptions.AllowSystemObjects = $true
                             $scriptOptions.IncludeDatabaseRoleMemberships = $true
-                            $scriptOptions.ContinueScriptingOnError = $false
-                            $scriptOptions.IncludeDatabaseContext = $false
-                            $scriptOptions.IncludeIfNotExists = $true
 
                             $exportSplat = @{
                                 SqlInstance            = $server
@@ -491,7 +492,7 @@ function Export-DbaLogin {
                             }
                         } else {
                             try {
-                                $sql = $server.Databases[$dbName].Users[$dbUserName].Script()
+                                $sql = $server.Databases[$dbName].Users[$dbUserName].Script($scriptOptions)
                                 $outsql += $sql
                             } catch {
                                 Write-Message -Level Warning -Message "User cannot be found in selected database"

--- a/tests/Export-DbaLogin.Tests.ps1
+++ b/tests/Export-DbaLogin.Tests.ps1
@@ -101,6 +101,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $allfiles += $file.FullName
             $results | Should Not Match "$login2|$dbname2"
             $results | Should Match "$login1|$dbname1"
+            $results | Should -Match ([regex]::Escape("IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$user1')"))
         }
         It "Should Export with object level permissions" {
             $results = Export-DbaLogin -SqlInstance $script:instance2 -Login $login2 -ObjectLevel -PassThru -WarningAction SilentlyContinue


### PR DESCRIPTION
Export-DbaLogin - Ensure the ScriptingOptions object with IncludeIfNotExists set to true is used when scripting the db users

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7158 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure the ScriptingOptions object with IncludeIfNotExists set to true is used when scripting the db users.

### Approach
<!-- How does this change solve that purpose -->
Minor refactor of the code.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
The "Should Export a specific user" integration test has an example.

