### PR TITLE
Fix typo in parameter `ReplaceInName`

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -440,7 +440,8 @@ function Backup-DbaDatabase {
                 Write-Message -Level Warning -Message "$failreason"
             }
 
-            $lastfull = ($db.Refresh()).LastBackupDate.Year
+            $db.Refresh()
+            $lastfull = $db.LastBackupDate.Year
 
             if ($Type -notin @("Database", "Full") -and $lastfull -eq 1) {
                 $failreason = "$db does not have an existing full backup, cannot take log or differentialbackup"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -440,7 +440,7 @@ function Backup-DbaDatabase {
                 Write-Message -Level Warning -Message "$failreason"
             }
 
-            $lastfull = $db.LastBackupDate.Year
+            $lastfull = ($db.Refresh()).LastBackupDate.Year
 
             if ($Type -notin @("Database", "Full") -and $lastfull -eq 1) {
                 $failreason = "$db does not have an existing full backup, cannot take log or differentialbackup"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -440,7 +440,7 @@ function Backup-DbaDatabase {
                 Write-Message -Level Warning -Message "$failreason"
             }
 
-            $lastfull = $db.Refresh().LastBackupDate.Year
+            $lastfull = $db.LastBackupDate.Year
 
             if ($Type -notin @("Database", "Full") -and $lastfull -eq 1) {
                 $failreason = "$db does not have an existing full backup, cannot take log or differentialbackup"

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -293,7 +293,7 @@ function Backup-DbaDatabase {
                 $FileCount = $Path.Count
             }
 
-            if ($InputObject.Count -gt 1 -and $FilePath -ne '' -and $True -ne $ReplaceInFile) {
+            if ($InputObject.Count -gt 1 -and $FilePath -ne '' -and $True -ne $ReplaceInName) {
                 Stop-Function -Message "1 BackupFile specified, but more than 1 database."
                 return
             }


### PR DESCRIPTION
Small typo bugfix

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, no need to create issue )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line, you can erase anything that is not applicable -->
The Fixies on their duty.
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 

### Approach
The function's parameter will work as designed

### Commands to test
```powershell
Backup-DbaDatabase -SqlInstance SRV-DBSERVER `
    -Path \\SRV-BACKUP\SQLBackup\servername\dbname\backuptype `
    -FilePath dbname_backuptype_timestamp.bak `
    -TimeStampFormat yyyyMMdd_HHmmss `
    -Checksum -Verify -BuildPath -ReplaceInName
```