### PR TITLE
Fix Get-DbaDbBackupHistory -Last when executed against an instance with log-shipping secondary databases 

### DIFF
--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -334,7 +334,7 @@ function Get-DbaDbBackupHistory {
                             if ($fullDb.FirstLsn) {
                                 [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
                             } else {
-                                [bigint]$tlogStartDsn = 0
+                                $tlogStartDsn = $null
                             }
                         } catch {
                             continue

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -330,12 +330,12 @@ function Get-DbaDbBackupHistory {
                         } else {
                             Write-Message -Level Verbose -Message "No Diff found"
                         }
+                        # Can't figure out a way around this, it pollutes $error
+                        # but if it's not at least attempted, we get an error that says:
+                        # Cannot process argument transformation on parameter 'LastLsn'.
+                        # Cannot convert null to type "System.Numerics.BigInteger".
                         try {
-                            if ($fullDb.FirstLsn) {
-                                [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
-                            } else {
-                                $tlogStartDsn = $null
-                            }
+                            [bigint]$tlogStartDsn = $fullDb.FirstLsn.ToString()
                         } catch {
                             continue
                         }


### PR DESCRIPTION

## Type of Change
 - [x] Bug fix (non-breaking change, fixes #7772)
