### PR TITLE
Get-DbaBackupInformation - Add Size to FileList

### DIFF
--- a/functions/Get-DbaBackupInformation.ps1
+++ b/functions/Get-DbaBackupInformation.ps1
@@ -319,7 +319,10 @@ function Get-DbaBackupInformation {
                 $historyObject.End = [DateTime]$group.Group[0].BackupFinishDate
                 $historyObject.Duration = ([DateTime]$group.Group[0].BackupFinishDate - [DateTime]$group.Group[0].BackupStartDate)
                 $historyObject.Path = [string[]]$group.Group.BackupPath
-                $historyObject.FileList = ($group.Group.FileList | Select-Object Type, LogicalName, PhysicalName -Unique)
+                $historyObject.FileList = ($group.Group.FileList | Select-Object Type, LogicalName, PhysicalName, @{
+                        Name       = "Size"
+                        Expression = { [dbasize]$PSItem.Size }
+                    } -Unique)
                 $historyObject.TotalSize = ($group.Group.BackupSize.Byte | Measure-Object -Sum).Sum
                 $HistoryObject.CompressedBackupSize = ($group.Group.CompressedBackupSize.Byte | Measure-Object -Sum).Sum
                 $historyObject.Type = $description


### PR DESCRIPTION
## Type of Change
 - [X] New feature (non-breaking change, adds functionality, fixes #7380)

Adds a `[dbasize]` Size column to Get-DbaBackupInformation

The dbasize type gives you a ton of info
```
Get-DbaBackupInformation -SqlInstance localhost -Path C:\temp\msdb_202105230949.bak | Select -ExpandProperty FileList -First 1 | Select -ExpandProperty Size                                                                                                                                                                                           Byte     : 18743296                                                                       Kilobyte : 18304                                                                          Megabyte : 17.875                                                                         Gigabyte : 0.0174560546875                                                                Terabyte : 1.70469284057617E-05
Digits   : 2
Style    : Dynamic

Byte     : 2883584
Kilobyte : 2816
Megabyte : 2.75
Gigabyte : 0.002685546875
Terabyte : 2.62260437011719E-06
Digits   : 2
Style    : Dynamic
```
You can also do

```
 (Get-DbaBackupInformation -SqlInstance localhost -Path C:\temp\msdb_202105230949.bak).FileList.Size.Kilobyte
```