### PR TITLE
Save-DbaKbUpdate - Using Architecture and some other fixes

### DIFF
--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -41,7 +41,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $results | Remove-Item -Confirm:$false
 
         # download multiple updates via piping
-        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All | Save-DbaKbUpdate -Path C:\temp
+        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path C:\temp
 
         # basic retry logic in case the first download didn't get all of the files
         if ($null -eq $results -or $results.Count -ne 2) {
@@ -50,7 +50,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
                 $results | Remove-Item -Confirm:$false
             }
             Start-Sleep -s 30
-            $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All | Save-DbaKbUpdate -Path C:\temp
+            $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Architecture All -Path C:\temp
         }
 
         $results.Count | Should -Be 2

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -15,17 +15,17 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 
 Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     It "downloads a small update" {
-        $results = Save-DbaKbUpdate -Name KB2992080 -Path C:\temp
+        $results = Save-DbaKbUpdate -Name KB2992080 -Architecture All -Path C:\temp
         $results.Name -match 'aspnet'
         $results | Remove-Item -Confirm:$false
     }
     It "supports piping" {
-        $results = Get-DbaKbUpdate -Name KB2992080 | select -First 1 | Save-DbaKbUpdate -Path C:\temp
+        $results = Get-DbaKbUpdate -Name KB2992080 | select -First 1 | Save-DbaKbUpdate -Architecture All -Path C:\temp
         $results.Name -match 'aspnet'
         $results | Remove-Item -Confirm:$false
     }
     It "Download multiple updates" {
-        $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Path C:\temp
+        $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path C:\temp
 
         # basic retry logic in case the first download didn't get all of the files
         if ($null -eq $results -or $results.Count -ne 2) {
@@ -34,14 +34,14 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
                 $results | Remove-Item -Confirm:$false
             }
             Start-Sleep -s 30
-            $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Path C:\temp
+            $results = Save-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All -Path C:\temp
         }
 
         $results.Count | Should -Be 2
         $results | Remove-Item -Confirm:$false
 
         # download multiple updates via piping
-        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Path C:\temp
+        $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All | Save-DbaKbUpdate -Path C:\temp
 
         # basic retry logic in case the first download didn't get all of the files
         if ($null -eq $results -or $results.Count -ne 2) {
@@ -50,7 +50,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
                 $results | Remove-Item -Confirm:$false
             }
             Start-Sleep -s 30
-            $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 | Save-DbaKbUpdate -Path C:\temp
+            $results = Get-DbaKbUpdate -Name KB2992080, KB4513696 -Architecture All | Save-DbaKbUpdate -Path C:\temp
         }
 
         $results.Count | Should -Be 2
@@ -61,7 +61,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     It "Ensuring that variable scope doesn't impact the command negatively" {
         $filter = "SQLServer*-KB-*x64*.exe"
 
-        $results = Save-DbaKbUpdate -Name KB4513696 -Path C:\temp
+        $results = Save-DbaKbUpdate -Name KB4513696 -Architecture All -Path C:\temp
         $results.Count | Should -Be 1
         $results | Remove-Item -Confirm:$false
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )

When downloading cumulative updates for SQL Server 2014 I noticed, that also the x86 files where downloaded.
Reason is that the filtering for Architecture was not working, as `$item in $InputObject.Link` was not a list of all files for the KB, but only a single file - with no chance to see the other files for that KB. So the "Could not find architecture match, downloading all" never worked here. Maybe worked before pipeline input from Get-DbaKbUpdate was enabled.
So I reduced the two loops into one - sorry, this makes the diff not very readable again.

I also found other issues with the tests and the way the filename was build.
