### PR TITLE
Internal: Replace Connect-SqlInstance by Connect-DbaInstance (part 6)

### DIFF
--- a/functions/New-DbaAgentAlertCategory.ps1
+++ b/functions/New-DbaAgentAlertCategory.ps1
@@ -73,12 +73,11 @@ function New-DbaAgentAlertCategory {
     }
 
     process {
-
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($cat in $Category) {

--- a/functions/New-DbaAgentJob.ps1
+++ b/functions/New-DbaAgentJob.ps1
@@ -236,11 +236,10 @@ function New-DbaAgentJob {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # Check if the job already exists

--- a/functions/New-DbaAgentJobCategory.ps1
+++ b/functions/New-DbaAgentJobCategory.ps1
@@ -87,9 +87,9 @@ function New-DbaAgentJobCategory {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($cat in $Category) {

--- a/functions/New-DbaAgentJobStep.ps1
+++ b/functions/New-DbaAgentJobStep.ps1
@@ -212,11 +212,10 @@ function New-DbaAgentJobStep {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $Server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $Server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($j in $Job) {

--- a/functions/New-DbaAgentOperator.ps1
+++ b/functions/New-DbaAgentOperator.ps1
@@ -270,9 +270,9 @@ function New-DbaAgentOperator {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $InputObject += Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
         }
 

--- a/functions/New-DbaAgentProxy.ps1
+++ b/functions/New-DbaAgentProxy.ps1
@@ -125,9 +125,9 @@ function New-DbaAgentProxy {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Subsystem -eq "ActiveScripting" -and $server.VersionMajor -ge 13) {

--- a/functions/New-DbaAgentSchedule.ps1
+++ b/functions/New-DbaAgentSchedule.ps1
@@ -427,11 +427,10 @@ function New-DbaAgentSchedule {
         if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # Check if the jobs parameter is set

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -354,9 +354,9 @@ function New-DbaAvailabilityGroup {
         }
 
         try {
-            $server = Connect-SqlInstance -SqlInstance $Primary -SqlCredential $PrimarySqlCredential
+            $server = Connect-DbaInstance -SqlInstance $Primary -SqlCredential $PrimarySqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $Primary" -Category ConnectionError -ErrorRecord $_ -Target $Primary
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Primary
             return
         }
 
@@ -385,10 +385,10 @@ function New-DbaAvailabilityGroup {
             }
             foreach ($instance in $Secondary) {
                 try {
-                    $second = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SecondarySqlCredential
+                    $second = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SecondarySqlCredential
                     $secondaries += $second
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
 
                 if (-not $second.IsHadrEnabled) {

--- a/functions/New-DbaCredential.ps1
+++ b/functions/New-DbaCredential.ps1
@@ -123,9 +123,9 @@ function New-DbaCredential {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($cred in $Identity) {

--- a/functions/New-DbaCustomError.ps1
+++ b/functions/New-DbaCustomError.ps1
@@ -106,9 +106,9 @@ function New-DbaCustomError {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $languageDetails = $server.Query("SELECT TOP 1 name, alias, msglangid FROM sys.syslanguages WHERE name = '$Language' OR alias = '$Language'")

--- a/functions/New-DbaDacProfile.ps1
+++ b/functions/New-DbaDacProfile.ps1
@@ -142,9 +142,9 @@ function New-DbaDacProfile {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $ConnectionString += $server.ConnectionContext.ConnectionString.Replace(';Application Name="dbatools PowerShell module - dbatools.io"', '').Replace(";Multiple Active Result Sets=False", "").Replace(";Encrypt=False", "").Replace(";Trust Server Certificate=False", "")

--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -186,9 +186,9 @@ function New-DbaDatabase {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($advancedconfig -and $server.VersionMajor -eq 8) {

--- a/functions/New-DbaDbMailAccount.ps1
+++ b/functions/New-DbaDbMailAccount.ps1
@@ -84,9 +84,9 @@ function New-DbaDbMailAccount {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if (Test-Bound -ParameterName MailServer) {

--- a/functions/New-DbaDbMailProfile.ps1
+++ b/functions/New-DbaDbMailProfile.ps1
@@ -71,9 +71,9 @@ function New-DbaDbMailProfile {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($instance, "Creating new db mail profile called $Name")) {

--- a/functions/New-DbaDbSnapshot.ps1
+++ b/functions/New-DbaDbSnapshot.ps1
@@ -155,9 +155,9 @@ function New-DbaDbSnapshot {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             #Checks for path existence, left the length test because test-bound wasn't working for some reason
             if ($Path.Length -gt 0) {

--- a/functions/New-DbaDbUser.ps1
+++ b/functions/New-DbaDbUser.ps1
@@ -140,9 +140,9 @@ function New-DbaDbUser {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $databases = $server.Databases | Where-Object IsAccessible -eq $true

--- a/functions/New-DbaDirectory.ps1
+++ b/functions/New-DbaDirectory.ps1
@@ -69,9 +69,9 @@ function New-DbaDirectory {
 
     foreach ($instance in $SqlInstance) {
         try {
-            $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
         }
 
         $Path = $Path.Replace("'", "''")

--- a/functions/New-DbaEndpoint.ps1
+++ b/functions/New-DbaEndpoint.ps1
@@ -134,9 +134,9 @@ function New-DbaEndpoint {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if (-not (Test-Bound -ParameterName Owner)) {

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -229,9 +229,9 @@ function New-DbaLogin {
         }
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($loginItem in $loginCollection) {

--- a/functions/New-DbaServerRole.ps1
+++ b/functions/New-DbaServerRole.ps1
@@ -69,9 +69,9 @@ function New-DbaServerRole {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $serverRoles = $server.Roles

--- a/functions/New-DbaXESession.ps1
+++ b/functions/New-DbaXESession.ps1
@@ -64,9 +64,9 @@ function New-DbaXESession {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($instance, "Creating new XESession")) {

--- a/functions/New-DbaXESmartQueryExec.ps1
+++ b/functions/New-DbaXESmartQueryExec.ps1
@@ -85,9 +85,9 @@ function New-DbaXESmartQueryExec {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Pscmdlet.ShouldProcess($instance, "Creating new XESmartQueryExec")) {

--- a/functions/New-DbaXESmartReplay.ps1
+++ b/functions/New-DbaXESmartReplay.ps1
@@ -99,9 +99,9 @@ function New-DbaXESmartReplay {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if ($Pscmdlet.ShouldProcess($instance, "Creating new XESmartReply")) {
                 Write-Message -Message "Making a New XE SmartReplay for $Event against $instance running on $($server.name)" -Level Verbose

--- a/functions/New-DbaXESmartTableWriter.ps1
+++ b/functions/New-DbaXESmartTableWriter.ps1
@@ -109,9 +109,9 @@ function New-DbaXESmartTableWriter {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if ($Pscmdlet.ShouldProcess($instance, "Creating new XESmartTableWriter")) {
                 try {

--- a/functions/Publish-DbaDacPackage.ps1
+++ b/functions/Publish-DbaDacPackage.ps1
@@ -213,9 +213,9 @@ function Publish-DbaDacPackage {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failure." -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $ConnectionString += $server.ConnectionContext.ConnectionString.Replace('"', "'") | Convert-ConnectionString
         }

--- a/functions/Read-DbaBackupHeader.ps1
+++ b/functions/Read-DbaBackupHeader.ps1
@@ -111,9 +111,9 @@ function Read-DbaBackupHeader {
         }
         Write-Message -Level InternalComment -Message "Starting reading headers"
         try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
         $getHeaderScript = {

--- a/functions/Read-DbaTraceFile.ps1
+++ b/functions/Read-DbaTraceFile.ps1
@@ -246,9 +246,9 @@ function Read-DbaTraceFile {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if (Test-Bound -Parameter Path) {

--- a/functions/Read-DbaTransactionLog.ps1
+++ b/functions/Read-DbaTransactionLog.ps1
@@ -71,9 +71,9 @@ function Read-DbaTransactionLog {
     )
 
     try {
-        $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
     } catch {
-        Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
         return
     }
 

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -78,9 +78,9 @@ function Remove-DbaAgentAlertCategory {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($cat in $Category) {

--- a/functions/Remove-DbaAgentJob.ps1
+++ b/functions/Remove-DbaAgentJob.ps1
@@ -93,9 +93,9 @@ function Remove-DbaAgentJob {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($j in $Job) {

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -78,9 +78,9 @@ function Remove-DbaAgentJobCategory {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($cat in $Category) {

--- a/functions/Remove-DbaAgentJobStep.ps1
+++ b/functions/Remove-DbaAgentJobStep.ps1
@@ -90,9 +90,9 @@ function Remove-DbaAgentJobStep {
         foreach ($instance in $SqlInstance) {
 
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($j in $Job) {

--- a/functions/Remove-DbaAgentOperator.ps1
+++ b/functions/Remove-DbaAgentOperator.ps1
@@ -67,9 +67,9 @@ function Remove-DbaAgentOperator {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $InputObject += Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
         }
 

--- a/functions/Remove-DbaCustomError.ps1
+++ b/functions/Remove-DbaCustomError.ps1
@@ -85,9 +85,9 @@ function Remove-DbaCustomError {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Language -ine "All") {

--- a/functions/Remove-DbaDatabase.ps1
+++ b/functions/Remove-DbaDatabase.ps1
@@ -86,9 +86,9 @@ function Remove-DbaDatabase {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $InputObject += $server.Databases | Where-Object { $_.Name -in $Database }
         }

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -147,19 +147,27 @@ function Remove-DbaDatabaseSafely {
             return
         }
 
-        $sourceserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $sqlCredential
+        try {
+            $sourceserver = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
+        }
 
-        if (-not $destination) {
-            $destination = $SqlInstance
+        if (-not $Destination) {
+            $Destination = $SqlInstance
             $DestinationCredential = $SqlCredential
         }
 
-        if ($SqlInstance -ne $destination) {
+        if ($SqlInstance -ne $Destination) {
 
-            $destserver = Connect-SqlInstance -SqlInstance $destination -SqlCredential $DestinationCredential
+            try {
+                $destserver = Connect-DbaInstance -SqlInstance $Destination -SqlCredential $DestinationCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Destination -Continue
+            }
 
-            $sourcenb = $instance.ComputerName
-            $destnb = $instance.ComputerName
+            $sourcenb = $sourceserver.ComputerName
+            $destnb = $destserver.ComputerName
 
             if ($BackupFolder.StartsWith("\\") -eq $false -and $sourcenb -ne $destnb) {
                 Stop-Function -Message "Backup folder must be a network share if the source and destination servers are not the same." -ErrorRecord $_ -Target $backupFolder

--- a/functions/Remove-DbaDatabaseSafely.ps1
+++ b/functions/Remove-DbaDatabaseSafely.ps1
@@ -150,7 +150,7 @@ function Remove-DbaDatabaseSafely {
         try {
             $sourceserver = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
         }
 
         if (-not $Destination) {

--- a/functions/Remove-DbaDbBackupRestoreHistory.ps1
+++ b/functions/Remove-DbaDbBackupRestoreHistory.ps1
@@ -97,9 +97,9 @@ function Remove-DbaDbBackupRestoreHistory {
         }
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if (-not $Database) {
                 try {

--- a/functions/Remove-DbaDbLogShipping.ps1
+++ b/functions/Remove-DbaDbLogShipping.ps1
@@ -109,9 +109,9 @@ function Remove-DbaDbLogShipping {
 
         # Try connecting to the source instance
         try {
-            $primaryServer = Connect-SqlInstance -SqlInstance $PrimarySqlInstance -SqlCredential $PrimarySqlCredential
+            $primaryServer = Connect-DbaInstance -SqlInstance $PrimarySqlInstance -SqlCredential $PrimarySqlCredential
         } catch {
-            Stop-Function -Message "Could not connect to Sql Server instance $PrimarySqlInstance" -ErrorRecord $_ -Target $PrimarySqlInstance
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $PrimarySqlInstance
             return
         }
     }
@@ -150,9 +150,9 @@ function Remove-DbaDbLogShipping {
 
             # Try connecting to the destination instance
             try {
-                $secondaryServer = Connect-SqlInstance -SqlInstance $SecondarySqlInstance -SqlCredential $SecondarySqlCredential
+                $secondaryServer = Connect-DbaInstance -SqlInstance $SecondarySqlInstance -SqlCredential $SecondarySqlCredential
             } catch {
-                Stop-Function -Message "Could not connect to Sql Server instance $SecondarySqlInstance" -ErrorRecord $_ -Target $SecondarySqlInstance
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SecondarySqlInstance
                 return
             }
 

--- a/functions/Remove-DbaDbMirrorMonitor.ps1
+++ b/functions/Remove-DbaDbMirrorMonitor.ps1
@@ -55,9 +55,9 @@ function Remove-DbaDbMirrorMonitor {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             if ($Pscmdlet.ShouldProcess($instance, "Removing mirror monitoring")) {
                 try {

--- a/functions/Remove-DbaDbOrphanUser.ps1
+++ b/functions/Remove-DbaDbOrphanUser.ps1
@@ -113,10 +113,9 @@ function Remove-DbaDbOrphanUser {
     process {
         foreach ($Instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $Instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $Instance -SqlCredential $SqlCredential
             } catch {
-                Write-Message -Level Warning -Message "Can't connect to $Instance or access denied. Skipping."
-                continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $DatabaseCollection = $server.Databases | Where-Object IsAccessible

--- a/functions/Remove-DbaDbSnapshot.ps1
+++ b/functions/Remove-DbaDbSnapshot.ps1
@@ -124,9 +124,9 @@ function Remove-DbaDbSnapshot {
         # if piped value either doesn't exist or is not the proper type
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $InputObject += Get-DbaDbSnapshot -SqlInstance $server -Database $Database -ExcludeDatabase $ExcludeDatabase -Snapshot $Snapshot

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -196,17 +196,14 @@ function Remove-DbaDbUser {
 
     process {
         if ($InputObject) {
-            $server = Connect-SqlInstance -SqlInstance $InputObject.Parent.Parent.Name
-            $user = $server.Databases[$InputObject.Parent.Name].Users[$InputObject.Name]
-
-            Remove-DbUser $user
+            Remove-DbUser $InputObject
 
         } else {
             foreach ($instance in $SqlInstance) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
 
                 $databases = $server.Databases | Where-Object IsAccessible

--- a/functions/Remove-DbaDbUser.ps1
+++ b/functions/Remove-DbaDbUser.ps1
@@ -98,6 +98,8 @@ function Remove-DbaDbUser {
     begin {
         if ($Force) { $ConfirmPreference = 'none' }
 
+        $pipedUsers = @( )
+
         function Remove-DbUser {
             [CmdletBinding(SupportsShouldProcess)]
             param ([Microsoft.SqlServer.Management.Smo.User[]]$users)
@@ -196,8 +198,7 @@ function Remove-DbaDbUser {
 
     process {
         if ($InputObject) {
-            Remove-DbUser $InputObject
-
+            $pipedUsers += $InputObject
         } else {
             foreach ($instance in $SqlInstance) {
                 try {
@@ -223,5 +224,10 @@ function Remove-DbaDbUser {
                 }
             }
         }
+    }
+
+    end {
+        # We have to delete in the end block to prevent "Collection was modified; enumeration operation may not execute." if directly piped from Get-DbaDbUser.
+        Remove-DbUser $pipedUsers
     }
 }

--- a/functions/Remove-DbaLogin.ps1
+++ b/functions/Remove-DbaLogin.ps1
@@ -83,9 +83,9 @@ function Remove-DbaLogin {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $InputObject += $server.Logins | Where-Object { $_.Name -in $Login }
         }

--- a/functions/Rename-DbaDatabase.ps1
+++ b/functions/Rename-DbaDatabase.ps1
@@ -277,9 +277,9 @@ function Rename-DbaDatabase {
         } else {
             foreach ($instance in $SqlInstance) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $sqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $sqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
                 $all_dbs = $server.Databases | Where-Object IsAccessible
                 $dbs += $all_dbs | Where-Object { @('master', 'model', 'msdb', 'tempdb', 'distribution') -notcontains $_.Name }

--- a/functions/Rename-DbaLogin.ps1
+++ b/functions/Rename-DbaLogin.ps1
@@ -86,9 +86,9 @@ function Rename-DbaLogin {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $Databases = $server.Databases | Where-Object IsAccessible

--- a/functions/Repair-DbaDbOrphanUser.ps1
+++ b/functions/Repair-DbaDbOrphanUser.ps1
@@ -111,12 +111,10 @@ function Repair-DbaDbOrphanUser {
     process {
 
         foreach ($instance in $SqlInstance) {
-
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Write-Message -Level Warning -Message "Failed to connect to: $SqlInstance."
-                continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $DatabaseCollection = $server.Databases | Where-Object IsAccessible

--- a/functions/Repair-DbaInstanceName.ps1
+++ b/functions/Repair-DbaInstanceName.ps1
@@ -83,9 +83,9 @@ function Repair-DbaInstanceName {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($server.isClustered) {

--- a/functions/Restore-DbaDatabase.ps1
+++ b/functions/Restore-DbaDatabase.ps1
@@ -418,9 +418,9 @@ function Restore-DbaDatabase {
 
         #region Validation
         try {
-            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database master
+            $RestoreInstance = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database master
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
 

--- a/functions/Restore-DbaDbCertificate.ps1
+++ b/functions/Restore-DbaDbCertificate.ps1
@@ -78,9 +78,9 @@ function Restore-DbaDbCertificate {
     )
     process {
         try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Failed to connect to: $SqlInstance" -Target $SqlInstance -ErrorRecord $_
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
 

--- a/functions/Restore-DbaDbSnapshot.ps1
+++ b/functions/Restore-DbaDbSnapshot.ps1
@@ -106,9 +106,9 @@ function Restore-DbaDbSnapshot {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $InputObject += Get-DbaDbSnapshot -SqlInstance $server -Database $Database -ExcludeDatabase $ExcludeDatabase -Snapshot $Snapshot | Sort-Object CreateDate -Descending

--- a/functions/Revoke-DbaAgPermission.ps1
+++ b/functions/Revoke-DbaAgPermission.ps1
@@ -121,9 +121,9 @@ function Revoke-DbaAgPermission {
         foreach ($instance in $SqlInstance) {
             if ($perm -contains "CreateAnyDatabase") {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
 
                 foreach ($ag in $AvailabilityGroup) {

--- a/tests/New-DbaDbUser.Tests.ps1
+++ b/tests/New-DbaDbUser.Tests.ps1
@@ -12,7 +12,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
         }
     }
     Context "Should error out if the database does not exist" {
-        Mock Connect-SqlInstance -MockWith {
+        Mock Connect-DbaInstance -MockWith {
             $obj = [PSCustomObject]@{
                 Databases    = [String]::Empty
                 IsAccessible = $false

--- a/tests/New-DbaLogin.Tests.ps1
+++ b/tests/New-DbaLogin.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 . "$PSScriptRoot\..\internal\functions\Get-PasswordHash.ps1"
 . "$PSScriptRoot\..\internal\functions\Convert-HexStringToByte.ps1"
 
@@ -23,8 +22,8 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     $password = 'MyV3ry$ecur3P@ssw0rd'
     $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
     $sid = '0xDBA700131337C0D30123456789ABCDEF'
-    $server1 = Connect-SqlInstance -SqlInstance $script:instance1
-    $server2 = Connect-SqlInstance -SqlInstance $script:instance2
+    $server1 = Connect-DbaInstance -SqlInstance $script:instance1
+    $server2 = Connect-DbaInstance -SqlInstance $script:instance2
     $servers = @($server1, $server2)
     $computerName = $server1.NetName
     $winLogin = "$computerName\$credLogin"

--- a/tests/Restart-DbaService.Tests.ps1
+++ b/tests/Restart-DbaService.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
@@ -18,7 +17,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
     Context "Command actually works" {
 
-        $instanceName = (Connect-SqlInstance -SqlInstance $script:instance2).ServiceName
+        $instanceName = (Connect-DbaInstance -SqlInstance $script:instance2).ServiceName
         It "restarts some services" {
             $services = Restart-DbaService -ComputerName $script:instance2 -InstanceName $instanceName -Type Agent
             $services | Should Not Be $null


### PR DESCRIPTION
Not a bug fix and not a new feature, just internal refactoring to align the part where commands open a connection.
This is the sixth step for #7319.

(Ok, fixed a bug in Remove-DbaDatabaseSafely.ps1...)
(Ok, and refactored Remove-DbaDbUser.ps1 when using piped input...)

Still 129 files to change...