### PR TITLE
New commands for interacting with sequence objects

### DIFF
--- a/functions/Get-DbaDbSequence.ps1
+++ b/functions/Get-DbaDbSequence.ps1
@@ -41,7 +41,7 @@ function Get-DbaDbSequence {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Data, Database, Migration, Sequence, Table
+        Tags: Data, Sequence, Table
         Author: Adam Lancaster https://github.com/lancasteradam
 
         dbatools PowerShell module (https://dbatools.io)
@@ -80,10 +80,14 @@ function Get-DbaDbSequence {
             return
         }
 
+        # caller specified the instance info
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+            foreach ($db in (Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database)) {
+                $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
+            }
         }
 
+        # caller has piped in one or more databases
         foreach ($db in $InputObject) {
             $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
         }

--- a/functions/Get-DbaDbSequence.ps1
+++ b/functions/Get-DbaDbSequence.ps1
@@ -1,0 +1,91 @@
+function Get-DbaDbSequence {
+    <#
+    .SYNOPSIS
+        Finds a sequence.
+
+    .DESCRIPTION
+        Finds a sequence in the database(s) specified.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database(s).
+
+    .PARAMETER Name
+        The name of the sequence.
+
+    .PARAMETER Schema
+        The name of the schema for the sequence. The default is dbo.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, Migration, Sequence, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaDbSequence
+
+    .EXAMPLE
+        PS C:\> Get-DbaDbSequence -SqlInstance sqldev01 -Database TestDB -Name TestSequence
+
+        Finds the sequence TestSequence in the TestDB database on the sqldev01 instance.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sqldev01 -Database TestDB | Get-DbaDbSequence -Name TestSequence -Schema TestSchema
+
+        Using a pipeline this command finds the sequence named TestSchema.TestSequence in the TestDB database on the sqldev01 instance.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$Schema = 'dbo',
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+            $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
+        }
+    }
+}

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -4,7 +4,7 @@ function New-DbaDbSequence {
         Creates a sequence.
 
     .DESCRIPTION
-        Creates a sequence in the database(s) specified.
+        Creates a sequence in the database(s) specified. SQL Server 2012 and higher are supported.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
@@ -118,6 +118,10 @@ function New-DbaDbSequence {
         }
 
         foreach ($db in $InputObject) {
+
+            if ($db.Parent.VersionMajor -lt 11) {
+                Stop-Function -Message "This command only supports SQL Server 2012 and higher." -Continue
+            }
 
             if (($db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name })) {
                 Stop-Function -Message "Sequence $Name already exists in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)" -Continue

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -1,0 +1,186 @@
+function New-DbaDbSequence {
+    <#
+    .SYNOPSIS
+        Creates a sequence.
+
+    .DESCRIPTION
+        Creates a sequence in the database(s) specified.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database(s).
+
+    .PARAMETER Name
+        The name of the new sequence
+
+    .PARAMETER Schema
+        The name of the schema for the sequence. The default is dbo.
+
+    .PARAMETER IntegerType
+        The integer type for the sequence. The default is bigint. User defined integer types can be used.
+
+    .PARAMETER StartWith
+        The first value for the sequence to start with. The default is 1.
+
+    .PARAMETER IncrementBy
+        The value to increment by. The default is 1.
+
+    .PARAMETER MinValue
+        The minimum bound for the sequence.
+
+    .PARAMETER MaxValue
+        The maximum bound for the sequence.
+
+    .PARAMETER Cycle
+        Switch parameter that indicates if the sequence should cycle the values
+
+    .PARAMETER CacheSize
+        The integer size of the cache. To specify NO CACHE for a sequence use -CacheSize 0. As noted in the Microsoft documentation if the cache size is not specified the Database Engine will select a size.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, Migration, Sequence, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/New-DbaDbSequence
+
+    .EXAMPLE
+        PS C:\> New-DbaDbSequence -SqlInstance sqldev01 -Database TestDB -Name TestSequence -StartWith 10000 -IncrementBy 10
+
+        Creates a new sequence TestSequence in the TestDB database on the sqldev01 instance. The sequence will start with 10000 and increment by 10.
+
+    .EXAMPLE
+        PS C:\> New-DbaDbSequence -SqlInstance sqldev01 -Database TestDB -Name TestSequence -Cycle
+
+        Creates a new sequence TestSequence in the TestDB database on the sqldev01 instance. The sequence will cycle the numbers.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sqldev01 -Database TestDB | New-DbaDbSequence -Name TestSequence -Schema TestSchema -IntegerType bigint
+
+        Using a pipeline this command creates a new bigint sequence named TestSchema.TestSequence in the TestDB database on the sqldev01 instance.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$Schema = 'dbo',
+        [string]$IntegerType = 'bigint',
+        [long]$StartWith = 1,
+        [long]$IncrementBy = 1,
+        [long]$MinValue,
+        [long]$MaxValue,
+        [switch]$Cycle,
+        [int32]$CacheSize,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+
+            if (($db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name })) {
+                Stop-Function -Message "Sequence $Name already exists in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)" -Continue
+            }
+
+            if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Creating the sequence $Name in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)")) {
+                try {
+                    if (Test-Bound Schema) {
+                        $schemaObject = $db | Get-DbaDbSchema -Schema $Schema
+
+                        # if the schema does not exist then create it
+                        if ($null -eq $schemaObject) {
+                            $schemaObject = $db | New-DbaDbSchema -Schema $Schema
+                        }
+                    }
+
+                    $newSequence = New-Object Microsoft.SqlServer.Management.Smo.Sequence -ArgumentList $db, $Name, $Schema
+                    $newSequence.IncrementValue = $IncrementBy
+                    $newSequence.IsCycleEnabled = $Cycle.IsPresent
+
+                    # support for user defined integer types
+                    $tableParts = $IntegerType -Split "\."
+
+                    if ($db.UserDefinedDataTypes[$IntegerType]) {
+                        # check to see if the type is in the user defined types for this db
+                        $newSequence.DataType = $db.UserDefinedDataTypes[$IntegerType]
+                    } elseif ($tableParts.Count -eq 2) {
+                        # custom type with the format "schema.typename"
+                        $newSequence.DataType = $db.UserDefinedDataTypes | Where-Object { $_.Schema -eq $tableParts[0] -and $_.Name -eq $tableParts[1] }
+                    } else {
+                        # system integer type
+                        $newSequence.DataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $IntegerType
+                    }
+
+                    if (Test-Bound StartWith) {
+                        $newSequence.StartValue = $StartWith
+                    }
+
+                    if (Test-Bound MinValue) {
+                        $newSequence.MinValue = $MinValue
+                    }
+
+                    if (Test-Bound MaxValue) {
+                        $newSequence.MaxValue = $MaxValue
+                    }
+
+                    if (Test-Bound CacheSize) {
+                        if ($CacheSize -eq 0) {
+                            $newSequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::NoCache
+                        } else {
+                            $newSequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::CacheWithSize
+                            $newSequence.CacheSize = $CacheSize
+                        }
+                    } else {
+                        $newSequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::DefaultCache
+                    }
+
+                    $newSequence.Create()
+                    $newSequence
+                } catch {
+                    Stop-Function -Message "Failure on $($db.Parent.Name) to create the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -62,7 +62,7 @@ function New-DbaDbSequence {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Data, Database, Migration, Sequence, Table
+        Tags: Data, Sequence, Table
         Author: Adam Lancaster https://github.com/lancasteradam
 
         dbatools PowerShell module (https://dbatools.io)
@@ -180,7 +180,8 @@ function New-DbaDbSequence {
                     }
 
                     $newSequence.Create()
-                    $newSequence
+                    $db.Refresh()
+                    $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
                 } catch {
                     Stop-Function -Message "Failure on $($db.Parent.Name) to create the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
                 }

--- a/functions/Remove-DbaDbSequence.ps1
+++ b/functions/Remove-DbaDbSequence.ps1
@@ -1,0 +1,99 @@
+function Remove-DbaDbSequence {
+    <#
+    .SYNOPSIS
+        Removes a sequence.
+
+    .DESCRIPTION
+        Removes a sequence in the database(s) specified.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database(s).
+
+    .PARAMETER Name
+        The name of the sequence.
+
+    .PARAMETER Schema
+        The name of the schema for the sequence. The default is dbo.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, Migration, Sequence, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaDbSequence
+
+    .EXAMPLE
+        PS C:\> Remove-DbaDbSequence -SqlInstance sqldev01 -Database TestDB -Name TestSequence
+
+        Removes the sequence TestSequence in the TestDB database on the sqldev01 instance.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sqldev01 -Database TestDB | Remove-DbaDbSequence -Name TestSequence -Schema TestSchema
+
+        Using a pipeline this command Removes the sequence named TestSchema.TestSequence in the TestDB database on the sqldev01 instance.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$Schema = 'dbo',
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+
+            if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Removing the sequence $Name in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)")) {
+                try {
+                    $sequenceToDrop = $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
+                    $sequenceToDrop.Drop()
+                } catch {
+                    Stop-Function -Message "Failure on $($db.Parent.Name) to drop the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/functions/Remove-DbaDbSequence.ps1
+++ b/functions/Remove-DbaDbSequence.ps1
@@ -41,7 +41,7 @@ function Remove-DbaDbSequence {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Data, Database, Migration, Sequence, Table
+        Tags: Data, Sequence, Table
         Author: Adam Lancaster https://github.com/lancasteradam
 
         dbatools PowerShell module (https://dbatools.io)

--- a/functions/Select-DbaDbSequenceNextValue.ps1
+++ b/functions/Select-DbaDbSequenceNextValue.ps1
@@ -41,7 +41,7 @@ function Select-DbaDbSequenceNextValue {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Data, Database, Migration, Sequence, Table
+        Tags: Data, Sequence, Table
         Author: Adam Lancaster https://github.com/lancasteradam
 
         dbatools PowerShell module (https://dbatools.io)

--- a/functions/Select-DbaDbSequenceNextValue.ps1
+++ b/functions/Select-DbaDbSequenceNextValue.ps1
@@ -1,0 +1,89 @@
+function Select-DbaDbSequenceNextValue {
+    <#
+    .SYNOPSIS
+        Selects the next value from a sequence.
+
+    .DESCRIPTION
+        Selects the next value from a sequence.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database.
+
+    .PARAMETER Name
+        The name of the sequence.
+
+    .PARAMETER Schema
+        The name of the schema for the sequence. The default is dbo.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, Migration, Sequence, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Select-DbaDbSequenceNextValue
+
+    .EXAMPLE
+        PS C:\> Select-DbaDbSequenceNextValue -SqlInstance sqldev01 -Database TestDB -Name TestSequence
+
+        Selects the next value from the sequence TestSequence in the TestDB database on the sqldev01 instance.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sqldev01 -Database TestDB | Select-DbaDbSequenceNextValue -Name TestSequence -Schema TestSchema
+
+        Using a pipeline this command selects the next value from the sequence TestSchema.TestSequence in the TestDB database on the sqldev01 instance.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string]$Database,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$Schema = 'dbo',
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        if (Test-Bound SqlInstance) {
+            $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        $InputObject.Query("SELECT NEXT VALUE FOR [$($Schema)].[$($Name)] AS NextValue").NextValue
+    }
+}

--- a/functions/Set-DbaDbSequence.ps1
+++ b/functions/Set-DbaDbSequence.ps1
@@ -59,7 +59,7 @@ function Set-DbaDbSequence {
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
     .NOTES
-        Tags: Data, Database, Migration, Sequence, Table
+        Tags: Data, Sequence, Table
         Author: Adam Lancaster https://github.com/lancasteradam
 
         dbatools PowerShell module (https://dbatools.io)
@@ -148,8 +148,8 @@ function Set-DbaDbSequence {
                     }
 
                     $sequence.Alter()
-                    $sequence.Refresh()
-                    $sequence
+                    $db.Refresh()
+                    $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
                 } catch {
                     Stop-Function -Message "Failure on $($db.Parent.Name) to modify the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
                 }

--- a/functions/Set-DbaDbSequence.ps1
+++ b/functions/Set-DbaDbSequence.ps1
@@ -1,0 +1,159 @@
+function Set-DbaDbSequence {
+    <#
+    .SYNOPSIS
+        Modifies a sequence.
+
+    .DESCRIPTION
+        Modifies a sequence in the database(s) specified.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database(s).
+
+    .PARAMETER Name
+        The name of the new sequence
+
+    .PARAMETER Schema
+        The name of the schema for the sequence. The default is dbo.
+
+    .PARAMETER RestartWith
+        The first value for the sequence to restart with.
+
+    .PARAMETER IncrementBy
+        The value to increment by.
+
+    .PARAMETER MinValue
+        The minimum bound for the sequence.
+
+    .PARAMETER MaxValue
+        The maximum bound for the sequence.
+
+    .PARAMETER Cycle
+        Switch that indicates if the sequence should cycle the values
+
+    .PARAMETER CacheSize
+        The integer size of the cache. To specify NO CACHE for a sequence use -CacheSize 0. As noted in the Microsoft documentation if the cache size is not specified the Database Engine will select a size.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, Migration, Sequence, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Set-DbaDbSequence
+
+    .EXAMPLE
+        PS C:\> Set-DbaDbSequence -SqlInstance sqldev01 -Database TestDB -Name TestSequence -RestartWith 10000 -IncrementBy 10
+
+        Modifies the sequence TestSequence in the TestDB database on the sqldev01 instance. The sequence will restart with 10000 and increment by 10.
+
+    .EXAMPLE
+        PS C:\> Get-DbaDatabase -SqlInstance sqldev01 -Database TestDB | Set-DbaDbSequence -Name TestSequence -Schema TestSchema -Cycle
+
+        Using a pipeline this command modifies the sequence named TestSchema.TestSequence in the TestDB database on the sqldev01 instance. The sequence will now cycle the sequence values.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$Schema = 'dbo',
+        [long]$RestartWith,
+        [long]$IncrementBy,
+        [long]$MinValue,
+        [long]$MaxValue,
+        [switch]$Cycle,
+        [int32]$CacheSize,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+
+            if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Modifying the sequence $Name in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)")) {
+                try {
+                    $sequence = $db | Get-DbaDbSequence -Schema $Schema -Name $Name
+
+                    if ($null -eq $sequence) {
+                        Stop-Function -Message "Unable to find sequence $Name in the $Schema schema in the database $($db.Name) on $($db.Parent.Name)" -Continue
+                    }
+
+                    if (Test-Bound IncrementBy) {
+                        $sequence.IncrementValue = $IncrementBy
+                    }
+
+                    $sequence.IsCycleEnabled = $Cycle.IsPresent
+
+                    if (Test-Bound RestartWith) {
+                        $sequence.StartValue = $RestartWith # SMO does the restart logic when this value is changed and then Alter() is called (i.e. CurrentValue is also updated)
+                    }
+
+                    if (Test-Bound MinValue) {
+                        $sequence.MinValue = $MinValue
+                    }
+
+                    if (Test-Bound MaxValue) {
+                        $sequence.MaxValue = $MaxValue
+                    }
+
+                    if (Test-Bound CacheSize) {
+                        if ($CacheSize -eq 0) {
+                            $sequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::NoCache
+                        } else {
+                            $sequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::CacheWithSize
+                            $sequence.CacheSize = $CacheSize
+                        }
+                    } else {
+                        $sequence.SequenceCacheType = [Microsoft.SqlServer.Management.Smo.SequenceCacheType]::DefaultCache
+                    }
+
+                    $sequence.Alter()
+                    $sequence.Refresh()
+                    $sequence
+                } catch {
+                    Stop-Function -Message "Failure on $($db.Parent.Name) to modify the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/tests/Get-DbaDbSequence.Tests.ps1
+++ b/tests/Get-DbaDbSequence.Tests.ps1
@@ -16,12 +16,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     BeforeAll {
         $random = Get-Random
-        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
-        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
-        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+        $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 
-        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+        $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
     }
 
     AfterAll {
@@ -31,20 +31,20 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequence = Get-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence = Get-DbaDbSequence -SqlInstance $instance2 -Name SequenceTest -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "finds a sequence" {
-            $sequence = Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence = Get-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName
         }
 
         It "supports piping databases" {
-            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Get-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence = Get-DbaDatabase -SqlInstance $instance2 -Database $newDbName | Get-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName

--- a/tests/Get-DbaDbSequence.Tests.ps1
+++ b/tests/Get-DbaDbSequence.Tests.ps1
@@ -1,0 +1,53 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'InputObject', 'EnableException'
+        It "Should only contain our specific parameters" {
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+
+        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+    }
+
+    AfterAll {
+        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "commands work as expected" {
+
+        It "validates required Database param" {
+            $sequence = Get-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error | Should -Match "Database is required when SqlInstance is specified"
+        }
+
+        It "finds a sequence" {
+            $sequence = Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "supports piping databases" {
+            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Get-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+    }
+}

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -16,10 +16,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     BeforeAll {
         $random = Get-Random
-        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
-        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
-        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+        $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 
         $newDb.Query("CREATE SCHEMA TestSchema")
         $newDb.Query("CREATE TYPE TestSchema.NonNullInteger FROM INTEGER NOT NULL")
@@ -33,31 +33,31 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Name SequenceTest -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "validates IncrementBy param cannot be 0" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name SequenceTest -IncrementBy 0 -ErrorVariable error
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name SequenceTest -IncrementBy 0 -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error.Exception | Should -Match "cannot be zero"
         }
 
         It "creates a new sequence" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName
         }
 
         It "tries to create a duplicate sequence" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequence | Should -BeNullOrEmpty
         }
 
         It "supports piping databases" {
-            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | New-DbaDbSequence -Name "Sequence2_$random" -Schema "Schema_$random"
+            $sequence = Get-DbaDatabase -SqlInstance $instance2 -Database $newDbName | New-DbaDbSequence -Name "Sequence2_$random" -Schema "Schema_$random"
             $sequence.Name | Should -Be "Sequence2_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName
@@ -67,7 +67,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $types = @('tinyint', 'smallint', 'int', 'bigint', 'decimal', 'numeric')
 
             foreach ($type in $types) {
-                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($type)_$($random)" -Schema "Schema_$random" -IntegerType $type
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($type)_$($random)" -Schema "Schema_$random" -IntegerType $type
                 $sequence.Name | Should -Be "Sequence_$($type)_$($random)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.DataType.ToString() | Should -Be $type
@@ -80,7 +80,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             foreach ($startValue in $startValues) {
                 $randomForStartValues = Get-Random
-                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForStartValues)" -Schema "Schema_$random" -StartWith $startValue
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForStartValues)" -Schema "Schema_$random" -StartWith $startValue
                 $sequence.Name | Should -Be "Sequence_$($randomForStartValues)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.StartValue | Should -Be $startValue
@@ -93,7 +93,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             foreach ($incrementByValue in $incrementByValues) {
                 $randomForIncrementValues = Get-Random
-                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForIncrementValues)" -Schema "Schema_$random" -IncrementBy $incrementByValue
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForIncrementValues)" -Schema "Schema_$random" -IncrementBy $incrementByValue
                 $sequence.Name | Should -Be "Sequence_$($randomForIncrementValues)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.IncrementValue | Should -Be $incrementByValue
@@ -106,7 +106,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             foreach ($minValue in $minValues) {
                 $randomForMinValues = Get-Random
-                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForMinValues)" -Schema "Schema_$random" -MinValue $minValue
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForMinValues)" -Schema "Schema_$random" -MinValue $minValue
                 $sequence.Name | Should -Be "Sequence_$($randomForMinValues)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.MinValue | Should -Be $minValue
@@ -119,7 +119,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             foreach ($maxValue in $maxValues) {
                 $randomForMaxValues = Get-Random
-                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForMaxValues)" -Schema "Schema_$random" -MaxValue $maxValue
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForMaxValues)" -Schema "Schema_$random" -MaxValue $maxValue
                 $sequence.Name | Should -Be "Sequence_$($randomForMaxValues)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.MaxValue | Should -Be $maxValue
@@ -128,13 +128,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates a new sequence with cycle options" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_cycle" -Cycle
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_cycle" -Cycle
             $sequence.Name | Should -Be "Sequence_with_cycle"
             $sequence.Schema | Should -Be "dbo"
             $sequence.IsCycleEnabled | Should -Be $true
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_without_cycle"
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_without_cycle"
             $sequence.Name | Should -Be "Sequence_without_cycle"
             $sequence.Schema | Should -Be "dbo"
             $sequence.IsCycleEnabled | Should -Be $false
@@ -142,19 +142,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates a new sequence with cache options" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_nocache" -CacheSize 0
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_nocache" -CacheSize 0
             $sequence.Name | Should -Be "Sequence_with_nocache"
             $sequence.Schema | Should -Be "dbo"
             $sequence.SequenceCacheType | Should -Be NoCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_defaultcache"
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_defaultcache"
             $sequence.Name | Should -Be "Sequence_with_defaultcache"
             $sequence.Schema | Should -Be "dbo"
             $sequence.SequenceCacheType | Should -Be DefaultCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_cache" -CacheSize 1000
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_cache" -CacheSize 1000
             $sequence.Name | Should -Be "Sequence_with_cache"
             $sequence.Schema | Should -Be "dbo"
             $sequence.SequenceCacheType | Should -Be CacheWithSize
@@ -163,13 +163,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates a new sequence with a user defined integer type" {
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_custom_type_without_schema_prefix" -IntegerType NonNullInteger
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_custom_type_without_schema_prefix" -IntegerType NonNullInteger
             $sequence.Name | Should -Be "Sequence_with_custom_type_without_schema_prefix"
             $sequence.DataType.Name | Should -Be NonNullInteger
             $sequence.DataType.Schema | Should -Be dbo
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_custom_type" -IntegerType TestSchema.NonNullInteger
+            $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_with_custom_type" -IntegerType TestSchema.NonNullInteger
             $sequence.Name | Should -Be "Sequence_with_custom_type"
             $sequence.DataType.Name | Should -Be NonNullInteger
             $sequence.DataType.Schema | Should -Be TestSchema

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -1,0 +1,179 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'IntegerType', 'StartWith', 'IncrementBy', 'MinValue', 'MaxValue', 'Cycle', 'CacheSize', 'InputObject', 'EnableException'
+        It "Should only contain our specific parameters" {
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+
+        $newDb.Query("CREATE SCHEMA TestSchema")
+        $newDb.Query("CREATE TYPE TestSchema.NonNullInteger FROM INTEGER NOT NULL")
+        $newDb.Query("CREATE TYPE dbo.NonNullInteger FROM INTEGER NOT NULL")
+    }
+
+    AfterAll {
+        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "commands work as expected" {
+
+        It "validates required Database param" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error | Should -Match "Database is required when SqlInstance is specified"
+        }
+
+        It "validates IncrementBy param cannot be 0" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name SequenceTest -IncrementBy 0 -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error.Exception | Should -Match "cannot be zero"
+        }
+
+        It "creates a new sequence" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "tries to create a duplicate sequence" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequence | Should -BeNullOrEmpty
+        }
+
+        It "supports piping databases" {
+            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | New-DbaDbSequence -Name "Sequence2_$random" -Schema "Schema_$random"
+            $sequence.Name | Should -Be "Sequence2_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "creates a new sequence with different integer types" {
+            $types = @('tinyint', 'smallint', 'int', 'bigint', 'decimal', 'numeric')
+
+            foreach ($type in $types) {
+                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($type)_$($random)" -Schema "Schema_$random" -IntegerType $type
+                $sequence.Name | Should -Be "Sequence_$($type)_$($random)"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.DataType.ToString() | Should -Be $type
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "creates a new sequence with different start values" {
+            $startValues = @(-100000, -10, 0, 1, 1000000)
+
+            foreach ($startValue in $startValues) {
+                $randomForStartValues = Get-Random
+                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForStartValues)" -Schema "Schema_$random" -StartWith $startValue
+                $sequence.Name | Should -Be "Sequence_$($randomForStartValues)"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.StartValue | Should -Be $startValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "creates a new sequence with different increment by values" {
+            $incrementByValues = @(-1, 1, 10)
+
+            foreach ($incrementByValue in $incrementByValues) {
+                $randomForIncrementValues = Get-Random
+                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForIncrementValues)" -Schema "Schema_$random" -IncrementBy $incrementByValue
+                $sequence.Name | Should -Be "Sequence_$($randomForIncrementValues)"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.IncrementValue | Should -Be $incrementByValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "creates a new sequence with different min values" {
+            $minValues = @(-10000, 1, 10000)
+
+            foreach ($minValue in $minValues) {
+                $randomForMinValues = Get-Random
+                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForMinValues)" -Schema "Schema_$random" -MinValue $minValue
+                $sequence.Name | Should -Be "Sequence_$($randomForMinValues)"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.MinValue | Should -Be $minValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "creates a new sequence with different max values" {
+            $maxValues = @(-100000, 1, 100000)
+
+            foreach ($maxValue in $maxValues) {
+                $randomForMaxValues = Get-Random
+                $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_$($randomForMaxValues)" -Schema "Schema_$random" -MaxValue $maxValue
+                $sequence.Name | Should -Be "Sequence_$($randomForMaxValues)"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.MaxValue | Should -Be $maxValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "creates a new sequence with cycle options" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_cycle" -Cycle
+            $sequence.Name | Should -Be "Sequence_with_cycle"
+            $sequence.Schema | Should -Be "dbo"
+            $sequence.IsCycleEnabled | Should -Be $true
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_without_cycle"
+            $sequence.Name | Should -Be "Sequence_without_cycle"
+            $sequence.Schema | Should -Be "dbo"
+            $sequence.IsCycleEnabled | Should -Be $false
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "creates a new sequence with cache options" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_nocache" -CacheSize 0
+            $sequence.Name | Should -Be "Sequence_with_nocache"
+            $sequence.Schema | Should -Be "dbo"
+            $sequence.SequenceCacheType | Should -Be NoCache
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_defaultcache"
+            $sequence.Name | Should -Be "Sequence_with_defaultcache"
+            $sequence.Schema | Should -Be "dbo"
+            $sequence.SequenceCacheType | Should -Be DefaultCache
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_cache" -CacheSize 1000
+            $sequence.Name | Should -Be "Sequence_with_cache"
+            $sequence.Schema | Should -Be "dbo"
+            $sequence.SequenceCacheType | Should -Be CacheWithSize
+            $sequence.CacheSize | Should -Be 1000
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "creates a new sequence with a user defined integer type" {
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_custom_type_without_schema_prefix" -IntegerType NonNullInteger
+            $sequence.Name | Should -Be "Sequence_with_custom_type_without_schema_prefix"
+            $sequence.DataType.Name | Should -Be NonNullInteger
+            $sequence.DataType.Schema | Should -Be dbo
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence_with_custom_type" -IntegerType TestSchema.NonNullInteger
+            $sequence.Name | Should -Be "Sequence_with_custom_type"
+            $sequence.DataType.Name | Should -Be NonNullInteger
+            $sequence.DataType.Schema | Should -Be TestSchema
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+    }
+}

--- a/tests/Remove-DbaDbSequence.Tests.ps1
+++ b/tests/Remove-DbaDbSequence.Tests.ps1
@@ -1,0 +1,52 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'InputObject', 'EnableException'
+        It "Should only contain our specific parameters" {
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+
+        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+        $sequence2 = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random"
+    }
+
+    AfterAll {
+        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "commands work as expected" {
+
+        It "validates required Database param" {
+            $sequence = Remove-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error | Should -Match "Database is required when SqlInstance is specified"
+        }
+
+        It "removes a sequence" {
+            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
+            Remove-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
+            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
+        }
+
+        It "supports piping sequences" {
+            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
+            Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Remove-DbaDbSequence -Confirm:$false -Name "Sequence2_$random" -Schema "Schema_$random"
+            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Remove-DbaDbSequence.Tests.ps1
+++ b/tests/Remove-DbaDbSequence.Tests.ps1
@@ -16,13 +16,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     BeforeAll {
         $random = Get-Random
-        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
-        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
-        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+        $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 
-        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
-        $sequence2 = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random"
+        $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+        $sequence2 = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random"
     }
 
     AfterAll {
@@ -32,21 +32,21 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequence = Remove-DbaDbSequence -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequence = Remove-DbaDbSequence -SqlInstance $instance2 -Name SequenceTest -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "removes a sequence" {
-            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
-            Remove-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
-            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
+            (Get-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
+            Remove-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
+            (Get-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
         }
 
         It "supports piping sequences" {
-            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
-            Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Remove-DbaDbSequence -Confirm:$false -Name "Sequence2_$random" -Schema "Schema_$random"
-            (Get-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
+            (Get-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -Not -BeNullOrEmpty
+            Get-DbaDatabase -SqlInstance $instance2 -Database $newDbName | Remove-DbaDbSequence -Confirm:$false -Name "Sequence2_$random" -Schema "Schema_$random"
+            (Get-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence2_$random" -Schema "Schema_$random") | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Select-DbaDbSequenceNextValue.Tests.ps1
+++ b/tests/Select-DbaDbSequenceNextValue.Tests.ps1
@@ -16,12 +16,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     BeforeAll {
         $random = Get-Random
-        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
-        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
-        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+        $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 
-        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -StartWith 100
+        $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -StartWith 100
     }
 
     AfterAll {
@@ -31,21 +31,21 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance2 -Name SequenceTest -ErrorVariable error
             $sequenceValue | Should -BeNullOrEmpty
             $error | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "selects the next value of a sequence" {
-            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequenceValue | Should -Be 100
 
-            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequenceValue | Should -Be 101
         }
 
         It "supports piping databases" {
-            $sequenceValue = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Select-DbaDbSequenceNextValue -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue = Get-DbaDatabase -SqlInstance $instance2 -Database $newDbName | Select-DbaDbSequenceNextValue -Name "Sequence1_$random" -Schema "Schema_$random"
             $sequenceValue | Should -Be 102
         }
     }

--- a/tests/Select-DbaDbSequenceNextValue.Tests.ps1
+++ b/tests/Select-DbaDbSequenceNextValue.Tests.ps1
@@ -1,0 +1,52 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'InputObject', 'EnableException'
+        It "Should only contain our specific parameters" {
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+
+        $sequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -StartWith 100
+    }
+
+    AfterAll {
+        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "commands work as expected" {
+
+        It "validates required Database param" {
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Name SequenceTest -ErrorVariable error
+            $sequenceValue | Should -BeNullOrEmpty
+            $error | Should -Match "Database is required when SqlInstance is specified"
+        }
+
+        It "selects the next value of a sequence" {
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue | Should -Be 100
+
+            $sequenceValue = Select-DbaDbSequenceNextValue -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue | Should -Be 101
+        }
+
+        It "supports piping databases" {
+            $sequenceValue = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Select-DbaDbSequenceNextValue -Name "Sequence1_$random" -Schema "Schema_$random"
+            $sequenceValue | Should -Be 102
+        }
+    }
+}

--- a/tests/Set-DbaDbSequence.Tests.ps1
+++ b/tests/Set-DbaDbSequence.Tests.ps1
@@ -16,12 +16,12 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
     BeforeAll {
         $random = Get-Random
-        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
-        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
-        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+        $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 
-        $newSequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+        $newSequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
     }
 
     AfterAll {
@@ -31,13 +31,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     Context "commands work as expected" {
 
         It "validates required Database param" {
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false -ErrorVariable error
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error | Should -Match "Database is required when SqlInstance is specified"
         }
 
         It "supports piping databases" {
-            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Set-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence = Get-DbaDatabase -SqlInstance $instance2 -Database $newDbName | Set-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.Parent.Name | Should -Be $newDbName
@@ -48,7 +48,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $startValues = @(-100000, -10, 0, 1, 1000)
 
             foreach ($startValue in $startValues) {
-                $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -RestartWith $startValue -Confirm:$false
+                $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -RestartWith $startValue -Confirm:$false
                 $sequence.Name | Should -Be "Sequence1_$random"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.StartValue | Should -Be $startValue
@@ -60,7 +60,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $incrementByValues = @(-1, 1, 10)
 
             foreach ($incrementByValue in $incrementByValues) {
-                $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy $incrementByValue -Confirm:$false
+                $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy $incrementByValue -Confirm:$false
                 $sequence.Name | Should -Be "Sequence1_$random"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.IncrementValue | Should -Be $incrementByValue
@@ -69,7 +69,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with min and max values" {
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -MinValue 0 -MaxValue 100000 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -MinValue 0 -MaxValue 100000 -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.MinValue | Should -Be 0
@@ -78,13 +78,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with cycle options" {
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.IsCycleEnabled | Should -Be $true
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle:$false -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle:$false -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.IsCycleEnabled | Should -Be $false
@@ -92,19 +92,19 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "updates a sequence with cache options" {
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 0 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 0 -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be NoCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be DefaultCache
             $sequence.Parent.Name | Should -Be $newDbName
 
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 1000 -Confirm:$false
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 1000 -Confirm:$false
             $sequence.Name | Should -Be "Sequence1_$random"
             $sequence.Schema | Should -Be "Schema_$random"
             $sequence.SequenceCacheType | Should -Be CacheWithSize
@@ -113,7 +113,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "validates IncrementBy param cannot be 0" {
-            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy 0 -Confirm:$false -ErrorVariable error
+            $sequence = Set-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy 0 -Confirm:$false -ErrorVariable error
             $sequence | Should -BeNullOrEmpty
             $error.Exception | Should -Match "cannot be zero"
         }

--- a/tests/Set-DbaDbSequence.Tests.ps1
+++ b/tests/Set-DbaDbSequence.Tests.ps1
@@ -1,0 +1,121 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Name', 'Schema', 'RestartWith', 'IncrementBy', 'MinValue', 'MaxValue', 'Cycle', 'CacheSize', 'InputObject', 'EnableException'
+        It "Should only contain our specific parameters" {
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+
+    BeforeAll {
+        $random = Get-Random
+        $instance1 = Connect-DbaInstance -SqlInstance $script:instance1
+        $null = Get-DbaProcess -SqlInstance $instance1 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
+        $newDbName = "dbatoolsci_newdb_$random"
+        $newDb = New-DbaDatabase -SqlInstance $instance1 -Name $newDbName
+
+        $newSequence = New-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random"
+    }
+
+    AfterAll {
+        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+    }
+
+    Context "commands work as expected" {
+
+        It "validates required Database param" {
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error | Should -Match "Database is required when SqlInstance is specified"
+        }
+
+        It "supports piping databases" {
+            $sequence = Get-DbaDatabase -SqlInstance $instance1 -Database $newDbName | Set-DbaDbSequence -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.Parent.Name | Should -Be $newDbName
+            $sequence.IsCycleEnabled | Should -Be $true
+        }
+
+        It "updates a sequence with different start values" {
+            $startValues = @(-100000, -10, 0, 1, 1000)
+
+            foreach ($startValue in $startValues) {
+                $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -RestartWith $startValue -Confirm:$false
+                $sequence.Name | Should -Be "Sequence1_$random"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.StartValue | Should -Be $startValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "updates a sequence with different increment by values" {
+            $incrementByValues = @(-1, 1, 10)
+
+            foreach ($incrementByValue in $incrementByValues) {
+                $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy $incrementByValue -Confirm:$false
+                $sequence.Name | Should -Be "Sequence1_$random"
+                $sequence.Schema | Should -Be "Schema_$random"
+                $sequence.IncrementValue | Should -Be $incrementByValue
+                $sequence.Parent.Name | Should -Be $newDbName
+            }
+        }
+
+        It "updates a sequence with min and max values" {
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -MinValue 0 -MaxValue 100000 -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.MinValue | Should -Be 0
+            $sequence.MaxValue | Should -Be 100000
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "updates a sequence with cycle options" {
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.IsCycleEnabled | Should -Be $true
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Cycle:$false -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.IsCycleEnabled | Should -Be $false
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "updates a sequence with cache options" {
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 0 -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.SequenceCacheType | Should -Be NoCache
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.SequenceCacheType | Should -Be DefaultCache
+            $sequence.Parent.Name | Should -Be $newDbName
+
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -CacheSize 1000 -Confirm:$false
+            $sequence.Name | Should -Be "Sequence1_$random"
+            $sequence.Schema | Should -Be "Schema_$random"
+            $sequence.SequenceCacheType | Should -Be CacheWithSize
+            $sequence.CacheSize | Should -Be 1000
+            $sequence.Parent.Name | Should -Be $newDbName
+        }
+
+        It "validates IncrementBy param cannot be 0" {
+            $sequence = Set-DbaDbSequence -SqlInstance $instance1 -Database $newDbName -Name "Sequence1_$random" -Schema "Schema_$random" -IncrementBy 0 -Confirm:$false -ErrorVariable error
+            $sequence | Should -BeNullOrEmpty
+            $error.Exception | Should -Match "cannot be zero"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7180 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add new commands for interacting with sequence objects. Due to a limitation in SMO I've added the restriction that the New-DbaDbSequence command will only support SQL 2012 and higher.

### Approach
<!-- How does this change solve that purpose -->
Implemented the commands to manage sequences and included a command to get a sequence value in case that is needed in scripts/pipelines.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new integration tests.