### PR TITLE
Invoke-DbaQuery - Accept Microsoft.Data.SqlClient.SqlParameter for SqlParameter

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -248,6 +248,7 @@
         'Get-DbaDbMailHistory',
         'Get-DbaDbView',
         'Remove-DbaDbView',
+        'New-DbaSqlParameter',
         'Get-DbaDbUdf',
         'Get-DbaDbPartitionFunction',
         'Get-DbaDbPartitionScheme',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -513,6 +513,7 @@ $script:xplat = @(
     'Get-DbaDbMailHistory',
     'Get-DbaDbView',
     'Remove-DbaDbView',
+    'New-DbaSqlParameter',
     'Get-DbaDbUdf',
     'Get-DbaDbPartitionFunction',
     'Get-DbaDbPartitionScheme',

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -38,7 +38,7 @@ function Invoke-DbaQuery {
         PSObject and PSObjectArray output introduces overhead but adds flexibility for working with results: https://forums.powershell.org/t/dealing-with-dbnull/2328/2
 
     .PARAMETER SqlParameters
-        Specifies a hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
+        Specifies a hashtable of parameters or output from New-DbaSqlParameter for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
 
     .PARAMETER AppendServerInstance
         If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.
@@ -135,8 +135,7 @@ function Invoke-DbaQuery {
         [Microsoft.SqlServer.Management.Smo.SqlSmoObject[]]$SqlObject,
         [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "PSObjectArray", "SingleValue")]
         [string]$As = "DataRow",
-        # do not cast -- we need this to accommodate different object types
-        $SqlParameters,
+        [psobject[]]$SqlParameters,
         [System.Data.CommandType]$CommandType = 'Text',
         [switch]$AppendServerInstance,
         [switch]$MessagesToOutput,

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -135,7 +135,8 @@ function Invoke-DbaQuery {
         [Microsoft.SqlServer.Management.Smo.SqlSmoObject[]]$SqlObject,
         [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "PSObjectArray", "SingleValue")]
         [string]$As = "DataRow",
-        [System.Collections.IDictionary]$SqlParameters,
+        # do not cast -- we need this to accommodate different object types
+        $SqlParameters,
         [System.Data.CommandType]$CommandType = 'Text',
         [switch]$AppendServerInstance,
         [switch]$MessagesToOutput,

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -37,7 +37,7 @@ function Invoke-DbaQuery {
 
         PSObject and PSObjectArray output introduces overhead but adds flexibility for working with results: https://forums.powershell.org/t/dealing-with-dbnull/2328/2
 
-    .PARAMETER SqlParameters
+    .PARAMETER SqlParameter
         Specifies a hashtable of parameters or output from New-DbaSqlParameter for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
 
     .PARAMETER AppendServerInstance
@@ -93,7 +93,7 @@ function Invoke-DbaQuery {
         Runs the sql commands stored in rebuild.sql against all accessible databases of the instances "server1", "server1\nordwind" and "server2"
 
     .EXAMPLE
-        PS C:\> Invoke-DbaQuery -SqlInstance . -Query 'SELECT * FROM users WHERE Givenname = @name' -SqlParameters @{ Name = "Maria" }
+        PS C:\> Invoke-DbaQuery -SqlInstance . -Query 'SELECT * FROM users WHERE Givenname = @name' -SqlParameter @{ Name = "Maria" }
 
         Executes a simple query against the users table using SQL Parameters.
         This avoids accidental SQL Injection and is the safest way to execute queries with dynamic content.
@@ -106,7 +106,7 @@ function Invoke-DbaQuery {
         Executes a query with ReadOnly application intent on aglistener1.
 
     .EXAMPLE
-        PS C:\> Invoke-DbaQuery -SqlInstance "server1" -Database tempdb -Query "Example_SP" -SqlParameters @{ Name = "Maria" } -CommandType StoredProcedure
+        PS C:\> Invoke-DbaQuery -SqlInstance "server1" -Database tempdb -Query "Example_SP" -SqlParameter @{ Name = "Maria" } -CommandType StoredProcedure
 
         Executes a stored procedure Example_SP using SQL Parameters
 
@@ -115,9 +115,16 @@ function Invoke-DbaQuery {
             "StartDate" = $startdate;
             "EndDate" = $enddate;
         };
-        PS C:\> Invoke-DbaQuery -SqlInstance "server1" -Database tempdb -Query "Example_SP" -SqlParameters $QueryParameters -CommandType StoredProcedure
+        PS C:\> Invoke-DbaQuery -SqlInstance "server1" -Database tempdb -Query "Example_SP" -SqlParameter $QueryParameters -CommandType StoredProcedure
 
         Executes a stored procedure Example_SP using multiple SQL Parameters
+
+    .EXAMPLE
+        PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
+        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        PS C:\> $output.Value
+
+        Creates an output parameter and uses it to invoke a stored procedure.
     #>
     [CmdletBinding(DefaultParameterSetName = "Query")]
     param (
@@ -138,7 +145,8 @@ function Invoke-DbaQuery {
         [Microsoft.SqlServer.Management.Smo.SqlSmoObject[]]$SqlObject,
         [ValidateSet("DataSet", "DataTable", "DataRow", "PSObject", "PSObjectArray", "SingleValue")]
         [string]$As = "DataRow",
-        [psobject[]]$SqlParameters,
+        [Alias("SqlParameters")]
+        [psobject[]]$SqlParameter,
         [System.Data.CommandType]$CommandType = 'Text',
         [switch]$AppendServerInstance,
         [switch]$MessagesToOutput,
@@ -156,8 +164,8 @@ function Invoke-DbaQuery {
             CommandType = $CommandType
         }
 
-        if (Test-Bound -ParameterName "SqlParameters") {
-            $splatInvokeDbaSqlAsync["SqlParameters"] = $SqlParameters
+        if (Test-Bound -ParameterName "SqlParameter") {
+            $splatInvokeDbaSqlAsync["SqlParameter"] = $SqlParameter
         }
         if (Test-Bound -ParameterName "AppendServerInstance") {
             $splatInvokeDbaSqlAsync["AppendServerInstance"] = $AppendServerInstance

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -161,7 +161,7 @@ function Invoke-DbaQuery {
 
         if ($PSBoundParameters.SqlParameter) {
             $first = $SqlParameter | Select-Object -First 1
-            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter.Count -gt 1)) {
+            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter -is [System.Collections.IDictionary[]])) {
                 Stop-Function -Message "SqlParameter only accepts a single hashtable or Microsoft.Data.SqlClient.SqlParameter"
                 return
             }

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -121,7 +121,7 @@ function Invoke-DbaQuery {
 
     .EXAMPLE
         PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameter $output
         PS C:\> $output.Value
 
         Creates an output parameter and uses it to invoke a stored procedure.

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -159,6 +159,14 @@ function Invoke-DbaQuery {
     begin {
         Write-Message -Level Debug -Message "Bound parameters: $($PSBoundParameters.Keys -join ", ")"
 
+        if ($PSBoundParameters.SqlParameter) {
+            $first = $SqlParameter | Select-Object -First 1
+            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter.Count -gt 1)) {
+                Stop-Function -Message "SqlParameter only accepts a single hashtable or Microsoft.Data.SqlClient.SqlParameter"
+                return
+            }
+        }
+
         $splatInvokeDbaSqlAsync = @{
             As          = $As
             CommandType = $CommandType

--- a/functions/New-DbaSqlParameter.ps1
+++ b/functions/New-DbaSqlParameter.ps1
@@ -91,7 +91,7 @@ function New-DbaSqlParameter {
 
     .EXAMPLE
         PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameter $output
         PS C:\> $output.Value
 
         Creates an output parameter and uses it to invoke a stored procedure.

--- a/functions/New-DbaSqlParameter.ps1
+++ b/functions/New-DbaSqlParameter.ps1
@@ -100,9 +100,7 @@ function New-DbaSqlParameter {
     param(
         [ValidateSet("None", "IgnoreCase", "IgnoreNonSpace", "IgnoreKanaType", "IgnoreWidth", "BinarySort2", "BinarySort")]
         [string]$CompareInfo,
-        [ValidateSet("AnsiString", "Binary", "Byte", "Boolean", "Currency", "Date", "DateTime", "Decimal", "Double", "Guid", "Int16", "Int32", "Int64", "Object,
-        SByte", "Single", "String", "Time", "UInt16", "UInt32", "UInt64", "VarNumeric", "AnsiStringFixedLength", "StringFixedLength", "Xml,
-        DateTime2", "DateTimeOffset")]
+        [ValidateSet("AnsiString", "Binary", "Byte", "Boolean", "Currency", "Date", "DateTime", "Decimal", "Double", "Guid", "Int16", "Int32", "Int64", "Object", "SByte", "Single", "String", "Time", "UInt16", "UInt32", "UInt64", "VarNumeric", "AnsiStringFixedLength", "StringFixedLength", "Xml", "DateTime2", "DateTimeOffset")]
         [string]$DbType,
         [ValidateSet("Input", "Output", "InputOutput", "ReturnValue")]
         [string]$Direction,
@@ -119,9 +117,7 @@ function New-DbaSqlParameter {
         [switch]$SourceColumnNullMapping,
         [ValidateSet("Original", "Current", "Proposed", "Default")]
         [string]$SourceVersion,
-        [ValidateSet("BigInt", "Binary", "Bit", "Char", "DateTime", "Decimal", "Float", "Image", "Int", "Money", "NChar", "NText", "NVarChar", "Real,
-        UniqueIdentifier", "SmallDateTime", "SmallInt", "SmallMoney", "Text", "Timestamp", "TinyInt", "VarBinary", "VarChar", "Variant", "Xml,
-        Udt", "Structured", "Date", "Time", "DateTime2", "DateTimeOffset")]
+        [ValidateSet("BigInt", "Binary", "Bit", "Char", "DateTime", "Decimal", "Float", "Image", "Int", "Money", "NChar", "NText", "NVarChar", "Real", "UniqueIdentifier", "SmallDateTime", "SmallInt", "SmallMoney", "Text", "Timestamp", "TinyInt", "VarBinary", "VarChar", "Variant", "Xml", "Udt", "Structured", "Date", "Time", "DateTime2", "DateTimeOffset")]
         [string]$SqlDbType,
         [string]$SqlValue,
         [string]$TypeName,

--- a/functions/New-DbaSqlParameter.ps1
+++ b/functions/New-DbaSqlParameter.ps1
@@ -69,6 +69,11 @@ function New-DbaSqlParameter {
     .PARAMETER Value
         Sets the value of the parameter.
 
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
     .NOTES
         Tags: Query
         Author: Chrissy LeMaire (@cl), netnerds.net
@@ -80,9 +85,11 @@ function New-DbaSqlParameter {
         https://dbatools.io/New-DbaSqlParameter
 
     .EXAMPLE
-        PS C:\> New-DbaSqlParameter -ParameterName ID -SqlDbType Int -Value 10
+        PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
+        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        PS C:\> $output.Value
 
-
+        No idea lol
     #>
     [CmdletBinding()]
     param(
@@ -98,6 +105,7 @@ function New-DbaSqlParameter {
         [switch]$IsNullable,
         [int]$LocaleId,
         [string]$Offset,
+        [Alias("Name")]
         [string]$ParameterName,
         [string]$Precision,
         [string]$Scale,
@@ -113,7 +121,8 @@ function New-DbaSqlParameter {
         [string]$SqlValue,
         [string]$TypeName,
         [string]$UdtTypeName,
-        [object]$Value
+        [object]$Value,
+        [switch]$EnableException
     )
     $param = New-Object Microsoft.Data.SqlClient.SqlParameter
 

--- a/functions/New-DbaSqlParameter.ps1
+++ b/functions/New-DbaSqlParameter.ps1
@@ -85,11 +85,16 @@ function New-DbaSqlParameter {
         https://dbatools.io/New-DbaSqlParameter
 
     .EXAMPLE
+        PS C:\> New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
+
+        Creates a SqlParameter object that can be used with Invoke-DbaQuery
+
+    .EXAMPLE
         PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
         PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         PS C:\> $output.Value
 
-        No idea lol
+        Creates an output parameter and uses it to invoke a stored procedure.
     #>
     [CmdletBinding()]
     param(

--- a/functions/New-DbaSqlParameter.ps1
+++ b/functions/New-DbaSqlParameter.ps1
@@ -1,0 +1,201 @@
+function New-DbaSqlParameter {
+    <#
+    .SYNOPSIS
+        Creates a new SQL parameter.
+
+    .DESCRIPTION
+        Creates a new SQL parameter.
+
+    .PARAMETER CompareInfo
+        Sets the CompareInfo object that defines how string comparisons should be performed for this parameter.
+
+    .PARAMETER DbType
+        Sets the SqlDbType of the parameter.
+
+    .PARAMETER Direction
+        Sets a value that indicates whether the parameter is input-only, output-only, bidirectional, or a stored procedure return value parameter.
+
+    .PARAMETER ForceColumnEncryption
+        Enforces encryption of a parameter when using Always Encrypted.
+
+        If SQL Server informs the driver that the parameter does not need to be encrypted, the query using the parameter will fail.
+
+        This property provides additional protection against security attacks that involve a compromised SQL Server providing incorrect encryption metadata to the client, which may lead to data disclosure.
+
+    .PARAMETER IsNullable
+        Sets a value that indicates whether the parameter accepts null values.
+
+        IsNullable is not used to validate the parameter's value and will not prevent sending or receiving a null value when executing a command.
+
+    .PARAMETER LocaleId
+        Sets the locale identifier that determines conventions and language for a particular region.
+
+    .PARAMETER Offset
+        Sets the offset to the Value property.
+
+    .PARAMETER ParameterName
+        Sets the name of the SqlParameter.
+
+    .PARAMETER Precision
+        Sets the maximum number of digits used to represent the Value property.
+
+    .PARAMETER Scale
+        Sets the number of decimal places to which Value is resolved.
+
+    .PARAMETER Size
+        Sets the maximum size, in bytes, of the data within the column.
+
+    .PARAMETER SourceColumn
+        Sets the name of the source column mapped to the DataSet and used for loading or returning the Value.
+
+    .PARAMETER SourceColumnNullMapping
+        Sets a value which indicates whether the source column is nullable. This allows SqlCommandBuilder to correctly generate Update statements for nullable columns.
+
+    .PARAMETER SourceVersion
+        Sets the DataRowVersion to use when you load Value.
+
+    .PARAMETER SqlDbType
+        Sets the SqlDbType of the parameter.
+
+    .PARAMETER SqlValue
+        Sets the value of the parameter as an SQL type.
+
+    .PARAMETER TypeName
+        Sets the type name for a table-valued parameter.
+
+    .PARAMETER UdtTypeName
+        Sets a string that represents a user-defined type as a parameter.
+
+    .PARAMETER Value
+        Sets the value of the parameter.
+
+    .NOTES
+        Tags: Query
+        Author: Chrissy LeMaire (@cl), netnerds.net
+        Website: https://dbatools.io
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/New-DbaSqlParameter
+
+    .EXAMPLE
+        PS C:\> New-DbaSqlParameter -ParameterName ID -SqlDbType Int -Value 10
+
+
+    #>
+    [CmdletBinding()]
+    param(
+        [ValidateSet("None", "IgnoreCase", "IgnoreNonSpace", "IgnoreKanaType", "IgnoreWidth", "BinarySort2", "BinarySort")]
+        [string]$CompareInfo,
+        [ValidateSet("AnsiString", "Binary", "Byte", "Boolean", "Currency", "Date", "DateTime", "Decimal", "Double", "Guid", "Int16", "Int32", "Int64", "Object,
+        SByte", "Single", "String", "Time", "UInt16", "UInt32", "UInt64", "VarNumeric", "AnsiStringFixedLength", "StringFixedLength", "Xml,
+        DateTime2", "DateTimeOffset")]
+        [string]$DbType,
+        [ValidateSet("Input", "Output", "InputOutput", "ReturnValue")]
+        [string]$Direction,
+        [switch]$ForceColumnEncryption,
+        [switch]$IsNullable,
+        [int]$LocaleId,
+        [string]$Offset,
+        [string]$ParameterName,
+        [string]$Precision,
+        [string]$Scale,
+        [int]$Size,
+        [string]$SourceColumn,
+        [switch]$SourceColumnNullMapping,
+        [ValidateSet("Original", "Current", "Proposed", "Default")]
+        [string]$SourceVersion,
+        [ValidateSet("BigInt", "Binary", "Bit", "Char", "DateTime", "Decimal", "Float", "Image", "Int", "Money", "NChar", "NText", "NVarChar", "Real,
+        UniqueIdentifier", "SmallDateTime", "SmallInt", "SmallMoney", "Text", "Timestamp", "TinyInt", "VarBinary", "VarChar", "Variant", "Xml,
+        Udt", "Structured", "Date", "Time", "DateTime2", "DateTimeOffset")]
+        [string]$SqlDbType,
+        [string]$SqlValue,
+        [string]$TypeName,
+        [string]$UdtTypeName,
+        [object]$Value
+    )
+    $param = New-Object Microsoft.Data.SqlClient.SqlParameter
+
+    try {
+        if ($PSBoundParameters.CompareInfo) {
+            $param.CompareInfo = $CompareInfo
+        }
+
+        if ($PSBoundParameters.DbType) {
+            $param.DbType = $DbType
+        }
+
+        if ($PSBoundParameters.Direction) {
+            $param.Direction = $Direction
+        }
+
+        if ($PSBoundParameters.ForceColumnEncryption) {
+            $param.ForceColumnEncryption = $ForceColumnEncryption
+        }
+
+        if ($PSBoundParameters.IsNullable) {
+            $param.IsNullable = $IsNullable
+        }
+
+        if ($PSBoundParameters.LocaleId) {
+            $param.LocaleId = $LocaleId
+        }
+
+        if ($PSBoundParameters.Offset) {
+            $param.Offset = $Offset
+        }
+
+        if ($PSBoundParameters.ParameterName) {
+            $param.ParameterName = $ParameterName
+        }
+
+        if ($PSBoundParameters.Precision) {
+            $param.Precision = $Precision
+        }
+
+        if ($PSBoundParameters.Scale) {
+            $param.Scale = $Scale
+        }
+
+        if ($PSBoundParameters.Size) {
+            $param.Size = $Size
+        }
+
+        if ($PSBoundParameters.SourceColumn) {
+            $param.SourceColumn = $SourceColumn
+        }
+
+        if ($PSBoundParameters.SourceColumnNullMapping) {
+            $param.SourceColumnNullMapping = $SourceColumnNullMapping
+        }
+
+        if ($PSBoundParameters.SourceVersion) {
+            $param.SourceVersion = $SourceVersion
+        }
+
+        if ($PSBoundParameters.SqlDbType) {
+            $param.SqlDbType = $SqlDbType
+        }
+
+        if ($PSBoundParameters.SqlValue) {
+            $param.SqlValue = $SqlValue
+        }
+
+        if ($PSBoundParameters.TypeName) {
+            $param.TypeName = $TypeName
+        }
+
+        if ($PSBoundParameters.UdtTypeName) {
+            $param.UdtTypeName = $UdtTypeName
+        }
+
+        if ($PSBoundParameters.Value) {
+            $param.Value = $Value
+        }
+        $param
+    } catch {
+        Stop-Function -Message "Failure" -ErrorRecord $_
+        return
+    }
+}

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -73,6 +73,13 @@ function Invoke-DbaAsync {
     )
 
     begin {
+        if ($PSBoundParameters.SqlParameter) {
+            $first = $SqlParameter | Select-Object -First 1
+            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter.Count -gt 1)) {
+                Stop-Function -Message "SqlParameter only accepts a single hashtable or Microsoft.Data.SqlClient.SqlParameter"
+                return
+            }
+        }
         function Resolve-SqlError {
             param($Err)
             if ($Err) {
@@ -157,6 +164,7 @@ function Invoke-DbaAsync {
 
     }
     process {
+        if (Test-FunctionInterrupt) { return }
         $Conn = $SQLConnection.SqlConnectionObject
 
 

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -25,10 +25,8 @@ function Invoke-DbaAsync {
 
             PSObject and PSObjectArray output introduces overhead but adds flexibility for working with results: http://powershell.org/wp/forums/topic/dealing-with-dbnull/
 
-        .PARAMETER SqlParameters
-            Specifies a hashtable of parameters for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
-
-            Example:
+        .PARAMETER SqlParameter
+            Specifies a hashtable of parameters or output from New-DbaSqlParameter for parameterized SQL queries.  http://blog.codinghorror.com/give-me-parameterized-sql-or-give-me-death/
 
         .PARAMETER AppendServerInstance
             If this switch is enabled, the SQL Server instance will be appended to PSObject and DataRow output.

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -57,7 +57,7 @@ function Invoke-DbaAsync {
         [string]
         $As = "DataRow",
 
-        [psobject[]]$SqlParameters,
+        [psobject[]]$SqlParameter,
 
         [System.Data.CommandType]
         $CommandType = 'Text',
@@ -171,13 +171,13 @@ function Invoke-DbaAsync {
             $cmd.CommandType = $CommandType
             $cmd.CommandTimeout = $QueryTimeout
 
-            if ($null -ne $SqlParameters) {
-                if (($SqlParameters | Select-Object -First 1) -is [Microsoft.Data.SqlClient.SqlParameter]) {
-                    foreach ($sqlparam in $SqlParameters) {
+            if ($null -ne $SqlParameter) {
+                if (($SqlParameter | Select-Object -First 1) -is [Microsoft.Data.SqlClient.SqlParameter]) {
+                    foreach ($sqlparam in $SqlParameter) {
                         $null = $cmd.Parameters.Add($sqlparam)
                     }
                 } else {
-                    ($SqlParameters | Select-Object -First 1).GetEnumerator() | ForEach-Object {
+                    ($SqlParameter | Select-Object -First 1).GetEnumerator() | ForEach-Object {
                         if ($null -ne $_.Value) {
                             $cmd.Parameters.AddWithValue($_.Key, $_.Value)
                         } else {

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -57,6 +57,7 @@ function Invoke-DbaAsync {
         [string]
         $As = "DataRow",
 
+        [Alias("SqlParameters")]
         [psobject[]]$SqlParameter,
 
         [System.Data.CommandType]

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -57,7 +57,7 @@ function Invoke-DbaAsync {
         [string]
         $As = "DataRow",
 
-        $SqlParameters,
+        [psobject[]]$SqlParameters,
 
         [System.Data.CommandType]
         $CommandType = 'Text',
@@ -172,12 +172,12 @@ function Invoke-DbaAsync {
             $cmd.CommandTimeout = $QueryTimeout
 
             if ($null -ne $SqlParameters) {
-                if ($SqlParameters | Get-Member -Type Method ResetSqlDbType) {
-                    foreach ($sqlparm in $SqlParameters) {
-                        $null = $cmd.Parameters.Add($sqlparm)
+                if (($SqlParameters | Select-Object -First 1) -is [Microsoft.Data.SqlClient.SqlParameter]) {
+                    foreach ($sqlparam in $SqlParameters) {
+                        $null = $cmd.Parameters.Add($sqlparam)
                     }
                 } else {
-                    $SqlParameters.GetEnumerator() | ForEach-Object {
+                    ($SqlParameters | Select-Object -First 1).GetEnumerator() | ForEach-Object {
                         if ($null -ne $_.Value) {
                             $cmd.Parameters.AddWithValue($_.Key, $_.Value)
                         } else {

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -75,7 +75,7 @@ function Invoke-DbaAsync {
     begin {
         if ($PSBoundParameters.SqlParameter) {
             $first = $SqlParameter | Select-Object -First 1
-            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter.Count -gt 1)) {
+            if ($first -isnot [Microsoft.Data.SqlClient.SqlParameter] -and ($first -isnot [System.Collections.IDictionary] -or $SqlParameter -is [System.Collections.IDictionary[]])) {
                 Stop-Function -Message "SqlParameter only accepts a single hashtable or Microsoft.Data.SqlClient.SqlParameter"
                 return
             }

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -186,7 +186,11 @@ function Invoke-DbaAsync {
                 } else {
                     ($SqlParameter | Select-Object -First 1).GetEnumerator() | ForEach-Object {
                         if ($null -ne $_.Value) {
-                            $cmd.Parameters.AddWithValue($_.Key, $_.Value)
+                            if (($_.Value -is [Microsoft.Data.SqlClient.SqlParameter])) {
+                                $cmd.Parameters.Add($_.Value)
+                            } else {
+                                $cmd.Parameters.AddWithValue($_.Key, $_.Value)
+                            }
                         } else {
                             $cmd.Parameters.AddWithValue($_.Key, [DBNull]::Value)
                         }

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Query', 'QueryTimeout', 'File', 'SqlObject', 'As', 'SqlParameters', 'AppendServerInstance', 'MessagesToOutput', 'InputObject', 'ReadOnly', 'EnableException', 'CommandType'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Database', 'Query', 'QueryTimeout', 'File', 'SqlObject', 'As', 'SqlParameter', 'AppendServerInstance', 'MessagesToOutput', 'InputObject', 'ReadOnly', 'EnableException', 'CommandType'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -26,6 +26,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     AfterAll {
         try {
             $null = $db.Query("DROP PROCEDURE dbo.dbatoolsci_procedure_example")
+            $null = $db.Query("DROP PROCEDURE dbo.my_proc")
         } catch {
             $null = 1
         }

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -226,7 +226,7 @@ SELECT @@servername as dbname
                 );
                 END"
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        Invoke-DbaQuery -SqlInstance localhost -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'
     }
 }

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -226,7 +226,7 @@ SELECT @@servername as dbname
                 );
                 END"
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        Invoke-DbaQuery -SqlInstance localhost -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'
     }
 }

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -32,7 +32,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $null = 1
         }
     }
-    It "supports using SqlParameters as Microsoft.Data.SqlClient.SqlParameter (#7434)" {
+    It "creates a usable sql parameter" {
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
         Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -34,7 +34,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     It "creates a usable sql parameter" {
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        Invoke-DbaQuery -SqlInstance localhost -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'
     }
 }

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -27,7 +27,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     AfterAll {
         try {
-            $null = $db.Query("DROP PROCEDURE dbo.my_proc")
+            $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "DROP PROCEDURE dbo.my_proc"
         } catch {
             $null = 1
         }

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -1,0 +1,40 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'CompareInfo', 'DbType', 'Direction', 'ForceColumnEncryption', 'IsNullable', 'LocaleId', 'Offset', 'ParameterName', 'Precision', 'Scale', 'Size', 'SourceColumn', 'SourceColumnNullMapping', 'SourceVersion', 'SqlDbType', 'SqlValue', 'TypeName', 'UdtTypeName', 'Value', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
+    BeforeAll {
+        $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "CREATE OR ALTER PROC [dbo].[my_proc]
+        @json_result nvarchar(max) output
+            AS
+            BEGIN
+            set @json_result = (
+                select 'sample' as 'example'
+                for json path, without_array_wrapper
+            );
+            END"
+    }
+    AfterAll {
+        try {
+            $null = $db.Query("DROP PROCEDURE dbo.my_proc")
+        } catch {
+            $null = 1
+        }
+    }
+    It "supports using SqlParameters as Microsoft.Data.SqlClient.SqlParameter (#7434)" {
+        $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
+        Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        $output.Value | Should -Be '{"example":"sample"}'
+    }
+}

--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -34,7 +34,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     }
     It "creates a usable sql parameter" {
         $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
-        Invoke-DbaQuery -SqlInstance localhost -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
+        Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be '{"example":"sample"}'
     }
 }

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -55,7 +55,9 @@ $TestsRunGroups = @{
         'Get-DbaDbMasterKey',
         'Get-DbaPermission',
         'Test-DbaManagementObject',
-        'Export-DbaDacPackage'
+        'Export-DbaDacPackage',
+        'New-DbaDbTransfer',
+        'Remove-DbaAgDatabase'
     )
     # do not run everywhere
     "disabled"          = @()

--- a/tests/pester.groups.ps1
+++ b/tests/pester.groups.ps1
@@ -57,7 +57,8 @@ $TestsRunGroups = @{
         'Test-DbaManagementObject',
         'Export-DbaDacPackage',
         'New-DbaDbTransfer',
-        'Remove-DbaAgDatabase'
+        'Remove-DbaAgDatabase',
+        'New-DbaDbTable'
     )
     # do not run everywhere
     "disabled"          = @()


### PR DESCRIPTION
## Type of Change
 - [x] New feature (non-breaking change, adds functionality, fixes #7434 )

* Now accepts both hashtables and Microsoft.Data.SqlClient.SqlParameter
* Created new command to make creating SqlParameters easier
* Changed and aliased SqlParameter since it was plural and PowerShell best practices says singular

@i7slegend if you can confirm that this is what you were asking for, I'd appreciate. I don't use Invoke-DbaQuery much and minimally tested

```powershell
$output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $output
$output.Value
```


```powershell
$output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
$hash = @{ whatever = $output }
Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameters $hash
$output.Value
```