### PR TITLE
New-DbaAvailabilityGroup - Add config for FailureConditionLevel and change the default

### DIFF
--- a/functions/Add-DbaAgReplica.ps1
+++ b/functions/Add-DbaAgReplica.ps1
@@ -54,7 +54,13 @@ function Add-DbaAgReplica {
         Specifies the connection intent mode of an Availability Replica in primary role. AllowAllConnections by default.
 
     .PARAMETER ConnectionModeInSecondaryRole
-        Specifies the connection intent mode of an Availability Replica in secondary role. AllowAllConnections by default.
+        Specifies the connection modes of an Availability Replica in secondary role.
+        Options include: AllowNoConnections, AllowReadIntentConnectionsOnly,  AllowAllConnections
+
+        Defaults to AllowNoConnections.
+
+        The default can be changed with:
+        Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.ConnectionModeInSecondaryRole' -Value '...' -Passthru | Register-DbatoolsConfig
 
     .PARAMETER ReadOnlyRoutingList
         Sets the read only routing ordered list of replica server names to use when redirecting read-only connections through this availability replica.
@@ -131,8 +137,8 @@ function Add-DbaAgReplica {
         [int]$BackupPriority = 50,
         [ValidateSet('AllowAllConnections', 'AllowReadWriteConnections')]
         [string]$ConnectionModeInPrimaryRole = 'AllowAllConnections',
-        [ValidateSet('AllowAllConnections', 'AllowNoConnections', 'AllowReadIntentConnectionsOnly')]
-        [string]$ConnectionModeInSecondaryRole = 'AllowAllConnections',
+        [ValidateSet('AllowNoConnections', 'AllowReadIntentConnectionsOnly', 'AllowAllConnections')]
+        [string]$ConnectionModeInSecondaryRole = (Get-DbatoolsConfigValue -FullName 'AvailabilityGroups.Default.ConnectionModeInSecondaryRole' -Fallback 'AllowNoConnections'),
         [ValidateSet('Automatic', 'Manual')]
         [string]$SeedingMode,
         [string]$Endpoint,

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -61,6 +61,16 @@ function New-DbaAvailabilityGroup {
     .PARAMETER FailureConditionLevel
         Specifies the different conditions that can trigger an automatic failover in Availability Group.
 
+        From https://docs.microsoft.com/en-us/sql/t-sql/statements/create-availability-group-transact-sql:
+            Level 1 = OnServerDown
+            Level 2 = OnServerUnresponsive
+            Level 3 = OnCriticalServerErrors (the default in CREATE AVAILABILITY GROUP and in this command)
+            Level 4 = OnModerateServerErrors
+            Level 5 = OnAnyQualifiedFailureCondition
+
+        The default can be changed with:
+        Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.FailureConditionLevel' -Value 'On...' -Passthru | Register-DbatoolsConfig
+
     .PARAMETER HealthCheckTimeout
         This setting used to specify the length of time, in milliseconds, that the SQL Server resource DLL should wait for information returned by the sp_server_diagnostics stored procedure before reporting the Always On Failover Cluster Instance (FCI) as unresponsive.
 
@@ -246,7 +256,7 @@ function New-DbaAvailabilityGroup {
         [ValidateSet('None', 'Primary', 'Secondary', 'SecondaryOnly')]
         [string]$AutomatedBackupPreference = 'Secondary',
         [ValidateSet('OnAnyQualifiedFailureCondition', 'OnCriticalServerErrors', 'OnModerateServerErrors', 'OnServerDown', 'OnServerUnresponsive')]
-        [string]$FailureConditionLevel = "OnServerDown",
+        [string]$FailureConditionLevel = (Get-DbatoolsConfigValue -FullName 'AvailabilityGroups.Default.FailureConditionLevel' -Fallback 'OnCriticalServerErrors'),
         [int]$HealthCheckTimeout = 30000,
         [switch]$Basic,
         [switch]$DatabaseHealthTrigger,

--- a/internal/configurations/settings/availabilitygroups.ps1
+++ b/internal/configurations/settings/availabilitygroups.ps1
@@ -2,5 +2,17 @@
 This is designed for all things related to availability groups
 #>
 
+
+# Parameters related to the availability group:
+
+# Sets the default ClusterType
+Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.ClusterType' -Value 'Wsfc' -Initialize -Description 'Used to identify if the availability group is on a Windows Server Failover Cluster (WSFC). See: https://docs.microsoft.com/en-us/sql/t-sql/statements/create-availability-group-transact-sql'
+
 # Sets the default FailureConditionLevel
 Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.FailureConditionLevel' -Value 'OnCriticalServerErrors' -Initialize -Description 'Specifies what failure conditions trigger an automatic failover for this availability group. See: https://docs.microsoft.com/en-us/sql/t-sql/statements/create-availability-group-transact-sql'
+
+
+# Parameters related to the replica:
+
+# Sets the default FailureConditionLevel
+Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.ConnectionModeInSecondaryRole' -Value 'AllowNoConnections' -Initialize -Description 'Specifies whether the databases of a given availability replica that is performing the secondary role can accept connections from clients. See: https://docs.microsoft.com/en-us/sql/t-sql/statements/create-availability-group-transact-sql'

--- a/internal/configurations/settings/availabilitygroups.ps1
+++ b/internal/configurations/settings/availabilitygroups.ps1
@@ -1,0 +1,6 @@
+<#
+This is designed for all things related to availability groups
+#>
+
+# Sets the default FailureConditionLevel
+Set-DbatoolsConfig -FullName 'AvailabilityGroups.Default.FailureConditionLevel' -Value 'OnCriticalServerErrors' -Initialize -Description 'Specifies what failure conditions trigger an automatic failover for this availability group. See: https://docs.microsoft.com/en-us/sql/t-sql/statements/create-availability-group-transact-sql'


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (effects multiple commands or functionality, fixes #6605 )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Changed the default to the same CREATE AVAILABILITY GROUP uses, but now use a config to be able to change this default if needed.
