### PR TITLE
Add-DbaAgDatabase - Fix step 4 (JoinAvailablityGroup) for versions 2012 and 2014

### DIFF
--- a/functions/Add-DbaAgDatabase.ps1
+++ b/functions/Add-DbaAgDatabase.ps1
@@ -405,7 +405,7 @@ function Add-DbaAgDatabase {
                     }
 
                     # With automatic seeding, .JoinAvailablityGroup() is not needed, just wait for the magic to happen
-                    if ($ag.AvailabilityReplicas[$replicaName].SeedingMode -eq 'Manual') {
+                    if ($ag.AvailabilityReplicas[$replicaName].SeedingMode -ne 'Automatic') {
                         try {
                             $progress['CurrentOperation'] = "Joining database $($db.Name) on replica $replicaName."
                             Write-Message -Level Verbose -Message $progress['CurrentOperation']

--- a/functions/Test-DbaAvailabilityGroup.ps1
+++ b/functions/Test-DbaAvailabilityGroup.ps1
@@ -153,6 +153,11 @@ function Test-DbaAvailabilityGroup {
         foreach ($dbName in $AddDatabase) {
             $db = $server.Databases[$dbName]
 
+            if ($SeedingMode -eq 'Automatic' -and $server.VersionMajor -lt 13) {
+                Stop-Function -Message "Automatic seeding mode only supported in SQL Server 2016 and above" -Target $server
+                return
+            }
+
             if (-not $db) {
                 Stop-Function -Message "Database $db is not found on $server." -Continue
             }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7487 )

Version before 2016 don't have the property SeedingMode in AvailabilityReplicas, so testing for 'Manual' was wrong and is now testing for not beeing 'Automatic'.
Added a check in Test-DbaAvailabilityGroup for automatic seeding in versions before 2016 as well.