### PR TITLE
Install-DbaInstance - Test for allowed ACTION before adding SQLTEMPDBFILECOUNT

### DIFF
--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -613,7 +613,7 @@ function Install-DbaInstance {
             if ($canonicVersion -gt '10.0') {
                 $execParams += '/IACCEPTSQLSERVERLICENSETERMS'
             }
-            if ($canonicVersion -ge '13.0' -and (-Not $configNode.SQLTEMPDBFILECOUNT)) {
+            if ($canonicVersion -ge '13.0' -and ($configNode.ACTION -in 'Install', 'CompleteImage', 'Rebuilddatabase', 'InstallFailoverCluster', 'CompleteFailoverCluster') -and (-not $configNode.SQLTEMPDBFILECOUNT)) {
                 # configure the number of cores
                 $cpuInfo = Get-DbaCmObject -ComputerName $fullComputerName -Credential $Credential -ClassName Win32_processor -EnableException:$EnableException
                 # trying to read NumberOfLogicalProcessors property. If it's not available, read NumberOfCores
@@ -625,7 +625,7 @@ function Install-DbaInstance {
                 if ($cores -gt 8) {
                     $cores = 8
                 }
-                if ($cores -and $configNode.ACTION -ne "AddNode") {
+                if ($cores) {
                     $configNode.SQLTEMPDBFILECOUNT = $cores
                 }
             }

--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -167,6 +167,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 $result.Notes | Should -BeNullOrEmpty
                 $result.Configuration.$mainNode.FEATURES | Should -Be 'SQLEngine,AS'
                 $result.Configuration.$mainNode.SQLSVCACCOUNT | Should -Be 'foo\bar'
+                $result.Configuration.$mainNode.ACTION | Should -Be 'Install'
                 if ($version -in '2016', '2017') {
                     $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
                 }

--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -86,6 +86,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 "[$mainNode]"
                 'SQLSVCACCOUNT="foo\bar"'
                 'FEATURES="SQLEngine,AS"'
+                'ACTION="Install"'
             ) | Set-Content -Path TestDrive:\Configuration.ini -Force
             It "Should install SQL$version with all features enabled" {
                 $result = Install-DbaInstance -Version $version -Path TestDrive: -EnableException -Confirm:$false -Feature All
@@ -167,7 +168,6 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
                 $result.Notes | Should -BeNullOrEmpty
                 $result.Configuration.$mainNode.FEATURES | Should -Be 'SQLEngine,AS'
                 $result.Configuration.$mainNode.SQLSVCACCOUNT | Should -Be 'foo\bar'
-                $result.Configuration.$mainNode.ACTION | Should -Be 'Install'
                 if ($version -in '2016', '2017') {
                     $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
I want to be able to run ACTION=Uninstall and use `-ConfigurationFile` for that. 
It's a similar case like #6479 that was addressed with #6480.
To be totally flexible I asked the documentation what ACTIONs allow SQLTEMPDBFILECOUNT:
https://docs.microsoft.com/en-us/sql/database-engine/install-windows/install-sql-server-from-the-command-prompt
So I added these 5 ACTIONs.
I moved the test so that there is no unsused call to the computer for no reason.

@nvarscar : What do you think? If you would like to solve it some other way, I'm open for feedback.