### PR TITLE
Set-DbaAgentOperator - Fix usage of parameter Operator

### DIFF
--- a/functions/Set-DbaAgentOperator.ps1
+++ b/functions/Set-DbaAgentOperator.ps1
@@ -274,7 +274,7 @@ function Set-DbaAgentOperator {
 
         if ($SqlInstance) {
             try {
-                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $($Operator) -EnableException
+                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $Operator -EnableException
             } catch {
                 Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }

--- a/functions/Set-DbaAgentOperator.ps1
+++ b/functions/Set-DbaAgentOperator.ps1
@@ -274,14 +274,13 @@ function Set-DbaAgentOperator {
 
         if ($SqlInstance) {
             try {
-                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $($op.Name) -EnableException
+                $InputObject += Get-DbaAgentOperator -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Operator $($Operator) -EnableException
             } catch {
                 Stop-Function -Message "Failed" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
         }
 
         foreach ($op in $InputObject) {
-            $server = $op | Get-ConnectionParent
             try {
                 if ($Name) {
                     if ($Pscmdlet.ShouldProcess($server, "Updating Operator $($op.Name) Name to $Name")) {

--- a/functions/Set-DbaAgentOperator.ps1
+++ b/functions/Set-DbaAgentOperator.ps1
@@ -281,6 +281,7 @@ function Set-DbaAgentOperator {
         }
 
         foreach ($op in $InputObject) {
+            $server = $op | Get-ConnectionParent
             try {
                 if ($Name) {
                     if ($Pscmdlet.ShouldProcess($server, "Updating Operator $($op.Name) Name to $Name")) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #7730 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
- Fix the fact this was updating all the the operators instead of just the ones specified.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->
- Set-DbaAgentOperator -SQLInstance . -Operator DBA -EmailAddress Test@test.com2
- Set-DbaAgentOperator -SQLInstance . -Operator DBA, DBA2 -EmailAddress Test@test.com2
- 
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
![image](https://user-images.githubusercontent.com/26776763/130163313-b2a9e26d-6ecd-4b96-bfb1-7f8d0409dd28.png)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
