### PR TITLE
split using simplematch functionality not regex

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -554,7 +554,7 @@ function Import-DbaCsv {
                                 try {
                                     $ColumnMap = @{ }
                                     $firstline = Get-Content -Path $file -TotalCount 1 -ErrorAction Stop
-                                    $firstline -split $Delimiter | ForEach-Object {
+                                    $firstline -split "$Delimiter", 0, "SimpleMatch" | ForEach-Object {
                                         $trimmed = $PSItem.Trim('"')
                                         Write-Message -Level Verbose -Message "Adding $trimmed to ColumnMap"
                                         $ColumnMap.Add($trimmed, $trimmed)

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -22,6 +22,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
     $CommaSeparatedWithHeader = "$script:appveyorlabrepo\csv\CommaSeparatedWithHeader.csv"
     $col1 = "$script:appveyorlabrepo\csv\cols.csv"
     $col2 = "$script:appveyorlabrepo\csv\col2.csv"
+    $pipe3 = "$script:appveyorlabrepo\csv\pipe3.psv"
 
 
     Context "Works as expected" {
@@ -30,9 +31,10 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $results | Should -Be $null
         }
 
-        It "creates the right columnmap (#7630)" {
+        It "creates the right columnmap (#7630), handles pipe delimiters (#7806)" {
             $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $col1 -Database tempdb -AutoCreateTable -Table cols
             $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $col2 -Database tempdb -Table cols
+            $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $pipe3 -Database tempdb -Table cols -Delimiter "|"
             $results = Invoke-DbaQuery -SqlInstance $script:instance1 -Database tempdb -Query "select * from cols"
             $results | Where-Object third -notmatch "three" | Should -BeNullOrEmpty
             $results | Where-Object firstcol -notmatch "one" | Should -BeNullOrEmpty

--- a/tests/Import-DbaCsv.Tests.ps1
+++ b/tests/Import-DbaCsv.Tests.ps1
@@ -34,8 +34,11 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         It "creates the right columnmap (#7630), handles pipe delimiters (#7806)" {
             $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $col1 -Database tempdb -AutoCreateTable -Table cols
             $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $col2 -Database tempdb -Table cols
-            $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $pipe3 -Database tempdb -Table cols -Delimiter "|"
+            $null = Import-DbaCsv -SqlInstance $script:instance1 -Path $pipe3 -Database tempdb -Table cols2 -Delimiter "|" -AutoCreateTable
             $results = Invoke-DbaQuery -SqlInstance $script:instance1 -Database tempdb -Query "select * from cols"
+            $results | Where-Object third -notmatch "three" | Should -BeNullOrEmpty
+            $results | Where-Object firstcol -notmatch "one" | Should -BeNullOrEmpty
+            $results = Invoke-DbaQuery -SqlInstance $script:instance1 -Database tempdb -Query "select * from cols2"
             $results | Where-Object third -notmatch "three" | Should -BeNullOrEmpty
             $results | Where-Object firstcol -notmatch "one" | Should -BeNullOrEmpty
         }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
 - [X] Bug fix (non-breaking change, fixes #7806 )
 - [X] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [x] If new file reference added for test, has is been added to appveyor-lab? yes, once sqlcollaborative/appveyor-lab#10 is complete

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fixes #7806 , increases test coverage

### Approach
Use the "SimpleMatch" option parameter with the -split operator.

### Screenshots
![image](https://user-images.githubusercontent.com/16762974/134708969-da035ae4-e453-4334-9be6-c53f8e9c872f.png)
