### PR TITLE
Invoke-Command2.ps1 internal command - fix repeated config call

### DIFF
--- a/internal/functions/Invoke-Command2.ps1
+++ b/internal/functions/Invoke-Command2.ps1
@@ -92,7 +92,7 @@ function Invoke-Command2 {
                 Authentication = $Authentication
                 Name           = $sessionName
                 ErrorAction    = 'Stop'
-                UseSSL         = (Get-DbatoolsConfigValue -FullName 'PSRemoting.PsSession.UseSSL' -Fallback $false)
+                UseSSL         = $UseSSL
             }
             if (Test-Windows -NoWarn) {
                 $psSessionOptionsSplat = @{


### PR DESCRIPTION
The usessl input is ignored so changed the splat to use the input rather than re-pulling from config

## Type of Change
 - [ x ] Bug fix (non-breaking change, fixes #<!--issue number--> )

### Purpose
simple change to use input parameter instead of ignoring it