### PR TITLE
New-DbaConnectionStringBuilder - move to noncoresmo import

### DIFF
--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -492,7 +492,6 @@ $script:xplat = @(
     'New-DbaServiceMasterKey',
     'Remove-DbaDbCertificate',
     'Remove-DbaDbMasterKey',
-    'New-DbaConnectionStringBuilder',
     'Get-DbaInstanceProperty',
     'Get-DbaInstanceUserOption',
     'New-DbaConnectionString',
@@ -828,6 +827,7 @@ $script:noncoresmo = @(
 )
 $script:windowsonly = @(
     # solvable filesystem issues or other workarounds
+    'New-DbaConnectionStringBuilder',
     'Copy-DbaBackupDevice',
     'Install-DbaSqlWatch',
     'Uninstall-DbaSqlWatch',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -805,6 +805,7 @@ $script:xplat = @(
 
 $script:noncoresmo = @(
     # SMO issues
+    'New-DbaConnectionStringBuilder',
     'Export-DbaUser',
     'Get-DbaSsisExecutionHistory',
     'Get-DbaRepDistributor',
@@ -827,7 +828,6 @@ $script:noncoresmo = @(
 )
 $script:windowsonly = @(
     # solvable filesystem issues or other workarounds
-    'New-DbaConnectionStringBuilder',
     'Copy-DbaBackupDevice',
     'Install-DbaSqlWatch',
     'Uninstall-DbaSqlWatch',

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -56,6 +56,7 @@ $TestsRunGroups = @{
         'Test-DbaAgentJobOwner',
         'Stop-DbaXESession',
         'Get-DbaPrivilege',
+        'Get-DbaPermission',
         # strange pester issues
         'Find-DbaAgentJob',
         'Remove-DbaDatabaseSafely',


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #7449<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #)

<!-- Below this line you can erase anything that is not applicable -->
### Purpose

`Data.SqlClient.SqlConnectionColumnEncryptionSetting` does not work on Core and this command requires it. So I moved the command to `noncoresmo`

This _would_ be considered a breaking change if `New-DbaConnectionStringBuilder` ever worked on Core but it doesn't look like it ever did.

As far as the other Pbm problem listed in #7449, all the PBM commands are already in the limited area. The error happened because `Get-DbaHelp` is an internal command that has access to other internal commands.