### PR TITLE
Connect-DbaInstance -- add MultiSubnetFailover config

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -703,16 +703,16 @@ function Connect-DbaInstance {
 
                     #AdditionalParameters   Property   string AdditionalParameters {get;set;}
                     if ($AppendConnectionString) {
-                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';$AppendConnectionString'"
-                        $sqlConnectionInfo.AdditionalParameters += "$AppendConnectionString"
+                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by '$AppendConnectionString;'"
+                        $sqlConnectionInfo.AdditionalParameters += "$AppendConnectionString;"
                     }
                     if ($FailoverPartner) {
-                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';FailoverPartner=$FailoverPartner'"
-                        $sqlConnectionInfo.AdditionalParameters += "FailoverPartner=$FailoverPartner"
+                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by 'FailoverPartner=$FailoverPartner;'"
+                        $sqlConnectionInfo.AdditionalParameters += "FailoverPartner=$FailoverPartner;"
                     }
                     if ($MultiSubnetFailover) {
-                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';MultiSubnetFailover=True'"
-                        $sqlConnectionInfo.AdditionalParameters += 'MultiSubnetFailover=True'
+                        Write-Message -Level Debug -Message "AdditionalParameters will be appended by 'MultiSubnetFailover=True;'"
+                        $sqlConnectionInfo.AdditionalParameters += 'MultiSubnetFailover=True;'
                     }
 
                     #ApplicationIntent      Property   string ApplicationIntent {get;set;}

--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -294,7 +294,7 @@ function Connect-DbaInstance {
         [int]$MinPoolSize,
         [int]$MinimumVersion,
         [switch]$MultipleActiveResultSets,
-        [switch]$MultiSubnetFailover,
+        [switch]$MultiSubnetFailover = (Get-DbatoolsConfigValue -FullName 'sql.connection.multisubnetfailover'),
         [ValidateSet('TcpIp', 'NamedPipes', 'Multiprotocol', 'AppleTalk', 'BanyanVines', 'Via', 'SharedMemory', 'NWLinkIpxSpx')]
         [string]$NetworkProtocol = (Get-DbatoolsConfigValue -FullName 'sql.connection.protocol'),
         [switch]$NonPooledConnection,
@@ -704,15 +704,15 @@ function Connect-DbaInstance {
                     #AdditionalParameters   Property   string AdditionalParameters {get;set;}
                     if ($AppendConnectionString) {
                         Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';$AppendConnectionString'"
-                        $sqlConnectionInfo.AdditionalParameters += ";$AppendConnectionString"
+                        $sqlConnectionInfo.AdditionalParameters += "$AppendConnectionString"
                     }
                     if ($FailoverPartner) {
                         Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';FailoverPartner=$FailoverPartner'"
-                        $sqlConnectionInfo.AdditionalParameters += ";FailoverPartner=$FailoverPartner"
+                        $sqlConnectionInfo.AdditionalParameters += "FailoverPartner=$FailoverPartner"
                     }
                     if ($MultiSubnetFailover) {
                         Write-Message -Level Debug -Message "AdditionalParameters will be appended by ';MultiSubnetFailover=True'"
-                        $sqlConnectionInfo.AdditionalParameters += ';MultiSubnetFailover=True'
+                        $sqlConnectionInfo.AdditionalParameters += 'MultiSubnetFailover=True'
                     }
 
                     #ApplicationIntent      Property   string ApplicationIntent {get;set;}

--- a/internal/configurations/settings/sql.ps1
+++ b/internal/configurations/settings/sql.ps1
@@ -10,6 +10,9 @@ Set-DbatoolsConfig -FullName 'sql.connection.packetsize' -Value 4096 -Initialize
 # The default network protocol for all connections unless otherwise specified
 Set-DbatoolsConfig -FullName 'sql.connection.protocol' -Value $null -Initialize -Validation string -Handler { } -Description "Network protocol"
 
+# Sets connect to use MultiSubnetFailover each time
+Set-DbatoolsConfig -FullName 'sql.connection.multisubnetfailover' -Value $false -Initialize -Validation bool -Handler { } -Description "Use MultiSubnetFailover by default"
+
 # How long to wait for results
 Set-DbatoolsConfig -FullName 'sql.execution.timeout' -Value 0 -Initialize -Validation integer -Handler { } -Description "Statement timeout"
 


### PR DESCRIPTION
## Type of Change
 - [x] New feature (non-breaking change, adds functionality, fixes #6454)

Enables the ability to use `MultiSubnetFailover` for every connect

For just the current session:
`Set-DbatoolsConfig -FullName sql.connection.multisubnetfailover -Value $true`

For all sessions ever (or until it's changed back to false)
`Set-DbatoolsConfig -FullName sql.connection.multisubnetfailover -Value $true -Register`

Back to default:
`Set-DbatoolsConfig -FullName sql.connection.multisubnetfailover -Value $false -Register`

While I was in the code, I noticed that `AdditionalParameters` needs a semicolon suffix, not prefix

Before:
![image](https://user-images.githubusercontent.com/8278033/127242626-fee1d089-0e51-4419-b004-ae0b9ce85c4e.png)

After:
![image](https://user-images.githubusercontent.com/8278033/127242713-756ef13c-6f5f-457c-8908-e8484cfeee52.png)
