### PR TITLE
Find-DbaLoginInGroup throws error when adding multiple groups to output

### DIFF
--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -130,6 +130,7 @@ function Find-DbaLoginInGroup {
 
             $AdGroups = $server.Logins | Where-Object { $_.LoginType -eq "WindowsGroup" -and $_.Name -ne "BUILTIN\Administrators" -and $_.Name -notlike "*NT SERVICE*" }
 
+            $ADGroupOut = @()
             foreach ($AdGroup in $AdGroups) {
                 Write-Message -Level Verbose -Message "Looking at Group: $AdGroup"
                 $ADGroupOut += Get-AllLogins $AdGroup.Name -ParentADGroup $AdGroup.Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When running the function, occasionally an op_Addition error is thrown in the code when adding new groups to the variable.

### Approach
<!-- How does this change solve that purpose -->
I added the declaration of the variable outside of the loop so that the addition error stops.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`$LoginGroup = Find-DbaLoginInGroup -SqlInstance $SQLInstance | Where-Object {$Logins.LoginType -eq "WindowsGroup"}`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/169602/120357998-a6f29f00-c2cb-11eb-9cc1-b6e9a719147d.png)

### Learning
<!-- Optional -->
<!-- 
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
