### PR TITLE
dbatools config: add ability to disable elevation requirement

### DIFF
--- a/internal/configurations/settings/commands.ps1
+++ b/internal/configurations/settings/commands.ps1
@@ -13,3 +13,6 @@ Set-DbatoolsConfig -FullName 'commands.get-dbaregserver.includelocal' -Value $fa
 
 # Initialize-CredSSP
 Set-DbatoolsConfig -FullName 'commands.initialize-credssp.bypass' -Value $false -Initialize -Validation bool -Description "Do not attempt to configure CredSSP authentication, use existing configuration as-is"
+
+# Test-ElevationRequirement
+Set-DbatoolsConfig -FullName 'commands.test-elevationrequirement.disable' -Value $false -Initialize -Validation bool -Description "Disable elevation (run as admin) requirement"

--- a/internal/functions/flowcontrol/Test-ElevationRequirement.ps1
+++ b/internal/functions/flowcontrol/Test-ElevationRequirement.ps1
@@ -60,6 +60,9 @@ function Test-ElevationRequirement {
         [bool]$EnableException = $EnableException
     )
 
+    if (Get-DbatoolsConfigValue -FullName 'commands.test-elevationrequirement.disable') {
+        return $true
+    }
     $isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     $testResult = $true
     if ($ComputerName.IsLocalHost -and (-not $isElevated)) { $testResult = $false }


### PR DESCRIPTION
## Type of Change
 - [x] New feature (non-breaking change, adds functionality, fixes #7146)

To disable elevation requirement for the current session

`Set-DbatoolsConfig -FullName commands.test-elevationrequirement.disable -Value $true`

To disable elevation requirement until it's explicitly reenabled

`Set-DbatoolsConfig -FullName commands.test-elevationrequirement.disable -Value $true -Register`

To reenable elevation requirement

`Set-DbatoolsConfig -FullName commands.test-elevationrequirement.disable -Value $false -Register`