### PR TITLE
Internal: Added missing Test-FunctionInterrupt calls

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -373,6 +373,8 @@ function Backup-DbaDatabase {
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
+
         if (-not $SqlInstance -and -not $InputObject) {
             Stop-Function -Message "You must specify a server and database or pipe some databases"
             return

--- a/functions/Expand-DbaDbLogFile.ps1
+++ b/functions/Expand-DbaDbLogFile.ps1
@@ -203,6 +203,7 @@ function Expand-DbaDbLogFile {
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
 
         try {
 

--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -61,6 +61,7 @@ function Find-DbaLoginInGroup {
             Add-Type -AssemblyName System.DirectoryServices.AccountManagement
         } catch {
             Stop-Function -Message "Failed to load Assembly needed" -ErrorRecord $_
+            return
         }
 
         function Get-AllLogins {
@@ -121,6 +122,8 @@ function Find-DbaLoginInGroup {
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
+
         foreach ($instance in $SqlInstance) {
             try {
                 $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential

--- a/functions/Get-DbaDbTable.ps1
+++ b/functions/Get-DbaDbTable.ps1
@@ -127,12 +127,15 @@ function Get-DbaDbTable {
                 }
             }
             if (!$fqtns) {
-                Stop-Function -Message "No Valid Table specified"  -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "No Valid Table specified"
+                return
             }
         }
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
+
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }

--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -116,12 +116,15 @@ function Get-DbaDbView {
                 }
             }
             if (-not $fqtns) {
-                Stop-Function -Message "No Valid View specified"  -ErrorRecord $_ -Target $instance -Continue
+                Stop-Function -Message "No Valid View specified"
+                return
             }
         }
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
+
         if (Test-Bound SqlInstance) {
             $InputObject = Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase
         }

--- a/functions/Get-DbaDbccHelp.ps1
+++ b/functions/Get-DbaDbccHelp.ps1
@@ -79,6 +79,7 @@ function Get-DbaDbccHelp {
         $null = $stringBuilder.Append("DBCC HELP($Statement) WITH NO_INFOMSGS;")
     }
     process {
+        if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
             try {

--- a/functions/Get-DbaDbccSessionBuffer.ps1
+++ b/functions/Get-DbaDbccSessionBuffer.ps1
@@ -125,6 +125,7 @@ function Get-DbaDbccSessionBuffer {
 
     }
     process {
+        if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
             try {

--- a/functions/New-DbaDbAsymmetricKey.ps1
+++ b/functions/New-DbaDbAsymmetricKey.ps1
@@ -100,12 +100,14 @@ function New-DbaDbAsymmetricKey {
     )
     begin {
         if (((Test-Bound 'KeySource') -xor (Test-Bound 'KeySourceType'))) {
-            write-message -level verbose -message 'keysource paramter check'
-            Stop-Function -Message 'Both Keysource and KeySourceType must be provided' -Continue
-            break
+            Write-Message -Level Verbose -Message 'keysource paramter check'
+            Stop-Function -Message 'Both Keysource and KeySourceType must be provided'
+            return
         }
     }
     process {
+        if (Test-FunctionInterrupt) { return }
+
         if ($SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database
         }

--- a/functions/New-DbaDbSnapshot.ps1
+++ b/functions/New-DbaDbSnapshot.ps1
@@ -148,6 +148,8 @@ function New-DbaDbSnapshot {
         }
     }
     process {
+        if (Test-FunctionInterrupt) { return }
+
         if (-not $InputObject -and -not $Database -and $AllDatabases -eq $false) {
             Stop-Function -Message "You must specify a -AllDatabases or -Database to continue" -EnableException $EnableException
             return

--- a/functions/New-DbaLogin.ps1
+++ b/functions/New-DbaLogin.ps1
@@ -206,6 +206,8 @@ function New-DbaLogin {
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
+
         #At least one of those should be specified
         if (!($Login -or $InputObject)) {
             Stop-Function -Message "No logins have been specified." -Category InvalidArgument -EnableException $EnableException

--- a/functions/Set-DbaAgentJobCategory.ps1
+++ b/functions/Set-DbaAgentJobCategory.ps1
@@ -76,11 +76,13 @@ function Set-DbaAgentJobCategory {
 
         # Check if multiple categories are being changed
         if ($Category.Count -gt 1 -and $NewName.Count -eq 1) {
-            Stop-Function -Message "You cannot rename multiple jobs to the same name" -Target $instance
+            Stop-Function -Message "You cannot rename multiple jobs to the same name"
+            return
         }
     }
 
     process {
+        if (Test-FunctionInterrupt) { return }
 
         foreach ($instance in $SqlInstance) {
             try {

--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -92,11 +92,15 @@ function Test-DbaBackupInformation {
         $InternalHistory = @()
     }
     process {
+        if (Test-FunctionInterrupt) { return }
+
         foreach ($bh in $BackupHistory) {
             $InternalHistory += $bh
         }
     }
     end {
+        if (Test-FunctionInterrupt) { return }
+
         $RegisteredFileCheck = Get-DbaDbPhysicalFile -SqlInstance $RestoreInstance
 
         $Databases = $InternalHistory.Database | Select-Object -Unique

--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -165,6 +165,8 @@ function Update-DbaServiceAccount {
         }
     }
     process {
+        if (Test-FunctionInterrupt) { return }
+
         if ($PsCmdlet.ParameterSetName -match 'ServiceName') {
             foreach ($Computer in $ComputerName.ComputerName) {
                 $Server = Resolve-DbaNetworkName -ComputerName $Computer -Credential $credential

--- a/internal/functions/flowcontrol/Test-FunctionInterrupt.ps1
+++ b/internal/functions/flowcontrol/Test-FunctionInterrupt.ps1
@@ -21,6 +21,7 @@ function Test-FunctionInterrupt {
             The calling function will stop if this function returns true.
        #>
     [CmdletBinding()]
+    [OutputType([System.Boolean])]
     param (
 
     )


### PR DESCRIPTION
There are some commands, that use Stop-Command in the begin block but don't test for the function interrupt so that the process block will run even it should not.

Also changed some `break` into `return` or added some missing `return`.
Also corrected some Stop-Command calls.