### PR TITLE
Get-DbaHelp, fix optional params

### DIFF
--- a/internal/functions/Get-DbaHelp.ps1
+++ b/internal/functions/Get-DbaHelp.ps1
@@ -99,11 +99,11 @@ function Get-DbaHelp {
                 }
                 foreach ($syntax in $splitted_paramsets) {
                     $x = 0
-                    foreach ($val in ($syntax -split '[\[]+-')) {
+                    foreach ($val in ($syntax.Replace("`r", '').Replace("`n", '') -split ' \[')) {
                         if ($x -eq 0) {
                             $null = $rtn.Add($val)
                         } else {
-                            $null = $rtn.Add('    [-' + $val.replace("`n", '').replace("`n", ''))
+                            $null = $rtn.Add('    -' + $val.replace("`n", '').replace("`n", ''))
                         }
                         $x += 1
                     }


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
### Purpose
Optional params were missing a `[` . I'll soon push a fix to sqlcollaborative/docs too to make it match the js logic to this.

Thanks to @andreasjordan for spotting and reporting
