### PR TITLE
Watch-DbaXESession - Use Get-DbaXESession to have Server SMO in .Parent

### DIFF
--- a/functions/Watch-DbaXESession.ps1
+++ b/functions/Watch-DbaXESession.ps1
@@ -71,19 +71,8 @@ function Watch-DbaXESession {
         [switch]$EnableException
     )
     process {
-        if (-not $SqlInstance) {
-
-        } else {
-            try {
-                $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -MinimumVersion 11
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
-            }
-            $SqlConn = $server.ConnectionContext.SqlConnectionObject
-            $SqlStoreConnection = New-Object Microsoft.SqlServer.Management.Sdk.Sfc.SqlStoreConnection $SqlConn
-            $XEStore = New-Object  Microsoft.SqlServer.Management.XEvent.XEStore $SqlStoreConnection
-            Write-Message -Level Verbose -Message "Getting XEvents Sessions on $SqlInstance."
-            $InputObject += $XEStore.sessions | Where-Object Name -eq $Session
+        if ($SqlInstance) {
+            $InputObject += Get-DbaXESession -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Session $Session
         }
 
         foreach ($xesession in $InputObject) {

--- a/tests/Watch-DbaXESession.Tests.ps1
+++ b/tests/Watch-DbaXESession.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command functions as expected" {
         It "warns if SQL instance version is not supported" {
             $results = Watch-DbaXESession -SqlInstance $script:instance1 -Session system_health -WarningAction SilentlyContinue -WarningVariable versionwarn
-            $versionwarn -match "not supported" | Should Be $true
+            $versionwarn -match "SQL Server version 11 required" | Should Be $true
         }
     }
 }

--- a/tests/Watch-DbaXESession.Tests.ps1
+++ b/tests/Watch-DbaXESession.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command functions as expected" {
         It "warns if SQL instance version is not supported" {
             $results = Watch-DbaXESession -SqlInstance $script:instance1 -Session system_health -WarningAction SilentlyContinue -WarningVariable versionwarn
-            $versionwarn -match "SQL Server version 11 required" | Should Be $true
+            $versionwarn -join '' -match "SQL Server version 11 required" | Should Be $true
         }
     }
 }

--- a/tests/Watch-DbaXESession.Tests.ps1
+++ b/tests/Watch-DbaXESession.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command functions as expected" {
         It "warns if SQL instance version is not supported" {
             $results = Watch-DbaXESession -SqlInstance $script:instance1 -Session system_health -WarningAction SilentlyContinue -WarningVariable versionwarn
-            $versionwarn -match "Unsupported version" | Should Be $true
+            $versionwarn -match "not supported" | Should Be $true
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7317 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
