### PR TITLE
Set-DbaLogin - implement warning message if policy settings are not enabled for -MustChange

### DIFF
--- a/tests/Get-DbaLogin.Tests.ps1
+++ b/tests/Get-DbaLogin.Tests.ps1
@@ -150,5 +150,13 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $results = Get-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -Type SQL
             $results.IsLocked | Should -Be $false
         }
+
+        It "MustChangePassword" {
+            $changeResult = Set-DbaLogin -SqlInstance $script:instance1 -Login "testlogin1_$random" -MustChange -Password $password -PasswordPolicyEnforced -PasswordExpirationEnabled
+            $changeResult.MustChangePassword | Should -Be $true
+
+            $result = Get-DbaLogin -SqlInstance $script:instance1 -MustChangePassword
+            $result.Name | Should -Contain "testlogin1_$random"
+        }
     }
 }


### PR DESCRIPTION
Set-DbaLogin - implement warning message if policy settings are not enabled for -MustChange

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7089 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [x] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure that the caller gets a warning message if they try to use the -MustChange but the login does not have the policy settings enabled.

### Approach
<!-- How does this change solve that purpose -->
1. Check the policy settings and return a warning if they are not enabled
2. Change the password after the login has been altered in case they are setting the policy settings and -MustChange all in one call.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new integration test.
