### PR TITLE
Restore-DbaDatabase - Fix SMO refresh

### DIFF
--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -747,8 +747,8 @@ function Restore-DbaDatabase {
                 Restore-DbaDatabase -SqlInstance $RestoreInstance -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
             }
             # refresh the SMO as we probably used T-SQL, but only if we already got a SMO
-            if ($SqlInstance -is [Microsoft.SqlServer.Management.Smo.Server]) {
-                $SqlInstance.Databases.Refresh()
+            if ($SqlInstance.InputObject -is [Microsoft.SqlServer.Management.Smo.Server]) {
+                $SqlInstance.InputObject.Databases.Refresh()
             }
         }
     }

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -747,8 +747,8 @@ function Restore-DbaDatabase {
                 Restore-DbaDatabase -SqlInstance $RestoreInstance -Recover -DatabaseName $DatabaseName -OutputScriptOnly:$OutputScriptOnly
             }
             # refresh the SMO as we probably used T-SQL, but only if we already got a SMO
-            if ($RestoreInstance.Equals($SqlInstance)) {
-                $RestoreInstance.Databases.Refresh()
+            if ($SqlInstance -is [Microsoft.SqlServer.Management.Smo.Server]) {
+                $SqlInstance.Databases.Refresh()
             }
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change )

As the connection context might have been changed by Connect-DbaInstance, `.Equals` does not work here in any cases.
So be better test for the type, that works.
And we refresh the original input object.