### PR TITLE
Repair-DbaInstanceName / Test-DbaInstanceName - Added more verbose and debug output and fix user problem

### DIFF
--- a/functions/Test-DbaInstanceName.ps1
+++ b/functions/Test-DbaInstanceName.ps1
@@ -94,12 +94,12 @@ function Test-DbaInstanceName {
             Write-Message -Level Verbose -Message "server.NetName is $netName"
 
             if ($instanceName.Length -eq 0) {
-                $actualServerName = $netName
+                $newServerName = $netName
                 $instanceName = "MSSQLSERVER"
             } else {
-                $actualServerName = "$netName\$instanceName"
+                $newServerName = "$netName\$instanceName"
             }
-            Write-Message -Level Verbose -Message "actualServerName is $actualServerName"
+            Write-Message -Level Verbose -Message "newServerName is $newServerName"
 
             # output some other properties that migth help to get the new servername
             Write-Message -Level Debug -Message "server.ComputerName is $($server.ComputerName)"
@@ -111,10 +111,11 @@ function Test-DbaInstanceName {
 
             $serverInfo = [PSCustomObject]@{
                 ComputerName   = $server.ComputerName
-                ServerName     = $configuredServerName
                 InstanceName   = $server.ServiceName
                 SqlInstance    = $server.DomainInstanceName
-                RenameRequired = $actualServerName -ne $configuredServerName
+                ServerName     = $configuredServerName
+                NewServerName  = $newServerName
+                RenameRequired = $newServerName -ne $configuredServerName
                 Updatable      = "N/A"
                 Warnings       = $null
                 Blockers       = $null
@@ -182,7 +183,7 @@ function Test-DbaInstanceName {
                 $serverInfo.Blockers = "N/A"
             }
 
-            $serverInfo | Select-DefaultView -ExcludeProperty InstanceName, SqlInstance
+            $serverInfo
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7332)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system

It adds more verbose and debug output to help to understand the situation at the user.
It also renames some variables to better reflect the values they store.
And it does not rely on $server.ComputerName but $server.NetName as depending on the used code path in Connect-DbaInstance, the ComputerName property might be in full qualified format.

I ordered the properties in the output object to reflect our standards.
I added the property NewServerName that is based on $server.NetName.
I removed the Select-DefaultView as I think that all properties should be displayed by default.

I updated Repair-DbaInstanceName as well and changed some variable names.
I also used the new property NewServerName from Test-DbaInstanceName.

![image](https://user-images.githubusercontent.com/66946165/118853716-5b57f280-b8d4-11eb-90b7-4360dd16c488.png)
