### PR TITLE
Install-DbaFirstResponderKit - New parameter to be more flexible

### DIFF
--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -233,7 +233,7 @@ function Install-DbaFirstResponderKit {
         foreach ($instance in $SqlInstance) {
             if ($PSCmdlet.ShouldProcess($instance, "Connecting to $instance")) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooled
                 } catch {
                     Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -233,7 +233,7 @@ function Install-DbaFirstResponderKit {
         foreach ($instance in $SqlInstance) {
             if ($PSCmdlet.ShouldProcess($instance, "Connecting to $instance")) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooled
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
                 } catch {
                     Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }

--- a/functions/Install-DbaFirstResponderKit.ps1
+++ b/functions/Install-DbaFirstResponderKit.ps1
@@ -121,6 +121,11 @@ function Install-DbaFirstResponderKit {
         [string]$Branch = "main",
         [object]$Database = "master",
         [string]$LocalFile,
+        [ValidateSet('Install-All-Scripts.sql', 'Install-Core-Blitz-No-Query-Store.sql', 'Install-Core-Blitz-With-Query-Store.sql',
+            'sp_Blitz.sql', 'sp_BlitzFirst.sql', 'sp_BlitzIndex.sql', 'sp_BlitzCache.sql', 'sp_BlitzWho.sql', 'sp_BlitzQueryStore.sql',
+            'sp_BlitzAnalysis.sql', 'sp_BlitzBackups.sql', 'sp_BlitzInMemoryOLTP.sql', 'sp_BlitzLock.sql',
+            'sp_AllNightLog.sql', 'sp_AllNightLog_Setup.sql', 'sp_DatabaseRestore.sql', 'sp_ineachdb.sql',
+            'SqlServerVersions.sql', 'Uninstall.sql')]
         [string[]]$OnlyScript,
         [switch]$Force,
         [switch]$EnableException

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'ScriptOnly', 'Force', 'EnableException'
 
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'ScriptOnly', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Branch', 'Database', 'LocalFile', 'OnlyScript', 'Force', 'EnableException'
 
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty

--- a/tests/Install-DbaFirstResponderKit.Tests.ps1
+++ b/tests/Install-DbaFirstResponderKit.Tests.ps1
@@ -45,7 +45,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         It "Shows status of Error" {
             $folder = Join-Path (Get-DbatoolsConfigValue -FullName Path.DbatoolsData) -Child "SQL-Server-First-Responder-Kit-main"
-            $sqlScript = (Get-ChildItem $folder | Select-Object -First 1).FullName
+            $sqlScript = (Get-ChildItem $folder -Filter "sp_*.sql" | Select-Object -First 1).FullName
             Add-Content $sqlScript (New-Guid).ToString()
             $result = Install-DbaFirstResponderKit -SqlInstance $script:instance2 -Database $database -Verbose:$false
             $result[0].Status -eq "Error" | Should -Be $true
@@ -88,7 +88,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         It "Shows status of Error" {
             $folder = Join-Path (Get-DbatoolsConfigValue -FullName Path.DbatoolsData) -Child "SQL-Server-First-Responder-Kit-main"
-            $sqlScript = (Get-ChildItem $folder | Select-Object -First 1).FullName
+            $sqlScript = (Get-ChildItem $folder -Filter "sp_*.sql" | Select-Object -First 1).FullName
             Add-Content $sqlScript (New-Guid).ToString()
             $result = Install-DbaFirstResponderKit -SqlInstance $script:instance3 -Database $database
             $result[0].Status -eq "Error" | Should -Be $true


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I want to be able to install only part of the First Responder Kit.
I want to be able to use the official install scripts to create all procedures in the correct order to suppress the warnings about missing procedures.
I want to be able to remove the First Responder Kit using the official Uninstall.sql.

### Approach
I added a parameter `-OnlyScript` to only run those scripts.
I copy all sql files to the local cache.
I also moved some code from the process block to the begin block to optimize the code (and the performance).

### Commands to test
```
$instance = 'SRV1'
Install-DbaFirstResponderKit -SqlInstance $instance -OnlyScript sp_Blitz.sql, sp_BlitzWho.sql, SqlServerVersions.sql | Format-Table
Install-DbaFirstResponderKit -SqlInstance $instance -OnlyScript Install-Core-Blitz-No-Query-Store.sql | Format-Table
Install-DbaFirstResponderKit -SqlInstance $instance -OnlyScript sp_Blitz.sql, NotValid.sql | Format-Table
Install-DbaFirstResponderKit -SqlInstance $instance -OnlyScript Uninstall.sql | Format-Table
```

### Screenshots
![image](https://user-images.githubusercontent.com/66946165/117690089-bf830400-b1ba-11eb-91af-dc4fe2266946.png)