### PR TITLE
Rename-DbaLogin - Check if user exists before attempting to rename it, require Force to rename db users too

### DIFF
--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -102,7 +102,7 @@ function Rename-DbaLogin {
                 $output = @()
                 try {
                     $dbenums = $currentLogin.EnumDatabaseMappings()
-                    $null = $currentLogin.rename($NewLogin)
+                    $null = $currentLogin.Rename($NewLogin)
                     $output += [pscustomobject]@{
                         ComputerName  = $server.ComputerName
                         InstanceName  = $server.ServiceName
@@ -110,6 +110,8 @@ function Rename-DbaLogin {
                         Database      = $null
                         PreviousLogin = $Login
                         NewLogin      = $NewLogin
+                        PreviousUser  = $null
+                        NewUser       = $null
                         Status        = "Successful"
                     }
                 } catch {
@@ -121,6 +123,8 @@ function Rename-DbaLogin {
                         Database      = $null
                         PreviousLogin = $Login
                         NewLogin      = $NewLogin
+                        PreviousUser  = $null
+                        NewUser       = $null
                         Status        = "Failure"
                     }
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Target $login -Continue
@@ -139,28 +143,33 @@ function Rename-DbaLogin {
                                 $oldname = $user.name
                                 $null = $user.Rename($NewLogin)
                                 $output += [pscustomobject]@{
-                                    ComputerName = $server.ComputerName
-                                    InstanceName = $server.ServiceName
-                                    SqlInstance  = $server.DomainInstanceName
-                                    Database     = $db.name
-                                    PreviousUser = $oldname
-                                    NewUser      = $NewLogin
-                                    Status       = "Successful"
+                                    ComputerName  = $server.ComputerName
+                                    InstanceName  = $server.ServiceName
+                                    SqlInstance   = $server.DomainInstanceName
+                                    Database      = $db.name
+                                    PreviousLogin = $null
+                                    NewLogin      = $null
+                                    PreviousUser  = $oldname
+                                    NewUser       = $NewLogin
+                                    Status        = "Successful"
                                 }
                             } catch {
                                 Write-Message -Level Warning -Message "Rolling back update to login: $Login"
-                                $currentLogin.rename($Login)
+                                $null = $currentLogin.Rename($Login)
 
                                 [pscustomobject]@{
-                                    ComputerName = $server.ComputerName
-                                    InstanceName = $server.ServiceName
-                                    SqlInstance  = $server.DomainInstanceName
-                                    Database     = $db.name
-                                    PreviousUser = $NewLogin
-                                    NewUser      = $oldname
-                                    Status       = "Failure to rename. Rolled back change."
+                                    ComputerName  = $server.ComputerName
+                                    InstanceName  = $server.ServiceName
+                                    SqlInstance   = $server.DomainInstanceName
+                                    Database      = $db.name
+                                    PreviousLogin = $null
+                                    NewLogin      = $null
+                                    PreviousUser  = $NewLogin
+                                    NewUser       = $oldname
+                                    Status        = "Failure to rename. Rolled back change."
                                 }
-                                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $NewLogin -Continue
+                                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $NewLogin
+                                return
                             }
                         }
                     }

--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -1,12 +1,14 @@
 function Rename-DbaLogin {
     <#
     .SYNOPSIS
-        Rename-DbaLogin will rename login and database mapping for a specified login.
+        Rename-DbaLogin will rename logins
 
     .DESCRIPTION
         There are times where you might want to rename a login that was copied down, or if the name is not descriptive for what it does.
 
         It can be a pain to update all of the mappings for a specific user, this does it for you.
+
+        Rename-DbaLogin will rename logins and database mappings for a specified login if Force is specified.
 
     .PARAMETER SqlInstance
         Source SQL Server.You must have sysadmin access and server version must be SQL Server version 2000 or greater.
@@ -26,6 +28,9 @@ function Rename-DbaLogin {
 
     .PARAMETER NewLogin
         The new Login that you wish to use. If it is a windows user login, then the SID must match.
+
+    .PARAMETER Force
+        Will attempt to rename any associated database users.
 
     .PARAMETER Confirm
         Prompts to confirm actions
@@ -74,6 +79,7 @@ function Rename-DbaLogin {
         [string]$Login,
         [parameter(Mandatory)]
         [string]$NewLogin,
+        [switch]$Force,
         [switch]$EnableException
     )
 
@@ -120,40 +126,42 @@ function Rename-DbaLogin {
                 }
             }
 
-            foreach ($db in $dbenums) {
-                $db = $databases[$db.DBName]
-                $user = $db.Users[$Login]
-                if ($user) {
-                    Write-Message -Level Verbose -Message "Starting update for $db"
+            if ($Force) {
+                foreach ($db in $dbenums) {
+                    $db = $databases[$db.DBName]
+                    $user = $db.Users[$Login]
+                    if ($user) {
+                        Write-Message -Level Verbose -Message "Starting update for $db"
 
-                    if ($Pscmdlet.ShouldProcess($SqlInstance, "Changing database $db user $user from [$Login] to [$NewLogin]")) {
-                        try {
-                            $oldname = $user.name
-                            $user.Rename($NewLogin)
-                            [pscustomobject]@{
-                                ComputerName = $server.ComputerName
-                                InstanceName = $server.ServiceName
-                                SqlInstance  = $server.DomainInstanceName
-                                Database     = $db.name
-                                PreviousUser = $oldname
-                                NewUser      = $NewLogin
-                                Status       = "Successful"
+                        if ($Pscmdlet.ShouldProcess($SqlInstance, "Changing database $db user $user from [$Login] to [$NewLogin]")) {
+                            try {
+                                $oldname = $user.name
+                                $user.Rename($NewLogin)
+                                [pscustomobject]@{
+                                    ComputerName = $server.ComputerName
+                                    InstanceName = $server.ServiceName
+                                    SqlInstance  = $server.DomainInstanceName
+                                    Database     = $db.name
+                                    PreviousUser = $oldname
+                                    NewUser      = $NewLogin
+                                    Status       = "Successful"
+                                }
+
+                            } catch {
+                                Write-Message -Level Warning -Message "Rolling back update to login: $Login"
+                                $currentLogin.rename($Login)
+
+                                [pscustomobject]@{
+                                    ComputerName = $server.ComputerName
+                                    InstanceName = $server.ServiceName
+                                    SqlInstance  = $server.DomainInstanceName
+                                    Database     = $db.name
+                                    PreviousUser = $NewLogin
+                                    NewUser      = $oldname
+                                    Status       = "Failure to rename. Rolled back change."
+                                }
+                                Stop-Function -Message "Failure" -ErrorRecord $_ -Target $NewLogin
                             }
-
-                        } catch {
-                            Write-Message -Level Warning -Message "Rolling back update to login: $Login"
-                            $currentLogin.rename($Login)
-
-                            [pscustomobject]@{
-                                ComputerName = $server.ComputerName
-                                InstanceName = $server.ServiceName
-                                SqlInstance  = $server.DomainInstanceName
-                                Database     = $db.name
-                                PreviousUser = $NewLogin
-                                NewUser      = $oldname
-                                Status       = "Failure to rename. Rolled back change."
-                            }
-                            Stop-Function -Message "Failure" -ErrorRecord $_ -Target $NewLogin
                         }
                     }
                 }

--- a/tests/Rename-DbaLogin.Tests.ps1
+++ b/tests/Rename-DbaLogin.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'NewLogin', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Login', 'NewLogin', 'EnableException', 'Force'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #7363 )
 
It was assumed the db user would exist since it came from an eum, so we didn't double-check.

I updated the docs to better align with the fix and I also added a force switch to also change associated db users and a check to see if the user indeed exists.

Since Force is now required to rename database users, this could be a breaking change if it worked before. I think this is safer, so if there is an issue with adding force, I'll at least add a -NoDbRename option so that people have the option to not rename db users too.