### PR TITLE
Test-DbaLastBackup - Added ReuseSourceFolderStructure

### DIFF
--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -434,17 +434,29 @@ function Test-DbaLastBackup {
                         Write-Message -Level Verbose -Message "Performing restore."
                         $startRestore = Get-Date
                         try {
-                            $restoreSplat = @{
-                                SqlInstance                = $destserver
-                                RestoredDatabaseNamePrefix = $prefix
-                                DestinationFilePrefix      = $Prefix
-                                DestinationDataDirectory   = $datadirectory
-                                DestinationLogDirectory    = $logdirectory
-                                IgnoreLogBackup            = $IgnoreLogBackup
-                                AzureCredential            = $AzureCredential
-                                TrustDbBackupHistory       = $true
-                                ReuseSourceFolderStructure = $ReuseSourceFolderStructure
-                                EnableException            = $true
+                            if ($ReuseSourceFolderStructure) {
+                                $restoreSplat = @{
+                                    SqlInstance                = $destserver
+                                    RestoredDatabaseNamePrefix = $prefix
+                                    DestinationFilePrefix      = $Prefix
+                                    IgnoreLogBackup            = $IgnoreLogBackup
+                                    AzureCredential            = $AzureCredential
+                                    TrustDbBackupHistory       = $true
+                                    ReuseSourceFolderStructure = $true
+                                    EnableException            = $true
+                                }
+                            } else {
+                                $restoreSplat = @{
+                                    SqlInstance                = $destserver
+                                    RestoredDatabaseNamePrefix = $prefix
+                                    DestinationFilePrefix      = $Prefix
+                                    DestinationDataDirectory   = $datadirectory
+                                    DestinationLogDirectory    = $logdirectory
+                                    IgnoreLogBackup            = $IgnoreLogBackup
+                                    AzureCredential            = $AzureCredential
+                                    TrustDbBackupHistory       = $true
+                                    EnableException            = $true
+                                }
                             }
 
                             if (Test-Bound "MaxTransferSize") {

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -104,6 +104,10 @@ function Test-DbaLastBackup {
         Refererence: https://msdn.microsoft.com/en-us/library/ms178615.aspx#data-transfer-options
         Parameter is used as passtrough for Restore-DbaDatabase.
 
+    .PARAMETER ReuseSourceFolderStructure
+        By default, databases will be migrated to the destination Sql Server's default data and log directories. You can override this by specifying -ReuseSourceFolderStructure.
+        The same structure on the SOURCE will be kept exactly, so consider this if you're migrating between different versions and use part of Microsoft's default Sql structure (MSSql12.INSTANCE, etc)
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -209,6 +213,7 @@ function Test-DbaLastBackup {
         [int]$BufferCount,
         [switch]$IgnoreDiffBackup,
         [int]$MaxDop,
+        [switch]$ReuseSourceFolderStructure,
         [switch]$EnableException
     )
     process {
@@ -438,6 +443,7 @@ function Test-DbaLastBackup {
                                 IgnoreLogBackup            = $IgnoreLogBackup
                                 AzureCredential            = $AzureCredential
                                 TrustDbBackupHistory       = $true
+                                ReuseSourceFolderStructure = $ReuseSourceFolderStructure
                                 EnableException            = $true
                             }
 

--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'MaxDop', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType', 'MaxTransferSize', 'BufferCount', 'IgnoreDiffBackup'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'ExcludeDatabase', 'Destination', 'DestinationCredential', 'DataDirectory', 'LogDirectory', 'Prefix', 'VerifyOnly', 'NoCheck', 'NoDrop', 'CopyFile', 'CopyPath', 'MaxSize', 'MaxDop', 'IncludeCopyOnly', 'IgnoreLogBackup', 'AzureCredential', 'InputObject', 'EnableException', 'DeviceType', 'MaxTransferSize', 'BufferCount', 'IgnoreDiffBackup', 'ReuseSourceFolderStructure'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #3893 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
Copy from issue: Bring the parameter ReuseSourceFolderStructure from Restore-DbaDatabase to Test-DbaLastBackup. This facilitates the restore of databases with multiple data files spanned across different disks to keep a consistent restore test.

Not tested!