### PR TITLE
Connect-DbaInstance - Optimize code for StatementTimeout and ApplicationIntent 

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -612,7 +612,7 @@ function Connect-DbaInstance {
                         $copyContext = $true
                     }
                     if ($ApplicationIntent -and $inputObject.ConnectionContext.ApplicationIntent -ne $ApplicationIntent) {
-                        Write-Message -Level Verbose -Message "Parameter ApplicationIntent passed in, and it's not the same as currently in ConnectionContext.ApplicationIntent, so we copy the connection context and set the ApplicationIntent"
+                        Write-Message -Level Verbose -Message "ApplicationIntent provided. Does not match ConnectionContext.ApplicationIntent, copying ConnectionContext and setting the ApplicationIntent"
                         $copyContext = $true
                     }
                     if ($NonPooledConnection -and -not $inputObject.ConnectionContext.NonPooledConnection) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -620,7 +620,7 @@ function Connect-DbaInstance {
                         $copyContext = $true
                     }
                     if (Test-Bound -Parameter StatementTimeout -and $inputObject.ConnectionContext.StatementTimeout -ne $StatementTimeout) {
-                        Write-Message -Level Verbose -Message "Parameter StatementTimeout passed in, and it's not the same as currently in ConnectionContext.StatementTimeout, so we copy the connection context and set the StatementTimeout"
+                        Write-Message -Level Verbose -Message "StatementTimeout provided. Does not match ConnectionContext.StatementTimeout, copying ConnectionContext and setting the StatementTimeout"
                         $copyContext = $true
                     }
                     if ($copyContext) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -107,6 +107,9 @@ function Connect-DbaInstance {
     .PARAMETER StatementTimeout
         Sets the number of seconds a statement is given to run before failing with a timeout error.
 
+        The default is read from the configuration 'sql.execution.timeout' that is currently set to 0 (unlimited).
+        If you want to change this to 10 minutes, use: Set-DbatoolsConfig -FullName 'sql.execution.timeout' -Value 600
+
     .PARAMETER TrustServerCertificate
         When this switch is enabled, the channel will be encrypted while bypassing walking the certificate chain to validate trust.
 

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -608,7 +608,7 @@ function Connect-DbaInstance {
                     # We do not test for SqlCredential as this would change the behavior compared to the legacy code path
                     $copyContext = $false
                     if ($Database -and $inputObject.ConnectionContext.CurrentDatabase -ne $Database) {
-                        Write-Message -Level Verbose -Message "Parameter Database passed in, and it's not the same as currently in ConnectionContext.CurrentDatabase, so we copy the connection context and set the CurrentDatabase"
+                        Write-Message -Level Verbose -Message "Database provided. Does not match ConnectionContext.CurrentDatabase, copying ConnectionContext and setting the CurrentDatabase"
                         $copyContext = $true
                     }
                     if ($ApplicationIntent -and $inputObject.ConnectionContext.ApplicationIntent -ne $ApplicationIntent) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -608,8 +608,8 @@ function Connect-DbaInstance {
                         Write-Message -Level Verbose -Message "Parameter Database passed in, and it's not the same as currently in ConnectionContext.CurrentDatabase, so we copy the connection context and set the CurrentDatabase"
                         $copyContext = $true
                     }
-                    if ($ApplicationIntent) {
-                        Write-Message -Level Verbose -Message "Parameter ApplicationIntent passed in, so we copy the connection context and set the ApplicationIntent"
+                    if ($ApplicationIntent -and $inputObject.ConnectionContext.ApplicationIntent -ne $ApplicationIntent) {
+                        Write-Message -Level Verbose -Message "Parameter ApplicationIntent passed in, and it's not the same as currently in ConnectionContext.ApplicationIntent, so we copy the connection context and set the ApplicationIntent"
                         $copyContext = $true
                     }
                     if ($NonPooledConnection -and -not $inputObject.ConnectionContext.NonPooledConnection) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -616,7 +616,7 @@ function Connect-DbaInstance {
                         $copyContext = $true
                     }
                     if ($NonPooledConnection -and -not $inputObject.ConnectionContext.NonPooledConnection) {
-                        Write-Message -Level Verbose -Message "Parameter NonPooledConnection passed in and we currently have a pooled connection, so we copy the connection context and set NonPooledConnection"
+                        Write-Message -Level Verbose -Message "NonPooledConnection provided. Does not match ConnectionContext.NonPooledConnection, copying ConnectionContext and setting NonPooledConnection"
                         $copyContext = $true
                     }
                     if (Test-Bound -Parameter StatementTimeout -and $inputObject.ConnectionContext.StatementTimeout -ne $StatementTimeout) {

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -605,7 +605,7 @@ function Connect-DbaInstance {
                     # We do not test for SqlCredential as this would change the behavior compared to the legacy code path
                     $copyContext = $false
                     if ($Database -and $inputObject.ConnectionContext.CurrentDatabase -ne $Database) {
-                        Write-Message -Level Verbose -Message "Parameter Database passed in, and it's not the same as currently in ConnectionContext.CurrentDatabase, so we copy the connection context"
+                        Write-Message -Level Verbose -Message "Parameter Database passed in, and it's not the same as currently in ConnectionContext.CurrentDatabase, so we copy the connection context and set the CurrentDatabase"
                         $copyContext = $true
                     }
                     if ($ApplicationIntent) {
@@ -616,8 +616,8 @@ function Connect-DbaInstance {
                         Write-Message -Level Verbose -Message "Parameter NonPooledConnection passed in and we currently have a pooled connection, so we copy the connection context and set NonPooledConnection"
                         $copyContext = $true
                     }
-                    if (Test-Bound -Parameter StatementTimeout) {
-                        Write-Message -Level Verbose -Message "Parameter StatementTimeout passed in, so we copy the connection context and set the StatementTimeout"
+                    if (Test-Bound -Parameter StatementTimeout -and $inputObject.ConnectionContext.StatementTimeout -ne $StatementTimeout) {
+                        Write-Message -Level Verbose -Message "Parameter StatementTimeout passed in, and it's not the same as currently in ConnectionContext.StatementTimeout, so we copy the connection context and set the StatementTimeout"
                         $copyContext = $true
                     }
                     if ($copyContext) {
@@ -900,10 +900,8 @@ function Connect-DbaInstance {
                         Write-Message -Level Debug -Message "Setting ConnectionContext.SqlExecutionModes to '$SqlExecutionModes'"
                         $server.ConnectionContext.SqlExecutionModes = $SqlExecutionModes
                     }
-                    if ($null -ne $StatementTimeout) {
-                        Write-Message -Level Debug -Message "Setting ConnectionContext.StatementTimeout to '$StatementTimeout'"
-                        $server.ConnectionContext.StatementTimeout = $StatementTimeout
-                    }
+                    Write-Message -Level Debug -Message "Setting ConnectionContext.StatementTimeout to '$StatementTimeout'"
+                    $server.ConnectionContext.StatementTimeout = $StatementTimeout
                 }
 
                 $maskedConnString = Hide-ConnectionString $server.ConnectionContext.ConnectionString


### PR DESCRIPTION
As StatementTimeout is an integer variable with a default from an integer configuration - this can never be $null. So we always set this.
But to not copy connection context if not needed, added a test like for Database and NonPooledConnection. Then did that also with ApplicationIntent to have them all aligned.