### PR TITLE
Backup-DbaDatabase - Added progress bar for all backups

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -396,9 +396,12 @@ function Backup-DbaDatabase {
         $topProgressTarget = $InputObject.Count
         $topProgressNumber = 0
         foreach ($db in $InputObject) {
-            $topProgressPercent = $topProgressNumber * 100.0 / $topProgressTarget
+            $topProgressPercent = $topProgressNumber * 100 / $topProgressTarget
             $topProgressNumber++
-            Write-Progress -Id $topProgressId -Activity "Backing up database $topProgressNumber of $topProgressTarget" -PercentComplete $topProgressPercent -Status ([System.String]::Format("Progress: {0} %", $topProgressPercent))
+            if (-not $PSCmdlet.MyInvocation.ExpectingInput) {
+                # Only when the databases to be processed are not piped to the command
+                Write-Progress -Id $topProgressId -Activity "Backing up database $topProgressNumber of $topProgressTarget" -PercentComplete $topProgressPercent -Status ([System.String]::Format("Progress: {0} %", $topProgressPercent))
+            }
 
             $ProgressId = Get-Random
             $failures = @()

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -392,7 +392,14 @@ function Backup-DbaDatabase {
             Write-Message -Level Warning -Message "No databases match the request for backups"
         }
 
+        $topProgressId = Get-Random
+        $topProgressTarget = $InputObject.Count
+        $topProgressNumber = 0
         foreach ($db in $InputObject) {
+            $topProgressPercent = $topProgressNumber * 100.0 / $topProgressTarget
+            $topProgressNumber++
+            Write-Progress -Id $topProgressId -Activity "Backing up database $topProgressNumber of $topProgressTarget" -PercentComplete $topProgressPercent -Status ([System.String]::Format("Progress: {0} %", $topProgressPercent))
+
             $ProgressId = Get-Random
             $failures = @()
             $dbName = $db.Name
@@ -621,7 +628,7 @@ function Backup-DbaDatabase {
                 $humanBackupFile = $FinalBackupPath -Join ','
                 Write-Message -Level Verbose -Message "Devices added"
                 $percent = [Microsoft.SqlServer.Management.Smo.PercentCompleteEventHandler] {
-                    Write-Progress -id $ProgressId -activity "Backing up database $dbName to $humanBackupFile" -PercentComplete $_.Percent -status ([System.String]::Format("Progress: {0} %", $_.Percent))
+                    Write-Progress -Id $ProgressId -Activity "Backing up database $dbName to $humanBackupFile" -PercentComplete $_.Percent -Status ([System.String]::Format("Progress: {0} %", $_.Percent))
                 }
                 $backup.add_PercentComplete($percent)
                 $backup.PercentCompleteNotification = 1
@@ -637,7 +644,7 @@ function Backup-DbaDatabase {
                     $backup.Blocksize = $BlockSize
                 }
 
-                Write-Progress -id $ProgressId -activity "Backing up database $dbName to $humanBackupFile" -PercentComplete 0 -status ([System.String]::Format("Progress: {0} %", 0))
+                Write-Progress -Id $ProgressId -Activity "Backing up database $dbName to $humanBackupFile" -PercentComplete 0 -Status ([System.String]::Format("Progress: {0} %", 0))
 
                 try {
                     if ($Pscmdlet.ShouldProcess($server.Name, "Backing up $dbName to $humanBackupFile")) {
@@ -648,7 +655,7 @@ function Backup-DbaDatabase {
 
                             $backup.SqlBackup($server)
                             $script = $backup.Script($server)
-                            Write-Progress -id $ProgressId -activity "Backing up database $dbName to $backupfile" -status "Complete" -Completed
+                            Write-Progress -Id $ProgressId -Activity "Backing up database $dbName to $backupfile" -Status "Complete" -Completed
                             $BackupComplete = $true
                             if ($server.VersionMajor -eq '8') {
                                 $HeaderInfo = Get-BackupAncientHistory -SqlInstance $server -Database $dbName
@@ -713,12 +720,14 @@ function Backup-DbaDatabase {
                     if ($NoRecovery -and ($_.Exception.InnerException.InnerException.InnerException -like '*cannot be opened. It is in the middle of a restore.')) {
                         Write-Message -Message "Exception thrown by db going into restoring mode due to recovery" -Leve Verbose
                     } else {
-                        Write-Progress -id $ProgressId -activity "Backup" -status "Failed" -completed
+                        Write-Progress -Id $ProgressId -Activity "Backup" -Status "Failed" -Completed
                         Stop-Function -message "Backup Failed" -ErrorRecord $_ -Continue
                         $BackupComplete = $false
                     }
                 }
             }
+            Write-Progress -Id $topProgressId -Activity 'Backup' -Completed
+
             $OutputExclude = 'FullName', 'FileList', 'SoftwareVersionMajor'
 
             if ($failures.Count -eq 0) {

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -396,7 +396,7 @@ function Backup-DbaDatabase {
         $topProgressTarget = $InputObject.Count
         $topProgressNumber = 0
         foreach ($db in $InputObject) {
-            $topProgressPercent = $topProgressNumber * 100 / $topProgressTarget
+            $topProgressPercent = [int]($topProgressNumber * 100 / $topProgressTarget)
             $topProgressNumber++
             if (-not $PSCmdlet.MyInvocation.ExpectingInput) {
                 # Only when the databases to be processed are not piped to the command


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #3659 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
### Purpose
Lets copy the request from the linked issue:

I would like to see a count of X of Y backups complete. I believe from looking at the command we have the count of databases we are going to back up. And as a database is backed up and the next one started that counter would follow.
Example: You have 90 databases to backup. The progress currently shows for the backup command, but I would like to see added X of 90 backups complete.

![image](https://user-images.githubusercontent.com/66946165/119167644-53c55480-ba60-11eb-906f-2e0f9c9afb15.png)

