### PR TITLE
Resolve-NetBiosName - Return ComputerNamePhysicalNetBIOS if clustered

### DIFF
--- a/internal/functions/Resolve-NetBiosName.ps1
+++ b/internal/functions/Resolve-NetBiosName.ps1
@@ -10,5 +10,9 @@ Internal function. Takes a best guess at the NetBIOS name of a server.
         [PSCredential]$SqlCredential
     )
     $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-    $server.ComputerName
+    if ($server.IsClustered) {
+        $server.ComputerNamePhysicalNetBIOS
+    } else {
+        $server.ComputerName
+    }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6053  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (will change functionality of all commands using Resolve-NetBiosName against clustered instances)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Resolve-NetBiosName now does what the name says: It resolves the (physical) NetBiosName of the computer, so in clustered instances the ComputerName of the cluster node the instance currently runs on.

So no change for all non-clustered instances. Only risk: This would fail if the computer would only accept connections to the cluster name and not the node name. But I think the more offen case is like in the linked issue, that the computer only accepts connection to the node name.