### PR TITLE
Test-DbaConnectionAuthScheme.ps1 flag fix

### DIFF
--- a/functions/Test-DbaConnectionAuthScheme.ps1
+++ b/functions/Test-DbaConnectionAuthScheme.ps1
@@ -110,7 +110,7 @@ function Test-DbaConnectionAuthScheme {
                     ComputerName = $results.ComputerName
                     InstanceName = $results.InstanceName
                     SqlInstance  = $results.SqlInstance
-                    Result       = ($server.AuthScheme -eq $auth)
+                    Result       = ($results.AuthScheme -eq $auth)
                 } | Select-DefaultView -Property SqlInstance, Result
             } else {
                 Select-DefaultView -InputObject $results -Property ComputerName, InstanceName, SqlInstance, Transport, AuthScheme


### PR DESCRIPTION
-ntlm and -kerberos flags giving incorrect results. The if statement that returns a true/false is checking against $server.AuthScheme instead of $results.AuthScheme so is a simple fix.

## Type of Change
 - [ x ] Bug fix (non-breaking change)

### Purpose
Fix output if -ntlm or -kerberos used
