### PR TITLE
Set-DbaPowerPlan - Fix for changing more than one computer at once

### DIFF
--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -114,7 +114,7 @@ function Set-DbaPowerPlan {
                 PreviousInstanceId = $instanceId
                 PreviousPowerPlan  = $powerPlanActive
                 ActiveInstanceId   = $instanceId
-                ActivePowerPlan    = $powerPlan
+                ActivePowerPlan    = $powerPlanActive
                 IsChanged          = $false
             }
 

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -121,7 +121,7 @@ function Set-DbaPowerPlan {
             if ($change.IsBestPractice) {
                 if ($Pscmdlet.ShouldProcess($computer, "Stating power plan is already set to $powerPlanRequested, won't change.")) {
                     Write-Message -Level Verbose -Message "PowerPlan on $computer is already set to $powerPlanRequested. Skipping."
-                    $output
+                    $output | Select-DefaultView -Property ComputerName, PreviousPowerPlan, ActivePowerPlan, IsChanged
                 }
             } else {
                 if ($Pscmdlet.ShouldProcess($computer, "Changing Power Plan from $powerPlanActive to $powerPlanRequested")) {

--- a/functions/Set-DbaPowerPlan.ps1
+++ b/functions/Set-DbaPowerPlan.ps1
@@ -101,7 +101,7 @@ function Set-DbaPowerPlan {
             }
 
             $instanceId = $change.ActiveInstanceId
-            $powerPlan = $change.ActivePowerPlan
+            $powerPlanActive = $change.ActivePowerPlan
             $instanceIdRequested = $change.RecommendedInstanceId
             $powerPlanRequested = $change.RecommendedPowerPlan
 
@@ -112,7 +112,7 @@ function Set-DbaPowerPlan {
             $output = [PSCustomObject]@{
                 ComputerName       = $computer
                 PreviousInstanceId = $instanceId
-                PreviousPowerPlan  = $powerPlan
+                PreviousPowerPlan  = $powerPlanActive
                 ActiveInstanceId   = $instanceId
                 ActivePowerPlan    = $powerPlan
                 IsChanged          = $false
@@ -124,7 +124,7 @@ function Set-DbaPowerPlan {
                     $output
                 }
             } else {
-                if ($Pscmdlet.ShouldProcess($computer, "Changing Power Plan from $powerPlan to $powerPlanRequested")) {
+                if ($Pscmdlet.ShouldProcess($computer, "Changing Power Plan from $powerPlanActive to $powerPlanRequested")) {
                     [System.Guid]$powerPlanGuid = $instanceIdRequested
                     $scriptBlock = {
                         Param ($Guid)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Used an internal variable with the same name as a parameter. That does not work correct when changing more than one computer.