### PR TITLE
Add ReadOnlyRoutingList param to Set-DbaAgReplica

### DIFF
--- a/functions/Set-DbaAgReplica.ps1
+++ b/functions/Set-DbaAgReplica.ps1
@@ -197,7 +197,7 @@ function Set-DbaAgReplica {
                         foreach ($rolist in $ReadOnlyRoutingList) {
                             $null = $rorl.Add([System.Collections.Generic.List[string]] $rolist)
                         }
-                        $agreplica.SetLoadBalancedReadOnlyRoutingList($rorl)
+                        $null = $agreplica.SetLoadBalancedReadOnlyRoutingList($rorl)
                     }
 
                     if ($SessionTimeout) {

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -32,5 +32,9 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
             $results.AvailabilityGroup | Should -Be $agname
             $results.BackupPriority | Should -Be 1000
         }
+        It "attempts to add a ReadOnlyRoutingList" {
+            $null = Get-DbaAgReplica -SqlInstance $script:instance3 -AvailabilityGroup $agname | Select-Object -First 1 | Set-DbaAgReplica -ReadOnlyRoutingList nondockersql -WarningVariable warn
+            $warn | Should -match "does not exist. Only availability"
+        }
     }
 } #$script:instance2 for appveyor

--- a/tests/Set-DbaAgReplica.Tests.ps1
+++ b/tests/Set-DbaAgReplica.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Replica', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'AvailabilityGroup', 'Replica', 'AvailabilityMode', 'FailoverMode', 'BackupPriority', 'ConnectionModeInPrimaryRole', 'ConnectionModeInSecondaryRole', 'SeedingMode', 'EndpointUrl', 'ReadonlyRoutingConnectionUrl', 'InputObject', 'EnableException', 'ReadOnlyRoutingList'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Add the ability to set a read-only routing list for an AG replica.

### Approach
<!-- How does this change solve that purpose -->

Adds a `-ReadOnlyRoutingList` parameter to `Set-DbaAgReplica`.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Set-DbaAgReplica`

---
Resolves #7732.