### PR TITLE
Update-DbaServiceAccount - Allow for not restarting services

### DIFF
--- a/tests/Update-DbaServiceAccount.Tests.ps1
+++ b/tests/Update-DbaServiceAccount.Tests.ps1
@@ -6,7 +6,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'InputObject', 'ServiceName', 'Username', 'ServiceCredential', 'PreviousPassword', 'SecurePassword', 'EnableException'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'InputObject', 'ServiceName', 'Username', 'ServiceCredential', 'PreviousPassword', 'SecurePassword', 'NoRestart', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0


### PR DESCRIPTION
## Type of Change
 - [x] New feature (non-breaking change, adds functionality, fixes #6853)


Adds a new `-NoRestart` switch, with examples and warnings.