### PR TITLE
Connect-DbaInstance - Reorder changes when connection context is copied

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -596,9 +596,6 @@ function Connect-DbaInstance {
                     }
                     if ($copyContext) {
                         $connContext = $inputObject.ConnectionContext.Copy()
-                        if ($Database) {
-                            $connContext = $connContext.GetDatabaseConnection($Database)
-                        }
                         if ($ApplicationIntent) {
                             $connContext.ApplicationIntent = $ApplicationIntent
                         }
@@ -607,6 +604,9 @@ function Connect-DbaInstance {
                         }
                         if (Test-Bound -Parameter StatementTimeout) {
                             $connContext.StatementTimeout = $StatementTimeout
+                        }
+                        if ($Database) {
+                            $connContext = $connContext.GetDatabaseConnection($Database)
                         }
                         $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
                     } else {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7546 )

```
$connContext = $connContext.GetDatabaseConnection($Database)
```
opens the new connection and thus has to be the last change and not the first made in the copied connection context.