### PR TITLE
Find-DbaLoginInGroup, fix #7820

### DIFF
--- a/functions/Find-DbaLoginInGroup.ps1
+++ b/functions/Find-DbaLoginInGroup.ps1
@@ -132,7 +132,8 @@ function Find-DbaLoginInGroup {
             }
 
             $AdGroups = $server.Logins | Where-Object { $_.LoginType -eq "WindowsGroup" -and $_.Name -ne "BUILTIN\Administrators" -and $_.Name -notlike "*NT SERVICE*" }
-
+            # remove local groups, see #7820
+            $AdGroups = $AdGroups | Where-Object Name -notlike "$($server.ComputerName)\*"
             $ADGroupOut = @()
             foreach ($AdGroup in $AdGroups) {
                 Write-Message -Level Verbose -Message "Looking at Group: $AdGroup"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7820 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system


### Purpose
Skip over local groups. 

### Approach
SQL doesn't do much distinction between an AD group and a local group, so we need to resort to the ugly trick of skipping over any group that starts with the same name as the computer running the instance. Dunno how much the usage of local groups is spread, I'd vouch very little since the issue just came up. The detection logic wouldn't work for cluster (it's have to be more convoluted) but people running cluster should know better than using local groups to grant access ;-)

