### PR TITLE
Set-DbaDbCompatibility - Added parameter and reworked code to use SMO

### DIFF
--- a/functions/Test-DbaDbCompatibility.ps1
+++ b/functions/Test-DbaDbCompatibility.ps1
@@ -77,7 +77,7 @@ function Test-DbaDbCompatibility {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
-            $serverversion = "Version$($server.VersionMajor)0"
+            $serverLevel = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($server.VersionMajor)0"
             $dbs = $server.Databases
 
             if ($Database) {
@@ -94,10 +94,10 @@ function Test-DbaDbCompatibility {
                     ComputerName          = $server.ComputerName
                     InstanceName          = $server.ServiceName
                     SqlInstance           = $server.DomainInstanceName
-                    ServerLevel           = $serverversion
+                    ServerLevel           = $serverLevel
                     Database              = $db.name
                     DatabaseCompatibility = $db.CompatibilityLevel
-                    IsEqual               = $db.CompatibilityLevel -eq $serverversion
+                    IsEqual               = $db.CompatibilityLevel -eq $serverLevel
                 }
             }
         }

--- a/tests/Set-DbaDbCompatibility.Tests.ps1
+++ b/tests/Set-DbaDbCompatibility.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'TargetCompatibility', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Compatibility', 'TargetCompatibility', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #5919 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
This PR probably leads to some discussion and I'm open for feedback.

Primary align the parameter type with the property type of the SMO and the output type of Test- and Get- command.
Then I use SMO instead of T-SQL.
I also changed the output based on the output of the Get- command but added the PreviousCompatibility.
And finally I have changed some variable names - because I always like to optimize their naming.

![image](https://user-images.githubusercontent.com/66946165/119138375-1baf1900-ba42-11eb-82d5-ceccc2c8286c.png)

![image](https://user-images.githubusercontent.com/66946165/119138423-2ec1e900-ba42-11eb-954f-7d4a4f391515.png)
