### PR TITLE
Get-DbaMemoryCondition: convert to bigint when calculating the NotificationTime

### DIFF
--- a/functions/Get-DbaMemoryCondition.ps1
+++ b/functions/Get-DbaMemoryCondition.ps1
@@ -56,7 +56,7 @@ function Get-DbaMemoryCondition {
         $sql = "
     SELECT
         CONVERT (varchar(30), GETDATE(), 121) as Runtime,
-        DATEADD (MILLISECOND, -1 * Convert(INT, (sys.ms_ticks - sys.s_ticks*1000) - (a.[RecordTime] - a.[RecordTime_S]*1000)), DATEADD (SECOND, -1 * (sys.s_ticks - a.[RecordTime_S]), GETDATE())) AS NotificationTime,
+        DATEADD (MILLISECOND, -1 * Convert(BIGINT, (sys.ms_ticks - sys.s_ticks*1000) - (a.[RecordTime] - a.[RecordTime_S]*1000)), DATEADD (SECOND, -1 * (sys.s_ticks - a.[RecordTime_S]), GETDATE())) AS NotificationTime,
         [NotificationType],
         [MemoryUtilizationPercent],
         [TotalPhysicalMemoryKB],
@@ -91,7 +91,7 @@ function Get-DbaMemoryCondition {
             x.value('(//Record/@type)[1]', 'varchar(30)') AS [Type],
             x.value('(//Record/ResourceMonitor/Indicators)[1]', 'bigint') AS [Indicators],
             x.value('(//Record/@time)[1]', 'bigint') AS [RecordTime],
-            Convert(int, x.value('(//Record/@time)[1]', 'bigint')/1000) AS [RecordTime_S]
+            Convert(bigint, x.value('(//Record/@time)[1]', 'bigint')/1000) AS [RecordTime_S]
         FROM
         (
             SELECT CAST (record as xml) FROM sys.dm_os_ring_buffers


### PR DESCRIPTION
Get-DbaMemoryCondition: convert to bigint when calculating the NotificationTime

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7238 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
Minor change to ensure the calculation of NotificationTime does not result in an arithmetic error as reported in #7238.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the integration test.