### PR TITLE
Fix multiple commands to restore compatibility for PSv3 - remove unsupported method `::new(`

### DIFF
--- a/functions/Get-DbaComputerCertificate.ps1
+++ b/functions/Get-DbaComputerCertificate.ps1
@@ -103,7 +103,7 @@ function Get-DbaComputerCertificate {
                 $storename = [System.Security.Cryptography.X509Certificates.StoreLocation]::$Store
                 $foldername = [System.Security.Cryptography.X509Certificates.StoreName]::$Folder
                 $flags = [System.Security.Cryptography.X509Certificates.OpenFlags]::$Flag
-                $certstore = [System.Security.Cryptography.X509Certificates.X509Store]::New($foldername, $storename)
+                $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $foldername, $storename
                 $certstore.Open($flags)
 
                 $certstore

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -206,7 +206,7 @@ function Invoke-DbaQuery {
                             if (Test-PsVersion -Maximum 4) {
                                 $uri = [uri]$item
                             } else {
-                                $uri = [uri]::New($item)
+                                $uri = New-Object uri -ArgumentList $item
                             }
                             $uriScheme = $uri.Scheme
                         } catch {
@@ -247,7 +247,7 @@ function Invoke-DbaQuery {
                                                 return
                                             }
                                         } else {
-                                            if ([uri]::New($path).Scheme -ne 'file') {
+                                            if ((New-Object uri -ArgumentList $path).Scheme -ne 'file') {
                                                 Stop-Function -Message "Could not resolve path $path as filesystem object"
                                                 return
                                             }

--- a/functions/New-DbaAzAccessToken.ps1
+++ b/functions/New-DbaAzAccessToken.ps1
@@ -236,8 +236,8 @@ function New-DbaAzAccessToken {
 
                     # thanks to Jose M Jurado - MSFT for this code
                     # https://blogs.msdn.microsoft.com/azuresqldbsupport/2018/05/10/lesson-learned-49-does-azure-sql-database-support-azure-active-directory-connections-using-service-principals/
-                    $cred = [Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential]::New($Credential.UserName, $Credential.GetNetworkCredential().Password)
-                    $context = [Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext]::New("https://login.windows.net/$Tenant")
+                    $cred = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList $Credential.UserName, $Credential.GetNetworkCredential().Password
+                    $context = New-Object Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext -ArgumentList "https://login.windows.net/$Tenant"
                     $result = $context.AcquireTokenAsync($Config.Resource, $cred)
 
                     if ($result.Result.AccessToken) {

--- a/functions/Remove-DbaComputerCertificate.ps1
+++ b/functions/Remove-DbaComputerCertificate.ps1
@@ -93,7 +93,7 @@ function Remove-DbaComputerCertificate {
                 $storename = [System.Security.Cryptography.X509Certificates.StoreLocation]::$Store
                 $foldername = [System.Security.Cryptography.X509Certificates.StoreName]::$Folder
                 $flags = [System.Security.Cryptography.X509Certificates.OpenFlags]::$Flag
-                $certstore = [System.Security.Cryptography.X509Certificates.X509Store]::New($foldername, $storename)
+                $certstore = New-Object System.Security.Cryptography.X509Certificates.X509Store -ArgumentList $foldername, $storename
                 $certstore.Open($flags)
 
                 $certstore


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #7513)

Please triple check for me, this is easy to mess up

I did not remove from any tests because all of our testing platforms are newer