### PR TITLE
Set-DbaDbQueryStoreOption - ensure that msdb is excluded

### DIFF
--- a/functions/Set-DbaDbQueryStoreOption.ps1
+++ b/functions/Set-DbaDbQueryStoreOption.ps1
@@ -140,7 +140,7 @@ function Set-DbaDbQueryStoreOption {
         [switch]$EnableException
     )
     begin {
-        $ExcludeDatabase += 'master', 'tempdb', "model"
+        $ExcludeDatabase += "master", "tempdb", "model", "msdb"
     }
 
     process {

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -58,10 +58,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
                 It "should not have any of the system databases" {
                     $results = Set-DbaDbQueryStoreOption -SqlInstance $instance -AllDatabases -State ReadWrite
-                    $results.Database | Should -Not -Contain "msdb"
-                    $results.Database | Should -Not -Contain "master"
-                    $results.Database | Should -Not -Contain "model"
-                    $results.Database | Should -Not -Contain "tempdb"
+                    ($results | Where-Object Database -in ("master", "model", "msdb", "tempdb")) | Should -BeNullOrEmpty
                 }
             }
         }

--- a/tests/Set-DbaDbQueryStoreOption.Tests.ps1
+++ b/tests/Set-DbaDbQueryStoreOption.Tests.ps1
@@ -55,6 +55,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
                     $result = $results | Where-Object Database -eq dbatoolsciqs
                     $result.Count | Should Be 0
                 }
+
+                It "should not have any of the system databases" {
+                    $results = Set-DbaDbQueryStoreOption -SqlInstance $instance -AllDatabases -State ReadWrite
+                    $results.Database | Should -Not -Contain "msdb"
+                    $results.Database | Should -Not -Contain "master"
+                    $results.Database | Should -Not -Contain "model"
+                    $results.Database | Should -Not -Contain "tempdb"
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7184 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Add msdb to the list of excluded databases for Set-DbaDbQueryStoreOption.

### Approach
<!-- How does this change solve that purpose -->
Minor change to the list of excluded dbs.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new integration test.
