### PR TITLE
Update Invoke-DbaDbLogShipping to use proper comparison

### DIFF
--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -1260,7 +1260,7 @@ function Invoke-DbaDbLogShipping {
                             $LastBackup = Get-DbaDbBackupHistory -SqlInstance $SourceSqlInstance -Database $($db.Name) -LastFull -Credential $SourceSqlCredential
 
                             # Check if there was a last backup
-                            if ($null -eq $LastBackup) {
+                            if ($null -ne $LastBackup) {
                                 # Test the path to the backup
                                 Write-Message -Message "Testing last backup path $(($LastBackup[-1]).Path[-1])" -Level Verbose
                                 if ((Test-DbaPath -Path ($LastBackup[-1]).Path[-1] -SqlInstance $SourceSqlInstance -SqlCredential $SourceCredential) -ne $true) {


### PR DESCRIPTION
Wrong comparison operator used (should be -ne instead of -eq).

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system
