### PR TITLE
Invoke-DbaQuery, added regr tests and TVP examples

### DIFF
--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -120,6 +120,22 @@ function Invoke-DbaQuery {
         Executes a stored procedure Example_SP using multiple SQL Parameters
 
     .EXAMPLE
+        PS C:\> $inparam = @()
+        PS C:\> $inparam += [pscustomobject]@{
+        >>     somestring = 'string1'
+        >>     somedate = '2021-07-15T01:02:00'
+        >> }
+        PS C:\> $inparam += [pscustomobject]@{
+        >>     somestring = 'string2'
+        >>     somedate = '2021-07-15T02:03:00'
+        >> }
+        >> $inparamAsDataTable = ConvertTo-DbaDataTable -InputObject $inparam
+        PS C:\> New-DbaSqlParameter -SqlDbType structured -Value $inparamAsDataTable -TypeName 'dbatools_tabletype'
+        PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameter $inparamAsDataTable
+
+        Creates an TVP input parameter and uses it to invoke a stored procedure.
+
+    .EXAMPLE
         PS C:\> $output = New-DbaSqlParameter -ParameterName json_result -SqlDbType NVarChar -Size -1 -Direction Output
         PS C:\> Invoke-DbaQuery -SqlInstance localhost -Database master -CommandType StoredProcedure -Query my_proc -SqlParameter $output
         PS C:\> $output.Value

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -187,6 +187,9 @@ function Invoke-DbaAsync {
                     ($SqlParameter | Select-Object -First 1).GetEnumerator() | ForEach-Object {
                         if ($null -ne $_.Value) {
                             if (($_.Value -is [Microsoft.Data.SqlClient.SqlParameter])) {
+                                if ($_.Value.ParameterName -ne $_.Key) {
+                                    $_.Value.ParameterName = $_.Key
+                                }
                                 $cmd.Parameters.Add($_.Value)
                             } else {
                                 $cmd.Parameters.AddWithValue($_.Key, $_.Value)

--- a/tests/Invoke-DbaQuery.Tests.ps1
+++ b/tests/Invoke-DbaQuery.Tests.ps1
@@ -238,7 +238,7 @@ SELECT @@servername as dbname
         AS
         BEGIN
             SELECT 'fixedval' as somevalue, @somevalue as 'input param'
-            SELECT @newid = select '12345'
+            SELECT @newid = '12345'
         END"
         $outparam = New-DbaSqlParameter -Direction Output -Size -1
         $sqlparams = @{
@@ -253,12 +253,14 @@ SELECT @@servername as dbname
 
     It "supports complex types, such as datatables (#7434)" {
         $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database tempdb -Query "
+IF NOT EXISTS (SELECT * FROM sys.types WHERE name = N'dbatools_tabletype')
 CREATE TYPE dbatools_tabletype AS TABLE(
     somestring varchar(50),
     somedate datetime2(7)
-);
+)
+GO
 CREATE OR ALTER PROCEDURE usp_Insertsomething
-    @sometable varchar(10),
+    @sometable dbatools_tabletype READONLY,
     @newid varchar(50) OUTPUT
 AS
 BEGIN
@@ -284,6 +286,5 @@ END"
         $result.Count | Should -Be 2
         $result[0].somestring | Should -Be 'string1'
         (Get-Date -Date $result[1].somedate -f 'yyyy-MM-ddTHH:mm:ss') | Should -Be '2021-07-15T02:03:00'
-        $result.somevalue | Should -Be 'fixedval'
     }
 }

--- a/tests/appveyor.common.ps1
+++ b/tests/appveyor.common.ps1
@@ -206,5 +206,5 @@ function Get-AllTestsIndications($Path, $ModuleBase) {
     }
     # add dbatools.Tests.ps1 always
     $evaluated["$ModuleBase\tests\dbatools.Tests.ps1"] = 1
-    $evaluated.Keys
+    Get-Item $evaluated.GetEnumerator().Name
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [x] Unit test is included
 - [x] Documentation
 - [ ] Build system


### Purpose
Fixed a mishap for people used to hashtables for params (also, saved from the obligation of using -ParameterName in that case)
Added an example for TVP

### Approach
When hashtables are used, name is set in stone, so we use that to set (or alter) the ParameterName

### Commands to test
Added regr tests at the bottom.

NB: quick and dirty edit from Notepad++, may the gods of appveyor have mercy on me