### PR TITLE
New command: New-DbaDbFileGroup

### DIFF
--- a/functions/Disable-DbaFilestream.ps1
+++ b/functions/Disable-DbaFilestream.ps1
@@ -93,7 +93,7 @@ function Disable-DbaFilestream {
             }
 
             # Instance level
-            $filestreamstate = [int]$server.Configuration.FilestreamAccessLevel.RunningValue
+            $filestreamstate = [int]$server.Configuration.FilestreamAccessLevel.RunValue
 
             if ($Force -or $PSCmdlet.ShouldProcess($instance, "Changing from '$($OutputLookup[$filestreamstate])' to '$($OutputLookup[$level])' at the instance level")) {
                 try {

--- a/functions/New-DbaDbFileGroup.ps1
+++ b/functions/New-DbaDbFileGroup.ps1
@@ -1,0 +1,153 @@
+function New-DbaDbFileGroup {
+    <#
+    .SYNOPSIS
+        Creates a new filegroup.
+
+    .DESCRIPTION
+        Creates a new filegroup for the specified database(s) and allows the filegroup options to be set.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        The target database(s).
+
+    .PARAMETER FileGroupName
+        The name of the new filegroup.
+
+    .PARAMETER FileGroupType
+        The type of the file group. Possible values are "FileStreamDataFileGroup", "MemoryOptimizedDataFileGroup", "RowsFileGroup". The default is "RowsFileGroup".
+
+    .PARAMETER Default
+        Specifies if the filegroup should be the default. Only one filegroup in a database can be specified as the default.
+
+    .PARAMETER ReadOnly
+        Specifies the filegroup should be readonly.
+
+    .PARAMETER AutoGrowAllFiles
+        Specifies the filegroup should auto grow all files if one file has met the threshold to autogrow.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaDatabase.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Data, Database, File, FileGroup, Migration, Partitioning, Table
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/New-DbaDbFileGroup
+
+    .EXAMPLE
+        PS C:\>New-DbaDbFileGroup -SqlInstance sqldev1 -Database TestDb -FileGroupName HRFG1
+
+        Creates the HRFG1 filegroup on the TestDb database on the sqldev1 instance and accepts the default options for the filegroup.
+
+    .EXAMPLE
+        PS C:\>New-DbaDbFileGroup -SqlInstance sqldev1 -Database TestDb -FileGroupName HRFG1 -Default -AutoGrowAllFiles
+
+        Creates the HRFG1 filegroup on the TestDb database on the sqldev1 instance and makes it the default filegroup with the option to auto-grow all files.
+
+    .EXAMPLE
+        PS C:\>New-DbaDbFileGroup -SqlInstance sqldev1 -Database TestDb -FileGroupName HRFG1 -FileGroupType FileStreamDataFileGroup
+
+        Creates a filestream filegroup named HRFG1 on the TestDb database on the sqldev1 instance and accepts the default options for the filegroup.
+
+    .EXAMPLE
+        PS C:\>New-DbaDbFileGroup -SqlInstance sqldev1 -Database TestDb -FileGroupName HRFG1 -FileGroupType MemoryOptimizedDataFileGroup
+
+        Creates a MemoryOptimized data filegroup named HRFG1 on the TestDb database on the sqldev1 instance and accepts the default options for the filegroup.
+
+    .EXAMPLE
+        PS C:\>Get-DbaDatabase -SqlInstance sqldev1 -Database TestDb | New-DbaDbFileGroup -FileGroupName HRFG1
+
+        Passes in the TestDB database via pipeline and creates the HRFG1 filegroup on the TestDb database on the sqldev1 instance and accepts the default options for the filegroup.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Database,
+        [string]$FileGroupName,
+        [ValidateSet("FileStreamDataFileGroup", "MemoryOptimizedDataFileGroup", "RowsFileGroup")]
+        [string]$FileGroupType = "RowsFileGroup",
+        [switch]$Default,
+        [switch]$ReadOnly,
+        [switch]$AutoGrowAllFiles,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Database[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        if (Test-Bound -Not -ParameterName FileGroupName) {
+            Stop-Function -Message "FileGroupName is required"
+            return
+        }
+
+        if ((Test-Bound -ParameterName SqlInstance) -and (Test-Bound -Not -ParameterName Database)) {
+            Stop-Function -Message "Database is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
+        }
+
+        foreach ($db in $InputObject) {
+
+            if ($db.FileGroups.Name -contains $FileGroupName) {
+                Stop-Function -Message "Filegroup $FileGroupName already exists in the database $($db.Name) on $($db.Parent.Name)" -Continue
+            }
+
+            if ($Pscmdlet.ShouldProcess($db.Parent.Name, "Creating the filegroup $FileGroupName on the database $($db.Name)")) {
+                try {
+                    $newFileGroup = New-Object Microsoft.SqlServer.Management.Smo.FileGroup -ArgumentList $db, $FileGroupName
+
+                    if (Test-Bound FileGroupType) {
+                        $newFileGroup.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::$FileGroupType
+                    }
+
+                    if ($Default.IsPresent) {
+                        $newFileGroup.IsDefault = $true
+                    }
+
+                    if ($ReadOnly.IsPresent) {
+                        $newFileGroup.ReadOnly = $true
+                    }
+
+                    if ($AutoGrowAllFiles.IsPresent) {
+                        $newFileGroup.AutogrowAllFiles = $true
+                    }
+
+                    $newFileGroup.Create()
+                    $newFileGroup
+                } catch {
+                    Stop-Function -Message "Failure on $($db.Parent.Name) to create the filegroup $FileGroupName in the database $($db.Name)" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/tests/New-DbaDbFileGroup.Tests.ps1
+++ b/tests/New-DbaDbFileGroup.Tests.ps1
@@ -1,0 +1,92 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FileGroupName', 'FileGroupType', 'Default', 'ReadOnly', 'AutoGrowAllFiles', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $random = Get-Random
+        $db1name = "dbatoolsci_filegroup_test_$random"
+        $db2name = "dbatoolsci_filegroup_test2_$random"
+
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $newDb1 = New-DbaDatabase -SqlInstance $script:instance2 -Name $db1name
+        $newDb2 = New-DbaDatabase -SqlInstance $script:instance2 -Name $db2name
+
+        $fileStreamStatus = Get-DbaFilestream -SqlInstance $script:instance2
+
+        if ($fileStreamStatus.InstanceAccessLevel -eq 0) {
+            Enable-DbaFilestream -SqlInstance $script:instance2 -Confirm:$false -Force
+        }
+    }
+    AfterAll {
+        $newDb1, $newDb2 | Remove-DbaDatabase -Confirm:$false
+        Disable-DbaFilestream -SqlInstance $script:instance2 -Confirm:$false -Force
+    }
+
+    Context "ensure command works" {
+
+        It "Creates a filegroup with the defaults" {
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_$random"
+            $results.Parent.Name | Should -Be $db1name
+            $results.Name | Should -Be "filegroup_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::RowsFileGroup
+            $results.AutogrowAllFiles = $false
+            $results.IsDefault = $false
+            $results.ReadOnly = $false
+
+            # check the validation for duplicate filegroup names
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_$random"
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Creates a filegroup of each FileGroupType" {
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_rows_$random" -FileGroupType RowsFileGroup
+            $results.Name | Should -Be "filegroup_rows_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::RowsFileGroup
+
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_filestream_$random" -FileGroupType FileStreamDataFileGroup
+            $results.Name | Should -Be "filegroup_filestream_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::FileStreamDataFileGroup
+
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_memory_optimized_$random" -FileGroupType MemoryOptimizedDataFileGroup
+            $results.Name | Should -Be "filegroup_memory_optimized_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::MemoryOptimizedDataFileGroup
+
+        }
+
+        It "Creates a filegroup with default, readonly, and autogrow" {
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_options_$random" -Default -AutoGrowAllFiles
+            $results.Name | Should -Be "filegroup_options_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::RowsFileGroup
+            $results.AutogrowAllFiles = $true
+            $results.IsDefault = $true
+
+            $results = New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db1name -FileGroupName "filegroup_options_RO_$random" -ReadOnly
+            $results.Name | Should -Be "filegroup_options_RO_$random"
+            $results.FileGroupType = [Microsoft.SqlServer.Management.Smo.FileGroupType]::RowsFileGroup
+            $results.AutogrowAllFiles = $false
+            $results.IsDefault = $false
+            $results.ReadOnly = $true
+        }
+
+        It "Creates a filegroup using a database from a pipeline" {
+            $results = $newDb1 | New-DbaDbFileGroup -FileGroupName "filegroup_pipeline_$random"
+            $results.Name | Should -Be "filegroup_pipeline_$random"
+
+            $results = $newDb1 | New-DbaDbFileGroup -SqlInstance $script:instance2 -Database $db2name -FileGroupName "filegroup_pipeline2_$random"
+            $results.Name | Should -Be "filegroup_pipeline2_$random", "filegroup_pipeline2_$random"
+            $results.Parent.Name | Should -Be $db1name, $db2name
+        }
+    }
+}


### PR DESCRIPTION
- New command: New-DbaDbFileGroup
- Minor fix for obtaining the filestream access level in Disable-DbaFilestream

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
1. Added a new command for creating a new filegroup.
2. Made a minor fix for Disable-DbaFilestream to change RunningValue to [RunValue](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.smo.configuration.filestreamaccesslevel)

### Approach
Basic command for filegroup creation with settings.

### Commands to test
See the command examples and the integration tests.