### PR TITLE
Test-DbaWindowsLogin, fix #7528

### DIFF
--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -153,7 +153,7 @@ function Test-DbaWindowsLogin {
                 $exists = $false
                 try {
                     $loginBinary = [byte[]]$login.Sid
-                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary,0)
+                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary, 0)
                     $SIDForAD = $SID.Value
                     Write-Message -Message "SID for AD is $SIDForAD" -Level Debug
                     $u = Get-DbaADObject -ADObject "$domain\$SIDForAD" -Type User -IdentityType Sid -EnableException
@@ -247,7 +247,7 @@ function Test-DbaWindowsLogin {
                 $exists = $false
                 try {
                     $loginBinary = [byte[]]$login.Sid
-                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary,0)
+                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary, 0)
                     $SIDForAD = $SID.Value
                     Write-Message -Message "SID for AD is $SIDForAD" -Level Debug
                     $u = Get-DbaADObject -ADObject "$domain\$SIDForAD" -Type Group -IdentityType Sid -EnableException

--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -152,7 +152,11 @@ function Test-DbaWindowsLogin {
                 Write-Message -Message "Parsing Login $adLogin." -Level Verbose
                 $exists = $false
                 try {
-                    $u = Get-DbaADObject -ADObject $adLogin -Type User -EnableException
+                    $loginBinary = [byte[]]$login.Sid
+                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary,0)
+                    $SIDForAD = $SID.Value
+                    Write-Message -Message "SID for AD is $SIDForAD" -Level Debug
+                    $u = Get-DbaADObject -ADObject "$domain\$SIDForAD" -Type User -IdentityType Sid -EnableException
                     if ($null -eq $u -and $adLogin -like '*$') {
                         Write-Message -Message "Parsing Login as computer" -Level Verbose
                         $u = Get-DbaADObject -ADObject $adLogin -Type Computer -EnableException
@@ -169,6 +173,10 @@ function Test-DbaWindowsLogin {
                         Write-Message -Message "SID mismatch detected for $adLogin." -Level Warning
                         Write-Message -Message "SID mismatch detected for $adLogin (MSSQL: $loginSid, AD: $foundSid)." -Level Debug
                         $exists = $false
+                    }
+                    if ($u.SamAccountName -ne $username) {
+                        Write-Message -Message "SamAccountName mismatch detected for $adLogin." -Level Warning
+                        Write-Message -Message "SamAccountName mismatch detected for $adLogin (MSSQL: $username, AD: $($u.SamAccountName))." -Level Debug
                     }
                 } catch {
                     Write-Message -Message "AD Searcher Error for $username." -Level Warning
@@ -238,7 +246,11 @@ function Test-DbaWindowsLogin {
                 Write-Message -Message "Parsing Login $adLogin on $server." -Level Verbose
                 $exists = $false
                 try {
-                    $u = Get-DbaADObject -ADObject $adLogin -Type Group -EnableException
+                    $loginBinary = [byte[]]$login.Sid
+                    $SID = New-Object Security.Principal.SecurityIdentifier($loginBinary,0)
+                    $SIDForAD = $SID.Value
+                    Write-Message -Message "SID for AD is $SIDForAD" -Level Debug
+                    $u = Get-DbaADObject -ADObject "$domain\$SIDForAD" -Type Group -IdentityType Sid -EnableException
                     $foundUser = $u.GetUnderlyingObject()
                     $foundSid = $foundUser.objectSid.Value -join ''
                     if ($foundUser) {
@@ -248,6 +260,10 @@ function Test-DbaWindowsLogin {
                         Write-Message -Message "SID mismatch detected for $adLogin." -Level Warning
                         Write-Message -Message "SID mismatch detected for $adLogin (MSSQL: $loginSid, AD: $foundSid)." -Level Debug
                         $exists = $false
+                    }
+                    if ($u.SamAccountName -ne $groupName) {
+                        Write-Message -Message "SamAccountName mismatch detected for $adLogin." -Level Warning
+                        Write-Message -Message "SamAccountName mismatch detected for $adLogin (MSSQL: $groupName, AD: $($u.SamAccountName))." -Level Debug
                     }
                 } catch {
                     Write-Message -Message "AD Searcher Error for $groupName on $server" -Level Warning


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7528 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
In some countries is pretty common to change surnames. Some naming conventions include the surname on the SamAccountUserName, so for those at some point in time you have the same SID for a renamed account.
This fix should force the searches on the SID itself rather than on the SamAccountName.

### Approach
Search AD by SID rather than SamAccountName

NB: given the cornercase, wait for merge for @carpewil to test.
