### PR TITLE
Get- / Test- / Set-DbaPowerPlan - Complete redesign to reduce duplicate code

### DIFF
--- a/functions/Get-DbaPowerPlan.ps1
+++ b/functions/Get-DbaPowerPlan.ps1
@@ -84,6 +84,8 @@ function Get-DbaPowerPlan {
             } catch {
                 if ($_.Exception -match "namespace") {
                     Stop-Function -Message "Can't get Power Plan Info for $computer. Unsupported operating system." -Continue -ErrorRecord $_ -Target $computer
+                } elseif ($_.Exception -match "credentials are known to not work") {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Login failure for $($Credential.UserName)." -Continue -ErrorRecord $_ -Target $computer
                 } else {
                     Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
                 }

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -82,7 +82,7 @@ function Set-DbaPowerPlan {
         foreach ($computer in $ComputerName) {
             try {
                 Write-Message -Level Verbose -Message "Getting and testing Power Plans on $computer."
-                $change = Test-DbaPowerPlan -ComputerName $computer -Credential $Credential -CustomPowerPlan $CustomPowerPlan -EnableException
+                $change = Test-DbaPowerPlan -ComputerName $computer -Credential $Credential -PowerPlan $PowerPlan -EnableException
             } catch {
                 Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
             }

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -18,16 +18,8 @@ function Set-DbaPowerPlan {
     .PARAMETER Credential
         Specifies a PSCredential object to use in authenticating to the server(s), instead of the current user account.
 
-    .PARAMETER PowerPlan
-        Specifies the Power Plan that you wish to use.
-
-        We use the English phrase "High Performance" by default. To specify Power Plans in another language, use this parameter (-PowerPlan Höchstleistung).
-
     .PARAMETER CustomPowerPlan
-        Specifies the name of a custom Power Plan to use.
-
-    .PARAMETER InputObject
-        Enables piping from Get-DbaPowerPlan
+        Specifies the name of a custom Power Plan to use. Use Get-DbaPowerPlan -List to get all available Power Plans on a computer.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -59,14 +51,7 @@ function Set-DbaPowerPlan {
         Sets the Power Plan to High Performance. Skips it if its already set.
 
     .EXAMPLE
-        PS C:\> Set-DbaPowerPlan -ComputerName sql2017 -PowerPlan Höchstleistung
-
-        Sets the PowerPlan on a German system to Höchstleistung.
-
-        We use the English phrase "High Performance" by default. To specify Power Plans in another language, use the -PowerPlan parameter.
-
-    .EXAMPLE
-        PS C:\> 'Server1', 'Server2' | Set-DbaPowerPlan -PowerPlan Balanced
+        PS C:\> 'Server1', 'Server2' | Set-DbaPowerPlan -CustomPowerPlan Balanced
 
         Sets the Power Plan to Balanced for Server1 and Server2. Skips it if its already set.
 
@@ -83,160 +68,68 @@ function Set-DbaPowerPlan {
 
     #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseOutputTypeCorrectly", "", Justification = "PSSA Rule Ignored by BOH")]
     param (
         [parameter(ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
         [PSCredential]$Credential,
-        [string]$PowerPlan = 'High Performance',
+        [Alias("PowerPlan")]
         [string]$CustomPowerPlan,
-        [parameter(ValueFromPipeline)]
-        [pscustomobject[]]$InputObject,
         [switch]$EnableException
     )
 
-    begin {
-        if ($CustomPowerPlan) {
-            $powerPlanRequested = $CustomPowerPlan
-        } else {
-            $powerPlanRequested = $PowerPlan
-        }
-        function Set-DbaPowerPlanInternal {
-            [CmdletBinding(SupportsShouldProcess)]
-            param (
-                [string]$ComputerName,
-                [PSCredential]$Credential
-            )
-
-            if (Test-Bound -ParameterName Credential) {
-                $IncludeCred = $true
-            }
-            try {
-                Write-Message -Level Verbose -Message "Testing connection to $computer"
-                $computerResolved = Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential
-
-                $computerResolved = $computerResolved.FullComputerName
-            } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $computer
-                return
-            }
-
-            $splatDbaCmObject = @{
-                ComputerName    = $computerResolved
-                EnableException = $true
-            }
-            if ($IncludeCred) {
-                $splatDbaCmObject["Credential"] = $Credential
-            }
-
-            try {
-                Write-Message -Level Verbose -Message "Getting Power Plan information from $computer."
-                $currentplan = Get-DbaCmObject @splatDbaCmObject -ClassName Win32_PowerPlan -Namespace "root\cimv2\power" | Where-Object IsActive -eq 'True'
-                $currentplan = $currentplan.ElementName
-            } catch {
-                if ($_.Exception -match "namespace") {
-                    Stop-Function -Message "Can't get Power Plan Info for $computer. Unsupported operating system." -Continue -ErrorRecord $_ -Target $computer
-                } else {
-                    Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
-                }
-            }
-
-            if ($null -eq $currentplan) {
-                # the try/catch above isn't working, so make it silent and handle it here.
-                Stop-Function -Message "Cannot get Power Plan for $computer." -Category ConnectionError -ErrorRecord $_ -Target $computer
-                return
-            }
-
-            $planinfo = [PSCustomObject]@{
-                ComputerName      = $computer
-                PreviousPowerPlan = $currentplan
-                ActivePowerPlan   = $powerPlanRequested
-            }
-            if ($Pscmdlet.ShouldProcess($powerPlanRequested, "Setting Powerplan on $computer")) {
-                if ($powerPlanRequested -ne $currentplan) {
-                    if ($Pscmdlet.ShouldProcess($computer, "Changing Power Plan from $CurrentPlan to $powerPlanRequested")) {
-                        Write-Message -Level Verbose -Message "Creating CIMSession on $computer over WSMan"
-                        if ($IncludeCred) {
-                            $cimSession = New-CimSession -ComputerName $computer -ErrorAction SilentlyContinue -Credential $Credential
-                        } else {
-                            $cimSession = New-CimSession -ComputerName $computer -ErrorAction SilentlyContinue
-                        }
-                        if (-not $cimSession) {
-                            Write-Message -Level Verbose -Message "Creating CIMSession on $computer over WSMan failed. Creating CIMSession on $computer over DCom"
-                            $sessionOption = New-CimSessionOption -Protocol DCom
-                            if ($IncludeCred) {
-                                $cimSession = New-CimSession -ComputerName $computer -SessionOption $sessionoption -ErrorAction SilentlyContinue -Credential $Credential
-                            } else {
-                                $cimSession = New-CimSession -ComputerName $computer -SessionOption $sessionoption -ErrorAction SilentlyContinue
-                            }
-                        }
-                        if ($cimSession) {
-                            Write-Message -Level Verbose -Message "Setting Power Plan to $powerPlanRequested."
-
-                            $cimInstance = Get-CimInstance -Namespace root\cimv2\power -ClassName win32_PowerPlan -Filter "ElementName = '$powerPlanRequested'" -CimSession $CIMSession
-                            if ($cimInstance) {
-                                # Because the activate method for powerplans is broken on windows server 2019, we use the powrprof.dll instead
-                                [System.Guid]$powerPlanGuid = $cimInstance.InstanceID -replace '.*{(.*)}', '$1'
-                                $scriptBlock = {
-                                    Param ($Guid)
-                                    $powerSetActiveSchemeDefinition = '[DllImport("powrprof.dll", CharSet = CharSet.Auto)] public static extern uint PowerSetActiveScheme(IntPtr RootPowerKey, Guid SchemeGuid);'
-                                    $powrprof = Add-Type -MemberDefinition $powerSetActiveSchemeDefinition -Name 'Win32PowerSetActiveScheme' -Namespace 'Win32Functions' -PassThru
-                                    $powrprof::PowerSetActiveScheme([System.IntPtr]::Zero, $Guid)
-                                }
-                                if ($IncludeCred) {
-                                    $returnCode = Invoke-CommandWithFallback -ComputerName $computer -ScriptBlock $scriptBlock -ArgumentList $powerPlanGuid -Raw -Credential $Credential
-                                } else {
-                                    $returnCode = Invoke-CommandWithFallback -ComputerName $computer -ScriptBlock $scriptBlock -ArgumentList $powerPlanGuid -Raw
-                                }
-                                if ($returnCode -ne 0) {
-                                    Stop-Function -Message "Couldn't set the requested Power Plan '$powerPlanRequested' on $computer (ReturnCode: $returnCode)." -Category ConnectionError -Target $computer
-                                    return
-                                }
-                            } else {
-                                Stop-Function -Message "Couldn't find the requested Power Plan '$powerPlanRequested' on $computer." -Category ConnectionError -Target $computer
-                                return
-                            }
-                        } else {
-                            Stop-Function -Message "Couldn't set Power Plan on $computer." -Category ConnectionError -ErrorRecord $_ -Target $computer
-                            return
-                        }
-                    }
-                } else {
-                    if ($Pscmdlet.ShouldProcess($computer, "Stating power plan is already set to $powerPlanRequested, won't change.")) {
-                        Write-Message -Level Verbose -Message "PowerPlan on $computer is already set to $powerPlanRequested. Skipping."
-                    }
-                }
-
-                return $planInfo
-            }
-        }
-    }
-
     process {
-        # uses cim commands
-
-
-        if (Test-Bound -ParameterName ComputerName) {
-            $InputObject += Get-DbaPowerPlan -ComputerName $ComputerName -Credential $Credential
-        }
-
-        foreach ($pplan in $InputObject) {
-            $computer = $pplan.ComputerName
-            $Credential = $pplan.Credential
-            Write-Message -Level Verbose -Message "Calling Set-DbaPowerPlanInternal for $computer"
-            if (Test-Bound -ParameterName Credential) {
-                $data = Set-DbaPowerPlanInternal -ComputerName $Computer -Credential $Credential
-            } else {
-                $data = Set-DbaPowerPlanInternal -ComputerName $Computer
+        foreach ($computer in $ComputerName) {
+            try {
+                Write-Message -Level Verbose -Message "Getting and testing Power Plans on $computer."
+                $change = Test-DbaPowerPlan -ComputerName $computer -Credential $Credential -CustomPowerPlan $CustomPowerPlan -EnableException
+            } catch {
+                Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
             }
 
-            if ($data.Count -gt 1) {
-                $data.GetEnumerator() | ForEach-Object {
-                    $_
+            $powerPlan = $change.ActivePowerPlan
+            $powerPlanRequested = $change.RecommendedPowerPlan
+            $output = [PSCustomObject]@{
+                ComputerName      = $computer
+                PreviousPowerPlan = $powerPlan
+                ActivePowerPlan   = $powerPlan
+                IsChanged         = $false
+            }
+
+            if ($change.IsBestPractice) {
+                if ($Pscmdlet.ShouldProcess($computer, "Stating power plan is already set to $powerPlanRequested, won't change.")) {
+                    Write-Message -Level Verbose -Message "PowerPlan on $computer is already set to $powerPlanRequested. Skipping."
                 }
             } else {
-                $data
+                if ($Pscmdlet.ShouldProcess($computer, "Changing Power Plan from $powerPlan to $powerPlanRequested")) {
+                    [System.Guid]$powerPlanGuid = $change.RecommendedInstanceId
+                    $scriptBlock = {
+                        Param ($Guid)
+                        $powerSetActiveSchemeDefinition = '[DllImport("powrprof.dll", CharSet = CharSet.Auto)] public static extern uint PowerSetActiveScheme(IntPtr RootPowerKey, Guid SchemeGuid);'
+                        $powrprof = Add-Type -MemberDefinition $powerSetActiveSchemeDefinition -Name 'Win32PowerSetActiveScheme' -Namespace 'Win32Functions' -PassThru
+                        $powrprof::PowerSetActiveScheme([System.IntPtr]::Zero, $Guid)
+                    }
+                    try {
+                        $resolvedComputerName = (Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential -EnableException).FullComputerName
+                    } catch {
+                        try {
+                            $resolvedComputerName = (Resolve-DbaNetworkName -ComputerName $computer -Credential $Credential -Turbo -EnableException).FullComputerName
+                        } catch {
+                            $resolvedComputerName = $computer
+                        }
+                    }
+                    try {
+                        $returnCode = Invoke-Command2 -ComputerName $resolvedComputerName -Credential $Credential -ArgumentList $powerPlanGuid -ScriptBlock $scriptBlock -Raw
+                        if ($returnCode -ne 0) {
+                            Stop-Function -Message "Couldn't set the requested Power Plan '$powerPlanRequested' on $computer (ReturnCode: $returnCode)." -Category ConnectionError -Target $computer -Continue
+                        }
+                        $output.IsChanged = $true
+                        $output.ActivePowerPlan = $powerPlanRequested
+                    } catch {
+                        Stop-Function -Message "Failed to connect to $computer." -ErrorRecord $_ -Target $computer -Continue
+                    }
+                }
             }
+            $output
         }
     }
 }

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -91,7 +91,13 @@ function Set-DbaPowerPlan {
                 Write-Message -Level Verbose -Message "Getting and testing Power Plans on $computer using '$PowerPlan' as best practice."
                 $change = Test-DbaPowerPlan -ComputerName $computer -Credential $Credential -PowerPlan $PowerPlan -EnableException
             } catch {
-                Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
+                if ($_.Exception -match "namespace") {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Unsupported operating system." -Continue -ErrorRecord $_ -Target $computer
+                } elseif ($_.Exception -match "credentials are known to not work") {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Login failure for $($Credential.UserName)." -Continue -ErrorRecord $_ -Target $computer
+                } else {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
+                }
             }
 
             $instanceId = $change.ActiveInstanceId

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -6,7 +6,7 @@ function Set-DbaPowerPlan {
     .DESCRIPTION
         Sets the SQL Server OS's Power Plan. Defaults to High Performance which is best practice.
 
-        If your organization uses a custom power plan that is considered best practice, specify -CustomPowerPlan.
+        If your organization uses a different power plan that is considered best practice, specify -PowerPlan.
 
         References:
         https://support.microsoft.com/en-us/kb/2207548
@@ -18,8 +18,9 @@ function Set-DbaPowerPlan {
     .PARAMETER Credential
         Specifies a PSCredential object to use in authenticating to the server(s), instead of the current user account.
 
-    .PARAMETER CustomPowerPlan
-        Specifies the name of a custom Power Plan to use. Use Get-DbaPowerPlan -List to get all available Power Plans on a computer.
+    .PARAMETER PowerPlan
+        If your organization uses a different Power Plan that's considered best practice, specify it here.
+        Use Get-DbaPowerPlan -List to get all available Power Plans on a computer.
 
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
@@ -51,7 +52,7 @@ function Set-DbaPowerPlan {
         Sets the Power Plan to High Performance. Skips it if its already set.
 
     .EXAMPLE
-        PS C:\> 'Server1', 'Server2' | Set-DbaPowerPlan -CustomPowerPlan Balanced
+        PS C:\> 'Server1', 'Server2' | Set-DbaPowerPlan -PowerPlan Balanced
 
         Sets the Power Plan to Balanced for Server1 and Server2. Skips it if its already set.
 
@@ -62,9 +63,9 @@ function Set-DbaPowerPlan {
         Connects using alternative Windows credential and sets the Power Plan to High Performance. Skips it if its already set.
 
     .EXAMPLE
-        PS C:\> Set-DbaPowerPlan -ComputerName sqlcluster -CustomPowerPlan 'Maximum Performance'
+        PS C:\> Set-DbaPowerPlan -ComputerName sqlcluster -PowerPlan 'Maximum Performance'
 
-        Sets the Power Plan to the custom power plan called "Maximum Performance". Skips it if its already set.
+        Sets the Power Plan to "Maximum Performance". Skips it if its already set.
 
     #>
     [CmdletBinding(SupportsShouldProcess)]
@@ -72,8 +73,8 @@ function Set-DbaPowerPlan {
         [parameter(ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
         [PSCredential]$Credential,
-        [Alias("PowerPlan")]
-        [string]$CustomPowerPlan,
+        [Alias("CustomPowerPlan")]
+        [string]$PowerPlan,
         [switch]$EnableException
     )
 

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -5,7 +5,9 @@ function Test-DbaPowerPlan {
 
     .DESCRIPTION
         Checks the Power Plan settings on a computer against best practices recommendations.
-        Each server's name, the active and the recommended Power Plan and an isBestPractice field are returned.
+        Each server's name, the active and the recommended Power Plan and an IsBestPractice field are returned.
+
+        If your organization uses a different Power Plan that is considered best practice, specify -PowerPlan.
 
         References:
         https://support.microsoft.com/en-us/kb/2207548
@@ -17,8 +19,8 @@ function Test-DbaPowerPlan {
     .PARAMETER Credential
         Specifies a PSCredential object to use in authenticating to the server(s), instead of the current user account.
 
-    .PARAMETER CustomPowerPlan
-        If your organization uses a custom power plan that's considered best practice, specify it here.
+    .PARAMETER PowerPlan
+        If your organization uses a different power plan that's considered best practice, specify it here.
 
     .PARAMETER InputObject
         Enables piping from Get-DbaPowerPlan
@@ -45,16 +47,17 @@ function Test-DbaPowerPlan {
         Checks the Power Plan settings for sqlserver2014a and indicates whether or not it complies with best practices.
 
     .EXAMPLE
-        PS C:\> Test-DbaPowerPlan -ComputerName sqlserver2014a -CustomPowerPlan 'Maximum Performance'
+        PS C:\> Test-DbaPowerPlan -ComputerName sqlserver2014a -PowerPlan 'Maximum Performance'
 
-        Checks the Power Plan settings for sqlserver2014a and indicates whether or not it is set to the custom plan "Maximum Performance".
+        Checks the Power Plan settings for sqlserver2014a and indicates whether or not it is set to the Power Plan "Maximum Performance".
 
     #>
     param (
         [parameter(ValueFromPipeline)]
         [DbaInstance[]]$ComputerName,
         [PSCredential]$Credential,
-        [string]$CustomPowerPlan,
+        [Alias("CustomPowerPlan")]
+        [string]$PowerPlan,
         [parameter(ValueFromPipeline)]
         [pscustomobject[]]$InputObject,
         [switch]$EnableException

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -83,7 +83,13 @@ function Test-DbaPowerPlan {
                 Write-Message -Level Verbose -Message "Getting Power Plans for $computer."
                 $powerPlans = Get-DbaPowerPlan -ComputerName $computer -Credential $Credential -List -EnableException
             } catch {
-                Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
+                if ($_.Exception -match "namespace") {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Unsupported operating system." -Continue -ErrorRecord $_ -Target $computer
+                } elseif ($_.Exception -match "credentials are known to not work") {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Login failure for $($Credential.UserName)." -Continue -ErrorRecord $_ -Target $computer
+                } else {
+                    Stop-Function -Message "Can't get Power Plan Info for $computer. Check logs for more details." -Continue -ErrorRecord $_ -Target $computer
+                }
             }
 
             if ($PowerPlan) {

--- a/functions/Test-DbaPowerPlan.ps1
+++ b/functions/Test-DbaPowerPlan.ps1
@@ -118,11 +118,11 @@ function Test-DbaPowerPlan {
     end {
         foreach ($computer in $powerPlanHashTable.Keys) {
             $powerPlans = $powerPlanHashTable.$computer
-            if ($CustomPowerPlan) {
-                $bpPowerPlan.PowerPlan = $CustomPowerPlan
-                $bpPowerPlan.InstanceID = ($powerPlans | Where-Object { $_.PowerPlan -eq $CustomPowerPlan }).InstanceID
+            if ($PowerPlan) {
+                $bpPowerPlan.PowerPlan = $PowerPlan
+                $bpPowerPlan.InstanceID = ($powerPlans | Where-Object { $_.PowerPlan -eq $PowerPlan }).InstanceID
                 if ($null -eq $bpPowerplan.InstanceID) {
-                    $bpPowerPlan.PowerPlan = "You do not have the Power Plan '$CustomPowerPlan' installed on this machine."
+                    $bpPowerPlan.PowerPlan = "You do not have the Power Plan '$PowerPlan' installed on this machine."
                 }
             } else {
                 $bpPowerPlan.PowerPlan = ($powerPlans | Where-Object { $_.InstanceID -eq $bpPowerPlan.InstanceID }).PowerPlan

--- a/tests/Get-DbaPowerPlan.Tests.ps1
+++ b/tests/Get-DbaPowerPlan.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'List', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Set-DbaPowerPlan.Tests.ps1
+++ b/tests/Set-DbaPowerPlan.Tests.ps1
@@ -35,8 +35,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results | Should Not Be Null
             $results.ActivePowerPlan -eq 'Balanced' | Should Be $true
         }
-        It "Should accept Piped input from Test-DbaPowerPlan" {
-            $results = Test-DbaPowerPlan -ComputerName $env:COMPUTERNAME | Set-DbaPowerPlan
+        It "Should accept Piped input for ComputerName" {
+            $results = $env:COMPUTERNAME | Set-DbaPowerPlan
             $results | Should Not Be Null
             $results.ActivePowerPlan -eq 'High Performance' | Should Be $true
         }

--- a/tests/Set-DbaPowerPlan.Tests.ps1
+++ b/tests/Set-DbaPowerPlan.Tests.ps1
@@ -19,31 +19,42 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     for more guidence.
 #>
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $powerPlan = Test-DbaPowerPlan -ComputerName $env:COMPUTERNAME
+        if ($powerPlan.PowerPlan -ne 'Balanced') {
+            $null = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -CustomPowerPlan 'Balanced'
+        }
+    }
     Context "Command actually works" {
         It "Should return result for the server" {
             $results = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME
             $results | Should Not Be Null
-            $results.ActivePowerPlan -eq 'High Performance' | Should Be $true
+            $results.ActivePowerPlan | Should Be 'High Performance'
+            $results.IsChanged | Should Be $true
         }
         It "Should skip if already set" {
             $results = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME
-            $results.ActivePowerPlan -eq 'High Performance' | Should Be $true
+            $results.ActivePowerPlan | Should Be 'High Performance'
+            $results.IsChanged | Should Be $false
             $results.ActivePowerPlan -eq $results.PreviousPowerPlan | Should Be $true
         }
         It "Should return result for the server when setting defined PowerPlan" {
             $results = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -PowerPlan Balanced
             $results | Should Not Be Null
-            $results.ActivePowerPlan -eq 'Balanced' | Should Be $true
+            $results.ActivePowerPlan | Should Be 'Balanced'
+            $results.IsChanged | Should Be $true
         }
         It "Should accept Piped input for ComputerName" {
             $results = $env:COMPUTERNAME | Set-DbaPowerPlan
             $results | Should Not Be Null
-            $results.ActivePowerPlan -eq 'High Performance' | Should Be $true
+            $results.ActivePowerPlan | Should Be 'High Performance'
+            $results.IsChanged | Should Be $true
         }
         It "Should return result for the server when using CustomPowerPlan" {
             $results = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -CustomPowerPlan Balanced
             $results | Should Not Be Null
-            $results.ActivePowerPlan -eq 'Balanced' | Should Be $true
+            $results.ActivePowerPlan | Should Be 'Balanced'
+            $results.IsChanged | Should Be $true
         }
     }
 }

--- a/tests/Set-DbaPowerPlan.Tests.ps1
+++ b/tests/Set-DbaPowerPlan.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'PowerPlan', 'CustomPowerPlan', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'CustomPowerPlan', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Set-DbaPowerPlan.Tests.ps1
+++ b/tests/Set-DbaPowerPlan.Tests.ps1
@@ -20,10 +20,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 #>
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
-        $powerPlan = Test-DbaPowerPlan -ComputerName $env:COMPUTERNAME
-        if ($powerPlan.PowerPlan -ne 'Balanced') {
-            $null = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -CustomPowerPlan 'Balanced'
-        }
+        $null = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -CustomPowerPlan 'Balanced'
     }
     Context "Command actually works" {
         It "Should return result for the server" {

--- a/tests/Set-DbaPowerPlan.Tests.ps1
+++ b/tests/Set-DbaPowerPlan.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'CustomPowerPlan', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'PowerPlan', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -50,7 +50,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.ActivePowerPlan | Should Be 'High Performance'
             $results.IsChanged | Should Be $true
         }
-        It "Should return result for the server when using CustomPowerPlan" {
+        It "Should return result for the server when using the alias CustomPowerPlan" {
             $results = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -CustomPowerPlan Balanced
             $results | Should Not Be Null
             $results.ActivePowerPlan | Should Be 'Balanced'

--- a/tests/Test-DbaPowerPlan.Tests.ps1
+++ b/tests/Test-DbaPowerPlan.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'PowerPlan', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'PowerPlan', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Test-DbaPowerPlan.Tests.ps1
+++ b/tests/Test-DbaPowerPlan.Tests.ps1
@@ -15,10 +15,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
-        $powerPlan = Test-DbaPowerPlan -ComputerName $script:instance2
-        if ($powerPlan.PowerPlan -ne 'Balanced') {
-            $null = Set-DbaPowerPlan -ComputerName $script:instance2 -PowerPlan 'Balanced'
-        }
+        $null = Set-DbaPowerPlan -ComputerName $script:instance2 -PowerPlan 'Balanced'
     }
     Context "Command actually works" {
         It "Should return result for the server" {

--- a/tests/Test-DbaPowerPlan.Tests.ps1
+++ b/tests/Test-DbaPowerPlan.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'CustomPowerPlan', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'PowerPlan', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -17,7 +17,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $powerPlan = Test-DbaPowerPlan -ComputerName $script:instance2
         if ($powerPlan.PowerPlan -ne 'Balanced') {
-            $null = Set-DbaPowerPlan -ComputerName $script:instance2 -CustomPowerPlan 'Balanced'
+            $null = Set-DbaPowerPlan -ComputerName $script:instance2 -PowerPlan 'Balanced'
         }
     }
     Context "Command actually works" {
@@ -30,7 +30,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results.IsBestPractice | Should Be $false
         }
         It "Use 'Balanced' plan as best practice" {
-            $results = Test-DbaPowerPlan -ComputerName $script:instance2 -CustomPowerPlan 'Balanced'
+            $results = Test-DbaPowerPlan -ComputerName $script:instance2 -PowerPlan 'Balanced'
             $results.IsBestPractice | Should Be $true
         }
     }

--- a/tests/Test-DbaPowerPlan.Tests.ps1
+++ b/tests/Test-DbaPowerPlan.Tests.ps1
@@ -14,16 +14,22 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $powerPlan = Test-DbaPowerPlan -ComputerName $script:instance2
+        if ($powerPlan.PowerPlan -ne 'Balanced') {
+            $null = Set-DbaPowerPlan -ComputerName $script:instance2 -CustomPowerPlan 'Balanced'
+        }
+    }
     Context "Command actually works" {
         It "Should return result for the server" {
             $results = Test-DbaPowerPlan -ComputerName $script:instance2
             $results | Should Not Be Null
+            $results.ActivePowerPlan | Should Be 'Balanced'
             $results.RecommendedPowerPlan | Should Be 'High performance'
             $results.RecommendedInstanceId | Should Be '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
-            $results.ActivePowerPlan | Should Be 'High performance'
+            $results.IsBestPractice | Should Be $false
         }
         It "Use 'Balanced' plan as best practice" {
-            $null = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -PowerPlan Balanced
             $results = Test-DbaPowerPlan -ComputerName $script:instance2 -CustomPowerPlan 'Balanced'
             $results.IsBestPractice | Should Be $true
         }

--- a/tests/Test-DbaPowerPlan.Tests.ps1
+++ b/tests/Test-DbaPowerPlan.Tests.ps1
@@ -18,10 +18,14 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         It "Should return result for the server" {
             $results = Test-DbaPowerPlan -ComputerName $script:instance2
             $results | Should Not Be Null
+            $results.RecommendedPowerPlan | Should Be 'High performance'
+            $results.RecommendedInstanceId | Should Be '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+            $results.ActivePowerPlan | Should Be 'High performance'
         }
-        It "Should state 'Balanced' plan does not meet best practice" {
+        It "Use 'Balanced' plan as best practice" {
+            $null = Set-DbaPowerPlan -ComputerName $env:COMPUTERNAME -PowerPlan Balanced
             $results = Test-DbaPowerPlan -ComputerName $script:instance2 -CustomPowerPlan 'Balanced'
-            $results.isBestPractice | Should Be $false
+            $results.IsBestPractice | Should Be $true
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (effects multiple commands or functionality, fixes #6397 )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Reducing duplicate  code and duplicate attempts to get Power Plan information from the target computer.

### Approach
<!-- How does this change solve that purpose -->
Added -List to Get-DbaPowerPlan and return InstanceIds in Test-DbaPowerPlan so that Test-DbaPowerPlan can be used in Set-DbaPowerPlan.
I have removed the ability to pipe from Get-DbaPowerPlan and Set-DbaPowerPlan as I can't see a use case for it.