### PR TITLE
New-DbaAvailabilityGroup - Refresh AvailabilityGroup information in SMO after join

### DIFF
--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -591,6 +591,7 @@ function New-DbaAvailabilityGroup {
                 } catch {
                     Stop-Function -Message "Failure" -ErrorRecord $_ -Target $second -Continue
                 }
+                $second.AvailabilityGroups.Refresh()
             }
         }
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7574 )

Because the SMO generated by New-DbaAvailabilityGroup is reused with Add-DbaAgDatabase and thus Test-DbaAvailabilityGroup, an up to date status of the SMO is important.