### PR TITLE
Remove-DbaDbSequence - fix test

### DIFF
--- a/tests/Remove-DbaDbSequence.Tests.ps1
+++ b/tests/Remove-DbaDbSequence.Tests.ps1
@@ -26,7 +26,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
 
     AfterAll {
-        $null = Remove-DbaDatabase -Confirm:$false -SqlInstance $instance2 -Name $newDbName
+        $null = Remove-DbaDatabase -Confirm:$false -SqlInstance $instance2 -Database $newDbName
     }
 
     Context "commands work as expected" {

--- a/tests/Remove-DbaDbSequence.Tests.ps1
+++ b/tests/Remove-DbaDbSequence.Tests.ps1
@@ -26,7 +26,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
 
     AfterAll {
-        $null = $newDb | Remove-DbaDatabase -Confirm:$false
+        $null = Remove-DbaDatabase -Confirm:$false -SqlInstance $instance2 -Name $newDbName
     }
 
     Context "commands work as expected" {


### PR DESCRIPTION
Fixes a test that failed in the `AfterAll` due to the db name being piped in instead of the SMO object