### PR TITLE
Update Set-DbaAgListener

### DIFF
--- a/functions/Set-DbaAgListener.ps1
+++ b/functions/Set-DbaAgListener.ps1
@@ -71,7 +71,7 @@ function Set-DbaAgListener {
         [Parameter(Mandatory)]
         [int]$Port,
         [parameter(ValueFromPipeline)]
-        [Microsoft.SqlServer.Management.Smo.AvailabilityGroup[]]$InputObject,
+        [Microsoft.SqlServer.Management.Smo.AvailabilityGroupListener[]]$InputObject,
         [switch]$EnableException
     )
     process {
@@ -80,16 +80,20 @@ function Set-DbaAgListener {
             return
         }
         if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName AvailabilityGroup)) {
-            Stop-Function -Message "You must specify one or more databases and one or more Availability Groups when using the SqlInstance parameter."
+            Stop-Function -Message "You must specify one or more Availability Groups when using the SqlInstance parameter."
             return
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaAgListener -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup -Listener $Listener
+            if (Test-Bound -ParameterName Listener) {
+                $InputObject += Get-DbaAgListener -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup -Listener $Listener
+            } else {
+                $InputObject += Get-DbaAgListener -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
+            }
         }
 
         foreach ($aglistener in $InputObject) {
-            if ($Pscmdlet.ShouldProcess($ag.Parent.Name, "Setting port to $Port for $($ag.Name)")) {
+            if ($Pscmdlet.ShouldProcess($aglistener.Parent.Name, "Setting port to $Port for $($aglistener.Name)")) {
                 try {
                     $aglistener.PortNumber = $Port
                     $aglistener.Alter()


### PR DESCRIPTION
Change pipeline parameter to AvailabilityGroupListener, matching
Get-DbaAgListener output in example

Only pass Listener parameter to Get-DbaAgListener if exists

Update messages

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7257 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Allow Set-DbaAgListener to update an Availability Group listener port without errors.

###Approach
The major change is to ensure the InputObject is an AvailabilityGroupListener not an AvailabilityGroup


### Commands to test
Examples in the help
