### PR TITLE
Invoke-DbaAdvancedInstall - Enhance processing of install summary

### DIFF
--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -124,11 +124,17 @@ function Invoke-DbaAdvancedInstall {
             $output = [PSCustomObject]@{
                 Path              = $null
                 Content           = $null
+                # Andreas Jordan: I would like to remove the next line
+                Log               = $null
+                ExitMessage       = $null
                 ConfigurationFile = $null
             }
             if (Test-Path $summaryPath) {
                 $output.Path = $summaryPath
-                $output.Content = Get-Content -Path $summaryPath | Select-String "Exit Message"
+                $output.Content = Get-Content -Path $summaryPath
+                # Andreas Jordan: I would like to remove the next line
+                $output.Log = $output.Content | Select-String "Exit Message"
+                $output.ExitMessage = $output.Content | Select-String "Exit Message" | Select-Object -ExpandProperty Line
                 # get last folder created - that's our setup
                 $lastLogFolder = Get-ChildItem -Path $rootPath -Directory | Sort-Object -Property Name -Descending | Select-Object -First 1 -ExpandProperty FullName
                 if (Test-Path $lastLogFolder\ConfigurationFile.ini) {
@@ -160,8 +166,11 @@ function Invoke-DbaAdvancedInstall {
         Port              = $Port
         Notes             = @()
         ExitCode          = $null
+        ExitMessage       = $null
+        # Andreas Jordan: I would like to remove the next line
         Log               = $null
         LogFile           = $null
+        LogFileContent    = $null
         ConfigurationFile = $null
 
     }
@@ -250,11 +259,14 @@ function Invoke-DbaAdvancedInstall {
         # Get setup log summary contents
         try {
             $summary = Get-SqlInstallSummary -ComputerName $ComputerName -Credential $Credential -Version $Version
-            $output.Log = $summary.Content
+            $output.ExitMessage = $summary.ExitMessage
+            # Andreas Jordan: I would like to remove the next line
+            $output.Log = $summary.Log
             $output.LogFile = $summary.Path
+            $output.LogFileContent = $summary.Content
             $output.ConfigurationFile = $summary.ConfigurationFile
         } catch {
-            Write-Message -Level Warning -Message "Could not get the contents of the summary file from $($ComputerName). 'Log' property will be empty" -ErrorRecord $_
+            Write-Message -Level Warning -Message "Could not get the contents of the summary file from $($ComputerName). Related properties will be empty" -ErrorRecord $_
         }
     } catch {
         Stop-Function -Message "Installation failed" -ErrorRecord $_
@@ -280,7 +292,7 @@ function Invoke-DbaAdvancedInstall {
     if ($installResult.Successful) {
         $output.Successful = $true
     } else {
-        $msg = "Installation failed with exit code $($installResult.ExitCode). Expand 'Log' property to find more details."
+        $msg = "Installation failed with exit code $($installResult.ExitCode). Expand 'ExitMessage' and 'LogFileContent' property to find more details."
         $output.Notes += $msg
         Stop-Function -Message $msg
         return $output

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -134,7 +134,7 @@ function Invoke-DbaAdvancedInstall {
                 $output.Content = Get-Content -Path $summaryPath
                 # Andreas Jordan: I would like to remove the next line
                 $output.Log = $output.Content | Select-String "Exit Message"
-                $output.ExitMessage = $output.Content | Select-String "Exit Message" | Select-Object -ExpandProperty Line
+                $output.ExitMessage = ($output.Content | Select-String "Exit message" | Select-Object -ExpandProperty Line) -replace '^ *Exit message: *', ''
                 # get last folder created - that's our setup
                 $lastLogFolder = Get-ChildItem -Path $rootPath -Directory | Sort-Object -Property Name -Descending | Select-Object -First 1 -ExpandProperty FullName
                 if (Test-Path $lastLogFolder\ConfigurationFile.ini) {

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -124,17 +124,13 @@ function Invoke-DbaAdvancedInstall {
             $output = [PSCustomObject]@{
                 Path              = $null
                 Content           = $null
-                # Andreas Jordan: I would like to remove the next line
-                Log               = $null
                 ExitMessage       = $null
                 ConfigurationFile = $null
             }
             if (Test-Path $summaryPath) {
                 $output.Path = $summaryPath
                 $output.Content = Get-Content -Path $summaryPath
-                # Andreas Jordan: I would like to remove the next line
-                $output.Log = $output.Content | Select-String "Exit Message"
-                $output.ExitMessage = ($output.Content | Select-String "Exit message" | Select-Object -ExpandProperty Line) -replace '^ *Exit message: *', ''
+                $output.ExitMessage = ($output.Content | Select-String "Exit message").Line -replace '^ *Exit message: *', ''
                 # get last folder created - that's our setup
                 $lastLogFolder = Get-ChildItem -Path $rootPath -Directory | Sort-Object -Property Name -Descending | Select-Object -First 1 -ExpandProperty FullName
                 if (Test-Path $lastLogFolder\ConfigurationFile.ini) {
@@ -167,10 +163,8 @@ function Invoke-DbaAdvancedInstall {
         Notes             = @()
         ExitCode          = $null
         ExitMessage       = $null
-        # Andreas Jordan: I would like to remove the next line
         Log               = $null
         LogFile           = $null
-        LogFileContent    = $null
         ConfigurationFile = $null
 
     }
@@ -260,10 +254,8 @@ function Invoke-DbaAdvancedInstall {
         try {
             $summary = Get-SqlInstallSummary -ComputerName $ComputerName -Credential $Credential -Version $Version
             $output.ExitMessage = $summary.ExitMessage
-            # Andreas Jordan: I would like to remove the next line
-            $output.Log = $summary.Log
+            $output.Log = $summary.Content
             $output.LogFile = $summary.Path
-            $output.LogFileContent = $summary.Content
             $output.ConfigurationFile = $summary.ConfigurationFile
         } catch {
             Write-Message -Level Warning -Message "Could not get the contents of the summary file from $($ComputerName). Related properties will be empty" -ErrorRecord $_
@@ -292,7 +284,7 @@ function Invoke-DbaAdvancedInstall {
     if ($installResult.Successful) {
         $output.Successful = $true
     } else {
-        $msg = "Installation failed with exit code $($installResult.ExitCode). Expand 'ExitMessage' and 'LogFileContent' property to find more details."
+        $msg = "Installation failed with exit code $($installResult.ExitCode). Expand 'ExitMessage' and 'Log' property to find more details."
         $output.Notes += $msg
         Stop-Function -Message $msg
         return $output


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes # )
 - [x] New feature (non-breaking change, adds functionality, fixes #7299 )
 - [x] Breaking change (effects multiple commands or functionality, fixes #7300 )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Getting the exit message as a string into the new property .ExitMessage and the full content of the summary.txt into the new property .LogFileContent.
Removing the old property .Log is a "breaking" change. But I don't think that a lot of users have build a process around that property.

### Screenshots
![image](https://user-images.githubusercontent.com/66946165/117646995-b7ac6b00-b18c-11eb-8aca-be60cf1f8388.png)
