### PR TITLE
Import-DbaCsv - ensure the reader is closed in the inner loop

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -654,6 +654,12 @@ function Import-DbaCsv {
                             Write-Progress -id 1 -activity "Inserting $resultcount rows" -status "Failed" -Completed
                         }
                         Stop-Function -Continue -Message "Failure" -ErrorRecord $_
+                    } finally {
+                        try {
+                            $reader.Close()
+                            $reader.Dispose()
+                        } catch {
+                        }
                     }
                 }
                 if ($PSCmdlet.ShouldProcess($instance, "Finalizing import")) {

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -644,8 +644,6 @@ function Import-DbaCsv {
                             Write-Progress -id 1 -activity "Inserting $resultcount rows" -status "Complete" -Completed
                         }
 
-                        $reader.Close()
-                        $reader.Dispose()
                         $completed = $true
                     } catch {
                         $completed = $false


### PR DESCRIPTION
Import-DbaCsv - ensure the reader is closed in the inner loop

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7162 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure that the file reader is closed in the inner loop where the bulk copy is being done.

### Approach
<!-- How does this change solve that purpose -->
Verified using Process Explorer that the file is locked. Added a finally block so that the reader will be closed in all cases.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests.

