### PR TITLE
Get-DbaDbMailProfile produces duplicate results

### DIFF
--- a/functions/Get-DbaDbMailProfile.ps1
+++ b/functions/Get-DbaDbMailProfile.ps1
@@ -73,6 +73,7 @@ function Get-DbaDbMailProfile {
     param (
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
+        [Alias("Name")]
         [string[]]$Profile,
         [string[]]$ExcludeProfile,
         [Parameter(ValueFromPipeline)]

--- a/functions/Get-DbaDbMailProfile.ps1
+++ b/functions/Get-DbaDbMailProfile.ps1
@@ -1,13 +1,13 @@
 function Get-DbaDbMailProfile {
     <#
     .SYNOPSIS
-        Gets database mail profiles from SQL Server
+        Gets database mail profile(s) from SQL Server
 
     .DESCRIPTION
-        Gets database mail profiles from SQL Server
+        Gets database mail profile(s) from SQL Server
 
     .PARAMETER SqlInstance
-        TThe target SQL Server instance or instances.
+        The target SQL Server instance or instances.
 
     .PARAMETER SqlCredential
         Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
@@ -62,6 +62,12 @@ function Get-DbaDbMailProfile {
 
         Returns the DBMail profiles for "sql2014","sql2016" and "sqlcluster\sharepoint"
 
+    .EXAMPLE
+        PS C:\> $servers = "sql2014","sql2016", "sqlcluster\sharepoint"
+        PS C:\> Get-DbaDbMailProfile -SqlInstance $servers
+
+        Returns the DBMail profiles for "sql2014","sql2016" and "sqlcluster\sharepoint"
+
     #>
     [CmdletBinding()]
     param (
@@ -75,7 +81,7 @@ function Get-DbaDbMailProfile {
     )
     process {
         foreach ($instance in $SqlInstance) {
-            $InputObject += Get-DbaDbMail -SqlInstance $SqlInstance -SqlCredential $SqlCredential
+            $InputObject += Get-DbaDbMail -SqlInstance $instance -SqlCredential $SqlCredential
         }
 
         if (-not $InputObject) {
@@ -88,17 +94,17 @@ function Get-DbaDbMailProfile {
                 $profiles = $mailserver.Profiles
 
                 if ($Profile) {
-                    $profiles = $profiles | Where-Object Name -in $Profile
+                    $profiles = $profiles | Where-Object Name -In $Profile
                 }
 
                 If ($ExcludeProfile) {
-                    $profiles = $profiles | Where-Object Name -notin $ExcludeProfile
+                    $profiles = $profiles | Where-Object Name -NotIn $ExcludeProfile
 
                 }
 
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name ComputerName -value $mailserver.ComputerName
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name InstanceName -value $mailserver.InstanceName
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -value $mailserver.SqlInstance
+                $profiles | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value $mailserver.ComputerName
+                $profiles | Add-Member -Force -MemberType NoteProperty -Name InstanceName -Value $mailserver.InstanceName
+                $profiles | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -Value $mailserver.SqlInstance
 
                 $profiles | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, ID, Name, Description, ForceDeleteForActiveProfiles, IsBusyProfile
             } catch {

--- a/functions/Get-DbaDbMailProfile.ps1
+++ b/functions/Get-DbaDbMailProfile.ps1
@@ -57,16 +57,16 @@ function Get-DbaDbMailProfile {
         Returns the DBMail profiles on sql01\sharepoint then return a bunch more columns
 
     .EXAMPLE
-        PS C:\> $servers = "sql2014","sql2016", "sqlcluster\sharepoint"
+        PS C:\> $servers = "sql2014", "sql2016", "sqlcluster\sharepoint"
         PS C:\> $servers | Get-DbaDbMail | Get-DbaDbMailProfile
 
-        Returns the DBMail profiles for "sql2014","sql2016" and "sqlcluster\sharepoint"
+        Returns the DBMail profiles for "sql2014", "sql2016" and "sqlcluster\sharepoint"
 
     .EXAMPLE
-        PS C:\> $servers = "sql2014","sql2016", "sqlcluster\sharepoint"
+        PS C:\> $servers = "sql2014", "sql2016", "sqlcluster\sharepoint"
         PS C:\> Get-DbaDbMailProfile -SqlInstance $servers
 
-        Returns the DBMail profiles for "sql2014","sql2016" and "sqlcluster\sharepoint"
+        Returns the DBMail profiles for "sql2014", "sql2016" and "sqlcluster\sharepoint"
 
     #>
     [CmdletBinding()]


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->

This command produces duplicate results. 
`Get-DbaDbMailProfile -SqlInstance $s1, $s2 -SqlCredential $credential | ft`

```
ComputerName InstanceName SqlInstance  ID Name         Description ForceDeleteForActiveProfiles IsBusyProfile
------------ ------------ -----------  -- ----         ----------- ---------------------------- -------------
localhost    MSSQLSERVER  6f34ddb8eb52 36 MailProfile                                      True         False
localhost    MSSQLSERVER  6f34ddb8eb52 37 MailProfile2                                     True         False
localhost    MSSQLSERVER  bbac38d1a5e9 19 MailProfile                                      True         False
localhost    MSSQLSERVER  bbac38d1a5e9 20 MailProfile2                                     True         False
localhost    MSSQLSERVER  6f34ddb8eb52 36 MailProfile                                      True         False
localhost    MSSQLSERVER  6f34ddb8eb52 37 MailProfile2                                     True         False
localhost    MSSQLSERVER  bbac38d1a5e9 19 MailProfile                                      True         False
localhost    MSSQLSERVER  bbac38d1a5e9 20 MailProfile2                                     True         False
```

and it is supposed to produce half of those
```
ComputerName InstanceName SqlInstance  ID Name         Description ForceDeleteForActiveProfiles IsBusyProfile
------------ ------------ -----------  -- ----         ----------- ---------------------------- -------------
localhost    MSSQLSERVER  6f34ddb8eb52 36 MailProfile                                      True         False
localhost    MSSQLSERVER  6f34ddb8eb52 37 MailProfile2                                     True         False
localhost    MSSQLSERVER  bbac38d1a5e9 19 MailProfile                                      True         False
localhost    MSSQLSERVER  bbac38d1a5e9 20 MailProfile2                                     True         False
```

### Approach
<!-- How does this change solve that purpose -->

The command uses $SqlInstance within the loop, where it should be $instance instead.

https://github.com/sqlcollaborative/dbatools/blob/c8b825a5fc65031b7635202e77274765b43b2416/functions/Get-DbaDbMailProfile.ps1#L77-L79


In addition to that, I have added a test to cover the scenario. Also, fixed the "Gets no DbMailProfile when using -ExcludeProfile" test as it did create a false results if there was already a different profile in the environment. 


### Commands to test
<!-- if these are the examples in the help just note it as such -->

`Get-DbaDbMailProfile -SqlInstance $s1, $s2 -SqlCredential $credential | ft`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
