### PR TITLE
Connect-DbaInstance, fix slow SMO enum for jobs

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -433,6 +433,9 @@ function Connect-DbaInstance {
         $Fields2000_Login = 'CreateDate', 'DateLastModified', 'DefaultDatabase', 'DenyWindowsLogin', 'IsSystemObject', 'Language', 'LanguageAlias', 'LoginType', 'Name', 'Sid', 'WindowsLoginAccessType'
         $Fields200x_Login = $Fields2000_Login + @('AsymmetricKey', 'Certificate', 'Credential', 'ID', 'IsDisabled', 'IsLocked', 'IsPasswordExpired', 'MustChangePassword', 'PasswordExpirationEnabled', 'PasswordPolicyEnforced')
         $Fields201x_Login = $Fields200x_Login + @('PasswordHashAlgorithm')
+
+        #see #7753
+        $Fields_Job = 'LastRunOutcome', 'CurrentRunStatus', 'CurrentRunStep', 'CurrentRunRetryAttempt', 'NextRunScheduleID', 'NextRunDate', 'LastRunDate', 'JobType', 'HasStep', 'HasServer', 'CurrentRunRetryAttempt', 'HasSchedule', 'Category', 'CategoryID', 'CategoryType', 'OperatorToEmail', 'OperatorToNetSend', 'OperatorToPage'
         if ($AzureDomain) { $AzureDomain = [regex]::escape($AzureDomain) }
     }
     process {
@@ -1046,6 +1049,7 @@ function Connect-DbaInstance {
                         Write-Message -Level Debug -Message "SetDefaultInitFields will be used"
                         $initFieldsDb = New-Object System.Collections.Specialized.StringCollection
                         $initFieldsLogin = New-Object System.Collections.Specialized.StringCollection
+                        $initFieldsJob = New-Object System.Collections.Specialized.StringCollection
                         if ($server.VersionMajor -eq 8) {
                             # 2000
                             [void]$initFieldsDb.AddRange($Fields2000_Db)
@@ -1061,6 +1065,9 @@ function Connect-DbaInstance {
                         }
                         $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Database], $initFieldsDb)
                         $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Login], $initFieldsLogin)
+                        #see 7753
+                        [void]$initFieldsJob.AddRange($Fields_Job)
+                        $server.SetDefaultInitFields([Microsoft.SqlServer.Management.Smo.Agent.Job], $initFieldsJob)
                     } catch {
                         Write-Message -Level Debug -Message "SetDefaultInitFields failed with $_"
                         # perhaps a DLL issue, continue going


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7753 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix slow SMO enumeration on jobs.

### Approach
Tracking what SMO did before this change basically resulted in:
- a query on sysjobs_view to get the job_id
- an sp_help_job @job_id = 'job_id' for each fetched job
- multiple queries to get operators, categories, runstatus, nextrundate, etc etc etc. like a dozen, for each job

Even if queries are fast, just running from a remote workstation with a bit of latency added several seconds to the whole process.

I added one by one the fields that cut down the queries issued by SMO to the minimum.
It now does:
- an sp_help_job without params to get the full list
- a single query to get the categories
- two queries for each job to get the 1:n relationships, which are Steps and Schedules

Steps and Schedules seems to not have an overridable way to avoid the two queries per job.


I also played around with JobServer.GetJobByID() that I _thought_ would cut the enumeration alltogether when people wanted to run something like `Get-DbaAgentJob -Job $list_of_jobs` but the improvement is negligible, it turns out to need to do:
- a query on sysjobs_view to get the job_id associated to the name
- one sp_help_job job_id='job_id' for each job
- two queries for each job to get the 1:n relationships, which are Steps and Schedules

On my rig it shaves off a few ms on an instance with 500 jobs so..... I left out that part. When someone will have still slow enum issues, we can try that way to see if it cuts times differently on those environments. 

### Commands to test
just measure what it takes to do a Get-DbaAgentJob before and after this fix

