### PR TITLE
Update Install-DbaFirstResponderKit.ps1

### DIFF
--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -181,6 +181,7 @@ function Install-DbaFirstResponderKit {
                     $null = New-Item -Path $LocalCachedCopy -ItemType Container
                 }
                 Copy-Item -Path "$zipFolder\sp_*.sql" -Destination $LocalCachedCopy
+                Copy-Item -Path "$zipFolder\SqlServerVersions.sql" -Destination $LocalCachedCopy
             }
         }
     }
@@ -203,6 +204,7 @@ function Install-DbaFirstResponderKit {
 
                 # Install/Update each FRK stored procedure
                 $sqlScripts = Get-ChildItem $LocalCachedCopy -Filter "sp_*.sql"
+                $sqlScripts += Get-ChildItem $LocalCachedCopy -Filter "SqlServerVersions.sql"
                 foreach ($script in $sqlScripts) {
                     $scriptName = $script.Name
                     $scriptError = $false


### PR DESCRIPTION
Added the SQLServerVersions.sql script to the list of scripts to install to satisfy requirements in #7242

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7242 
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
To automatically install the SQLServerVersions.sql script provided by Brent.
We personally use this as another check to CIS standards via T-SQL checks to ensure latest SP/CU combinations installed etc.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Install-DbaFirstResponderKit

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/40231097/114866329-52fb2c00-9deb-11eb-9c6b-e8f361906c6a.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
