### PR TITLE
Connect-DbaInstance - Add back support for Tenant

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -452,12 +452,13 @@ function Connect-DbaInstance {
             Write-Message -Level Verbose "Tenant detected, switching to experimental code path"
             try {
                 Set-DbatoolsConfig -FullName sql.connection.experimental -Value $true
-                $AccessToken = (New-DbaAzAccessToken -Type RenewableServicePrincipal -Subtype AzureSqlDb -Tenant $Tenant -Credential $SqlCredential -EnableException).GetAccessToken()
+                $AccessToken = (New-DbaAzAccessToken -Type RenewableServicePrincipal -Subtype AzureSqlDb -Tenant $Tenant -Credential $SqlCredential -ErrorAction Stop).GetAccessToken()
                 $PSBoundParameters.Tenant = $Tenant = $null
                 $PSBoundParameters.SqlCredential = $SqlCredential = $null
                 $PSBoundParameters.AccessToken = $AccessToken
             } catch {
-                Stop-Function -Message "Failed to get access token for Azure SQL DB" -ErrorRecord $_
+                $errormessage = Get-ErrorMessage -Record $_
+                Stop-Function -Message "Failed to get access token for Azure SQL DB ($errormessage)"
                 return
             }
         }

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -448,6 +448,19 @@ function Connect-DbaInstance {
     }
     process {
         if (Test-FunctionInterrupt) { return }
+        if ($Tenant -and -not $AccessToken) {
+            Write-Message -Level Verbose "Tenant detected, switching to experimental code path"
+            try {
+                Set-DbatoolsConfig -FullName sql.connection.experimental -Value $true
+                $AccessToken = (New-DbaAzAccessToken -Type RenewableServicePrincipal -Subtype AzureSqlDb -Tenant $Tenant -Credential $SqlCredential -EnableException).GetAccessToken()
+                $PSBoundParameters.Tenant = $Tenant = $null
+                $PSBoundParameters.SqlCredential = $SqlCredential = $null
+                $PSBoundParameters.AccessToken = $AccessToken
+            } catch {
+                Stop-Function -Message "Failed to get access token for Azure SQL DB" -ErrorRecord $_
+                return
+            }
+        }
 
         Write-Message -Level Debug -Message "Starting process block"
         foreach ($instance in $SqlInstance) {


### PR DESCRIPTION
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 
It seems like the new SMO libraries or .NET updates broke the way we connect using Tenants. The new experimental path is the easiest way to connect, so we will default to it.

![image](https://user-images.githubusercontent.com/8278033/124754162-3114cf80-df2a-11eb-8af1-e178c6f4c151.png)
