### PR TITLE
Get-DbaDbBackupHistory - Avoid a .ToString() that pollutes $error

### DIFF
--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -331,7 +331,9 @@ function Get-DbaDbBackupHistory {
                             Write-Message -Level Verbose -Message "No Diff found"
                         }
                         try {
-                            [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
+                            if ($fullDb.FirstLsn) {
+                                [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
+                            }
                         } catch {
                             continue
                         }
@@ -391,7 +393,7 @@ function Get-DbaDbBackupHistory {
                             if (-not $LastFull) {
                                 Write-Message -Message "Found backups from multiple recovery forks for $($db.name) on $($server.name), this may affect your results" -Level Warning
                                 foreach ($result in $results) {
-                                    Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.database_name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)"   -Level Warning
+                                    Write-Message -Message "Between $($result.MinDate)/$($result.FirstLsn) and $($result.MaxDate)/$($result.FinalLsn) $($result.database_name) was on Recovery Fork GUID $($result.RecFork) ($($result.backupcount) backups)" -Level Warning
                                 }
                             }
                         }

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -333,6 +333,8 @@ function Get-DbaDbBackupHistory {
                         try {
                             if ($fullDb.FirstLsn) {
                                 [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
+                            } else {
+                                [bigint]$tlogStartDsn = 0
                             }
                         } catch {
                             continue


### PR DESCRIPTION
Found this while cleaning up Linux paths but wanted to make it its own PR since the command is so important