### PR TITLE
Get-DbaCmObject - Use Invoke-Command2 to enable UseSSL config

### DIFF
--- a/functions/Get-DbaCmObject.ps1
+++ b/functions/Get-DbaCmObject.ps1
@@ -431,10 +431,10 @@ function Get-DbaCmObject {
                             $parameters = @{
                                 ScriptBlock  = ([System.Management.Automation.ScriptBlock]::Create($scp_string))
                                 ComputerName = $ComputerName
-                                ErrorAction  = 'Stop'
+                                Raw          = $true
                             }
                             if ($Credential) { $parameters["Credential"] = $Credential }
-                            Invoke-Command @parameters
+                            Invoke-Command2 @parameters
 
                             Write-Message -Level Verbose -Message "[$computer] Accessing computer using PowerShell Remoting - Success"
                             $connection.ReportSuccess('PowerShellRemoting')


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7473 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Use Invoke-Command2 instead of Invoke-Command to be able to use PSRemoting.PsSession.UseSSL with the command.

