### PR TITLE
Get-DbaRunningJob - add StartDate property

### DIFF
--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -149,17 +149,20 @@ function Get-DbaAgentJob {
             }
 
             foreach ($agentJob in $jobs) {
+                $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'StartDate', 'Category', 'OwnerLoginName', 'CurrentRunStatus', 'CurrentRunRetryAttempt', 'Enabled', 'LastRunDate', 'LastRunOutcome', 'HasSchedule', 'OperatorToEmail', 'CreateDate'
+
                 $currentJobId = $agentJob.JobId
                 if ($currentJobId -in $jobExecutionResults.JobId) {
                     $agentJobStartDate = [DbaDateTime]($jobExecutionResults | Where-Object JobId -eq $currentJobId).StartDate
                     Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name StartDate -Value $agentJobStartDate
+                    $defaults += 'StartDate'
                 }
 
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.ComputerName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name InstanceName -value $agentJob.Parent.Parent.ServiceName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName
 
-                Select-DefaultView -InputObject $agentJob -Property ComputerName, InstanceName, SqlInstance, Name, Category, OwnerLoginName, CurrentRunStatus, CurrentRunRetryAttempt, 'IsEnabled as Enabled', LastRunDate, LastRunOutcome, HasSchedule, OperatorToEmail, 'DateCreated as CreateDate'
+                Select-DefaultView -InputObject $agentJob -Property $defaults
             }
         }
     }

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -149,7 +149,7 @@ function Get-DbaAgentJob {
             }
 
             foreach ($agentJob in $jobs) {
-                $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'StartDate', 'Category', 'OwnerLoginName', 'CurrentRunStatus', 'CurrentRunRetryAttempt', 'Enabled', 'LastRunDate', 'LastRunOutcome', 'HasSchedule', 'OperatorToEmail', 'CreateDate'
+                $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'Category', 'OwnerLoginName', 'CurrentRunStatus', 'CurrentRunRetryAttempt', 'IsEnabled as Enabled', 'LastRunDate', 'LastRunOutcome', 'HasSchedule', 'OperatorToEmail', 'DateCreated as CreateDate'
 
                 $currentJobId = $agentJob.JobId
                 if ($currentJobId -in $jobExecutionResults.JobId) {

--- a/functions/Get-DbaAgentJob.ps1
+++ b/functions/Get-DbaAgentJob.ps1
@@ -34,6 +34,9 @@ function Get-DbaAgentJob {
     .PARAMETER ExcludeCategory
         Categories to exclude - jobs associated with these categories will not be returned.
 
+    .PARAMETER IncludeExecution
+        Include Execution details if the job is currently running
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -101,6 +104,7 @@ function Get-DbaAgentJob {
         [string[]]$Category,
         [string[]]$ExcludeCategory,
         [switch]$ExcludeDisabledJobs,
+        [switch]$IncludeExecution,
         [switch]$EnableException
     )
 
@@ -111,6 +115,16 @@ function Get-DbaAgentJob {
                 $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            if (Test-Bound 'IncludeExecution') {
+                $query = "SELECT [job].[job_id] as [JobId], [activity].[start_execution_date] AS [StartDate]
+                FROM [msdb].[dbo].[sysjobs_view] as [job]
+                    INNER JOIN [msdb].[dbo].[sysjobactivity] AS [activity] ON [job].[job_id] = [activity].[job_id]
+                WHERE [activity].[run_requested_date] IS NOT NULL
+                    AND [activity].[stop_execution_date] IS NULL;"
+
+                $jobExecutionResults = $server.Query($query)
             }
 
             $jobs = $server.JobServer.Jobs
@@ -135,6 +149,12 @@ function Get-DbaAgentJob {
             }
 
             foreach ($agentJob in $jobs) {
+                $currentJobId = $agentJob.JobId
+                if ($currentJobId -in $jobExecutionResults.JobId) {
+                    $agentJobStartDate = [DbaDateTime]($jobExecutionResults | Where-Object JobId -eq $currentJobId).StartDate
+                    Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name StartDate -Value $agentJobStartDate
+                }
+
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name ComputerName -value $agentJob.Parent.Parent.ComputerName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name InstanceName -value $agentJob.Parent.Parent.ServiceName
                 Add-Member -Force -InputObject $agentJob -MemberType NoteProperty -Name SqlInstance -value $agentJob.Parent.Parent.DomainInstanceName

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -61,10 +61,11 @@ function Get-DbaRunningJob {
         [switch]$EnableException
     )
     process {
-        if ($SqlInstance) {
-            Get-DbaAgentJob -SqlInstance $SqlInstance -SqlCredential $SqlCredential | Where-Object CurrentRunStatus -ne 'Idle'
-        }
+        $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'StartDate', 'Category', 'OwnerLoginName', 'CurrentRunStatus', 'CurrentRunRetryAttempt', 'Enabled', 'LastRunDate', 'LastRunOutcome', 'HasSchedule', 'OperatorToEmail', 'CreateDate'
 
-        $InputObject | Where-Object CurrentRunStatus -ne 'Idle'
+        if ($SqlInstance) {
+            Get-DbaAgentJob -SqlInstance $SqlInstance -SqlCredential $SqlCredential -IncludeExecution | Where-Object CurrentRunStatus -ne 'Idle' | Select-Object -Property $defaults
+        }
+        $InputObject | Where-Object CurrentRunStatus -ne 'Idle' | Select-Object -Property $defaults
     }
 }

--- a/functions/Get-DbaRunningJob.ps1
+++ b/functions/Get-DbaRunningJob.ps1
@@ -61,11 +61,9 @@ function Get-DbaRunningJob {
         [switch]$EnableException
     )
     process {
-        $defaults = 'ComputerName', 'InstanceName', 'SqlInstance', 'Name', 'StartDate', 'Category', 'OwnerLoginName', 'CurrentRunStatus', 'CurrentRunRetryAttempt', 'Enabled', 'LastRunDate', 'LastRunOutcome', 'HasSchedule', 'OperatorToEmail', 'CreateDate'
-
         if ($SqlInstance) {
-            Get-DbaAgentJob -SqlInstance $SqlInstance -SqlCredential $SqlCredential -IncludeExecution | Where-Object CurrentRunStatus -ne 'Idle' | Select-Object -Property $defaults
+            Get-DbaAgentJob -SqlInstance $SqlInstance -SqlCredential $SqlCredential -IncludeExecution | Where-Object CurrentRunStatus -ne 'Idle'
         }
-        $InputObject | Where-Object CurrentRunStatus -ne 'Idle' | Select-Object -Property $defaults
+        $InputObject | Where-Object CurrentRunStatus -ne 'Idle'
     }
 }

--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -5,7 +5,8 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'Database', 'Category', 'ExcludeDisabledJobs', 'EnableException', 'ExcludeCategory'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Job', 'ExcludeJob', 'Database', 'Category', 'ExcludeDisabledJobs', 'EnableException', 'ExcludeCategory', 'IncludeExecution'
+
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }

--- a/tests/Get-DbaRunningJob.Tests.ps1
+++ b/tests/Get-DbaRunningJob.Tests.ps1
@@ -4,16 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'InputObject', 'EnableException'
-        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
     }
 }
-<#
-    Integration test should appear below and are custom to the command you are writing.
-    Read https://github.com/sqlcollaborative/dbatools/blob/development/contributing.md#tests
-    for more guidence.
-#>


### PR DESCRIPTION
### Purpose
The way `Get-DbaRunningJob` is called does not provide an easy method for running a query, without adding in making a connection and all that stuff. Made more sense to simply add a parameter and query execution to `Get-DbaAgentJob` itself.

The parameter `-IncludeExecution` is used by `Get-DbaRunningJob` to include the `StartDate` property in the output. Adding it via the parameter ensures it not a breaking change.

### Screenshots

![image](https://user-images.githubusercontent.com/11204251/124697768-0173b200-dead-11eb-8b7b-0e15c6554133.png)

## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #1917 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
