### PR TITLE
Remove-DbaDbSnapshot - should ask for confirmation

### DIFF
--- a/functions/Remove-DbaDbSnapshot.ps1
+++ b/functions/Remove-DbaDbSnapshot.ps1
@@ -82,7 +82,7 @@ function Remove-DbaDbSnapshot {
         Removes all snapshots associated with databases that have dumpsterfire in the name
 
     .EXAMPLE
-        PS C:\> Get-DbaDbSnapshot -SqlInstance sql2016 | Out-GridView -Passthru | Remove-DbaDbSnapshot
+        PS C:\> Get-DbaDbSnapshot -SqlInstance sql2016 | Out-GridView -PassThru | Remove-DbaDbSnapshot
 
         Allows the selection of snapshots on sql2016 to remove
 
@@ -97,7 +97,7 @@ function Remove-DbaDbSnapshot {
         Removes all database snapshots from sql2014 and prompts for each database
 
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Medium")]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
@@ -113,7 +113,7 @@ function Remove-DbaDbSnapshot {
     begin {
         if ($Force) { $ConfirmPreference = 'none' }
 
-        $defaultprops = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database as Name', 'Status'
+        $defaultProps = 'ComputerName', 'InstanceName', 'SqlInstance', 'Database as Name', 'Status'
     }
     process {
         if (!$Snapshot -and !$Database -and !$AllSnapshots -and $null -eq $InputObject -and !$ExcludeDatabase) {
@@ -140,10 +140,10 @@ function Remove-DbaDbSnapshot {
             }
 
             if ($Force) {
-                $db | Remove-DbaDatabase -Confirm:$false | Select-DefaultView -Property $defaultprops
+                $db | Remove-DbaDatabase -Confirm:$false | Select-DefaultView -Property $defaultProps
             } else {
                 try {
-                    if ($Pscmdlet.ShouldProcess("$db on $server", "Drop snapshot")) {
+                    if ($PsCmdlet.ShouldProcess("$db on $server", "Drop snapshot")) {
                         $db.Drop()
                         $server.Refresh()
 
@@ -153,7 +153,7 @@ function Remove-DbaDbSnapshot {
                             SqlInstance  = $server.DomainInstanceName
                             Database     = $db.name
                             Status       = "Dropped"
-                        } | Select-DefaultView -Property $defaultprops
+                        } | Select-DefaultView -Property $defaultProps
                     }
                 } catch {
                     Write-Message -Level Verbose -Message "Could not drop database $db on $server"
@@ -164,7 +164,7 @@ function Remove-DbaDbSnapshot {
                         SqlInstance  = $server.DomainInstanceName
                         Database     = $db.name
                         Status       = (Get-ErrorMessage -Record $_)
-                    } | Select-DefaultView -Property $defaultprops
+                    } | Select-DefaultView -Property $defaultProps
                 }
             }
         }

--- a/tests/Remove-DbaDbSnapshot.Tests.ps1
+++ b/tests/Remove-DbaDbSnapshot.Tests.ps1
@@ -64,7 +64,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.Count | Should Be 3
         }
         It "Honors the Snapshot parameter" {
-            $result = Remove-DbaDbSnapshot -SqlInstance $script:instance2 -Snapshot $db1_snap1
+            $result = Remove-DbaDbSnapshot -SqlInstance $script:instance2 -Snapshot $db1_snap1 -Confirm:$false
             $result.Name | Should Be $db1_snap1
         }
         It "Works with piped snapshots" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Removing snapshots should ask for confirmation

### Approach
Change `confirmimpact` to high

### Commands to test
```
New-DbaDbSnapshot -SqlInstance mssql1 -Database AdventureWorks 
Get-DbaDbSnapshot -SqlInstance mssql1 -Database AdventureWorks | Remove-DbaDbSnapshot 
```
Should get a prompt to drop the snap

### Screenshots
![image](https://user-images.githubusercontent.com/981370/120095889-660a5700-c120-11eb-897f-346398919c4b.png)
