### PR TITLE
Added connection timeout. Fixes #7417

### DIFF
--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -367,7 +367,7 @@ function Invoke-DbaDbDataMasking {
 
                         $query = "CREATE NONCLUSTERED INDEX [$($maskingIndexName)] ON [$($dbTable.Schema)].[$($dbTable.Name)]([$($identityColumn)])"
 
-                        Invoke-DbaQuery -SqlInstance $server -SqlCredential $SqlCredential -Database $db.Name -Query $query
+                        Invoke-DbaQuery -SqlInstance $server -SqlCredential $SqlCredential -Database $db.Name -Query $query -QueryTimeout
                     } catch {
                         Stop-Function -Message "Could not add identity index to table [$($dbTable.Schema)].[$($dbTable.Name)]" -Continue
                     }
@@ -1025,7 +1025,16 @@ function Invoke-DbaDbDataMasking {
 
                                                 Write-Message -Level Verbose -Message "Executing batch $batchNr/$totalBatches"
 
-                                                Invoke-DbaQuery -SqlInstance $instance -SqlCredential $SqlCredential -Database $db.Name -Query $stringBuilder.ToString() -EnableException
+                                                $queryParams = @{
+                                                    SqlInstance     = $instance
+                                                    SqlCredential   = $SqlCredential
+                                                    Database        = $db.Name
+                                                    Query           = $stringBuilder.ToString()
+                                                    EnableException = $EnableException
+                                                    QueryTimeout    = $ConnectionTimeout
+                                                }
+
+                                                Invoke-DbaQuery @queryParams
                                             } catch {
                                                 $maskingErrorFlag = $true
                                                 Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $_ `n$($stringBuilder.ToString())" -Target $stringBuilder.ToString() -Continue -ErrorRecord $_
@@ -1053,7 +1062,16 @@ function Invoke-DbaDbDataMasking {
 
                                             Write-Message -Level Verbose -Message "Executing batch $batchNr/$totalBatches"
 
-                                            Invoke-DbaQuery -SqlInstance $instance -SqlCredential $SqlCredential -Database $db.Name -Query $stringBuilder.ToString() -EnableException
+                                            $queryParams = @{
+                                                SqlInstance     = $instance
+                                                SqlCredential   = $SqlCredential
+                                                Database        = $db.Name
+                                                Query           = $stringBuilder.ToString()
+                                                EnableException = $EnableException
+                                                QueryTimeout    = $ConnectionTimeout
+                                            }
+
+                                            Invoke-DbaQuery @queryParams
                                         } catch {
                                             $maskingErrorFlag = $true
                                             Stop-Function -Message "Error updating $($tableobject.Schema).$($tableobject.Name): $_`n$($stringBuilder.ToString())" -Target $stringBuilder.ToString() -Continue -ErrorRecord $_

--- a/functions/Invoke-DbaDbDataMasking.ps1
+++ b/functions/Invoke-DbaDbDataMasking.ps1
@@ -62,9 +62,6 @@ function Invoke-DbaDbDataMasking {
     .PARAMETER ExactLength
         Mask string values to the same length. So 'Tate' will be replaced with 4 random characters.
 
-    .PARAMETER ConnectionTimeout
-        Timeout for the database connection in seconds. Default is 0
-
     .PARAMETER CommandTimeout
         Timeout for the database connection in seconds. Default is 300.
 
@@ -145,7 +142,6 @@ function Invoke-DbaDbDataMasking {
         [int]$MaxValue,
         [int]$ModulusFactor,
         [switch]$ExactLength,
-        [int]$ConnectionTimeout,
         [int]$CommandTimeout,
         [int]$BatchSize,
         [int]$Retry,
@@ -180,11 +176,6 @@ function Invoke-DbaDbDataMasking {
         if (-not $ModulusFactor) {
             $ModulusFactor = 10
             Write-Message -Level Verbose -Message "Modulus factor set to $ModulusFactor"
-        }
-
-        if (-not $ConnectionTimeout) {
-            $ConnectionTimeout = 0
-            Write-Message -Level Verbose -Message "Connection time-out set to $ConnectionTimeout"
         }
 
         if (-not $CommandTimeout) {
@@ -367,7 +358,15 @@ function Invoke-DbaDbDataMasking {
 
                         $query = "CREATE NONCLUSTERED INDEX [$($maskingIndexName)] ON [$($dbTable.Schema)].[$($dbTable.Name)]([$($identityColumn)])"
 
-                        Invoke-DbaQuery -SqlInstance $server -SqlCredential $SqlCredential -Database $db.Name -Query $query -QueryTimeout
+                        $queryParams = @{
+                            SqlInstance   = $server
+                            SqlCredential = $SqlCredential
+                            Database      = $db.Name
+                            Query         = $query
+                            QueryTimeout  = $CommandTimeout
+                        }
+
+                        Invoke-DbaQuery @queryParams
                     } catch {
                         Stop-Function -Message "Could not add identity index to table [$($dbTable.Schema)].[$($dbTable.Name)]" -Continue
                     }
@@ -1031,7 +1030,7 @@ function Invoke-DbaDbDataMasking {
                                                     Database        = $db.Name
                                                     Query           = $stringBuilder.ToString()
                                                     EnableException = $EnableException
-                                                    QueryTimeout    = $ConnectionTimeout
+                                                    QueryTimeout    = $CommandTimeout
                                                 }
 
                                                 Invoke-DbaQuery @queryParams
@@ -1068,7 +1067,7 @@ function Invoke-DbaDbDataMasking {
                                                 Database        = $db.Name
                                                 Query           = $stringBuilder.ToString()
                                                 EnableException = $EnableException
-                                                QueryTimeout    = $ConnectionTimeout
+                                                QueryTimeout    = $CommandTimeout
                                             }
 
                                             Invoke-DbaQuery @queryParams

--- a/tests/Invoke-DbaDbDataMasking.Tests.ps1
+++ b/tests/Invoke-DbaDbDataMasking.Tests.ps1
@@ -4,8 +4,27 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
+        $CommandName = "Invoke-DbaDbDataMasking"
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'FilePath', 'Locale', 'CharacterString', 'Table', 'Column', 'ExcludeTable', 'ExcludeColumn', 'MaxValue', 'ModulusFactor', 'ExactLength', 'ConnectionTimeout', 'CommandTimeout', 'BatchSize', 'Retry', 'DictionaryFilePath', 'DictionaryExportPath', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance',
+        'SqlCredential',
+        'Database',
+        'FilePath',
+        'Locale',
+        'CharacterString',
+        'Table',
+        'Column',
+        'ExcludeTable',
+        'ExcludeColumn',
+        'MaxValue',
+        'ModulusFactor',
+        'ExactLength',
+        'CommandTimeout',
+        'BatchSize',
+        'Retry',
+        'DictionaryFilePath',
+        'DictionaryExportPath',
+        'EnableException'
 
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {


### PR DESCRIPTION
Added splatting fof command for readability

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #7417 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The invoke command the connection timeout to make sure that commands would not execute for a long period of time

### Approach
Added variable to several query commands

### Commands to test
Invoke-DbaDbDataMasking


