### PR TITLE
SQL Watch commands cannot be used in PowerShell 7

### DIFF
--- a/functions/Export-DbaDacPackage.ps1
+++ b/functions/Export-DbaDacPackage.ps1
@@ -120,6 +120,11 @@ function Export-DbaDacPackage {
     process {
         if (Test-FunctionInterrupt) { return }
 
+        if ($PSEdition -eq 'Core') {
+            Stop-Function -Message "PowerShell Core is not supported, please use Windows PowerShell."
+            return
+        }
+
         if ((Test-Bound -Not -ParameterName Database) -and (Test-Bound -Not -ParameterName ExcludeDatabase) -and (Test-Bound -Not -ParameterName AllUserDatabases)) {
             Stop-Function -Message "You must specify databases to execute against using either -Database, -ExcludeDatabase or -AllUserDatabases"
             return

--- a/functions/Install-DbaSqlWatch.ps1
+++ b/functions/Install-DbaSqlWatch.ps1
@@ -182,6 +182,10 @@ function Install-DbaSqlWatch {
             return
         }
 
+        if ($PSEdition -eq 'Core') {
+            Stop-Function -Message "PowerShell Core is not supported, please use Windows PowerShell."
+            return
+        }
         $totalSteps = $stepCounter + $SqlInstance.Count * 2
         foreach ($instance in $SqlInstance) {
             if ($PSCmdlet.ShouldProcess($instance, "Installing SqlWatch on $Database")) {

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -178,6 +178,11 @@ function Publish-DbaDacPackage {
             return
         }
 
+        if ($PSEdition -eq 'Core') {
+            Stop-Function -Message "PowerShell Core is not supported, please use Windows PowerShell."
+            return
+        }
+
         if (-not (Test-Path -Path $Path)) {
             Stop-Function -Message "$Path not found."
             return

--- a/functions/Uninstall-DbaSqlWatch.ps1
+++ b/functions/Uninstall-DbaSqlWatch.ps1
@@ -81,6 +81,10 @@ Function Uninstall-DbaSqlWatch {
             return
         }
 
+        if ($PSEdition -eq 'Core') {
+            Stop-Function -Message "PowerShell Core is not supported, please use Windows PowerShell."
+            return
+        }
         foreach ($instance in $SqlInstance) {
 
             try {


### PR DESCRIPTION
Tempoary fix until we address import process.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6567 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The DLL used is not supported in dotnet Core, only .NET 4.6 making this command only compatible with Windows PowerShell.

SQL Watch commands in addition to any command trying to use the `Microsoft.SqlServer.Dac.dll` are now going to throw a message that PowerShell Core is not supported if they are on Windows.

The commands are only imported at this time if they are Windows but we do not address the Edition of PowerShell in our import process. Our import process needs to have an additional check on PowerShell Edition so we can properly exclude these commands on import and lessen the confusion.