### PR TITLE
Mount-DbaDatabase - Removed Code that will never be used

### DIFF
--- a/functions/Mount-DbaDatabase.ps1
+++ b/functions/Mount-DbaDatabase.ps1
@@ -106,10 +106,6 @@ function Mount-DbaDatabase {
                     Stop-Function -Message "$db is already attached to $server." -Target $db -Continue
                 }
 
-                if ($server.Databases[$db].IsSystemObject) {
-                    Stop-Function -Message "$db is a system database and cannot be attached using this method." -Target $db -Continue
-                }
-
                 if (-Not (Test-Bound -Parameter FileStructure)) {
                     $backuphistory = Get-DbaDbBackupHistory -SqlInstance $server -Database $db -Type Full | Sort-Object End -Descending | Select-Object -First 1
 


### PR DESCRIPTION
Not a bug, but I don't like unused code...

All existing databases will be skipped (see a few lines above), so no need to test for existing system databases.