### PR TITLE
Get-DbaComputerSystem - Added test for pending reboot

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -128,6 +128,15 @@ function Get-DbaComputerSystem {
                         $awsProps = Invoke-Command2 -ComputerName $computerResolved -Credential $Credential -ArgumentList $ProxiedFunc -ScriptBlock $scriptBlock
                     }
                 }
+
+                $pendingReboot = $null
+                try {
+                    Write-Message -Level Verbose -Message "Getting information about pending reboots."
+                    $pendingReboot = Test-PendingReboot -ComputerName $computerResolved -Credential $Credential -PendingRename
+                } catch {
+                    Write-Message -Level Verbose -Message "Not able to get information about pending reboots."
+                }
+
                 $inputObject = [PSCustomObject]@{
                     ComputerName            = $computerResolved
                     Domain                  = $computerSystem.Domain
@@ -149,6 +158,7 @@ function Get-DbaComputerSystem {
                     DnsHostName             = $computerSystem.DNSHostName
                     IsSystemManagedPageFile = $computerSystem.AutomaticManagedPagefile
                     AdminPasswordStatus     = $adminPasswordStatus
+                    PendingReboot           = $pendingReboot
                 }
                 if ($IncludeAws -and $isAws) {
                     Add-Member -Force -InputObject $inputObject -MemberType NoteProperty -Name AwsAmiId -Value $awsProps.AmiId


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #6595 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Test a computer for a pending reboot.
As the used command Test-PendingReboot is only an internal command, now Get-DbaComputerSystem is the public interface to this command.
To see details about the pending reboot, -Verbose can be used as Test-PendingReboot outputs the reason on -Verbose.

![image](https://user-images.githubusercontent.com/66946165/119101944-d1b23d00-ba19-11eb-8ade-72408fa845ef.png)
