### PR TITLE
Export-DbaScript - Clean file even if no prefix is used

### DIFF
--- a/functions/Export-DbaScript.ps1
+++ b/functions/Export-DbaScript.ps1
@@ -158,10 +158,6 @@ function Export-DbaScript {
         $appendToScript = $false
         if ($Append) {
             $appendToScript = $true
-
-            if ($ScriptingOptionsObject) {
-                $ScriptingOptionsObject.AppendToFile = $true
-            }
         }
 
         if ($ScriptingOptionsObject) {
@@ -252,11 +248,10 @@ function Export-DbaScript {
                             Stop-Function -Message "File already exists. If you want to overwrite it remove the -NoClobber parameter. If you want to append data, please Use -Append parameter." -Target $scriptPath -Continue
                         }
                         #Only at the first output we use the passed variables Append & NoClobber. For this execution the next ones need to use -Append
-                        if ($null -ne $prefix) {
-                            $prefix | Out-File -FilePath $scriptPath -Encoding $encoding -Append:$appendToScript -NoClobber:$NoClobber
-                            $prefixArray += $scriptPath
-                            Write-Message -Level Verbose -Message "Writing prefix to file $scriptPath"
-                        }
+                        # Empty $prefix will clean file in case $appendToScript is not set.
+                        Write-Message -Level Verbose -Message "Writing (maybe empty) prefix to file $scriptPath"
+                        $prefix | Out-File -FilePath $scriptPath -Encoding $encoding -Append:$appendToScript -NoClobber:$NoClobber
+                        $prefixArray += $scriptPath
                     }
                 }
 
@@ -286,7 +281,7 @@ function Export-DbaScript {
                         if ($ScriptingOptionsObject) {
                             if ($scriptBatchTerminator) {
                                 # Option to script batch terminator via ScriptingOptionsObject needs to write to file only
-                                $ScriptingOptionsObject.AppendToFile = (($null -ne $prefix) -or $appendToScript )
+                                $ScriptingOptionsObject.AppendToFile = $true
                                 $ScriptingOptionsObject.ToFileOnly = $true
                                 if (-not  $ScriptingOptionsObject.FileName) {
                                     $ScriptingOptionsObject.FileName = $scriptPath


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7451 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

When `-NoPrefix` is used, the file is not "initialized". Because of a possible prefix, every export is done with "append" to not lose the prefix. So the "initialization" of the file has to be done even if $prefix is $null.