### PR TITLE
Internal: Replace Connect-SqlInstance by Connect-DbaInstance (part 7)

### DIFF
--- a/functions/Set-DbaAgentAlert.ps1
+++ b/functions/Set-DbaAgentAlert.ps1
@@ -103,11 +103,10 @@ function Set-DbaAgentAlert {
         }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             foreach ($a in $Alert) {
                 # Check if the alert exists

--- a/functions/Set-DbaAgentJob.ps1
+++ b/functions/Set-DbaAgentJob.ps1
@@ -262,11 +262,10 @@ function Set-DbaAgentJob {
         }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             foreach ($j in $Job) {

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -83,11 +83,10 @@ function Set-DbaAgentJobCategory {
     process {
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # Loop through each of the categories

--- a/functions/Set-DbaAgentJobOutputFile.ps1
+++ b/functions/Set-DbaAgentJobOutputFile.ps1
@@ -87,10 +87,9 @@ function Set-DbaAgentJobOutputFile {
 
     foreach ($instance in $SqlInstance) {
         try {
-            $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
         } catch {
-            Write-Message -Level Warning -Message "Failed to connect to: $instance"
-            continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
         }
 
         if (!$Job) {

--- a/functions/Set-DbaAgentJobOwner.ps1
+++ b/functions/Set-DbaAgentJobOwner.ps1
@@ -102,9 +102,9 @@ function Set-DbaAgentJobOwner {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             #Get job list. If value for -Job is passed, massage to make it a string array.

--- a/functions/Set-DbaAgentJobStep.ps1
+++ b/functions/Set-DbaAgentJobStep.ps1
@@ -233,9 +233,9 @@ function Set-DbaAgentJobStep {
         # gather the SqlInstance(s) and pipeline of connected instances
         foreach ($instance in $SqlInstance) {
             try {
-                $InputObject += Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
         }
 

--- a/functions/Set-DbaAgentServer.ps1
+++ b/functions/Set-DbaAgentServer.ps1
@@ -212,15 +212,14 @@ function Set-DbaAgentServer {
         }
 
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
+            $server.JobServer.Refresh()
             $InputObject += $server.JobServer
-            $InputObject.Refresh()
         }
 
         foreach ($jobServer in $InputObject) {

--- a/functions/Set-DbaDbCompression.ps1
+++ b/functions/Set-DbaDbCompression.ps1
@@ -122,12 +122,10 @@ function Set-DbaDbCompression {
         $starttime = Get-Date
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10 -StatementTimeout 0
             } catch {
-                Stop-Function -Message "Failed to process Instance $instance" -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-
-            $Server.ConnectionContext.StatementTimeout = 0
 
             #The reason why we do this is because of SQL 2016 and they now allow for compression on standard edition.
             if ($server.EngineEdition -notmatch 'Enterprise' -and $server.VersionMajor -lt '13') {

--- a/functions/Set-DbaDbIdentity.ps1
+++ b/functions/Set-DbaDbIdentity.ps1
@@ -105,9 +105,9 @@ function Set-DbaDbIdentity {
         foreach ($instance in $SqlInstance) {
             Write-Message -Message "Attempting Connection to $instance" -Level Verbose
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $dbs = $server.Databases

--- a/functions/Set-DbaDbQueryStoreOption.ps1
+++ b/functions/Set-DbaDbQueryStoreOption.ps1
@@ -156,9 +156,9 @@ function Set-DbaDbQueryStoreOption {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 13
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 13
             } catch {
-                Stop-Function -Message "Can't connect to $instance. Moving on." -Category InvalidOperation -InnerErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($CaptureMode -contains "Custom" -and $server.VersionMajor -lt 15) {

--- a/functions/Set-DbaDbRecoveryModel.ps1
+++ b/functions/Set-DbaDbRecoveryModel.ps1
@@ -104,9 +104,9 @@ function Set-DbaDbRecoveryModel {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if (!$Database -and !$AllDatabases -and !$ExcludeDatabase) {

--- a/functions/Set-DbaDbState.ps1
+++ b/functions/Set-DbaDbState.ps1
@@ -246,9 +246,9 @@ function Set-DbaDbState {
         } else {
             foreach ($instance in $SqlInstance) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
                 $all_dbs = $server.Databases
                 $dbs += $all_dbs | Where-Object { @('master', 'model', 'msdb', 'tempdb', 'distribution') -notcontains $_.Name }

--- a/functions/Set-DbaDefaultPath.ps1
+++ b/functions/Set-DbaDefaultPath.ps1
@@ -71,9 +71,9 @@ function Set-DbaDefaultPath {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -AzureUnsupported
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $Path = $Path.Trim().TrimEnd("\")

--- a/functions/Set-DbaErrorLogConfig.ps1
+++ b/functions/Set-DbaErrorLogConfig.ps1
@@ -76,9 +76,9 @@ function Set-DbaErrorLogConfig {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $currentNumLogs = $server.NumberOfLogFiles

--- a/functions/Set-DbaLogin.ps1
+++ b/functions/Set-DbaLogin.ps1
@@ -240,9 +240,9 @@ function Set-DbaLogin {
         foreach ($instance in $SqlInstance) {
             # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9 -AzureUnsupported
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9 -AzureUnsupported
             } catch {
-                Stop-Function -Message 'Failure' -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $allLogins[$instance.ToString()] = Get-DbaLogin -SqlInstance $server
             $InputObject += $allLogins[$instance.ToString()] | Where-Object { ($_.Name -in $Login) -and ($_.Name -notlike '##*') }

--- a/functions/Set-DbaStartupParameter.ps1
+++ b/functions/Set-DbaStartupParameter.ps1
@@ -208,10 +208,10 @@ function Set-DbaStartupParameter {
         foreach ($instance in $SqlInstance) {
             if (-not $Offline) {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
                     Write-Message -Level Warning -Message "Failed to connect to $instance, will try to work with just WMI. Path options will be ignored unless Force was indicated"
-                    $Server = $instance
+                    $server = $instance
                     $Offline = $true
                 }
             } else {

--- a/functions/Set-DbaTempDbConfig.ps1
+++ b/functions/Set-DbaTempDbConfig.ps1
@@ -118,10 +118,9 @@ function Set-DbaTempDbConfig {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
-
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $cores = $server.Processors

--- a/functions/Show-DbaDbList.ps1
+++ b/functions/Show-DbaDbList.ps1
@@ -125,16 +125,17 @@ function Show-DbaDbList {
         $foldericon = Convert-b64toimg "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAHaSURBVDhPY/j//z9VMVZBSjBWQUowVkFKMApnzZL+/+gYWZ4YDGeANL95sun/j3fbwPjbm5X/Pz+cRLKhcAayq2B45YKe/8vndoHx4lltYLxgajMKhumHYRQDf37Yh4J/fNry//fb1f9/v1n6/8/Tqf//3O/6/+dO9f9fV4v+fzmV/v/L0aj/lflJQO1YDAS5AmwI1MvfPyAZ9KgbYtDlvP/fzyT9/3w45P+HPT7/z8+UwG0gyDvIBmIYBnQVyDCQq0CGPV9p8v94P/f/rKQwoHYsBs4HhgfIQJjLfr+YjdOwt5tt/z9eov1/fxf3/+ggD6B2HAaCXQYKM6hhv+81oYQXzLCXq03/P5qn/H9LE/9/LycroHYsBs7oq4EYCDIM6FVshr3Z4gg2DOS6O9Nk/q+sFvlvZawD1I7FwKldleC0h2zY9wuZEMP2+aMYdn+W/P/rE0T/zy+T+q+jJg/UjsXASe1l/z/cX/T/1dn8/492ePy/vc7s/82VOv8vLVT9f3yGwv89ffL/1zXL/l9dJwF2GciwaYVy/xVlxIDasRjY31Lyv7Uy+39ZTvz/1JiA/8Hejv8dLA3+62sqgTWJC/HixDAzQBjOoBbGKkgJxipICcYqSD7+zwAAkIiWzSGuSg0AAAAASUVORK5CYII="
         $dbatoolsicon = Convert-b64toimg "iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNWWFMmUAAAO9SURBVEhL3VVdTFNXHO9MzPTF+OzDeBixFdTMINIWsAUK3AIVkFvAIQVFRLYZKR8Wi1IEKV9DYB8PGFAyEx8QScySabYY5+I2JvK18iWISKGk0JGhLzA3+e2c29uHtpcvH/0lv9yennN+v3vO/3fOFb2fCAg4vXWPNOmMRJ745TtTSskqeElviGXJ0XtkWvjJkyGLPoFAVQZoe/NkX/n6Mh/ysu4Qy7WZdJAutxRW6zT6LcNQaE4LiGgREH4cibpCMNqzCIk9hbScEoSSZ0zKOa7fRxG/k5d1h8ukvO4a5ubmMT1jw5E0vZcBZWzqOTS3dcB8tRXZeRX4/v5DZH5uIu0Wrn8NEzaNDjgYoUPd120oMjViX2iql8H6ZFd8DzE7eFl3iOWpuyQydlh44kbJroilSd8RuQ+cqh7wC9Z+JJaxY8KTN0gp+5Yk9DaREzYhb5FOBwZFZ6LlZifKa5ux//AxYTHCvSEp8A9O5n77B6dwqXS119guZ+GrGq9jfn4eM7ZZxB/PdxN2UfOpHq3kRWq/uoE8Yx3u/fQLzhSYUdN0g+tfN126z0oxNj6BJz0Dq0b4E2UawuJzuPhKyZmKYr/AocgMrk37VzWRBLGRdE/psuXqk9wkT/GNUCJLWqS3By/rDh9FxjaSrnahiZ7cq8wCUzKImLIJqC+Ngbk4gmjjIKKKB6Aq7l+OLBmfVF0YnlQZR1p4eSd2y5IiyEr+oyJ0CwIi0gUNKAOPmnG04Q0utf+DHweWkFjjQOyVWajLpsCUPkeUcRgqAzE09Dfz8k64aqI9YcDziUk87bMgOCZL0CQ0ux2J9UtIbXyFwall/PD0NeLKrU6DkhGymj8RXtRDjU7x8k64TKpJQmi6bLOzSEgv8DYhNWMujiK+9jU0VQs4Vm/H2MwSOh4vcP+rii2cQVh+F+IqbRJe3glyReuoSFBUJtpu3eWulv2h3ueE1iOu0g5N9QL3jLk8jerbdrz59y1yGoYQUdSLsII/CLscIsD9UPrLUz4myXhBhWjCPMVdPBBnhMbsIAZzSDDbcOvRIhyLy6i4+Qyq82QFxECR9xjK/K5OXtodNHo+CsW2tagunbxADbK+sXP16Bv/G7lNQ8hpHEX21UGoDb/j8NmfoSzoNvCymwdTPvMotsKGB32LaL1H0mS0oOHOFLpH/0L3iAOF3/YSk4dgTBMh/JTNgdVbtzNl1il12UuSpHE+SRayTb0IL3yCMP2vUJKtUuh/szNNK8Jfxw3BZNpiMoGjiKPJm54Ffw8gEv0PQRYX7wDAUKEAAAAASUVORK5CYII="
 
-        try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-        } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
-            return
-        }
     }
 
     process {
         if (Test-FunctionInterrupt) { return }
+
+        try {
+            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            return
+        }
 
         # Create XAML form in Visual Studio, ensuring the ListView looks chromeless
         [xml]$xaml = "<Window

--- a/functions/Show-DbaInstanceFileSystem.ps1
+++ b/functions/Show-DbaInstanceFileSystem.ps1
@@ -141,9 +141,9 @@ function Show-DbaInstanceFileSystem {
         if (Test-FunctionInterrupt) { return }
 
         try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
 

--- a/functions/Start-DbaAgentJob.ps1
+++ b/functions/Start-DbaAgentJob.ps1
@@ -162,9 +162,9 @@ function Start-DbaAgentJob {
         # Loop through each of the instances and store agent jobs
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # Check if all the jobs need to included

--- a/functions/Start-DbaMigration.ps1
+++ b/functions/Start-DbaMigration.ps1
@@ -311,7 +311,7 @@ function Start-DbaMigration {
         }
 
         try {
-            $sourceserver = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SqlCredential
+            $sourceserver = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
         } catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
             return

--- a/functions/Start-DbaMigration.ps1
+++ b/functions/Start-DbaMigration.ps1
@@ -269,7 +269,6 @@ function Start-DbaMigration {
 
         $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
         $started = Get-Date
-        $sourceserver = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
     }
 
     process {
@@ -310,6 +309,14 @@ function Start-DbaMigration {
         if ($UseLastBackup -and -not $BackupRestore) {
             $BackupRestore = $true
         }
+
+        try {
+            $sourceserver = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SqlCredential
+        } catch {
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
+            return
+        }
+
         if ($Exclude -notcontains 'SpConfigure') {
             Write-Message -Level Verbose -Message "Migrating SQL Server Configuration"
             Copy-DbaSpConfigure -Source $sourceserver -Destination $Destination -DestinationSqlCredential $DestinationSqlCredential

--- a/functions/Start-DbaXESmartTarget.ps1
+++ b/functions/Start-DbaXESmartTarget.ps1
@@ -134,9 +134,9 @@ function Start-DbaXESmartTarget {
 
                 foreach ($instance in $SqlInstance) {
                     try {
-                        $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
+                        $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 11
                     } catch {
-                        Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                        Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                     }
 
                     $target = New-Object -TypeName XESmartTarget.Core.Target

--- a/functions/Stop-DbaAgentJob.ps1
+++ b/functions/Stop-DbaAgentJob.ps1
@@ -82,9 +82,9 @@ function Stop-DbaAgentJob {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $InputObject += $server.JobServer.Jobs

--- a/functions/Sync-DbaAvailabilityGroup.ps1
+++ b/functions/Sync-DbaAvailabilityGroup.ps1
@@ -174,9 +174,9 @@ function Sync-DbaAvailabilityGroup {
             $server = $InputObject.Parent
         } else {
             try {
-                $server = Connect-SqlInstance -SqlInstance $Primary -SqlCredential $PrimarySqlCredential
+                $server = Connect-DbaInstance -SqlInstance $Primary -SqlCredential $PrimarySqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $Primary" -Category ConnectionError -ErrorRecord $_ -Target $Primary
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Primary
                 return
             }
         }
@@ -194,10 +194,9 @@ function Sync-DbaAvailabilityGroup {
             $secondaries = @()
             foreach ($computer in $Secondary) {
                 try {
-                    $secondaries += Connect-SqlInstance -SqlInstance $computer -SqlCredential $SecondarySqlCredential
+                    $secondaries += Connect-DbaInstance -SqlInstance $computer -SqlCredential $SecondarySqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $computer" -Category ConnectionError -ErrorRecord $_ -Target $Primary
-                    return
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $computer -Continue
                 }
             }
         }

--- a/functions/Sync-DbaLoginPermission.ps1
+++ b/functions/Sync-DbaLoginPermission.ps1
@@ -123,11 +123,11 @@ function Sync-DbaLoginPermission {
         }
 
         try {
-            $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
+            $sourceServer = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
             $allLogins = Get-DbaLogin -SqlInstance $sourceServer -Login $Login -ExcludeLogin $ExcludeLogin
             $loginName = $allLogins.Name
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $Source" -Category ConnectionError -ErrorRecord $_ -Target $Source
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
             return
         }
     }
@@ -141,9 +141,9 @@ function Sync-DbaLoginPermission {
 
         foreach ($dest in $Destination) {
             try {
-                $destServer = Connect-SqlInstance -SqlInstance $dest -SqlCredential $DestinationSqlCredential -MinimumVersion 8
+                $destServer = Connect-DbaInstance -SqlInstance $dest -SqlCredential $DestinationSqlCredential -MinimumVersion 8
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $dest -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $dest -Continue
             }
 
             if ($PSCmdlet.ShouldProcess("Syncing Logins $Login")) {

--- a/functions/Test-DbaAgentJobOwner.ps1
+++ b/functions/Test-DbaAgentJobOwner.ps1
@@ -81,8 +81,11 @@ function Test-DbaAgentJobOwner {
     }
     process {
         foreach ($instance in $SqlInstance) {
-            #connect to the instance
-            $server = Connect-SqlInstance $instance -SqlCredential $SqlCredential
+            try {
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
 
             #Validate login
             if ($Login -and ($server.Logins.Name) -notcontains $Login) {

--- a/functions/Test-DbaAvailabilityGroup.ps1
+++ b/functions/Test-DbaAvailabilityGroup.ps1
@@ -89,9 +89,9 @@ function Test-DbaAvailabilityGroup {
     )
     process {
         try {
-            $server = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $server = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Failed to connect to $SqlInstance." -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
 
@@ -209,10 +209,10 @@ function Test-DbaAvailabilityGroup {
             $failure = $false
             foreach ($replica in $secondaryReplicas) {
                 try {
-                    $replicaServer = Connect-SqlInstance -SqlInstance $replica -SqlCredential $SecondarySqlCredential
+                    $replicaServer = Connect-DbaInstance -SqlInstance $replica -SqlCredential $SecondarySqlCredential
                 } catch {
                     $failure = $true
-                    Stop-Function -Message "Failed to connect to $replica." -Category ConnectionError -ErrorRecord $_ -Target $replica -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $replica -Continue
                 }
 
                 try {

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -84,9 +84,9 @@ function Test-DbaBackupInformation {
 
     begin {
         try {
-            $RestoreInstance = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $RestoreInstance = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
             return
         }
         $InternalHistory = @()

--- a/functions/Test-DbaConnection.ps1
+++ b/functions/Test-DbaConnection.ps1
@@ -165,7 +165,7 @@ function Test-DbaConnection {
             }
 
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 $connectSuccess = $true
                 $instanceName = $server.InstanceName
                 if (-not $instanceName) {
@@ -195,7 +195,7 @@ function Test-DbaConnection {
             } catch {
                 $connectSuccess = $false
                 $instanceName = $instance.InputObject
-                Stop-Function -Message "Issue connection to SQL Server on $instance" -Category ConnectionError -Target $instance -ErrorRecord $_
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance
             }
 
             [PSCustomObject]@{

--- a/functions/Test-DbaConnectionAuthScheme.ps1
+++ b/functions/Test-DbaConnectionAuthScheme.ps1
@@ -85,11 +85,10 @@ function Test-DbaConnectionAuthScheme {
 
     process {
         foreach ($instance in $SqlInstance) {
-
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             Write-Message -Level Verbose -Message "Getting results for the following query: $sql."

--- a/functions/Test-DbaDbCollation.ps1
+++ b/functions/Test-DbaDbCollation.ps1
@@ -70,11 +70,10 @@ function Test-DbaDbCollation {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $dbs = $server.Databases | Where-Object IsAccessible

--- a/functions/Test-DbaDbCompatibility.ps1
+++ b/functions/Test-DbaDbCompatibility.ps1
@@ -72,9 +72,9 @@ function Test-DbaDbCompatibility {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $serverLevel = [Microsoft.SqlServer.Management.Smo.CompatibilityLevel]"Version$($server.VersionMajor)0"

--- a/functions/Test-DbaDbCompression.ps1
+++ b/functions/Test-DbaDbCompression.ps1
@@ -236,9 +236,9 @@ function Test-DbaDbCompression {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Failed to process Instance $instance" -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $Server.ConnectionContext.StatementTimeout = 0

--- a/functions/Test-DbaDbLogShipStatus.ps1
+++ b/functions/Test-DbaDbLogShipStatus.ps1
@@ -164,9 +164,9 @@ EXEC master.sys.sp_help_log_shipping_monitor"
         foreach ($instance in $SqlInstance) {
             # Try connecting to the instance
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($server.EngineEdition -match "Express") {

--- a/functions/Test-DbaDbQueryStore.ps1
+++ b/functions/Test-DbaDbQueryStore.ps1
@@ -124,9 +124,9 @@ function Test-DbaDbQueryStore {
             }
 
             try {
-                $smo = Connect-SqlInstance -SqlInstance $dbDatabases[0].Parent -SqlCredential $SqlCredential -MinimumVersion 13
+                $server = Connect-DbaInstance -SqlInstance $dbDatabases[0].Parent -SqlCredential $SqlCredential -MinimumVersion 13
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($Database) {
@@ -185,7 +185,7 @@ function Test-DbaDbQueryStore {
 
             try {
                 Write-Message -Level Verbose -Message "Evaluating Query Store options"
-                $currentOptions = Get-DbaDbQueryStoreOption -SqlInstance $smo -Database $dbDatabases.name
+                $currentOptions = Get-DbaDbQueryStoreOption -SqlInstance $server -Database $dbDatabases.name
 
                 foreach ($db in $currentOptions) {
                     $props = $db.GetPropertySet() | Where-Object Name -NotIn ('CurrentStorageSizeInMB', 'ReadOnlyReason', 'DesiredState')
@@ -204,7 +204,7 @@ function Test-DbaDbQueryStore {
                     }
                 }
             } catch {
-                Stop-Function -Message "Unable to get Query Store data $smo" -Target $smo -ErrorRecord $_
+                Stop-Function -Message "Unable to get Query Store data $server" -Target $server -ErrorRecord $_
             }
 
             # Trace flags
@@ -218,11 +218,11 @@ function Test-DbaDbQueryStore {
             }
             try {
                 foreach ($tf in $queryStoreTF) {
-                    $tfEnabled = Get-DbaTraceFlag -SqlInstance $smo -TraceFlag $tf.TraceFlag
+                    $tfEnabled = Get-DbaTraceFlag -SqlInstance $server -TraceFlag $tf.TraceFlag
                     [PSCustomObject]@{
-                        ComputerName     = $smo.ComputerName
-                        InstanceName     = $smo.DbaInstanceName
-                        SqlInstance      = $smo.Name
+                        ComputerName     = $server.ComputerName
+                        InstanceName     = $server.DbaInstanceName
+                        SqlInstance      = $server.Name
                         Name             = ('Trace Flag {0} Enabled' -f $tf.TraceFlag)
                         Value            = if ($tfEnabled) { 'Enabled' } else { 'Disabled' }
                         RecommendedValue = $tf.TraceFlag
@@ -232,7 +232,7 @@ function Test-DbaDbQueryStore {
                     $tfEnabled = $null
                 }
             } catch {
-                Stop-Function -Message "Unable to get Trace Flag data $smo" -Target $smo -ErrorRecord $_
+                Stop-Function -Message "Unable to get Trace Flag data $server" -Target $server -ErrorRecord $_
             }
         }
     }

--- a/functions/Test-DbaDbRecoveryModel.ps1
+++ b/functions/Test-DbaDbRecoveryModel.ps1
@@ -119,9 +119,9 @@ function Test-DbaDbRecoveryModel {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             try {

--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -122,18 +122,18 @@ function Test-DbaDiskAllocation {
                     if ($NoSqlCheck -eq $false) {
                         $sqldisk = $false
 
-                        foreach ($SqlInstance in $SqlInstances) {
+                        foreach ($instance in $SqlInstances) {
                             try {
-                                $smoserver = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
-                                $sql = "Select count(*) as Count from sys.master_files where physical_name like '$diskname%'"
-                                $sqlcount = $smoserver.Databases['master'].ExecuteWithResults($sql).Tables[0].Count
-                                if ($sqlcount -gt 0) {
-                                    $sqldisk = $true
-                                    break
-                                }
+                                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                             } catch {
-                                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-                                continue
+                                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                            }
+
+                            $sql = "Select count(*) as Count from sys.master_files where physical_name like '$diskname%'"
+                            $sqlcount = $server.Query($sql).Count
+                            if ($sqlcount -gt 0) {
+                                $sqldisk = $true
+                                break
                             }
                         }
                     }

--- a/functions/Test-DbaIdentityUsage.ps1
+++ b/functions/Test-DbaIdentityUsage.ps1
@@ -143,9 +143,9 @@ function Test-DbaIdentityUsage {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $dbs = $server.Databases

--- a/functions/Test-DbaInstanceName.ps1
+++ b/functions/Test-DbaInstanceName.ps1
@@ -76,9 +76,9 @@ function Test-DbaInstanceName {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             if ($server.IsClustered) {

--- a/functions/Test-DbaLastBackup.ps1
+++ b/functions/Test-DbaLastBackup.ps1
@@ -261,9 +261,9 @@ function Test-DbaLastBackup {
             }
 
             try {
-                $destserver = Connect-SqlInstance -SqlInstance $destination -SqlCredential $DestinationCredential
+                $destserver = Connect-DbaInstance -SqlInstance $Destination -SqlCredential $DestinationCredential
             } catch {
-                Stop-Function -Message "Failed to connect to: $destination." -Target $destination -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Destination -Continue
             }
 
             if ($destserver.VersionMajor -lt $sourceserver.VersionMajor) {
@@ -492,7 +492,7 @@ function Test-DbaLastBackup {
                         }
                     }
 
-                    $destserver = Connect-SqlInstance -SqlInstance $destination -SqlCredential $DestinationCredential
+                    $destserver = Connect-DbaInstance -SqlInstance $Destination -SqlCredential $DestinationCredential
 
                     if (-not $NoCheck -and -not $VerifyOnly) {
                         # shouldprocess is taken care of in Start-DbccCheck

--- a/functions/Test-DbaLinkedServerConnection.ps1
+++ b/functions/Test-DbaLinkedServerConnection.ps1
@@ -75,9 +75,9 @@ function Test-DbaLinkedServerConnection {
                 $linkedServerCollection = $instance.LinkedServer
             } else {
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
                 $linkedServerCollection = $server.LinkedServers
             }

--- a/functions/Test-DbaLoginPassword.ps1
+++ b/functions/Test-DbaLoginPassword.ps1
@@ -119,10 +119,9 @@ function Test-DbaLoginPassword {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
-                Write-Message -Message "Connected to: $instance." -Level Verbose
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $InputObject += Get-DbaLogin -SqlInstance $server -Login $Login
         }

--- a/functions/Test-DbaMaxDop.ps1
+++ b/functions/Test-DbaMaxDop.ps1
@@ -84,9 +84,9 @@ function Test-DbaMaxDop {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             #Get current configured value

--- a/functions/Test-DbaMaxMemory.ps1
+++ b/functions/Test-DbaMaxMemory.ps1
@@ -64,12 +64,10 @@ function Test-DbaMaxMemory {
 
     process {
         foreach ($instance in $SqlInstance) {
-            Write-Message -Level VeryVerbose -Message "Processing $instance" -Target $instance
-
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             Write-Message -Level Verbose -Target $instance -Message "Retrieving maximum memory statistics from $instance"

--- a/functions/Test-DbaMigrationConstraint.ps1
+++ b/functions/Test-DbaMigrationConstraint.ps1
@@ -117,15 +117,15 @@ function Test-DbaMigrationConstraint {
     }
     process {
         try {
-            $sourceServer = Connect-SqlInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
+            $sourceServer = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $Source" -Category ConnectionError -ErrorRecord $_ -Target $Source -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
         }
 
         try {
-            $destServer = Connect-SqlInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
+            $destServer = Connect-DbaInstance -SqlInstance $Destination -SqlCredential $DestinationSqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $Destination -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Destination
         }
 
         if (-Not $Database) {

--- a/functions/Test-DbaNetworkLatency.ps1
+++ b/functions/Test-DbaNetworkLatency.ps1
@@ -80,9 +80,9 @@ function Test-DbaNetworkLatency {
                 $start = [System.Diagnostics.Stopwatch]::StartNew()
                 $currentCount = 0
                 try {
-                    $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                    $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 } catch {
-                    Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                    Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
                 }
 
                 do {

--- a/functions/Test-DbaOptimizeForAdHoc.ps1
+++ b/functions/Test-DbaOptimizeForAdHoc.ps1
@@ -58,9 +58,9 @@ function Test-DbaOptimizeForAdHoc {
 
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 10
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             #Get current configured value

--- a/functions/Test-DbaPath.ps1
+++ b/functions/Test-DbaPath.ps1
@@ -60,9 +60,9 @@ function Test-DbaPath {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
             $counter = [pscustomobject] @{ Value = 0 }
             $groupSize = 100

--- a/functions/Test-DbaRepLatency.ps1
+++ b/functions/Test-DbaRepLatency.ps1
@@ -101,9 +101,9 @@ function Test-DbaRepLatency {
 
             # Connect to the publisher
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             $publicationNames = Get-DbaRepPublication -SqlInstance $server -Database $Database -SqlCredential $SqlCredentials -PublicationType "Transactional"
@@ -148,9 +148,9 @@ function Test-DbaRepLatency {
             # Step 1: Connect to the distributor
 
             try {
-                $distServer = Connect-SqlInstance -SqlInstance $DistributionServer -SqlCredential $SqlCredential -MinimumVersion 9
+                $distServer = Connect-DbaInstance -SqlInstance $DistributionServer -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $DistributionServer -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $DistributionServer -Continue
             }
 
             foreach ($publication in $publicationNames) {

--- a/functions/Test-DbaTempDbConfig.ps1
+++ b/functions/Test-DbaTempDbConfig.ps1
@@ -68,9 +68,9 @@ function Test-DbaTempDbConfig {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # removed previous assumption that 2016+ will have it enabled

--- a/functions/Test-DbaWindowsLogin.ps1
+++ b/functions/Test-DbaWindowsLogin.ps1
@@ -108,10 +108,9 @@ function Test-DbaWindowsLogin {
     process {
         foreach ($instance in $SqlInstance) {
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
-                Write-Message -Message "Connected to: $instance." -Level Verbose
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
 

--- a/functions/Uninstall-DbaSqlWatch.ps1
+++ b/functions/Uninstall-DbaSqlWatch.ps1
@@ -86,11 +86,10 @@ Function Uninstall-DbaSqlWatch {
             return
         }
         foreach ($instance in $SqlInstance) {
-
             try {
-                $server = Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
 
             # get SqlWatch objects

--- a/functions/Watch-DbaDbLogin.ps1
+++ b/functions/Watch-DbaDbLogin.ps1
@@ -106,9 +106,10 @@ function Watch-DbaDbLogin {
         }
 
         try {
-            $serverDest = Connect-SqlInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $serverDest = Connect-DbaInstance -SqlInstance $SqlInstance -SqlCredential $SqlCredential
         } catch {
-            Stop-Function -Message "Error occurred while establishing connection to $SqlInstance" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance -Continue
+            Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $SqlInstance
+            return
         }
 
         $systemdbs = "master", "msdb", "model", "tempdb"
@@ -140,12 +141,12 @@ function Watch-DbaDbLogin {
         foreach ($instance in $servers) {
             try {
                 if ($instance -is [Microsoft.SqlServer.Management.RegisteredServers.RegisteredServer]) {
-                    $InputObject += Connect-SqlInstance -SqlInstance $instance.ServerName -SqlCredential $SqlCredential -MinimumVersion 9
+                    $InputObject += Connect-DbaInstance -SqlInstance $instance.ServerName -SqlCredential $SqlCredential -MinimumVersion 9
                 } else {
-                    $InputObject += Connect-SqlInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
+                    $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential -MinimumVersion 9
                 }
             } catch {
-                Stop-Function -Message "Error occurred while establishing connection to $instance" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
         }
 

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -16,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 }
 Describe "$commandname Integration Test" -Tag "IntegrationTests" {
     BeforeAll {
-        $server = Connect-SqlInstance -SqlInstance $script:instance2
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
         $random = Get-Random
         $tableName1 = "dbatools_getdbtbl1"
         $tableName2 = "dbatools_getdbtbl2"

--- a/tests/Start-DbaService.Tests.ps1
+++ b/tests/Start-DbaService.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
@@ -17,7 +16,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
 Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
     Context "Command actually works" {
 
-        $server = Connect-SqlInstance -SqlInstance $script:instance2
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
         $instanceName = $server.ServiceName
         $computerName = $server.NetName
 

--- a/tests/Stop-DbaService.Tests.ps1
+++ b/tests/Stop-DbaService.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
@@ -18,7 +17,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
     Context "Command actually works" {
 
-        $server = Connect-SqlInstance -SqlInstance $script:instance2
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
         $instanceName = $server.ServiceName
         $computerName = $server.NetName
 

--- a/tests/Test-DbaBackupInformation.Tests.ps1
+++ b/tests/Test-DbaBackupInformation.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
         Context "Everything as it should" {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 $obj = [PSCustomObject]@{
                     Name                 = 'BASEName'
                     NetName              = 'BASENetName'
@@ -65,7 +65,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
         Context "Not being able to see backups is bad" {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 $obj = [PSCustomObject]@{
                     Name                 = 'BASEName'
                     NetName              = 'BASENetName'
@@ -112,7 +112,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 $obj = [PSCustomObject]@{
                     Name                 = 'BASEName'
                     NetName              = 'BASENetName'
@@ -159,7 +159,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 $obj = [PSCustomObject]@{
                     Name                 = 'BASEName'
                     NetName              = 'BASENetName'
@@ -206,7 +206,7 @@ Describe "$commandname Integration Tests" -Tag 'IntegrationTests' {
             $BackupHistory = Import-CliXml $PSScriptRoot\..\tests\ObjectDefinitions\BackupRestore\RawInput\CleanFormatDbaInformation.xml
             $BackupHistory = $BackupHistory | Format-DbaBackupInformation
             $BackupHistory[1].OriginalDatabase = 'Error'
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 $obj = [PSCustomObject]@{
                     Name                 = 'BASEName'
                     NetName              = 'BASENetName'

--- a/tests/Test-DbaDbRecoveryModel.Tests.ps1
+++ b/tests/Test-DbaDbRecoveryModel.Tests.ps1
@@ -89,7 +89,7 @@ Describe "$CommandName Intigration Tests" -Tag  "IntegrationTests" {
             {Test-DbaDbRecoveryModel -SqlInstance $script:instance2 -RecoveryModel Awesome -EnableException -Database 'dontexist' } | should -Throw
         }
 
-        Mock Connect-SqlInstance { Throw } -ModuleName dbatools
+        Mock Connect-DbaInstance { Throw } -ModuleName dbatools
         It "Should Thow Error for a DB Connection Error" {
             {Test-DbaDbRecoveryModel -SqlInstance $script:instance2 -EnableException | Should -Throw }
         }

--- a/tests/Test-DbaMaxMemory.Tests.ps1
+++ b/tests/Test-DbaMaxMemory.Tests.ps1
@@ -27,7 +27,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
         }
 
         Context 'Validate functionality - Single Instance' {
-            Mock Connect-SqlInstance -MockWith {
+            Mock Connect-DbaInstance -MockWith {
                 "nothing"
             }
 
@@ -53,7 +53,7 @@ Describe "$commandname Unit Tests" -Tag 'UnitTests' {
 
                 $result = Test-DbaMaxMemory -SqlInstance 'ABC'
 
-                Assert-MockCalled Connect-SqlInstance -Scope It -Times 1
+                Assert-MockCalled Connect-DbaInstance -Scope It -Times 1
                 Assert-MockCalled Get-DbaService -Scope It -Times 1
                 Assert-MockCalled Get-DbaMaxMemory -Scope It -Times 1
             }

--- a/tests/Test-DbaRepLatency.Tests.ps1
+++ b/tests/Test-DbaRepLatency.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 
 Describe "$commandname Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {

--- a/tests/Update-DbaServiceAccount.Tests.ps1
+++ b/tests/Update-DbaServiceAccount.Tests.ps1
@@ -1,7 +1,6 @@
 $CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
 Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 . "$PSScriptRoot\constants.ps1"
-. "$PSScriptRoot\..\internal\functions\Connect-SqlInstance.ps1"
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
@@ -22,7 +21,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
         $newPassword = 'Myxtr33mly$ecur3P@ssw0rd'
         $newSecurePassword = ConvertTo-SecureString $newPassword -AsPlainText -Force
-        $server = Connect-SqlInstance -SqlInstance $script:instance2
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
         $computerName = $server.NetName
         $instanceName = $server.ServiceName
         $winLogin = "$computerName\$login"


### PR DESCRIPTION
Not a bug fix and not a new feature, just internal refactoring to align the part where commands open a connection.
This is the seventh step for #7319.

Plus a bit of refactoring of:
* Set-DbaAgentSchedule.ps1
* Set-DbaMaxDop.ps1
* Show-DbaDbList.ps1
* Start-DbaMigration.ps1 
* Test-DbaDbQueryStore.ps1
* Test-DbaDiskAlignment.ps1
* Test-DbaDiskAllocation.ps1
* Test-DbaDiskSpeed.ps1

Only 64 files left...