### PR TITLE
Connect-DbaInstance - Initialize $isAzure

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -880,6 +880,7 @@ function Connect-DbaInstance {
             }
 
             # Gracefully handle Azure connections
+            $isAzure = $false
             if ($connstring -match $AzureDomain -or $instance.ComputerName -match $AzureDomain -or $instance.InputObject.ComputerName -match $AzureDomain) {
                 Write-Message -Level Debug -Message "We are about to connect to Azure"
                 # so far, this is not evaluating


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #7276 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Prevent that a usage of $isAzure outside of the command has an effect inside of the command.

### Approach
Correctly initialize the variable.

### Commands to test
$isAzure = $true
$server = Connect-DbaInstance -SqlInstance LOCALSERVER