### PR TITLE
Bug fix: Get-DbaOperatingSystem - WMI Datetime incompatible with DbaDateTime

### DIFF
--- a/functions/Get-DbaOperatingSystem.ps1
+++ b/functions/Get-DbaOperatingSystem.ps1
@@ -138,6 +138,16 @@ function Get-DbaOperatingSystem {
                 $IsWsfc = $null
             }
 
+            try {
+                $installDate = [DbaDateTime]$os.InstallDate
+                $lastBootTime = [DbaDateTime]$os.LastBootUpTime
+                $localDateTime = [DbaDateTime]$os.LocalDateTime
+            } catch {
+                $installDate = [dbadate]($os.ConverttoDateTime($os.InstallDate))
+                $lastBootTime = [dbadate]($os.ConverttoDateTime($os.LastBootUpTime))
+                $localDateTime = [dbadate]($os.ConverttoDateTime($os.LocalDateTime))
+            }
+
             [PSCustomObject]@{
                 ComputerName             = $computerResolved
                 Manufacturer             = $os.Manufacturer
@@ -147,9 +157,9 @@ function Get-DbaOperatingSystem {
                 Build                    = $os.BuildNumber
                 OSVersion                = $os.caption
                 SPVersion                = $os.servicepackmajorversion
-                InstallDate              = [DbaDateTime]$os.InstallDate
-                LastBootTime             = [DbaDateTime]$os.LastBootUpTime
-                LocalDateTime            = [DbaDateTime]$os.LocalDateTime
+                InstallDate              = $installDate
+                LastBootTime             = $lastBootTime
+                LocalDateTime            = $localDateTime
                 PowerShellVersion        = $PowerShellVersion
                 TimeZone                 = $tz.Caption
                 TimeZoneStandard         = $tz.StandardName


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change, fixes #6511)

Try with a method that formats cim and if it fails, fallback to wmi formatting

reference: https://devblogs.microsoft.com/scripting/powertip-get-the-last-boot-time-with-powershell/