### PR TITLE
Set-DbaAgentJob - Added parameter test

### DIFF
--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -222,7 +222,7 @@ function Set-DbaAgentJob {
         }
 
         # Check the e-mail level parameter
-        if ($null -ne $EmailOperator -and ($null -eq $EmailLevel)) {
+        if ($EmailOperator -and ($null -eq $EmailLevel)) {
             Stop-Function -Message "Please set the e-mail level parameter when the e-mail level operator is set." -Target $SqlInstance
             return
         }
@@ -234,7 +234,7 @@ function Set-DbaAgentJob {
         }
 
         # Check the net send level parameter
-        if ($null -ne $NetsendOperator -and ($null -eq $NetsendLevel)) {
+        if ($NetsendOperator -and ($null -eq $NetsendLevel)) {
             Stop-Function -Message "Please set the net send level parameter when the net send level operator is set." -Target $SqlInstance
             return
         }
@@ -246,7 +246,7 @@ function Set-DbaAgentJob {
         }
 
         # Check the page level parameter
-        if ($null -ne $PageOperator -and ($null -eq $PageLevel)) {
+        if ($PageOperator -and ($null -eq $PageLevel)) {
             Stop-Function -Message "Please set the page level parameter when the page level operator is set." -Target $SqlInstance
             return
         }

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -221,15 +221,33 @@ function Set-DbaAgentJob {
             return
         }
 
-        # Check the e-mail operator name
+        # Check the e-mail level parameter
+        if ($null -ne $EmailOperator -and ($null -eq $EmailLevel)) {
+            Stop-Function -Message "Please set the e-mail level parameter when the e-mail level operator is set." -Target $SqlInstance
+            return
+        }
+
+        # Check the net send operator name
         if (($NetsendLevel -ge 1) -and (-not $NetsendOperator)) {
             Stop-Function -Message "Please set the netsend operator when the netsend level parameter is set." -Target $SqlInstance
             return
         }
 
-        # Check the e-mail operator name
+        # Check the net send level parameter
+        if ($null -ne $NetsendOperator -and ($null -eq $NetsendLevel)) {
+            Stop-Function -Message "Please set the net send level parameter when the net send level operator is set." -Target $SqlInstance
+            return
+        }
+
+        # Check the page operator name
         if (($PageLevel -ge 1) -and (-not $PageOperator)) {
             Stop-Function -Message "Please set the page operator when the page level parameter is set." -Target $SqlInstance
+            return
+        }
+
+        # Check the page level parameter
+        if ($null -ne $PageOperator -and ($null -eq $PageLevel)) {
+            Stop-Function -Message "Please set the page level parameter when the page level operator is set." -Target $SqlInstance
             return
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6847 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
For all three possible types (e-mail, net send, page) now both operator and level have to be set, otherwise a warning is thrown and the command returns.

Also corrected some comments.

![image](https://user-images.githubusercontent.com/66946165/119452446-acce0a80-bd36-11eb-8119-f0d4dcbc17b5.png)

