### PR TITLE
Set-DBAAgentOperator Failsafe Operator Handling Correction

### DIFF
--- a/functions/Set-DbaAgentOperator.ps1
+++ b/functions/Set-DbaAgentOperator.ps1
@@ -29,7 +29,7 @@ function Set-DbaAgentOperator {
         The net send address the SQL Agent will use for the operator to net send alerts.
 
     .PARAMETER PagerAddress
-        The pager email address the SQL Agent will use to send alerts to the oeprator.
+        The pager email address the SQL Agent will use to send alerts to the operator.
 
     .PARAMETER PagerDay
         Defines what days the pager portion of the operator will be used. The default is 'Everyday'. Valid parameters
@@ -58,7 +58,7 @@ function Set-DbaAgentOperator {
         If this switch is enabled, this operator will be your failsafe operator and replace the one that existed before.
 
     .PARAMETER FailsafeNotificationMethod
-        Defines the notification method for the failsafe oeprator.  Value must be NotifyMail or NotifyPager.
+        Defines the notification method for the failsafe operator.  Value must be NotifyEmail, Pager or NotifyAll.
         The default is NotifyEmail.
 
     .PARAMETER WhatIf
@@ -221,7 +221,7 @@ function Set-DbaAgentOperator {
             }
         }
 
-        if ($IsFailsafeOperator -and ($FailsafeNotificationMethod -notin ('NotifyMail', 'NotifyPager'))) {
+        if ($IsFailsafeOperator -and ($FailsafeNotificationMethod -notin ('NotifyEmail', 'Pager', 'NotifyAll'))) {
             Stop-Function -Message "You must specify a notification method for the failsafe operator."
             return
         }
@@ -250,7 +250,7 @@ function Set-DbaAgentOperator {
 
         if ($SqlInstance) {
             try {
-                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlIntance -SqlCredential $SqlCredential -Operator $($op.Name) -EnableException
+                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $($op.Name) -EnableException
             } catch {
                 Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
@@ -336,7 +336,7 @@ function Set-DbaAgentOperator {
                 if ($IsFailsafeOperator) {
                     if ($Pscmdlet.ShouldProcess($server, "Updating FailSafe Operator to $operator")) {
                         $server.JobServer.AlertSystem.FailSafeOperator = $Operator
-                        $server.JobServer.AlertSystem.FailSafeOperator.NotificationMethod = $FailsafeNotificationMethod
+                        $server.JobServer.AlertSystem.NotificationMethod = $FailsafeNotificationMethod
                         $server.JobServer.AlertSystem.Alter()
                     }
                 }


### PR DESCRIPTION
- Modified to set the failsafe notification method on the AlertSystem
  object rather than the FailSafeOperator object
- Modified the list of possible input values for the
  $FailSafeNotificationMethod input parameter to include 'NotifyAll'
- Comment and variable spelling corrections

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Correction to the function to allow the FailSafeOperator to be set without error.
### Approach
<!-- How does this change solve that purpose -->
By setting the NotificationMethod property of the correct SMO object.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
Set-DbaAgentOperator -SqlInstance localhost -Operator DBA -EmailAddress test@mydomain.com -IsFailsafeOperator NotifyAll
