### PR TITLE
Add-DbaAgDatabase - Add missing SqlCredential when calling Test-DbaAvailabilityGroup

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -193,6 +193,7 @@ function Add-DbaAgDatabase {
                 Write-Progress @progress
                 $testSplat = @{
                     SqlInstance            = $SqlInstance
+                    SqlCredential          = $SqlCredential
                     Secondary              = $Secondary
                     SecondarySqlCredential = $SecondarySqlCredential
                     AvailabilityGroup      = $AvailabilityGroup


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7481 )
