### PR TITLE
New-DbaDbSchema and Get-DbaDbSchema: change param name to 'Schema'

### DIFF
--- a/functions/Get-DbaDbSchema.ps1
+++ b/functions/Get-DbaDbSchema.ps1
@@ -20,7 +20,7 @@ function Get-DbaDbSchema {
     .PARAMETER Database
         The target database(s).
 
-    .PARAMETER SchemaName
+    .PARAMETER Schema
         The name(s) of the schema(s)
 
     .PARAMETER SchemaOwner
@@ -63,7 +63,7 @@ function Get-DbaDbSchema {
         Gets all non-system database schemas from all user databases on the localhost instance. Note: the dbo schema is a system schema and won't be included in the output from this example. To include the dbo schema specify -IncludeSystemSchemas
 
     .EXAMPLE
-        PS C:\> Get-DbaDbSchema -SqlInstance localhost -SchemaName dbo -IncludeSystemSchemas
+        PS C:\> Get-DbaDbSchema -SqlInstance localhost -Schema dbo -IncludeSystemSchemas
 
         Returns the dbo schema from the databases on the localhost instance.
 
@@ -73,7 +73,7 @@ function Get-DbaDbSchema {
         Gets all database schemas from all databases on the localhost instance.
 
     .EXAMPLE
-        PS C:\> Get-DbaDbSchema -SqlInstance localhost -SchemaName TestSchema
+        PS C:\> Get-DbaDbSchema -SqlInstance localhost -Schema TestSchema
 
         Finds and returns the TestSchema schema from the localhost instance.
 
@@ -88,21 +88,21 @@ function Get-DbaDbSchema {
         Finds and returns the schemas owned by DBUser1 in the TestDB database from the localhost instance.
 
     .EXAMPLE
-        PS C:\> $schema = Get-DbaDbSchema -SqlInstance localhost -Database TestDB -SchemaName TestSchema
+        PS C:\> $schema = Get-DbaDbSchema -SqlInstance localhost -Database TestDB -Schema TestSchema
         PS C:\> $schema.Owner = DBUser2
         PS C:\> $schema.Alter()
 
         Finds the TestSchema in the TestDB on the localhost instance and then changes the schema owner to DBUser2
 
     .EXAMPLE
-        PS C:\> $schema = Get-DbaDbSchema -SqlInstance localhost -Database TestDB -SchemaName TestSchema
+        PS C:\> $schema = Get-DbaDbSchema -SqlInstance localhost -Database TestDB -Schema TestSchema
         PS C:\> $schema.Drop()
 
         Finds the TestSchema in the TestDB on the localhost instance and then drops it. Note: to drop a schema all objects must be transferred to another schema or dropped.
 
     .EXAMPLE
         PS C:\> $db = Get-DbaDatabase -SqlInstance localhost -Database TestDB
-        PS C:\> $schema = $db | Get-DbaDbSchema -SchemaName TestSchema
+        PS C:\> $schema = $db | Get-DbaDbSchema -Schema TestSchema
 
         Finds the TestSchema in the TestDB which is passed via pipeline into the Get-DbaDbSchema command.
     #>
@@ -111,7 +111,7 @@ function Get-DbaDbSchema {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,
-        [string[]]$SchemaName,
+        [string[]]$Schema,
         [string[]]$SchemaOwner,
         [switch]$IncludeSystemDatabases,
         [switch]$IncludeSystemSchemas,
@@ -126,7 +126,7 @@ function Get-DbaDbSchema {
         }
 
         foreach ($db in $InputObject) {
-            $db.Schemas | Where-Object { ($_.IsSystemObject -eq $false) -or ($_.IsSystemObject -eq $IncludeSystemSchemas) } | Where-Object { ($_.Name -in $SchemaName) -or ($null -eq $SchemaName) } | Where-Object { ($_.Owner -in $SchemaOwner) -or ($null -eq $SchemaOwner) }
+            $db.Schemas | Where-Object { ($_.IsSystemObject -eq $false) -or ($_.IsSystemObject -eq $IncludeSystemSchemas) } | Where-Object { ($_.Name -in $Schema) -or ($null -eq $Schema) } | Where-Object { ($_.Owner -in $SchemaOwner) -or ($null -eq $SchemaOwner) }
         }
     }
 }

--- a/functions/New-DbaDbSchema.ps1
+++ b/functions/New-DbaDbSchema.ps1
@@ -20,7 +20,7 @@ function New-DbaDbSchema {
     .PARAMETER Database
         The target database(s).
 
-    .PARAMETER SchemaName
+    .PARAMETER Schema
         The name(s) of the new schema(s)
 
     .PARAMETER SchemaOwner
@@ -52,22 +52,22 @@ function New-DbaDbSchema {
         https://dbatools.io/New-DbaDbSchema
 
     .EXAMPLE
-        PS C:\> New-DbaDbSchema -SqlInstance localhost -Database example1 -SchemaName TestSchema1
+        PS C:\> New-DbaDbSchema -SqlInstance localhost -Database example1 -Schema TestSchema1
 
         Creates the TestSchema1 schema in the example1 database in the localhost instance. The dbo user will be the owner of the schema.
 
     .EXAMPLE
-        PS C:\> New-DbaDbSchema -SqlInstance localhost -Database example1 -SchemaName TestSchema1, TestSchema2 -SchemaOwner dbatools
+        PS C:\> New-DbaDbSchema -SqlInstance localhost -Database example1 -Schema TestSchema1, TestSchema2 -SchemaOwner dbatools
 
         Creates the TestSchema1 and TestSchema2 schemas in the example1 database in the localhost instance and assigns the dbatools user as the owner of the schemas.
 
     .EXAMPLE
-        PS C:\> New-DbaDbSchema -SqlInstance localhost, localhost\sql2017 -Database example1 -SchemaName TestSchema1, TestSchema2 -SchemaOwner dbatools
+        PS C:\> New-DbaDbSchema -SqlInstance localhost, localhost\sql2017 -Database example1 -Schema TestSchema1, TestSchema2 -SchemaOwner dbatools
 
         Creates the TestSchema1 and TestSchema2 schemas in the example1 database in the localhost and localhost\sql2017 instances and assigns the dbatools user as the owner of the schemas.
 
     .EXAMPLE
-        PS C:\> Get-DbaDatabase -SqlInstance localhost, localhost\sql2017 -Database example1 | New-DbaDbSchema -SchemaName TestSchema1, TestSchema2 -SchemaOwner dbatools
+        PS C:\> Get-DbaDatabase -SqlInstance localhost, localhost\sql2017 -Database example1 | New-DbaDbSchema -Schema TestSchema1, TestSchema2 -SchemaOwner dbatools
 
         Passes in the example1 db via pipeline and creates the TestSchema1 and TestSchema2 schemas and assigns the dbatools user as the owner of the schemas.
     #>
@@ -76,7 +76,7 @@ function New-DbaDbSchema {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,
-        [string[]]$SchemaName,
+        [string[]]$Schema,
         [string]$SchemaOwner,
         [parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
@@ -84,8 +84,8 @@ function New-DbaDbSchema {
     )
     process {
 
-        if (Test-Bound -Not -ParameterName SchemaName) {
-            Stop-Function -Message "SchemaName is required"
+        if (Test-Bound -Not -ParameterName Schema) {
+            Stop-Function -Message "Schema is required"
             return
         }
 
@@ -100,7 +100,7 @@ function New-DbaDbSchema {
 
         foreach ($db in $InputObject) {
 
-            foreach ($sName in $SchemaName) {
+            foreach ($sName in $Schema) {
 
                 if ($db.Schemas.Name -contains $sName) {
                     Stop-Function -Message "Schema $sName already exists in the database $($db.Name) on $($db.Parent.Name)" -Continue

--- a/functions/Remove-DbaDbSchema.ps1
+++ b/functions/Remove-DbaDbSchema.ps1
@@ -86,7 +86,7 @@ function Remove-DbaDbSchema {
 
                 if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Dropping the schema $sName on the database $($db.Name)")) {
                     try {
-                        $schemaObject = $db | Get-DbaDbSchema -SchemaName $sName
+                        $schemaObject = $db | Get-DbaDbSchema -Schema $sName
                         $schemaObject.Drop()
                     } catch {
                         Stop-Function -Message "Failure on $($db.Parent.Name) to drop the schema $sName in the database $($db.Name)" -ErrorRecord $_ -Continue

--- a/functions/Set-DbaDbSchema.ps1
+++ b/functions/Set-DbaDbSchema.ps1
@@ -91,7 +91,7 @@ function Set-DbaDbSchema {
 
                 if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Updating the schema $sName on the database $($db.Name) to be owned by $SchemaOwner")) {
                     try {
-                        $schemaObject = $db | Get-DbaDbSchema -SchemaName $sName
+                        $schemaObject = $db | Get-DbaDbSchema -Schema $sName
                         $schemaObject.Owner = $SchemaOwner
                         $schemaObject.Alter()
                         $schemaObject

--- a/tests/Get-DbaDbSchema.Tests.ps1
+++ b/tests/Get-DbaDbSchema.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'SchemaName', 'SchemaOwner', 'IncludeSystemDatabases', 'IncludeSystemSchemas', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Schema', 'SchemaOwner', 'IncludeSystemDatabases', 'IncludeSystemSchemas', 'InputObject', 'EnableException'
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
@@ -68,19 +68,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "get non-system schemas from a user database" {
-            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -SchemaName $schemaName
+            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Schema $schemaName
             $schemas.Name | Should -Contain $schemaName
             $schemas.Parent.Name | Should -Contain $newDbName
         }
 
         It "get a schema by name from a user database" {
-            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName $schemaName
+            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema $schemaName
             $schemas.Count | Should -Be 1
             $schemas.Name | Should -Be $schemaName
         }
 
         It "get the dbo schema" {
-            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName dbo -IncludeSystemSchemas
+            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema dbo -IncludeSystemSchemas
             $schemas.Count | Should -Be 1
             $schemas.Name | Should -Be dbo
         }
@@ -100,7 +100,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "supports piping databases" {
-            $schemas = $newDbs | Get-DbaDbSchema -SchemaName $schemaName, $schemaName2
+            $schemas = $newDbs | Get-DbaDbSchema -Schema $schemaName, $schemaName2
             $schemas.Count | Should -Be 2
             $schemas.Owner | Should -Be $userName, $userName2
             $schemas.Name | Should -Be $schemaName, $schemaName2
@@ -108,26 +108,26 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "get a schema and then change the owner" {
-            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName $schemaName
+            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema $schemaName
             $schemas.Count | Should -Be 1
             $schemas.Owner | Should -Be $userName
 
             $schemas.Owner = $userName2
             $schemas.Alter()
 
-            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName $schemaName
+            $schemas = Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema $schemaName
             $schemas.Count | Should -Be 1
             $schemas.Owner | Should -Be $userName2
         }
 
         It "get a schema and then drop it (assuming that it does not contain any objects)" {
-            $schemas = Get-DbaDbSchema -SqlInstance $instance2 -Database $newDbName -SchemaName $schemaName2
+            $schemas = Get-DbaDbSchema -SqlInstance $instance2 -Database $newDbName -Schema $schemaName2
             $schemas.Count | Should -Be 1
             $schemas.Owner | Should -Be $userName2
 
             $schemas.Drop()
 
-            $schemas = Get-DbaDbSchema -SqlInstance $instance2 -Database $newDbName -SchemaName $schemaName2
+            $schemas = Get-DbaDbSchema -SqlInstance $instance2 -Database $newDbName -Schema $schemaName2
             $schemas | Should -BeNullOrEmpty
         }
     }

--- a/tests/New-DbaDbSchema.Tests.ps1
+++ b/tests/New-DbaDbSchema.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'SchemaName', 'SchemaOwner', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Schema', 'SchemaOwner', 'InputObject', 'EnableException'
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
@@ -37,24 +37,24 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     Context "commands work as expected" {
 
-        It "validates required SchemaName" {
+        It "validates required Schema" {
             $schema = New-DbaDbSchema -SqlInstance $instance1
             $schema | Should -BeNullOrEmpty
         }
 
         It "validates required Database param" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -SchemaName TestSchema1
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Schema TestSchema1
             $schema | Should -BeNullOrEmpty
         }
 
         It "creates a new schema" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1 -SchemaOwner $userName
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1 -SchemaOwner $userName
             $schema.Count | Should -Be 1
             $schema.Owner | Should -Be $userName
             $schema.Name | Should -Be TestSchema1
             $schema.Parent.Name | Should -Be $newDbName
 
-            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -SchemaName TestSchema2, TestSchema3 -SchemaOwner $userName
+            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -Schema TestSchema2, TestSchema3 -SchemaOwner $userName
             $schemas.Count | Should -Be 4
             $schemas.Owner | Should -Be $userName, $userName, $userName, $userName
             $schemas.Name | Should -Be TestSchema2, TestSchema3, TestSchema2, TestSchema3
@@ -62,12 +62,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "reports a warning that the schema already exists" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1 -SchemaOwner $userName
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1 -SchemaOwner $userName
             $schema | Should -BeNullOrEmpty
         }
 
         It "supports piping databases" {
-            $schema = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | New-DbaDbSchema -SchemaName TestSchema4
+            $schema = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | New-DbaDbSchema -Schema TestSchema4
             $schema.Count | Should -Be 1
             $schema.Owner | Should -Be dbo
             $schema.Name | Should -Be TestSchema4

--- a/tests/Remove-DbaDbSchema.Tests.ps1
+++ b/tests/Remove-DbaDbSchema.Tests.ps1
@@ -30,34 +30,34 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "drops the schema" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1
             $schema.Count | Should -Be 1
             $schema.Name | Should -Be TestSchema1
             $schema.Parent.Name | Should -Be $newDbName
 
             Remove-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1 -Confirm:$false
 
-            (Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1) | Should -BeNullOrEmpty
+            (Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1) | Should -BeNullOrEmpty
 
-            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -SchemaName TestSchema2, TestSchema3
+            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -Schema TestSchema2, TestSchema3
             $schemas.Count | Should -Be 4
             $schemas.Name | Should -Be TestSchema2, TestSchema3, TestSchema2, TestSchema3
             $schemas.Parent.Name | Should -Be $newDbName, $newDbName, $newDbName, $newDbName
 
             Remove-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -Schema TestSchema2, TestSchema3 -Confirm:$false
 
-            (Get-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -SchemaName TestSchema2, TestSchema3) | Should -BeNullOrEmpty
+            (Get-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -Schema TestSchema2, TestSchema3) | Should -BeNullOrEmpty
         }
 
         It "supports piping databases" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1
             $schema.Count | Should -Be 1
             $schema.Name | Should -Be TestSchema1
             $schema.Parent.Name | Should -Be $newDbName
 
             Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Remove-DbaDbSchema -Schema TestSchema1 -Confirm:$false
 
-            (Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1) | Should -BeNullOrEmpty
+            (Get-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1) | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Set-DbaDbSchema.Tests.ps1
+++ b/tests/Set-DbaDbSchema.Tests.ps1
@@ -40,7 +40,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "updates the schema to a different owner" {
-            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -SchemaName TestSchema1 -SchemaOwner $userName
+            $schema = New-DbaDbSchema -SqlInstance $instance1 -Database $newDbName -Schema TestSchema1 -SchemaOwner $userName
             $schema.Count | Should -Be 1
             $schema.Owner | Should -Be $userName
             $schema.Name | Should -Be TestSchema1
@@ -52,7 +52,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $updatedSchema.Name | Should -Be TestSchema1
             $updatedSchema.Parent.Name | Should -Be $newDbName
 
-            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -SchemaName TestSchema2, TestSchema3 -SchemaOwner $userName
+            $schemas = New-DbaDbSchema -SqlInstance $instance1, $instance2 -Database $newDbName -Schema TestSchema2, TestSchema3 -SchemaOwner $userName
             $schemas.Count | Should -Be 4
             $schemas.Owner | Should -Be $userName, $userName, $userName, $userName
             $schemas.Name | Should -Be TestSchema2, TestSchema3, TestSchema2, TestSchema3


### PR DESCRIPTION
New-DbaDbSchema and Get-DbaDbSchema: change param name to 'Schema' as discussed in #7125

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7177 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Minor change to param name for consistency.

### Approach
Updates have been made to the commands and the integration tests.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration tests.