### PR TITLE
Set-DbaPrivilege - Don't write a warning if privilege is already set

### DIFF
--- a/functions/Set-DbaPrivilege.ps1
+++ b/functions/Set-DbaPrivilege.ps1
@@ -123,7 +123,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                             Write-Verbose "Added $acc to Batch Logon Privileges on $env:ComputerName"
                                         } else {
                                             <# DO NOT use Write-Message as this is inside of a script block #>
-                                            Write-Warning "$acc already has Batch Logon Privilege on $env:ComputerName"
+                                            Write-Verbose "$acc already has Batch Logon Privilege on $env:ComputerName"
                                         }
                                     }
                                 }
@@ -144,7 +144,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                             Write-Verbose "Added $acc to Instant File Initialization Privileges on $env:ComputerName"
                                         } else {
                                             <# DO NOT use Write-Message as this is inside of a script block #>
-                                            Write-Warning "$acc already has Instant File Initialization Privilege on $env:ComputerName"
+                                            Write-Verbose "$acc already has Instant File Initialization Privilege on $env:ComputerName"
                                         }
                                     }
                                 }
@@ -165,7 +165,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                             Write-Verbose "Added $acc to Lock Pages in Memory Privileges on $env:ComputerName"
                                         } else {
                                             <# DO NOT use Write-Message as this is inside of a script block #>
-                                            Write-Warning "$acc already has Lock Pages in Memory Privilege on $env:ComputerName"
+                                            Write-Verbose "$acc already has Lock Pages in Memory Privilege on $env:ComputerName"
                                         }
                                     }
                                 }
@@ -186,7 +186,7 @@ function Convert-UserNameToSID ([string] `$Acc ) {
                                             Write-Verbose "Added $acc to Write to Security Log Privileges on $env:ComputerName"
                                         } else {
                                             <# DO NOT use Write-Message as this is inside of a script block #>
-                                            Write-Warning "$acc already has Write To Security Audit Privilege on $env:ComputerName"
+                                            Write-Verbose "$acc already has Write To Security Audit Privilege on $env:ComputerName"
                                         }
                                     }
                                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7232 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
When installing a second instance on a system under the same service account, and thereby setting the instant file initialization privilege again, I don't what to see a warning message, that the privilege was already set.
But on the over hand I think it's worth to have a verbose message in the else path of these ifs for debugging.