### PR TITLE
Get-DbaHelp, gfm compatibility

### DIFF
--- a/internal/functions/Get-DbaHelp.ps1
+++ b/internal/functions/Get-DbaHelp.ps1
@@ -103,7 +103,7 @@ function Get-DbaHelp {
                         if ($x -eq 0) {
                             $null = $rtn.Add($val)
                         } else {
-                            $null = $rtn.Add('    -' + $val.replace("`n", '').replace("`n", ''))
+                            $null = $rtn.Add('    [' + $val.replace("`n", '').replace("`n", ''))
                         }
                         $x += 1
                     }
@@ -134,7 +134,7 @@ function Get-DbaHelp {
                         $inside = 0
                         $null = $rtn.Add('```')
                     }
-                    $null = $rtn.Add($row)
+                    $null = $rtn.Add("$row<br>")
                 }
             }
             if ($inside -eq 1) {
@@ -156,7 +156,7 @@ function Get-DbaHelp {
                         $null = $rtn.Add('### Required Parameters')
                     }
                     $null = $rtn.Add('##### -' + $el[0])
-                    $null = $rtn.Add($el[1])
+                    $null = $rtn.Add($el[1] + '<br>')
                     $null = $rtn.Add('')
                     $null = $rtn.Add('|  |  |')
                     $null = $rtn.Add('| - | - |')
@@ -183,7 +183,7 @@ function Get-DbaHelp {
                     }
 
                     $null = $rtn.Add('##### -' + $el[0])
-                    $null = $rtn.Add($el[1])
+                    $null = $rtn.Add($el[1] + '<br>')
                     $null = $rtn.Add('')
                     $null = $rtn.Add('|  |  |')
                     $null = $rtn.Add('| - | - |')
@@ -197,10 +197,10 @@ function Get-DbaHelp {
                     $null = $rtn.Add('')
                 }
             }
-
             $null = $rtn.Add('')
             $null = $rtn.Add("`n" + '&nbsp;' + "`n")
             $null = $rtn.Add('Want to see the source code for this command? Check out [' + $doc_to_render.CommandName + '](https://github.com/sqlcollaborative/dbatools/blob/master/functions/' + $doc_to_render.CommandName + '.ps1) on GitHub.')
+            $null = $rtn.Add("<br>")
             $null = $rtn.Add('Want to see the Bill Of Health for this command? Check out [' + $doc_to_render.CommandName + '](https://sqlcollaborative.github.io/boh#' + $doc_to_render.CommandName + ').')
             $null = $rtn.Add('')
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [x] Documentation
 - [ ] Build system
 
### Purpose
Compared to what is used on the docs.dbatools.io site, which uses markdown with the "gfm" dialect, some fixes were needed as moving forward PS7's ConvertFrom-Markdown will be used (see https://github.com/sqlcollaborative/docs/issues/36) . The point is/was that in gfm-style soft breaks (i.e. a line ending in our inline help) ended up being properly separated by a `<br>`.
ConvertFrom-Markdown from PS7 doesn't support it, so we need to generate it in here.

