### PR TITLE
Fix Copy-DbaDbTableData when new table name has number at start

### DIFF
--- a/functions/Copy-DbaDbTableData.ps1
+++ b/functions/Copy-DbaDbTableData.ps1
@@ -346,12 +346,12 @@ function Copy-DbaDbTableData {
                         #replacing table name
                         if ($newTableParts.Name) {
                             $rX = "(CREATE TABLE \[$([regex]::Escape($schemaNameToReplace))\]\.\[)$([regex]::Escape($tableNameToReplace))(\]\()"
-                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Name)`$2"
+                            $tablescript = $tablescript -replace $rX, "`${1}$($newTableParts.Name)`${2}"
                         }
                         #replacing table schema
                         if ($newTableParts.Schema) {
                             $rX = "(CREATE TABLE \[)$([regex]::Escape($schemaNameToReplace))(\]\.\[$([regex]::Escape($newTableParts.Name))\]\()"
-                            $tablescript = $tablescript -replace $rX, "`$1$($newTableParts.Schema)`$2"
+                            $tablescript = $tablescript -replace $rX, "`${1}$($newTableParts.Schema)`${2}"
                         }
 
                         if ($PSCmdlet.ShouldProcess($destServer, "Creating new table: $DestinationTable")) {


### PR DESCRIPTION
When copying to a new table with the -AutoCreateTable switch, the -replace function when updating the new table name and schema does not work when the destination table has a number at the start. Added {} around the $1 and $2 regex to fix this.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
I noticed when copying a table to a new , non-existing DestinationTable, if the new table has a number at the start, the function returns a syntax error. 


### Approach
<!-- How does this change solve that purpose -->
I found the cause of this error was the regex replace functions on lines 349 and 355. Wrapping the $1 and $2 in curly brackets - ${1} and ${2} - resolved the issue and the copy now works.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
````powershell
Copy-DbaDbTableData -SqlInstance SourceInstance -Database testdb -Destination DestInstance -DestinationDatabase testdb -Table ExampleTable -DestinationTable 2ExampleTable -AutoCreateTable
````

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Currently the above command will return a syntax error if you run it;
````
WARNING: [12:11:58][Copy-DbaDbTableData] Unable to determine destination table: 2member | Incorrect syntax near '$12'.
````
![image](https://user-images.githubusercontent.com/3007124/111329229-e1eb1c00-8666-11eb-8d22-2b2d71a72738.png)

I debugged the execution and found the syntax of the $tablescript variable's CREATE TABLE sql is indeed incorrect;
![image](https://user-images.githubusercontent.com/3007124/111329611-224a9a00-8667-11eb-9815-e9fe860a3a3e.png)

I resolved the issue by wrapping the $1 and $2 parts of the replace functions on lines 349 and 355, and the syntax is now correct when running;
![image](https://user-images.githubusercontent.com/3007124/111329741-41e1c280-8667-11eb-9a9e-084c52c564e4.png)

And the function runs as expected and the new table gets created successfully;
![image](https://user-images.githubusercontent.com/3007124/111330350-c2a0be80-8667-11eb-908f-5fb05f98dd18.png)