### PR TITLE
Remove SSIS Commands - Incompatible SMO version

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -531,13 +531,13 @@
         # noncoresmo
         # SMO issues
         'Export-DbaUser',
-        'Get-DbaSsisExecutionHistory',
+        #'Get-DbaSsisExecutionHistory',
         'Get-DbaRepDistributor',
         'Copy-DbaPolicyManagement',
         'Copy-DbaDataCollector',
-        'Copy-DbaSsisCatalog',
-        'New-DbaSsisCatalog',
-        'Get-DbaSsisEnvironmentVariable',
+        #'Copy-DbaSsisCatalog',
+        #'New-DbaSsisCatalog',
+        #'Get-DbaSsisEnvironmentVariable',
         'Get-DbaPbmCategory',
         'Get-DbaPbmCategorySubscription',
         'Get-DbaPbmCondition',


### PR DESCRIPTION
fixes #7553

Seems these have not been doable for a while -- the DLLs were not even loaded. Ultimately, these commands were always problematic because of the DLLs. Just commenting them out until... later? Unsure when they'll be ported to the new SMO. 

