### PR TITLE
Get-DbaDbOrphanUser: Fix for when login name <> user name for Windows Logins

### DIFF
--- a/functions/Get-DbaDbOrphanUser.ps1
+++ b/functions/Get-DbaDbOrphanUser.ps1
@@ -92,7 +92,7 @@ function Get-DbaDbOrphanUser {
                         Write-Message -Level Verbose -Message "Validating users on database '$db'."
                         $UsersToWork = @()
                         $UsersToWork += $db.Users | Where-Object { $_.Login -eq "" -and ($_.ID -gt 4) -and (($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::SqlLogin, [Microsoft.SqlServer.Management.Smo.LoginType]::Certificate)) -eq $false) }
-                        $UsersToWork += $db.Users | Where-Object { ($_.Name -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser, [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsGroup)) }
+                        $UsersToWork += $db.Users | Where-Object { ($_.Login -notin $server.Logins.Name) -and ($_.ID -gt 4) -and ($_.Sid.Length -gt 16 -and $_.LoginType -in @([Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser, [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsGroup)) }
                         if ($UsersToWork.Count -gt 0) {
                             Write-Message -Level Verbose -Message "Orphan users found"
                             foreach ($user in $UsersToWork) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #7268 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
To fix #7268 - issue when database user name does not match login name for Windows accounts

### Approach
<!-- How does this change solve that purpose -->
Compare underlying Login name not the user name which could be different

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Setup envirioment
```
New-ADUser JessP
New-DbaLogin -SqlInstance dscsvr2 -Login pomfret\JessP 
New-DbaDbUser -SqlInstance dscsvr2 -Login pomfret\JessP -Database NewDatabase -Username JessNew
```
Test on dev branch
![image](https://user-images.githubusercontent.com/981370/116867971-d8f9de00-ac05-11eb-8b74-0faa7fb12792.png)

Test on fix
![image](https://user-images.githubusercontent.com/981370/116867980-de572880-ac05-11eb-9009-247b356a8d9f.png)

