### PR TITLE
Close connection inside of commands that use non-pooled connections

### DIFF
--- a/functions/Get-DbaDbExtentDiff.ps1
+++ b/functions/Get-DbaDbExtentDiff.ps1
@@ -87,7 +87,7 @@ function Get-DbaDbExtentDiff {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooled
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -167,6 +167,9 @@ function Get-DbaDbExtentDiff {
                     }
                 }
             }
+
+            # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
+            $server.ConnectionContext.Disconnect()
         }
     }
 }

--- a/functions/Install-DbaMaintenanceSolution.ps1
+++ b/functions/Install-DbaMaintenanceSolution.ps1
@@ -300,7 +300,7 @@ function Install-DbaMaintenanceSolution {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooled
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -NonPooledConnection
             } catch {
                 Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -432,13 +432,9 @@ function Install-DbaMaintenanceSolution {
                 SqlInstance  = $instance
                 Results      = $result
             }
-        }
-        # Only here due to need for non-pooled connection in this command
-        try {
+
+            # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
             $server.ConnectionContext.Disconnect()
-        } catch {
-            # here to avoid an empty catch
-            $null = 1
         }
 
         Write-ProgressHelper -ExcludePercent -Message "Installation complete"

--- a/functions/Write-DbaDbTableData.ps1
+++ b/functions/Write-DbaDbTableData.ps1
@@ -730,5 +730,8 @@ function Write-DbaDbTableData {
             $bulkCopy.Close()
             $bulkCopy.Dispose()
         }
+
+        # Close non-pooled connection as this is not done automatically. If it is a reused Server SMO, connection will be opened again automatically on next request.
+        $server.ConnectionContext.Disconnect()
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

It's a bugfix as `Connect-SqlInstance ... -NonPooled` did not open a non-pooled connection so I changed to use `Connect-DbaInstance`.
It's a new feature as the non-pooled connection is closed after the command.
It's a bugfix as `Install-DbaMaintenanceSolution` did the connection close at the wrong level.
