### PR TITLE
New-DbaDbSequence - Don't use Test-Bound with defaults

### DIFF
--- a/functions/Get-DbaDbSequence.ps1
+++ b/functions/Get-DbaDbSequence.ps1
@@ -82,7 +82,7 @@ function Get-DbaDbSequence {
         Finds all the sequences in the sch schema on the localhost instance.
 
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    [CmdletBinding()]
     param (
         [parameter(ValueFromPipeline)]
         [DbaInstance[]]$SqlInstance,

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -139,6 +139,7 @@ function New-DbaDbSequence {
                     }
 
                     $newSequence = New-Object Microsoft.SqlServer.Management.Smo.Sequence -ArgumentList $db, $Name, $Schema
+                    $newSequence.StartValue = $StartWith
                     $newSequence.IncrementValue = $IncrementBy
                     $newSequence.IsCycleEnabled = $Cycle.IsPresent
 
@@ -154,10 +155,6 @@ function New-DbaDbSequence {
                     } else {
                         # system integer type
                         $newSequence.DataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $IntegerType
-                    }
-
-                    if ($StartWith) {
-                        $newSequence.StartValue = $StartWith
                     }
 
                     if (Test-Bound MinValue) {

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -177,8 +177,7 @@ function New-DbaDbSequence {
                     }
 
                     $newSequence.Create()
-                    $db.Refresh()
-                    $db.Sequences | Where-Object { $_.Schema -eq $Schema -and $_.Name -eq $Name }
+                    $newSequence
                 } catch {
                     Stop-Function -Message "Failure on $($db.Parent.Name) to create the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
                 }

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -177,7 +177,7 @@ function New-DbaDbSequence {
                     }
 
                     $newSequence.Create()
-                    $db | Get-DbaDbSequence
+                    $db | Get-DbaDbSequence -Name $newSequence.Name -Schema $newSequence.Schema
                 } catch {
                     Stop-Function -Message "Failure on $($db.Parent.Name) to create the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
                 }

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -156,7 +156,7 @@ function New-DbaDbSequence {
                         $newSequence.DataType = New-Object Microsoft.SqlServer.Management.Smo.DataType $IntegerType
                     }
 
-                    if (Test-Bound StartWith) {
+                    if ($StartWith) {
                         $newSequence.StartValue = $StartWith
                     }
 

--- a/functions/New-DbaDbSequence.ps1
+++ b/functions/New-DbaDbSequence.ps1
@@ -177,7 +177,7 @@ function New-DbaDbSequence {
                     }
 
                     $newSequence.Create()
-                    $newSequence
+                    $db | Get-DbaDbSequence
                 } catch {
                     Stop-Function -Message "Failure on $($db.Parent.Name) to create the sequence $Name in the $Schema schema in the database $($db.Name)" -ErrorRecord $_ -Continue
                 }

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -105,7 +105,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
 
             foreach ($minValue in $minValues) {
                 $randomForMinValues = Get-Random
-                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForMinValues)" -Schema "Schema_$random" -MinValue $minValue
+                $sequence = New-DbaDbSequence -SqlInstance $instance2 -Database $newDbName -Name "Sequence_$($randomForMinValues)" -Schema "Schema_$random" -MinValue $minValue -StartWith $minValue
                 $sequence.Name | Should -Be "Sequence_$($randomForMinValues)"
                 $sequence.Schema | Should -Be "Schema_$random"
                 $sequence.MinValue | Should -Be $minValue
@@ -114,7 +114,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates a new sequence with different max values" {
-            $maxValues = @(-100000, 1, 100000)
+            $maxValues = @(10000, 100000)
 
             foreach ($maxValue in $maxValues) {
                 $randomForMaxValues = Get-Random

--- a/tests/New-DbaDbSequence.Tests.ps1
+++ b/tests/New-DbaDbSequence.Tests.ps1
@@ -17,7 +17,6 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     BeforeAll {
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
-        $null = Get-DbaProcess -SqlInstance $instance2 | Where-Object Program -match dbatools | Stop-DbaProcess -Confirm:$false
         $newDbName = "dbatoolsci_newdb_$random"
         $newDb = New-DbaDatabase -SqlInstance $instance2 -Name $newDbName
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
StartWith was not set when not explicitly set by parameter. 