### PR TITLE
Connect-DbaInstance - Test for GUID username when using Tenant

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -448,6 +448,7 @@ function Connect-DbaInstance {
     }
     process {
         if (Test-FunctionInterrupt) { return }
+        # if tenant is specified with a GUID username such as 21f5633f-6776-4bab-b878-bbd5e3e5ed72 (for clientid)
         if ($Tenant -and -not $AccessToken -and $SqlCredential.UserName -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
             Write-Message -Level Verbose "Tenant detected, switching to experimental code path"
             try {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -448,7 +448,7 @@ function Connect-DbaInstance {
     }
     process {
         if (Test-FunctionInterrupt) { return }
-        if ($Tenant -and -not $AccessToken) {
+        if ($Tenant -and -not $AccessToken -and $SqlCredential.UserName -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
             Write-Message -Level Verbose "Tenant detected, switching to experimental code path"
             try {
                 Set-DbatoolsConfig -FullName sql.connection.experimental -Value $true


### PR DESCRIPTION
Add in GUID check to invoke when azure.tenantid is in dbatoolsconfig or otherwise specificed

Fixes #7518 and #6896

I _could_ add a little more safety and say `(Get-DbatoolsConfigValue -FullName 'azure.tenantid' -and $SqlCredential.UserName -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')` but I'm not sure it's required

I tested this with the command line against username `beb` and with an azure client ID and it passed 👍🏼  Good work GitHub Copilot!