### PR TITLE
logfilescript.ps1 - Better pipeline processing to prevent 4100 errors in Windows Event Log

### DIFF
--- a/internal/scripts/logfilescript.ps1
+++ b/internal/scripts/logfilescript.ps1
@@ -80,12 +80,11 @@ $scriptBlock = {
                 $root = New-Item $path -ItemType Directory -Force -ErrorAction Stop
             } else { $root = Get-Item -Path $path }
 
-            try { [int]$num_Error = (Get-ChildItem -Path $root.FullName -Filter "dbatools_$($pid)_error_*.xml" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty Name | Select-String -Pattern "(\d+)" -AllMatches).Matches[1].Value }
-            catch { }
-            try { [int]$num_Message = (Get-ChildItem -Path $root.FullName -Filter "dbatools_$($pid)_message_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty Name | Select-String -Pattern "(\d+)" -AllMatches).Matches[1].Value }
-            catch { }
-            if (-not ($num_Error)) { $num_Error = 0 }
-            if (-not ($num_Message)) { $num_Message = 0 }
+            $errorFiles = Get-ChildItem -Path $root.FullName -Filter "dbatools_$($pid)_error_*.xml" | Sort-Object LastWriteTime -Descending
+            [int]$num_Error = if ($errorFiles) { (Select-String -InputObject $errorFiles[0].Name -Pattern "(\d+)" -AllMatches).Matches[1].Value } else { 0 }
+
+            $messageFiles = Get-ChildItem -Path $root.FullName -Filter "dbatools_$($pid)_message_*.xml" | Sort-Object LastWriteTime -Descending
+            [int]$num_Message = if ($messageFiles) { (Select-String -InputObject $messageFiles[0].Name -Pattern "(\d+)" -AllMatches).Matches[1].Value } else { 0 }
 
             #region Process Errors
             while ([Sqlcollaborative.Dbatools.Message.LogHost]::OutQueueError.Count -gt 0) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6543 )

I carefully read the thread again and just gave these proposed changes from Pete Whelpton (@peedeeboy) a try: https://github.com/sqlcollaborative/dbatools/issues/6543#issuecomment-633255928

And yes, that worked.

Learning for the future: If something is very often `$null`, don't pipe it to `| Select-Object -First 1`.