### PR TITLE
Get-/Set-DbaNetworkConfiguration - New commands for managing network configuration of instance

### DIFF
--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -1,0 +1,107 @@
+function Get-DbaNetworkConfiguration {
+    <#
+    .SYNOPSIS
+        Returns the network configuration of a SQL Server instance as shown in the SQL Server Configuration Manager.
+
+    .DESCRIPTION
+        Returns a PowerShell object with the network configuration of a SQL Server instance as shown in the SQL Server Configuration Manager.
+
+        Remote SQL WMI is used by default. If this doesn't work, then remoting is used.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances.
+
+    .PARAMETER Credential
+        Credential object used to connect to the Computer as a different user.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: SQLWMI
+        Author: Andreas Jordan (@JordanOrdix), ordix.de
+
+        Website: https://dbatools.io
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaNetworkConfiguration
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkConfiguration -SqlInstance sqlserver2014a
+
+        Returns the network configuration for the default instance on sqlserver2014a.
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkConfiguration -SqlInstance winserver\sqlexpress, sql2016
+
+        Returns the network configuration for the sqlexpress on winserver and the default instance on sql2016.
+
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$Credential,
+        [switch]$EnableException
+    )
+
+    begin {
+        $wmiScriptBlock = {
+            $instance = $args[0]
+
+            $wmiServerProtocols = $wmi.ServerInstances.Where( { $_.Name -eq $instance.InstanceName } ).ServerProtocols
+
+            $wmiTcpIp = $wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } )[0]
+            $outputTcpIpProtocol = [PSCustomObject]@{
+                Enabled   = $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'Enabled' } ).Value
+                KeepAlive = $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'KeepAlive' } ).Value
+                ListenAll = $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'ListenOnAllIPs' } ).Value
+            }
+
+            $outputTcpIpIPAddressesIPn = foreach ($ip in $wmiTcpIp.IPAddresses.Where( { $_.Name -ne 'IPAll' } )) {
+                [PSCustomObject]@{
+                    Name            = $ip.Name
+                    Active          = $ip.IPAddressProperties.Where( { $_.Name -eq 'Active' } ).Value
+                    Enabled         = $ip.IPAddressProperties.Where( { $_.Name -eq 'Enabled' } ).Value
+                    IPAddress       = $ip.IPAddressProperties.Where( { $_.Name -eq 'IpAddress' } ).Value
+                    TCPDynamicPorts = $ip.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } ).Value
+                    TCPPort         = $ip.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } ).Value
+                }
+            }
+
+            $ipAll = $wmiTcpIp.IPAddresses.Where( { $_.Name -eq 'IPAll' } )
+            $outputTcpIpIPAddressesIPAll = [PSCustomObject]@{
+                Name            = $ipAll.Name
+                TCPDynamicPorts = $ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } ).Value
+                TCPPort         = $ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } ).Value
+            }
+
+            $outputTcpIpIPAddresses = $outputTcpIpIPAddressesIPn + $outputTcpIpIPAddressesIPAll
+
+            [PSCustomObject]@{
+                ComputerName        = $instance.ComputerName
+                InstanceName        = $instance.InstanceName
+                SqlInstance         = $instance.SqlFullName.Trim('[]')
+                SharedMemoryEnabled = $wmiServerProtocols.Where( { $_.Name -eq 'Sm' } ).IsEnabled
+                NamedPipesEnabled   = $wmiServerProtocols.Where( { $_.Name -eq 'Np' } ).IsEnabled
+                TCPIPEnabled        = $wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } ).IsEnabled
+                TCPIPProtokoll      = $outputTcpIpProtocol
+                TCPIPIPAddresses    = $outputTcpIpIPAddresses
+            }
+        }
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -Credential $Credential -ScriptBlock $wmiScriptBlock -ArgumentList $instance
+            } catch {
+                Stop-Function -Message "Connection to $($instance.ComputerName) not possible." -Target $instance -ErrorRecord $_ -Continue
+            }
+        }
+    }
+}

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -1,12 +1,12 @@
 function Get-DbaNetworkConfiguration {
     <#
     .SYNOPSIS
-        Returns the network configuration of a SQL Server instance as shown in the SQL Server Configuration Manager.
+        Returns the network configuration of a SQL Server instance as shown in SQL Server Configuration Manager.
 
     .DESCRIPTION
-        Returns a PowerShell object with the network configuration of a SQL Server instance as shown in the SQL Server Configuration Manager.
+        Returns a PowerShell object with the network configuration of a SQL Server instance as shown in SQL Server Configuration Manager.
 
-        Remote SQL WMI is used by default. If this doesn't work, then remoting is used.
+        Remote SQL WMI is used by default, with PS Remoting used as a fallback.
 
         For a detailed explenation of the different properties see the documentation at:
         https://docs.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-network-configuration

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -8,6 +8,9 @@ function Get-DbaNetworkConfiguration {
 
         Remote SQL WMI is used by default. If this doesn't work, then remoting is used.
 
+        For a detailed explenation of the different properties see the documentation at:
+        https://docs.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-network-configuration
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -169,7 +169,7 @@ function Get-DbaNetworkConfiguration {
                     }
                 }
             } catch {
-                Stop-Function -Message "Connection to $($instance.ComputerName) not possible." -Target $instance -ErrorRecord $_ -Continue
+                Stop-Function -Message "Failed to collect network configuration from $($instance.ComputerName) for instance $($instance.InstanceName)." -Target $instance -ErrorRecord $_ -Continue
             }
         }
     }

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -72,6 +72,15 @@ function Get-DbaNetworkConfiguration {
 
     begin {
         $wmiScriptBlock = {
+            # This scriptblock will be processed by Invoke-ManagedComputerCommand.
+            # It is extended there above this line by the following lines:
+            #   $ipaddr = $args[$args.GetUpperBound(0)]
+            #   [void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SqlWmiManagement')
+            #   $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $ipaddr
+            #   $null = $wmi.Initialize()
+            # So we can use $wmi here and assume that there is a successful connection.
+
+            # We take on object as the first parameter which has to include the property InstanceName.
             $instance = $args[0]
 
             $wmiServerProtocols = ($wmi.ServerInstances | Where-Object { $_.Name -eq $instance.InstanceName } ).ServerProtocols

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -132,6 +132,11 @@ function Get-DbaNetworkConfiguration {
             try {
                 $netConf = Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -Credential $Credential -ScriptBlock $wmiScriptBlock -ArgumentList $instance
 
+                # Test if object is filled to test if instance was found on computer
+                if ($null -eq $netConf.SharedMemoryEnabled) {
+                    Stop-Function -Message "Failed to collect network configuration from $($instance.ComputerName) for instance $($instance.InstanceName). No data was found for this instance, so skipping." -Target $instance -ErrorRecord $_ -Continue
+                }
+
                 if ($OutputType -eq 'Full') {
                     $netConf
                 } elseif ($OutputType -eq 'ServerProtocols') {

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -6,7 +6,7 @@ function Set-DbaNetworkConfiguration {
     .DESCRIPTION
         Sets the network configuration of a SQL Server instance.
 
-        Parameters are available for typical tasks like enabling or disabling a protokoll or switching between dynamic and static ports.
+        Parameters are available for typical tasks like enabling or disabling a protocol or switching between dynamic and static ports.
         To be more flexible, you can use Get-DbaNetworkConfiguration to get an object that represents the complete network configuration
         like you would see it with the SQL Server Configuration Manager.
         You can change any setting of this object and then pass it to Set-DbaNetworkConfiguration via pipeline or InputObject parameter.
@@ -24,21 +24,21 @@ function Set-DbaNetworkConfiguration {
     .PARAMETER Credential
         Credential object used to connect to the Computer as a different user.
 
-    .PARAMETER EnableProtokoll
-        Enables one of the following network protokolls: SharedMemory, NamedPipes, TcpIp.
+    .PARAMETER EnableProtocol
+        Enables one of the following network protocols: SharedMemory, NamedPipes, TcpIp.
 
-    .PARAMETER DisableProtokoll
-        Disables one of the following network protokolls: SharedMemory, NamedPipes, TcpIp.
+    .PARAMETER DisableProtocol
+        Disables one of the following network protocols: SharedMemory, NamedPipes, TcpIp.
 
     .PARAMETER DynamicPortForIPAll
         Configures the instance to listen on a dynamic port for all IP addresses.
-        Will enable the TCP/IP protokoll if needed.
+        Will enable the TCP/IP protocol if needed.
         Will set TcpIpProperties.ListenAll to $true if needed.
         Will reset the last used dynamic port if already set.
 
     .PARAMETER StaticPortForIPAll
         Configures the instance to listen on one or more static ports for all IP addresses.
-        Will enable the TCP/IP protokoll if needed.
+        Will enable the TCP/IP protocol if needed.
         Will set TcpIpProperties.ListenAll to $true if needed.
 
     .PARAMETER RestartService
@@ -72,15 +72,15 @@ function Set-DbaNetworkConfiguration {
         https://dbatools.io/Set-DbaNetworkConfiguration
 
     .EXAMPLE
-        PS C:\> Set-DbaNetworkConfiguration -SqlInstance sql2016 -EnableProtokoll SharedMemory -RestartService
+        PS C:\> Set-DbaNetworkConfiguration -SqlInstance sql2016 -EnableProtocol SharedMemory -RestartService
 
-        Ensures that the shared memory network protokoll for the default instance on sql2016 is enabled.
+        Ensures that the shared memory network protocol for the default instance on sql2016 is enabled.
         Restarts the service if needed.
 
     .EXAMPLE
         PS C:\> Set-DbaNetworkConfiguration -SqlInstance sql2016\test -StaticPortForIPAll 14331, 14332 -RestartService
 
-        Ensures that the TCP/IP network protokoll is enabled and configured to use the ports 14331 and 14332 for all IP addresses.
+        Ensures that the TCP/IP network protocol is enabled and configured to use the ports 14331 and 14332 for all IP addresses.
         Restarts the service if needed.
 
     .EXAMPLE
@@ -100,10 +100,10 @@ function Set-DbaNetworkConfiguration {
         [PSCredential]$Credential,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [ValidateSet('SharedMemory', 'NamedPipes', 'TcpIp')]
-        [string]$EnableProtokoll,
+        [string]$EnableProtocol,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [ValidateSet('SharedMemory', 'NamedPipes', 'TcpIp')]
-        [string]$DisableProtokoll,
+        [string]$DisableProtocol,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [switch]$DynamicPortForIPAll,
         [Parameter(ParameterSetName = 'NonPipeline')]
@@ -133,10 +133,10 @@ function Set-DbaNetworkConfiguration {
             $exception = $null
 
             try {
-                $verbose += "Getting server protokolls for $($targetConf.InstanceName)"
+                $verbose += "Getting server protocols for $($targetConf.InstanceName)"
                 $wmiServerProtocols = ($wmi.ServerInstances | Where-Object { $_.Name -eq $targetConf.InstanceName } ).ServerProtocols
 
-                $verbose += 'Getting server protokoll shared memory'
+                $verbose += 'Getting server protocol shared memory'
                 $wmiSpSm = $wmiServerProtocols | Where-Object { $_.Name -eq 'Sm' }
                 if ($null -eq $targetConf.SharedMemoryEnabled) {
                     $verbose += 'SharedMemoryEnabled not in target object'
@@ -146,7 +146,7 @@ function Set-DbaNetworkConfiguration {
                     $changes += "Changed SharedMemoryEnabled to $($targetConf.SharedMemoryEnabled)"
                 }
 
-                $verbose += 'Getting server protokoll named pipes'
+                $verbose += 'Getting server protocol named pipes'
                 $wmiSpNp = $wmiServerProtocols | Where-Object { $_.Name -eq 'Np' }
                 if ($null -eq $targetConf.NamedPipesEnabled) {
                     $verbose += 'NamedPipesEnabled not in target object'
@@ -156,7 +156,7 @@ function Set-DbaNetworkConfiguration {
                     $changes += "Changed NamedPipesEnabled to $($targetConf.NamedPipesEnabled)"
                 }
 
-                $verbose += 'Getting server protokoll TCP/IP'
+                $verbose += 'Getting server protocol TCP/IP'
                 $wmiSpTcp = $wmiServerProtocols | Where-Object { $_.Name -eq 'Tcp' }
                 if ($null -eq $targetConf.TcpIpEnabled) {
                     $verbose += 'TcpIpEnabled not in target object'
@@ -166,7 +166,7 @@ function Set-DbaNetworkConfiguration {
                     $changes += "Changed TcpIpEnabled to $($targetConf.TcpIpEnabled)"
                 }
 
-                $verbose += 'Getting properties for server protokoll TCP/IP'
+                $verbose += 'Getting properties for server protocol TCP/IP'
                 $wmiSpTcpEnabled = $wmiSpTcp.ProtocolProperties | Where-Object { $_.Name -eq 'Enabled' }
                 if ($null -eq $targetConf.TcpIpProperties.Enabled) {
                     $verbose += 'TcpIpProperties.Enabled not in target object'
@@ -279,12 +279,12 @@ function Set-DbaNetworkConfiguration {
     }
 
     process {
-        if ($SqlInstance -and (Test-Bound -Not -ParameterName EnableProtokoll, DisableProtokoll, DynamicPortForIPAll, StaticPortForIPAll)) {
+        if ($SqlInstance -and (Test-Bound -Not -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll)) {
             Stop-Function -Message "You must choose an action if SqlInstance is used."
             return
         }
 
-        if ($SqlInstance -and (Test-Bound -ParameterName EnableProtokoll, DisableProtokoll, DynamicPortForIPAll, StaticPortForIPAll -Not -Max 1)) {
+        if ($SqlInstance -and (Test-Bound -ParameterName EnableProtocol, DisableProtocol, DynamicPortForIPAll, StaticPortForIPAll -Not -Max 1)) {
             Stop-Function -Message "Only one action is allowed at a time."
             return
         }
@@ -297,41 +297,41 @@ function Set-DbaNetworkConfiguration {
                 Stop-Function -Message "Failed to collect network configuration from $($instance.ComputerName) for instance $($instance.InstanceName)." -Target $instance -ErrorRecord $_ -Continue
             }
 
-            if ($EnableProtokoll) {
-                if ($netConf."${EnableProtokoll}Enabled") {
-                    Write-Message -Level Verbose -Message "Protokoll $EnableProtokoll is already enabled on $instance."
+            if ($EnableProtocol) {
+                if ($netConf."${EnableProtocol}Enabled") {
+                    Write-Message -Level Verbose -Message "Protocol $EnableProtocol is already enabled on $instance."
                 } else {
-                    Write-Message -Level Verbose -Message "Will enable protokoll $EnableProtokoll on $instance."
-                    $netConf."${EnableProtokoll}Enabled" = $true
-                    if ($EnableProtokoll -eq 'TcpIp') {
+                    Write-Message -Level Verbose -Message "Will enable protocol $EnableProtocol on $instance."
+                    $netConf."${EnableProtocol}Enabled" = $true
+                    if ($EnableProtocol -eq 'TcpIp') {
                         $netConf.TcpIpProperties.Enabled = $true
                     }
                 }
             }
 
-            if ($DisableProtokoll) {
-                if ($netConf."${DisableProtokoll}Enabled") {
-                    Write-Message -Level Verbose -Message "Will disable protokoll $EnableProtokoll on $instance."
-                    $netConf."${DisableProtokoll}Enabled" = $false
-                    if ($DisableProtokoll -eq 'TcpIp') {
+            if ($DisableProtocol) {
+                if ($netConf."${DisableProtocol}Enabled") {
+                    Write-Message -Level Verbose -Message "Will disable protocol $EnableProtocol on $instance."
+                    $netConf."${DisableProtocol}Enabled" = $false
+                    if ($DisableProtocol -eq 'TcpIp') {
                         $netConf.TcpIpProperties.Enabled = $false
                     }
                 } else {
-                    Write-Message -Level Verbose -Message "Protokoll $EnableProtokoll is already disabled on $instance."
+                    Write-Message -Level Verbose -Message "Protocol $EnableProtocol is already disabled on $instance."
                 }
             }
 
             if ($DynamicPortForIPAll) {
                 if (-not $netConf.TcpIpEnabled) {
-                    Write-Message -Level Verbose -Message "Will enable protokoll TcpIp on $instance."
+                    Write-Message -Level Verbose -Message "Will enable protocol TcpIp on $instance."
                     $netConf.TcpIpEnabled = $true
                 }
                 if (-not $netConf.TcpIpProperties.Enabled) {
-                    Write-Message -Level Verbose -Message "Will set property Enabled of protokoll TcpIp to True on $instance."
+                    Write-Message -Level Verbose -Message "Will set property Enabled of protocol TcpIp to True on $instance."
                     $netConf.TcpIpProperties.Enabled = $true
                 }
                 if (-not $netConf.TcpIpProperties.ListenAll) {
-                    Write-Message -Level Verbose -Message "Will set property ListenAll of protokoll TcpIp to True on $instance."
+                    Write-Message -Level Verbose -Message "Will set property ListenAll of protocol TcpIp to True on $instance."
                     $netConf.TcpIpProperties.ListenAll = $true
                 }
                 $ipAll = $netConf.TcpIpAddresses | Where-Object { $_.Name -eq 'IPAll' }
@@ -343,15 +343,15 @@ function Set-DbaNetworkConfiguration {
 
             if ($StaticPortForIPAll) {
                 if (-not $netConf.TcpIpEnabled) {
-                    Write-Message -Level Verbose -Message "Will enable protokoll TcpIp on $instance."
+                    Write-Message -Level Verbose -Message "Will enable protocol TcpIp on $instance."
                     $netConf.TcpIpEnabled = $true
                 }
                 if (-not $netConf.TcpIpProperties.Enabled) {
-                    Write-Message -Level Verbose -Message "Will set property Enabled of protokoll TcpIp to True on $instance."
+                    Write-Message -Level Verbose -Message "Will set property Enabled of protocol TcpIp to True on $instance."
                     $netConf.TcpIpProperties.Enabled = $true
                 }
                 if (-not $netConf.TcpIpProperties.ListenAll) {
-                    Write-Message -Level Verbose -Message "Will set property ListenAll of protokoll TcpIp to True on $instance."
+                    Write-Message -Level Verbose -Message "Will set property ListenAll of protocol TcpIp to True on $instance."
                     $netConf.TcpIpProperties.ListenAll = $true
                 }
                 $ipAll = $netConf.TcpIpAddresses | Where-Object { $_.Name -eq 'IPAll' }

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -118,6 +118,15 @@ function Set-DbaNetworkConfiguration {
 
     begin {
         $wmiScriptBlock = {
+            # This scriptblock will be processed by Invoke-ManagedComputerCommand.
+            # It is extended there above this line by the following lines:
+            #   $ipaddr = $args[$args.GetUpperBound(0)]
+            #   [void][System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SqlWmiManagement')
+            #   $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $ipaddr
+            #   $null = $wmi.Initialize()
+            # So we can use $wmi here and assume that there is a successful connection.
+
+            # We take on object as the first parameter which has to include the instance name and the target network configuration.
             $targetConf = $args[0]
             $changes = @()
             $verbose = @()

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -239,7 +239,7 @@ function Set-DbaNetworkConfiguration {
             return
         }
 
-        if (Test-Bound -ParameterName EnableProtokoll, DisableProtokoll, DynamicPortForIPAll, StaticPortForIPAll -Not -Max 1) {
+        if ($SqlInstance -and (Test-Bound -ParameterName EnableProtokoll, DisableProtokoll, DynamicPortForIPAll, StaticPortForIPAll -Not -Max 1)) {
             Stop-Function -Message "Only one action is allowed at a time."
             return
         }

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -1,0 +1,166 @@
+function Set-DbaNetworkConfiguration {
+    <#
+    .SYNOPSIS
+        Sets the network configuration of a SQL Server instance.
+
+    .DESCRIPTION
+        Sets the network configuration of a SQL Server instance. Needs an object with the structure that Get-DbaNetworkConfiguration returns.
+
+        Remote SQL WMI is used by default. If this doesn't work, then remoting is used.
+
+    .PARAMETER InputObject
+        The object with the structure that Get-DbaNetworkConfiguration returns.
+
+    .PARAMETER Credential
+        Credential object used to connect to the Computer as a different user.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: SQLWMI
+        Author: Andreas Jordan (@JordanOrdix), ordix.de
+
+        Website: https://dbatools.io
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Set-DbaNetworkConfiguration
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkConfiguration -SqlInstance sqlserver2014a
+
+        Returns the network configuration for the default instance on sqlserver2014a.
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkConfiguration -SqlInstance winserver\sqlexpress, sql2016
+
+        Returns the network configuration for the sqlexpress on winserver and the default instance on sql2016.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [object[]]$InputObject,
+        [PSCredential]$Credential,
+        [switch]$EnableException
+    )
+
+    begin {
+        $wmiScriptBlock = {
+            $instance = $args[0]
+            $changes = @()
+
+            $wmiServerProtocols = $wmi.ServerInstances.Where( { $_.Name -eq $instance.InstanceName } ).ServerProtocols
+
+            if ($wmiServerProtocols.Where( { $_.Name -eq 'Sm' } ).IsEnabled -ne $instance.SharedMemoryEnabled) {
+                $wmiServerProtocols.Where( { $_.Name -eq 'Sm' } )[0].IsEnabled = $instance.SharedMemoryEnabled
+                $wmiServerProtocols.Where( { $_.Name -eq 'Sm' } )[0].Alter()
+                $changes += "Changed SharedMemoryEnabled to $($instance.SharedMemoryEnabled)"
+            }
+
+            if ($wmiServerProtocols.Where( { $_.Name -eq 'Np' } ).IsEnabled -ne $instance.NamedPipesEnabled) {
+                $wmiServerProtocols.Where( { $_.Name -eq 'Np' } )[0].IsEnabled = $instance.NamedPipesEnabled
+                $wmiServerProtocols.Where( { $_.Name -eq 'Np' } )[0].Alter()
+                $changes += "Changed NamedPipesEnabled to $($instance.NamedPipesEnabled)"
+            }
+
+            if ($wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } ).IsEnabled -ne $instance.TCPIPEnabled) {
+                $wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } )[0].IsEnabled = $instance.TCPIPEnabled
+                $wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } )[0].Alter()
+                $changes += "Changed TCPIPEnabled to $($instance.TCPIPEnabled)"
+            }
+
+            $wmiTcpIp = $wmiServerProtocols.Where( { $_.Name -eq 'Tcp' } )[0]
+
+            if ($wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'Enabled' } ).Value -ne $instance.TCPIPProtokoll.Enabled) {
+                $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'Enabled' } )[0].Value = $instance.TCPIPProtokoll.Enabled
+                $wmiTcpIp.Alter()
+                $changes += "Changed TCPIPProtokoll.Enabled to $($instance.TCPIPProtokoll.Enabled)"
+            }
+
+            if ($wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'KeepAlive' } ).Value -ne $instance.TCPIPProtokoll.KeepAlive) {
+                $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'KeepAlive' } )[0].Value = $instance.TCPIPProtokoll.KeepAlive
+                $wmiTcpIp.Alter()
+                $changes += "Changed TCPIPProtokoll.KeepAlive to $($instance.TCPIPProtokoll.KeepAlive)"
+            }
+
+            if ($wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'ListenOnAllIPs' } ).Value -ne $instance.TCPIPProtokoll.ListenAll) {
+                $wmiTcpIp.ProtocolProperties.Where( { $_.Name -eq 'ListenOnAllIPs' } )[0].Value = $instance.TCPIPProtokoll.ListenAll
+                $wmiTcpIp.Alter()
+                $changes += "Changed TCPIPProtokoll.ListenAll to $($instance.TCPIPProtokoll.ListenAll)"
+            }
+
+            foreach ($ip in $wmiTcpIp.IPAddresses.Where( { $_.Name -ne 'IPAll' } )) {
+                $ipTarget = $instance.TCPIPIPAddresses.Where( { $_.Name -eq $ip.Name } )
+
+                if ($ip.IPAddressProperties.Where( { $_.Name -eq 'Active' } ).Value -ne $ipTarget.Active) {
+                    $ip.IPAddressProperties.Where( { $_.Name -eq 'Active' } )[0].Value = $ipTarget.Active
+                    $wmiTcpIp.Alter()
+                    $changes += "Changed Active for $($ip.Name) to $($ipTarget.Active)"
+                }
+
+                if ($ip.IPAddressProperties.Where( { $_.Name -eq 'Enabled' } ).Value -ne $ipTarget.Enabled) {
+                    $ip.IPAddressProperties.Where( { $_.Name -eq 'Enabled' } )[0].Value = $ipTarget.Enabled
+                    $wmiTcpIp.Alter()
+                    $changes += "Changed Enabled for $($ip.Name) to $($ipTarget.Enabled)"
+                }
+
+                if ($ip.IPAddressProperties.Where( { $_.Name -eq 'IpAddress' } ).Value -ne $ipTarget.IpAddress) {
+                    $ip.IPAddressProperties.Where( { $_.Name -eq 'IpAddress' } )[0].Value = $ipTarget.IpAddress
+                    $wmiTcpIp.Alter()
+                    $changes += "Changed IpAddress for $($ip.Name) to $($ipTarget.IpAddress)"
+                }
+
+                if ($ip.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } ).Value -ne $ipTarget.TcpDynamicPorts) {
+                    $ip.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } )[0].Value = $ipTarget.TcpDynamicPorts
+                    $wmiTcpIp.Alter()
+                    $changes += "Changed TcpDynamicPorts for $($ip.Name) to $($ipTarget.TcpDynamicPorts)"
+                }
+
+                if ($ip.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } ).Value -ne $ipTarget.TcpPort) {
+                    $ip.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } )[0].Value = $ipTarget.TcpPort
+                    $wmiTcpIp.Alter()
+                    $changes += "Changed TcpPort for $($ip.Name) to $($ipTarget.TcpPort)"
+                }
+            }
+
+            $ipAll = $wmiTcpIp.IPAddresses.Where( { $_.Name -eq 'IPAll' } )
+            $ipTarget = $instance.TCPIPIPAddresses.Where( { $_.Name -eq 'IPAll' } )
+
+            if ($ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } ).Value -ne $ipTarget.TcpDynamicPorts) {
+                $ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpDynamicPorts' } )[0].Value = $ipTarget.TcpDynamicPorts
+                $wmiTcpIp.Alter()
+                $changes += "Changed TcpDynamicPorts for $($ipAll.Name) to $($ipTarget.TcpDynamicPorts)"
+            }
+
+            if ($ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } ).Value -ne $ipTarget.TcpPort) {
+                $ipAll.IPAddressProperties.Where( { $_.Name -eq 'TcpPort' } )[0].Value = $ipTarget.TcpPort
+                $wmiTcpIp.Alter()
+                $changes += "Changed TcpPort for $($ipAll.Name) to $($ipTarget.TcpPort)"
+            }
+
+            [PSCustomObject]@{
+                ComputerName = $instance.ComputerName
+                InstanceName = $instance.InstanceName
+                SqlInstance  = $instance.SqlInstance
+                Changes      = $changes
+            }
+        }
+    }
+
+    process {
+        foreach ($instance in $InputObject) {
+            try {
+                if ($Pscmdlet.ShouldProcess("Setting network configuration for instance $($instance.InstanceName) on $($instance.ComputerName)")) {
+                    Invoke-ManagedComputerCommand -ComputerName $instance.ComputerName -Credential $Credential -ScriptBlock $wmiScriptBlock -ArgumentList $instance
+                }
+            } catch {
+                Stop-Function -Message "Setting network configuration for instance $($instance.InstanceName) on $($instance.ComputerName) not possible." -Target $instance -ErrorRecord $_ -Continue
+            }
+        }
+    }
+}

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -7,15 +7,15 @@ function Set-DbaNetworkConfiguration {
         Sets the network configuration of a SQL Server instance.
 
         Parameters are available for typical tasks like enabling or disabling a protocol or switching between dynamic and static ports.
-        To be more flexible, you can use Get-DbaNetworkConfiguration to get an object that represents the complete network configuration
-        like you would see it with the SQL Server Configuration Manager.
-        You can change any setting of this object and then pass it to Set-DbaNetworkConfiguration via pipeline or InputObject parameter.
+        The object returned by Get-DbaNetworkConfiguration can be used to adjust settings of the properties
+        and then passed to this command via pipeline or -InputObject parameter.
 
-        Every change to the network configuration needs a service restart to take effect. To do this, use the RestartService parameter.
+        A change to the network configuration with SQL Server requires a restart to take effect,
+        support for this can be done via the RestartService parameter.
 
-        Remote SQL WMI is used by default. If this doesn't work, then remoting is used.
+        Remote SQL WMI is used by default, with PS Remoting used as a fallback.
 
-        For a detailed explenation of the different properties see the documentation at:
+        For a detailed explanation of the different properties see the documentation at:
         https://docs.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-network-configuration
 
     .PARAMETER SqlInstance
@@ -46,8 +46,8 @@ function Set-DbaNetworkConfiguration {
         This switch will force a restart of the service if the network configuration has changed.
 
     .PARAMETER InputObject
-        The object with the structure that Get-DbaNetworkConfiguration returns.
-        Get-DbaNetworkConfiguration has be run with the default OutputType Full to get the complete object.
+        The output object from Get-DbaNetworkConfiguration.
+        Get-DbaNetworkConfiguration has to be run with -OutputType Full (default) to get the complete object.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -71,36 +71,36 @@ function Set-DbaNetworkConfiguration {
             }
 
             $wmiSpTcp = $wmiServerProtocols | Where-Object { $_.Name -eq 'Tcp' }
-            if ($wmiSpTcp.IsEnabled -ne $instance.TCPIPEnabled) {
-                $wmiSpTcp.IsEnabled = $instance.TCPIPEnabled
+            if ($wmiSpTcp.IsEnabled -ne $instance.TcpIpEnabled) {
+                $wmiSpTcp.IsEnabled = $instance.TcpIpEnabled
                 $wmiSpTcp.Alter()
-                $changes += "Changed TCPIPEnabled to $($instance.TCPIPEnabled)"
+                $changes += "Changed TcpIpEnabled to $($instance.TcpIpEnabled)"
             }
 
             $wmiSpTcpEnabled = $wmiSpTcp.ProtocolProperties | Where-Object { $_.Name -eq 'Enabled' }
-            if ($wmiSpTcpEnabled.Value -ne $instance.TCPIPProtokoll.Enabled) {
-                $wmiSpTcpEnabled.Value = $instance.TCPIPProtokoll.Enabled
+            if ($wmiSpTcpEnabled.Value -ne $instance.TcpIpProperties.Enabled) {
+                $wmiSpTcpEnabled.Value = $instance.TcpIpProperties.Enabled
                 $wmiSpTcp.Alter()
-                $changes += "Changed TCPIPProtokoll.Enabled to $($instance.TCPIPProtokoll.Enabled)"
+                $changes += "Changed TcpIpProperties.Enabled to $($instance.TcpIpProperties.Enabled)"
             }
 
             $wmiSpTcpKeepAlive = $wmiSpTcp.ProtocolProperties | Where-Object { $_.Name -eq 'KeepAlive' }
-            if ($wmiSpTcpKeepAlive.Value -ne $instance.TCPIPProtokoll.KeepAlive) {
-                $wmiSpTcpKeepAlive.Value = $instance.TCPIPProtokoll.KeepAlive
+            if ($wmiSpTcpKeepAlive.Value -ne $instance.TcpIpProperties.KeepAlive) {
+                $wmiSpTcpKeepAlive.Value = $instance.TcpIpProperties.KeepAlive
                 $wmiSpTcp.Alter()
-                $changes += "Changed TCPIPProtokoll.KeepAlive to $($instance.TCPIPProtokoll.KeepAlive)"
+                $changes += "Changed TcpIpProperties.KeepAlive to $($instance.TcpIpProperties.KeepAlive)"
             }
 
             $wmiSpTcpListenOnAllIPs = $wmiSpTcp.ProtocolProperties | Where-Object { $_.Name -eq 'ListenOnAllIPs' }
-            if ($wmiSpTcpListenOnAllIPs.Value -ne $instance.TCPIPProtokoll.ListenAll) {
-                $wmiSpTcpListenOnAllIPs.Value = $instance.TCPIPProtokoll.ListenAll
+            if ($wmiSpTcpListenOnAllIPs.Value -ne $instance.TcpIpProperties.ListenAll) {
+                $wmiSpTcpListenOnAllIPs.Value = $instance.TcpIpProperties.ListenAll
                 $wmiSpTcp.Alter()
-                $changes += "Changed TCPIPProtokoll.ListenAll to $($instance.TCPIPProtokoll.ListenAll)"
+                $changes += "Changed TcpIpProperties.ListenAll to $($instance.TcpIpProperties.ListenAll)"
             }
 
             $wmiIPn = $wmiSpTcp.IPAddresses | Where-Object { $_.Name -ne 'IPAll' }
             foreach ($ip in $wmiIPn) {
-                $ipTarget = $instance.TCPIPIPAddresses | Where-Object { $_.Name -eq $ip.Name }
+                $ipTarget = $instance.TcpIpAddresses | Where-Object { $_.Name -eq $ip.Name }
 
                 $ipActive = $ip.IPAddressProperties | Where-Object { $_.Name -eq 'Active' }
                 if ($ipActive.Value -ne $ipTarget.Active) {
@@ -139,7 +139,7 @@ function Set-DbaNetworkConfiguration {
             }
 
             $wmiIPAll = $wmiSpTcp.IPAddresses | Where-Object { $_.Name -eq 'IPAll' }
-            $ipTarget = $instance.TCPIPIPAddresses | Where-Object { $_.Name -eq 'IPAll' }
+            $ipTarget = $instance.TcpIpAddresses | Where-Object { $_.Name -eq 'IPAll' }
 
             $ipTcpDynamicPorts = $wmiIPAll.IPAddressProperties | Where-Object { $_.Name -eq 'TcpDynamicPorts' }
             if ($ipTcpDynamicPorts.Value -ne $ipTarget.TcpDynamicPorts) {

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -387,7 +387,7 @@ function Set-DbaNetworkConfiguration {
                     }
                 }
 
-                if ($changes.Changes.Count -gt 0) {
+                if ($return.Changes.Count -gt 0) {
                     $output.RestartNeeded = $true
                     if ($RestartService) {
                         if ($Pscmdlet.ShouldProcess("Restarting service for instance $($netConf.InstanceName) on $($netConf.ComputerName)")) {

--- a/functions/Set-DbaNetworkConfiguration.ps1
+++ b/functions/Set-DbaNetworkConfiguration.ps1
@@ -19,6 +19,12 @@ function Set-DbaNetworkConfiguration {
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
         Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
 
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
     .NOTES
         Tags: SQLWMI
         Author: Andreas Jordan (@JordanOrdix), ordix.de

--- a/functions/Set-DbaTcpPort.ps1
+++ b/functions/Set-DbaTcpPort.ps1
@@ -88,7 +88,6 @@ function Set-DbaTcpPort {
             $IpAddress = $args[3]
             $sqlInstanceName = $args[4]
 
-            $wmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $computerName
             $wmiinstance = $wmi.ServerInstances | Where-Object {
                 $_.Name -eq $wmiInstanceName
             }
@@ -139,11 +138,11 @@ function Set-DbaTcpPort {
             if ($Pscmdlet.ShouldProcess($computerName, "Setting port to $Port for $wmiInstanceName")) {
                 try {
                     Write-Message -Level Verbose -Message "Trying Invoke-ManagedComputerCommand with ComputerName = '$resolvedComputerName'"
-                    Invoke-ManagedComputerCommand -ComputerName $resolvedComputerName -ScriptBlock $scriptblock -ArgumentList $computerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
+                    Invoke-ManagedComputerCommand -ComputerName $resolvedComputerName -ScriptBlock $scriptblock -ArgumentList $computerName, $wmiInstanceName, "$($Port)", "$($IpAddress)", "$($instance.InputObject)" -Credential $Credential
                 } catch {
                     try {
                         Write-Message -Level Verbose -Message "Fallback: Trying Invoke-ManagedComputerCommand with ComputerName = '$computerName'"
-                        Invoke-ManagedComputerCommand -ComputerName $computerName -ScriptBlock $scriptblock -ArgumentList $computerName, $wmiInstanceName, $port, $IpAddress, $instance.InputObject -Credential $Credential
+                        Invoke-ManagedComputerCommand -ComputerName $computerName -ScriptBlock $scriptblock -ArgumentList $computerName, $wmiInstanceName, "$($Port)", "$($IpAddress)", "$($instance.InputObject)" -Credential $Credential
                     } catch {
                         Stop-Function -Message "Failure setting port to $Port for $wmiInstanceName on $computerName" -Continue
                     }

--- a/internal/functions/Invoke-ManagedComputerCommand.ps1
+++ b/internal/functions/Invoke-ManagedComputerCommand.ps1
@@ -33,7 +33,7 @@ function Invoke-ManagedComputerCommand {
         [PSCredential]$Credential,
         [Parameter(Mandatory)]
         [scriptblock]$ScriptBlock,
-        [string[]]$ArgumentList,
+        [object[]]$ArgumentList,
         [switch]$EnableException # Left in for legacy but this command needs to throw
     )
 

--- a/tests/Get-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Get-DbaNetworkConfiguration.Tests.ps1
@@ -1,0 +1,32 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'OutputType', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        $resultsFull = Get-DbaNetworkConfiguration -SqlInstance $script:instance2
+        $resultsTcpIpProperties = Get-DbaNetworkConfiguration -SqlInstance $script:instance2 -OutputType TcpIpProperties
+
+        It "Should Return a Result" {
+            $resultsFull | Should -Not -Be $null
+            $resultsTcpIpProperties | Should -Not -Be $null
+        }
+
+        It "has the correct properties" {
+            $ExpectedPropsFull = 'ComputerName,InstanceName,SqlInstance,SharedMemoryEnabled,NamedPipesEnabled,TcpIpEnabled,TcpIpProperties,TcpIpAddresses'.Split(',')
+            ($resultsFull.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsFull | Sort-Object)
+            $ExpectedPropsTcpIpProperties = 'ComputerName,InstanceName,SqlInstance,Enabled,KeepAlive,ListenAll'.Split(',')
+            ($resultsTcpIpProperties.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsTcpIpProperties | Sort-Object)
+        }
+    }
+}

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtokoll', 'DisableProtokoll', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'RestartService', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtocol', 'DisableProtocol', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'RestartService', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -30,9 +30,9 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command works with commandline input" {
         $netConf = Get-DbaNetworkConfiguration -SqlInstance $script:instance2
         if ($netConf.NamedPipesEnabled) {
-            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes -Confirm:$false
+            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtocol NamedPipes -Confirm:$false
         } else {
-            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes -Confirm:$false
+            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtocol NamedPipes -Confirm:$false
         }
 
         It "Should Return a Result" {
@@ -44,9 +44,9 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         if ($netConf.NamedPipesEnabled) {
-            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes -Confirm:$false
+            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtocol NamedPipes -Confirm:$false
         } else {
-            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes -Confirm:$false
+            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtocol NamedPipes -Confirm:$false
         }
     }
 }

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -20,7 +20,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         } else {
             $netConf.NamedPipesEnabled = $true
         }
-        $results = $netConf | Set-DbaNetworkConfiguration
+        $results = $netConf | Set-DbaNetworkConfiguration -Confirm:$false
 
         It "Should Return a Result" {
             $results.ComputerName | Should -Be $netConf.ComputerName
@@ -35,15 +35,15 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         } else {
             $netConf.NamedPipesEnabled = $true
         }
-        $null = $netConf | Set-DbaNetworkConfiguration
+        $null = $netConf | Set-DbaNetworkConfiguration -Confirm:$false
     }
 
     Context "Command works with commandline input" {
         $netConf = Get-DbaNetworkConfiguration -SqlInstance $script:instance2
         if ($netConf.NamedPipesEnabled) {
-            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes
+            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes -Confirm:$false
         } else {
-            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes
+            $results = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes -Confirm:$false
         }
 
         It "Should Return a Result" {
@@ -55,9 +55,9 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         if ($netConf.NamedPipesEnabled) {
-            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes
+            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -EnableProtokoll NamedPipes -Confirm:$false
         } else {
-            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes
+            $null = Set-DbaNetworkConfiguration -SqlInstance $script:instance2 -DisableProtokoll NamedPipes -Confirm:$false
         }
     }
 }

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -1,0 +1,36 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'InputObject', 'Credential', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    Context "Command actually works" {
+        $netConf = Get-DbaNetworkConfiguration -SqlInstance $script:instance2
+        if ($netConf.NamedPipesEnabled) {
+            $netConf.NamedPipesEnabled = $false
+        } else {
+            $netConf.NamedPipesEnabled = $true
+        }
+        $results = $netConf | Set-DbaNetworkConfiguration
+
+        It "Should Return a Result" {
+            $results.Changes | Should -Match "Changed NamedPipesEnabled to"
+        }
+
+        if ($netConf.NamedPipesEnabled) {
+            $netConf.NamedPipesEnabled = $false
+        } else {
+            $netConf.NamedPipesEnabled = $true
+        }
+        $null = $netConf | Set-DbaNetworkConfiguration
+    }
+}

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtokoll', 'DisableProtokoll', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableProtokoll', 'DisableProtokoll', 'DynamicPortForIPAll', 'StaticPortForIPAll', 'RestartService', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -23,6 +23,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $results = $netConf | Set-DbaNetworkConfiguration
 
         It "Should Return a Result" {
+            $results.ComputerName | Should -Be $netConf.ComputerName
+        }
+
+        It "Should Return a Change" {
             $results.Changes | Should -Match "Changed NamedPipesEnabled to"
         }
 
@@ -43,6 +47,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Should Return a Result" {
+            $results.ComputerName | Should -Be $netConf.ComputerName
+        }
+
+        It "Should Return a Change" {
             $results.Changes | Should -Match "Changed NamedPipesEnabled to"
         }
 

--- a/tests/Set-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Set-DbaNetworkConfiguration.Tests.ps1
@@ -15,11 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command works with piped input" {
         $netConf = Get-DbaNetworkConfiguration -SqlInstance $script:instance2
-        if ($netConf.NamedPipesEnabled) {
-            $netConf.NamedPipesEnabled = $false
-        } else {
-            $netConf.NamedPipesEnabled = $true
-        }
+        $netConf.TcpIpProperties.KeepAlive = 60000
         $results = $netConf | Set-DbaNetworkConfiguration -Confirm:$false
 
         It "Should Return a Result" {
@@ -27,15 +23,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Should Return a Change" {
-            $results.Changes | Should -Match "Changed NamedPipesEnabled to"
+            $results.Changes | Should -Match "Changed TcpIpProperties.KeepAlive to 60000"
         }
-
-        if ($netConf.NamedPipesEnabled) {
-            $netConf.NamedPipesEnabled = $false
-        } else {
-            $netConf.NamedPipesEnabled = $true
-        }
-        $null = $netConf | Set-DbaNetworkConfiguration -Confirm:$false
     }
 
     Context "Command works with commandline input" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #3170, fixes #5327 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
General commands that get or set the network configuration like SQL Server Configuration Manager does.

At the moment, this is just a first concept and I would like to have feedback about it.
