### PR TITLE
Update-DbaBuildReference - Set offline_time on first copy

### DIFF
--- a/functions/Update-DbaBuildReference.ps1
+++ b/functions/Update-DbaBuildReference.ps1
@@ -77,6 +77,7 @@ function Update-DbaBuildReference {
         # If no writable copy exists, create one and return the module original
         if (-not (Test-Path $writable_idxfile)) {
             Copy-Item -Path $orig_idxfile -Destination $writable_idxfile -Force -ErrorAction Stop
+            $offline_time = Get-Date (Get-Content $orig_idxfile -Raw | ConvertFrom-Json).LastUpdated
         }
 
         # Else, if both exist, update the writeable if necessary and return the current version


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7827 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

`$offline_time` is needed in `if ($webdata_time -gt $offline_time) {` in any case, but is only calculated in the last `elseif`. So I added it in the `if` block, that is executed on the first run of a new installation.
