### PR TITLE
Invoke-DbaDbLogShipping - Fixed restore threshold parameter not being used

### DIFF
--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -246,7 +246,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
-            if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)
@@ -258,7 +258,7 @@ function New-DbaLogShippingSecondaryDatabase {
                     ,@secondary_id = '$($lsDetails.secondary_id)'
                     ,@primary_server = '$($lsDetails.primary_server)'
                     ,@primary_database = '$($lsDetails.primary_database)'
-                    ,@restore_threshold = $($lsDetails.restore_threshold)
+                    ,@restore_threshold = $RestoreThreshold
                     ,@threshold_alert = $([int]$lsDetails.threshold_alert)
                     ,@threshold_alert_enabled = $([int]$lsDetails.threshold_alert_enabled)
                     ,@history_retention_period = $([int]$lsDetails.history_retention_period)

--- a/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
+++ b/internal/functions/New-DbaLogShippingSecondaryDatabase.ps1
@@ -246,7 +246,7 @@ function New-DbaLogShippingSecondaryDatabase {
 
             # For versions prior to SQL Server 2014, adding a monitor works in a different way.
             # The next section makes sure the settings are being synchronized with earlier versions
-            if ($MonitorServer -and ($SqlInstance.Version.Major -lt 12)) {
+            if ($MonitorServer -and ($ServerSecondary.Version.Major -lt 12)) {
                 # Get the details of the primary database
                 $query = "SELECT * FROM msdb.dbo.log_shipping_monitor_secondary WHERE primary_database = '$PrimaryDatabase' AND primary_server = '$PrimaryServer'"
                 $lsDetails = $ServerSecondary.Query($query)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #5308 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix problem with restore thresshold not being passed on 

### Approach
Fixed the parameters

### Commands to test
New-DbaLogShippingSecondaryDatabase

