### PR TITLE
Get-DbaLogin - Fixed parameter types

### DIFF
--- a/functions/Get-DbaLogin.ps1
+++ b/functions/Get-DbaLogin.ps1
@@ -157,10 +157,10 @@ function Get-DbaLogin {
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
-        [object[]]$Login,
-        [object[]]$IncludeFilter,
-        [object[]]$ExcludeLogin,
-        [object[]]$ExcludeFilter,
+        [string[]]$Login,
+        [string[]]$IncludeFilter,
+        [string[]]$ExcludeLogin,
+        [string[]]$ExcludeFilter,
         [Alias('ExcludeSystemLogins')]
         [switch]$ExcludeSystemLogin,
         [ValidateSet('Windows', 'SQL')]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7215 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
As these parameters are treated as strings in the code, they should be declared as string.
I had a look at other commands like Get-DbaDatabase and they all declare those as string.
