### PR TITLE
Get-DbaAgBackupHistory - Stop even if no exception is raised

### DIFF
--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -183,7 +183,7 @@ function Get-DbaAgBackupHistory {
             Write-Message -Level Verbose -Message "We have one server, so it should be a listener"
             $server = $serverList[0]
 
-            $replicaNames = $server.AvailabilityGroups.Where( { $_.Name -in $AvailabilityGroup }).AvailabilityReplicas.Name
+            $replicaNames = $server.AvailabilityGroups.Where( { $_.Name -in $AvailabilityGroup } ).AvailabilityReplicas.Name
             Write-Message -Level Verbose -Message "We have found these replicas: $replicaNames"
 
             $serverList = $replicaNames
@@ -194,7 +194,7 @@ function Get-DbaAgBackupHistory {
         $null = $PSBoundParameters.Remove('AvailabilityGroup')
         $null = $PSBoundParameters.Remove('Last')
         $AgResults = Get-DbaDbBackupHistory -SqlInstance $serverList @PSBoundParameters
-        Foreach ($agr in $AgResults) {
+        foreach ($agr in $AgResults) {
             $agr.AvailabilityGroupName = $AvailabilityGroup
         }
 

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -176,6 +176,7 @@ function Get-DbaAgBackupHistory {
     end {
         if ($serverList.Count -eq 0) {
             Stop-Function -Message "No instances with availability group named '$AvailabilityGroup' found, so finishing without results."
+            return
         }
 
         if ($serverList.Count -eq 1) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
When no exception is raised by Stop-Function, then the end block continues and tries to connect to an empty list of instances.

### Approach
Add a return after Stop-Function
