### PR TITLE
Test-DbaSpn - ensure the string replacement for port numbers only replaces the instance name portion of the SPN

### DIFF
--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -104,6 +104,7 @@ function Test-DbaSpn {
                         12 { "SQL Server 2014" }
                         13 { "SQL Server 2016" }
                         14 { "SQL Server 2017" }
+                        15 { "SQL Server 2019" }
                         default { $version }
                     }
                 }

--- a/functions/Test-DbaSpn.ps1
+++ b/functions/Test-DbaSpn.ps1
@@ -209,7 +209,7 @@ function Test-DbaSpn {
                         $newspn = $spn.PSObject.Copy()
                         if ($port -like "*d") {
                             $newspn.Port = ($port.replace("d", ""))
-                            $newspn.RequiredSPN = $newspn.RequiredSPN.Replace($newSPN.InstanceName, $newspn.Port)
+                            $newspn.RequiredSPN = $newspn.RequiredSPN.Replace(":" + $newSPN.InstanceName, ":" + $newspn.Port)
                             $newspn.DynamicPort = $true
                             $newspn.Warning = "Dynamic port is enabled"
                         } else {
@@ -220,7 +220,7 @@ function Test-DbaSpn {
                             if ($newspn.InstanceName -eq "MSSQLSERVER") {
                                 $newspn.RequiredSPN = $newspn.RequiredSPN + ":" + $port
                             } else {
-                                $newspn.RequiredSPN = $newspn.RequiredSPN.Replace($newSPN.InstanceName, $newspn.Port)
+                                $newspn.RequiredSPN = $newspn.RequiredSPN.Replace(":" + $newSPN.InstanceName, ":" + $newspn.Port)
                             }
                         }
                         $spns += $newspn


### PR DESCRIPTION
Test-DbaSpn - ensure the string replacement for port numbers only replaces the instance name portion of the SPN

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7185 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Ensure the string replacement for the port number does not replace other parts of the SPN.

### Approach
<!-- How does this change solve that purpose -->
Minor change to the string replacement for port numbers.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration test.