### PR TITLE
Convert-ConnectionString - remove old code syntax

### DIFF
--- a/internal/functions/Convert-ConnectionString.ps1
+++ b/internal/functions/Convert-ConnectionString.ps1
@@ -12,16 +12,13 @@ function Convert-ConnectionString {
     )
 
     foreach ($connstring in $ConnectionString) {
-        $array = $connstring.Split(';')
-        foreach ($item in $array) {
-            $connstring = $connstring.Replace("Application Intent", "ApplicationIntent")
-            $connstring = $connstring.Replace("Connect Retry Count", "ConnectRetryCount")
-            $connstring = $connstring.Replace("Connect Retry Interval", "ConnectRetryInterval")
-            $connstring = $connstring.Replace("Pool Blocking Period", "PoolBlockingPeriod")
-            $connstring = $connstring.Replace("Multiple Active Result Sets", "MultipleActiveResultSets")
-            $connstring = $connstring.Replace("Multiple Subnet Failover", "MultiSubnetFailover")
-            $connstring = $connstring.Replace("Trust Server Certificate", "TrustServerCertificate")
-        }
+        $connstring = $connstring.Replace("Application Intent", "ApplicationIntent")
+        $connstring = $connstring.Replace("Connect Retry Count", "ConnectRetryCount")
+        $connstring = $connstring.Replace("Connect Retry Interval", "ConnectRetryInterval")
+        $connstring = $connstring.Replace("Pool Blocking Period", "PoolBlockingPeriod")
+        $connstring = $connstring.Replace("Multiple Active Result Sets", "MultipleActiveResultSets")
+        $connstring = $connstring.Replace("Multiple Subnet Failover", "MultiSubnetFailover")
+        $connstring = $connstring.Replace("Trust Server Certificate", "TrustServerCertificate")
         $connstring
     }
 }


### PR DESCRIPTION
I created this using a loop then realized it wasn't needed, but then forgot to remove the iteration through an array