### PR TITLE
Get-DbaAgBackupHistory - Use Where-Object instead of .Where() for PS3

### DIFF
--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -190,6 +190,11 @@ function Get-DbaAgBackupHistory {
         }
 
         Write-Message -Level Verbose -Message "We have more than one server, so query them all and aggregate"
+        # If -Database is not set, we want to filter on all databases of the availability group
+        if (Test-Bound -Not -ParameterName Database) {
+            $agDatabase = (Get-DbaAgDatabase -SqlInstance $serverList[0] -AvailabilityGroup $AvailabilityGroup).Name
+            $PSBoundParameters.Add('Database', $agDatabase)
+        }
         $null = $PSBoundParameters.Remove('SqlInstance')
         $null = $PSBoundParameters.Remove('AvailabilityGroup')
         $null = $PSBoundParameters.Remove('Last')

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -183,7 +183,7 @@ function Get-DbaAgBackupHistory {
             Write-Message -Level Verbose -Message "We have one server, so it should be a listener"
             $server = $serverList[0]
 
-            $replicaNames = $server.AvailabilityGroups.Where( { $_.Name -in $AvailabilityGroup } ).AvailabilityReplicas.Name
+            $replicaNames = ($server.AvailabilityGroups | Where-Object { $_.Name -in $AvailabilityGroup } ).AvailabilityReplicas.Name
             Write-Message -Level Verbose -Message "We have found these replicas: $replicaNames"
 
             $serverList = $replicaNames

--- a/functions/Get-DbaAgBackupHistory.ps1
+++ b/functions/Get-DbaAgBackupHistory.ps1
@@ -123,8 +123,8 @@ function Get-DbaAgBackupHistory {
         [PsCredential]$SqlCredential,
         [parameter(Mandatory)]
         [string]$AvailabilityGroup,
-        [object[]]$Database,
-        [object[]]$ExcludeDatabase,
+        [string[]]$Database,
+        [string[]]$ExcludeDatabase,
         [switch]$IncludeCopyOnly,
         [Parameter(ParameterSetName = "NoLast")]
         [switch]$Force,


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7381 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For PS3 support.