### PR TITLE
Test-DbaTempDbConfig checks SQL 2017 and 2019 for TF1118 and it is not needed

### DIFF
--- a/functions/Test-DbaTempDbConfig.ps1
+++ b/functions/Test-DbaTempDbConfig.ps1
@@ -77,15 +77,28 @@ function Test-DbaTempDbConfig {
             $tfCheck = $server.Databases['tempdb'].Query("DBCC TRACEON (3604);DBCC TRACESTATUS(-1)")
             $current = ($tfCheck.TraceFlag -join ',').Contains('1118')
 
-            [PSCustomObject]@{
-                ComputerName   = $server.ComputerName
-                InstanceName   = $server.ServiceName
-                SqlInstance    = $server.DomainInstanceName
-                Rule           = 'TF 1118 Enabled'
-                Recommended    = $true
-                CurrentSetting = $current
-                IsBestPractice = $current -eq $true
-                Notes          = 'KB328551 describes how TF 1118 can benefit performance. SQL Server 2016 has this functionality enabled by default.'
+            If ($server.VersionMajor -gt 12) {
+                [PSCustomObject]@{
+                    ComputerName   = $server.ComputerName
+                    InstanceName   = $server.ServiceName
+                    SqlInstance    = $server.DomainInstanceName
+                    Rule           = 'TF 1118 Enabled'
+                    Recommended    = $false
+                    CurrentSetting = $current
+                    IsBestPractice = $true
+                    Notes          = 'SQL Server 2016 and above has this functionality enabled by default.'
+                }
+            } else {
+                [PSCustomObject]@{
+                    ComputerName   = $server.ComputerName
+                    InstanceName   = $server.ServiceName
+                    SqlInstance    = $server.DomainInstanceName
+                    Rule           = 'TF 1118 Enabled'
+                    Recommended    = $true
+                    CurrentSetting = $current
+                    IsBestPractice = $current -eq $true
+                    Notes          = 'KB328551 describes how TF 1118 can benefit performance. SQL Server 2016 has this functionality enabled by default.'
+                }
             }
 
             Write-Message -Level Verbose -Message "TF 1118 evaluated"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When deploying a new server recently I noticed that the TF1118 best practice check is still being executed against SQL 2016, 17 and 19 where the functionality is enabled by default.  This in my opinion causes confusing on best practice check when best practice is returned as false, but the functionality is enabled by default.  So it is like a false positive.
### Approach
<!-- How does this change solve that purpose -->
I added a version check and changed the output text for SQL 2016 and above for this check.
### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
SQL 2019 output
![image](https://user-images.githubusercontent.com/169602/119234261-8ddf3680-baf2-11eb-89c7-3433e4cb8f2d.png)

SQL 2014 output
![image](https://user-images.githubusercontent.com/169602/119234281-a8b1ab00-baf2-11eb-9ee7-3e21ab7b8226.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
