### PR TITLE
Linked Servers/Credentials: Microsoft.Data.SqlClient -> System.Data.SqlClient for remote connections

### DIFF
--- a/internal/functions/Get-DecryptedObject.ps1
+++ b/internal/functions/Get-DecryptedObject.ps1
@@ -132,8 +132,8 @@ function Get-DecryptedObject {
         $results = Invoke-Command2 -ErrorAction Stop -Raw -Credential $Credential -ComputerName $fullComputerName -ArgumentList $connString, $sql {
             $connString = $args[0]
             $sql = $args[1]
-            $conn = New-Object Microsoft.Data.SqlClient.SQLConnection($connString)
-            $cmd = New-Object Microsoft.Data.SqlClient.SqlCommand($sql, $conn)
+            $conn = New-Object System.Data.SqlClient.SQLConnection($connString)
+            $cmd = New-Object System.Data.SqlClient.SqlCommand($sql, $conn)
             $dt = New-Object System.Data.DataTable
             $conn.open()
             $dt.Load($cmd.ExecuteReader())


### PR DESCRIPTION
This scriptblock is executed against the remote machine, and Microsoft.Data can't be guaranteed to exist there. So we'll use System.Data instead.