### PR TITLE
Remove-DbaServerRoleMember  - new command 

### DIFF
--- a/functions/Remove-DbaServerRoleMember.ps1
+++ b/functions/Remove-DbaServerRoleMember.ps1
@@ -158,8 +158,8 @@ function Remove-DbaServerRoleMember {
             foreach ($sr in $serverRoles) {
                 $instance = $sr.Parent
                 foreach ($l in $Login) {
-                    if ($PSCmdlet.ShouldProcess($instance, "Removing login $l to server-level role: $sr")) {
-                        Write-Message -Level Verbose -Message "Removing login $l to server-level role: $sr on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, "Removing login $l from server-level role: $sr")) {
+                        Write-Message -Level Verbose -Message "Removing login $l from server-level role: $sr on $instance"
                         try {
                             $sr.DropMember($l)
                         } catch {

--- a/functions/Remove-DbaServerRoleMember.ps1
+++ b/functions/Remove-DbaServerRoleMember.ps1
@@ -1,0 +1,194 @@
+function Remove-DbaServerRoleMember {
+    <#
+    .SYNOPSIS
+        Removes a login to a server-level role(s) for each instance(s) of SQL Server.
+
+    .DESCRIPTION
+        Removes a login to a server-level role(s) for each instance(s) of SQL Server.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER ServerRole
+        The server-level role(s) to process.
+
+    .PARAMETER Login
+        The login(s) to remove from server-level role(s) specified.
+
+    .PARAMETER Role
+        The role(s) to remove from server-level role(s) specified.
+
+    .PARAMETER InputObject
+        Enables piped input from Get-DbaServerRole or New-DbaServerRole
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Role, Security, Login
+        Author: Mikey Bronowski (@MikeyBronowski), https://bronowski.it
+
+        Website: https://dbatools.io
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaServerRoleMember
+
+    .EXAMPLE
+        PS C:\> Remove-DbaServerRoleMember -SqlInstance server1 -ServerRole dbcreator -Login login1
+
+        Removes login1 from the server-level role dbcreator on the instance server1
+
+    .EXAMPLE
+        PS C:\> Remove-DbaServerRoleMember -SqlInstance server1, sql2016 -ServerRole customrole -Login login1
+
+        Removes login1 from custom, server-level role customrole on the instance server1 and sql2016
+
+    .EXAMPLE
+        PS C:\> Remove-DbaServerRoleMember -SqlInstance server1 -ServerRole customrole -Role dbcreator
+
+        Removes custom, server-level role customrole from dbcreator server-level fixed role.
+
+    .EXAMPLE
+        PS C:\> $servers = Get-Content C:\servers.txt
+        PS C:\> $servers | Remove-DbaServerRoleMember -ServerRole sysadmin -Login login1
+
+        Removes login1 from the sysadmin server-level role in every server in C:\servers.txt
+
+    .EXAMPLE
+        PS C:\> Remove-DbaServerRoleMember -SqlInstance localhost -ServerRole "bulkadmin","dbcreator" -Login login1
+
+        Removes login1 from the server localhost to the server-level roles bulkadmin and dbcreator
+
+    .EXAMPLE
+        PS C:\> $roles = Get-DbaServerRole -SqlInstance localhost -ServerRole "bulkadmin","dbcreator"
+        PS C:\> $roles | Remove-DbaServerRoleMember -Login login1
+
+        Removes login1 from the server localhost to the server-level roles bulkadmin and dbcreator
+
+    .EXAMPLE
+        PS C:\ $logins = Get-Content C:\logins.txt
+        PS C:\ $srvLogins = Get-DbaLogin -SqlInstance server1 -Login $logins
+        PS C:\ Remove-DbaServerRoleMember -Login $logins
+
+        Removes all the logins found in C:\logins.txt from server-level role mycustomrole on server1.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [parameter(ValueFromPipeline)]
+        [DbaInstance[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [parameter(ValueFromPipeline)]
+        [string[]]$ServerRole,
+        [string[]]$Login,
+        [string[]]$Role,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [switch]$EnableException
+    )
+
+    begin {
+        if ( (Test-Bound SqlInstance -Not) -and (Test-Bound ServerRole -Not) -and (Test-Bound Login -Not) ) {
+            Stop-Function -Message "You must pipe in a ServerRole, Login, or specify a SqlInstance"
+            return
+        }
+
+        if (Test-Bound SqlInstance) {
+            $InputObject = $SqlInstance
+        }
+    }
+    process {
+        if (Test-FunctionInterrupt) { return }
+
+        foreach ($input in $InputObject) {
+            $inputType = $input.GetType().FullName
+
+            if ((Test-Bound ServerRole -Not ) -and ($inputType -ne 'Microsoft.SqlServer.Management.Smo.ServerRole')) {
+                Stop-Function -Message "You must pipe in a ServerRole or specify a ServerRole."
+                return
+            }
+
+            switch ($inputType) {
+                'Sqlcollaborative.Dbatools.Parameter.DbaInstanceParameter' {
+                    Write-Message -Level Verbose -Message "Processing DbaInstanceParameter through InputObject"
+                    try {
+                        $serverRoles = Get-DbaServerRole -SqlInstance $input -SqlCredential $SqlCredential -ServerRole $ServerRole -EnableException
+                    } catch {
+                        Stop-Function -Message "Failure access $input" -ErrorRecord $_ -Target $input -Continue
+                    }
+                }
+                'Microsoft.SqlServer.Management.Smo.Server' {
+                    Write-Message -Level Verbose -Message "Processing Server through InputObject"
+                    try {
+                        $serverRoles = Get-DbaServerRole -SqlInstance $input -SqlCredential $SqlCredential -ServerRole $ServerRole -EnableException
+                    } catch {
+                        Stop-Function -Message "Failure access $input" -ErrorRecord $_ -Target $input -Continue
+                    }
+                }
+                'Microsoft.SqlServer.Management.Smo.ServerRole' {
+                    Write-Message -Level Verbose -Message "Processing ServerRole through InputObject"
+                    try {
+                        $serverRoles = $inputObject
+                    } catch {
+                        Stop-Function -Message "Failure access $input" -ErrorRecord $_ -Target $input -Continue
+                    }
+                }
+                default {
+                    Stop-Function -Message "InputObject is not a server or role."
+                    continue
+                }
+            }
+
+            foreach ($sr in $serverRoles) {
+                $instance = $sr.Parent
+                foreach ($l in $Login) {
+                    if ($PSCmdlet.ShouldProcess($instance, "Removeing login $l to server-level role: $sr")) {
+                        Write-Message -Level Verbose -Message "Removeing login $l to server-level role: $sr on $instance"
+                        try {
+                            $sr.DropMember($l)
+                        } catch {
+                            Stop-Function -Message "Failure removing $l on $instance" -ErrorRecord $_ -Target $sr
+                        }
+                    }
+
+                }
+                foreach ($r in $Role) {
+                    try {
+                        $isServerRole = Get-DbaServerRole -SqlInstance $input -SqlCredential $SqlCredential -ServerRole $r -EnableException
+                    } catch {
+                        Stop-Function -Message "Failure access $input" -ErrorRecord $_ -Target $input
+                        continue
+                    }
+                    if (-not $isServerRole) {
+                        Write-Message -Level Warning -Message "$r server-level role was not found on $instance"
+                        continue
+                    }
+                    if ($PSCmdlet.ShouldProcess($instance, "Removing role $r from server-level role: $sr")) {
+                        Write-Message -Level Verbose -Message "Removing role $r from server-level role: $sr on $instance"
+                        try {
+                            $sr.DropMembershipFromRole($r)
+                        } catch {
+                            Stop-Function -Message "Failure removing $r on $instance" -ErrorRecord $_ -Target $sr
+                        }
+                    }
+                }
+            }
+        }
+    }
+

--- a/functions/Remove-DbaServerRoleMember.ps1
+++ b/functions/Remove-DbaServerRoleMember.ps1
@@ -158,8 +158,8 @@ function Remove-DbaServerRoleMember {
             foreach ($sr in $serverRoles) {
                 $instance = $sr.Parent
                 foreach ($l in $Login) {
-                    if ($PSCmdlet.ShouldProcess($instance, "Removeing login $l to server-level role: $sr")) {
-                        Write-Message -Level Verbose -Message "Removeing login $l to server-level role: $sr on $instance"
+                    if ($PSCmdlet.ShouldProcess($instance, "Removing login $l to server-level role: $sr")) {
+                        Write-Message -Level Verbose -Message "Removing login $l to server-level role: $sr on $instance"
                         try {
                             $sr.DropMember($l)
                         } catch {

--- a/functions/Remove-DbaServerRoleMember.ps1
+++ b/functions/Remove-DbaServerRoleMember.ps1
@@ -1,10 +1,10 @@
 function Remove-DbaServerRoleMember {
     <#
     .SYNOPSIS
-        Removes a login to a server-level role(s) for each instance(s) of SQL Server.
+        Removes login(s) from a server-level role(s) for each instance(s) of SQL Server.
 
     .DESCRIPTION
-        Removes a login to a server-level role(s) for each instance(s) of SQL Server.
+        Removes login(s) from a server-level role(s) for each instance(s) of SQL Server.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
@@ -53,41 +53,41 @@ function Remove-DbaServerRoleMember {
     .EXAMPLE
         PS C:\> Remove-DbaServerRoleMember -SqlInstance server1 -ServerRole dbcreator -Login login1
 
-        Removes login1 from the server-level role dbcreator on the instance server1
+        Removes login1 from the dbcreator fixed server-level role on the instance server1.
 
     .EXAMPLE
         PS C:\> Remove-DbaServerRoleMember -SqlInstance server1, sql2016 -ServerRole customrole -Login login1
 
-        Removes login1 from custom, server-level role customrole on the instance server1 and sql2016
+        Removes login1 from customrole custom server-level role on the instance server1 and sql2016.
 
     .EXAMPLE
         PS C:\> Remove-DbaServerRoleMember -SqlInstance server1 -ServerRole customrole -Role dbcreator
 
-        Removes custom, server-level role customrole from dbcreator server-level fixed role.
+        Removes customrole custom server-level role from the dbcreator fixed server-level role.
 
     .EXAMPLE
         PS C:\> $servers = Get-Content C:\servers.txt
         PS C:\> $servers | Remove-DbaServerRoleMember -ServerRole sysadmin -Login login1
 
-        Removes login1 from the sysadmin server-level role in every server in C:\servers.txt
+        Removes login1 from the sysadmin fixed server-level role in every server in C:\servers.txt.
 
     .EXAMPLE
-        PS C:\> Remove-DbaServerRoleMember -SqlInstance localhost -ServerRole "bulkadmin","dbcreator" -Login login1
+        PS C:\> Remove-DbaServerRoleMember -SqlInstance localhost -ServerRole bulkadmin, dbcreator -Login login1
 
-        Removes login1 from the server localhost to the server-level roles bulkadmin and dbcreator
+        Removes login1 from the bulkadmin and dbcreator fixed server-level roles on the server localhost.
 
     .EXAMPLE
-        PS C:\> $roles = Get-DbaServerRole -SqlInstance localhost -ServerRole "bulkadmin","dbcreator"
+        PS C:\> $roles = Get-DbaServerRole -SqlInstance localhost -ServerRole bulkadmin, dbcreator
         PS C:\> $roles | Remove-DbaServerRoleMember -Login login1
 
-        Removes login1 from the server localhost to the server-level roles bulkadmin and dbcreator
+        Removes login1 from the bulkadmin and dbcreator fixed server-level roles on the server localhost.
 
     .EXAMPLE
         PS C:\ $logins = Get-Content C:\logins.txt
         PS C:\ $srvLogins = Get-DbaLogin -SqlInstance server1 -Login $logins
         PS C:\ Remove-DbaServerRoleMember -Login $logins
 
-        Removes all the logins found in C:\logins.txt from server-level role mycustomrole on server1.
+        Removes all the logins found in C:\logins.txt from mycustomrole custom server-level role on server1.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (

--- a/functions/Remove-DbaServerRoleMember.ps1
+++ b/functions/Remove-DbaServerRoleMember.ps1
@@ -191,4 +191,4 @@ function Remove-DbaServerRoleMember {
             }
         }
     }
-
+}

--- a/tests/Remove-DbaServerRoleMember.Tests.ps1
+++ b/tests/Remove-DbaServerRoleMember.Tests.ps1
@@ -1,0 +1,70 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tags "UnitTests" {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('WhatIf', 'Confirm')}
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'ServerRole', 'Login', 'Role', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should -Be 0
+        }
+    }
+}
+
+Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $login1 = "dbatoolsci_login1_$(Get-Random)"
+        $login2 = "dbatoolsci_login2_$(Get-Random)"
+        $customServerRole = "dbatoolsci_customrole_$(Get-Random)"
+        $fixedServerRoles = 'dbcreator','processadmin'
+        $null = New-DbaLogin -SqlInstance $script:instance2 -Login $login1 -Password ('Password1234!' | ConvertTo-SecureString -asPlainText -Force)
+        $null = New-DbaLogin -SqlInstance $script:instance2 -Login $login2 -Password ('Password1234!' | ConvertTo-SecureString -asPlainText -Force)
+        $null = New-DbaServerRole -SqlInstance $script:instance2 -ServerRole $customServerRole -Owner sa
+        Add-DbaServerRoleMember -SqlInstance $server -ServerRole $fixedServerRoles[0] -Login $login1, $login2 -Confirm:$false
+    }
+    AfterAll {
+        $server = Connect-DbaInstance -SqlInstance $script:instance2
+        $null = Remove-DbaLogin -SqlInstance $script:instance2 -Login $login1, $login2 -Confirm:$false
+    }
+
+    Context "Functionality" {
+        It 'Removes Login from Role' {
+            Remove-DbaServerRoleMember -SqlInstance $script:instance2 -ServerRole $fixedServerRoles[0] -Login $login1 -Confirm:$false
+            $roleAfter = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles[0]
+
+            $roleAfter.Role | Should -Be $fixedServerRoles[0]
+            $roleAfter.EnumMemberNames().Contains($login1) | Should -Be $false
+            $roleAfter.EnumMemberNames().Contains($login2) | Should -Be $true
+        }
+
+        It 'Removes Login from Multiple Roles' {
+            $serverRoles = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles
+            Remove-DbaServerRoleMember -SqlInstance $script:instance2 -ServerRole $serverRoles -Login $login1 -Confirm:$false
+
+            $roleDBAfter = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles
+            $roleDBAfter.Count | Should -Be $serverRoles.Count
+            $roleDBAfter.Login -contains $login1 | Should -Be $false
+            $roleDBAfter.Login -contains $login2 | Should -Be $true
+
+        }
+
+        It 'Removes Custom Server-Level Role Membership' {
+            Remove-DbaServerRoleMember -SqlInstance $script:instance2 -ServerRole $customServerRole -Role $fixedServerRoles[-1] -Confirm:$false
+            $roleAfter = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles[-1]
+
+            $roleAfter.Role | Should -Be $fixedServerRoles[-1]
+            $roleAfter.EnumMemberNames().Contains($customServerRole) | Should -Be $false
+        }
+
+        It 'Removes Login from Roles via piped input from Get-DbaServerRole' {
+            $serverRole = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles[0]
+            $serverRole | Remove-DbaServerRoleMember -Login $login2 -Confirm:$false
+
+            $roleAfter = Get-DbaServerRole -SqlInstance $server -ServerRole $fixedServerRoles[0]
+            $roleAfter.EnumMemberNames().Contains($login2) | Should -Be $false
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7681 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
The function was missing from the set. See #7681.

### Approach
<!-- How does this change solve that purpose -->
I've used `Remove-DbaServerRoleMember` as a template and based on that created the `Remove-DbaServerRoleMember`. They are basically identical with 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

`Remove-DbaServerRoleMember -SqlInstance localhost -ServerRole bulkadmin, dbcreator -Login login1`

```
$roles = Get-DbaServerRole -SqlInstance localhost -ServerRole bulkadmin, dbcreator
$roles | Remove-DbaServerRoleMember -Login login1
```
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
