### PR TITLE
Invoke-DbaDbLogShipRecovery - update help examples

### DIFF
--- a/functions/Invoke-DbaDbLogShipRecovery.ps1
+++ b/functions/Invoke-DbaDbLogShipRecovery.ps1
@@ -69,12 +69,12 @@ function Invoke-DbaDbLogShipRecovery {
         https://dbatools.io/Invoke-DbaDbLogShipRecovery
 
     .EXAMPLE
-        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1
+        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -Force
 
         Recovers all the databases on the instance that are enabled for log shipping
 
     .EXAMPLE
-        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -SqlCredential $cred -Verbose
+        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -SqlCredential $cred -Verbose -Force
 
         Recovers all the databases on the instance that are enabled for log shipping using a credential
 
@@ -89,7 +89,7 @@ function Invoke-DbaDbLogShipRecovery {
         Recovers the database db1, db2, db3, db4 to a normal status
 
     .EXAMPLE
-        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -WhatIf
+        PS C:\> Invoke-DbaDbLogShipRecovery -SqlInstance server1 -Force -WhatIf
 
         Shows what would happen if the command were executed.
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Running the examples from the help cause a warning about having to use either `-Database` param or `-Force` to do all databases... updated help examples to reflect this.

```PowerShell
PS C:\Users\dbatoolsadmin> Invoke-DbaDbLogShipRecovery -SqlInstance dbatoolslab
WARNING: [07:59:53][Invoke-DbaDbLogShipRecovery] You must specify a -Database or -Force for all databases
```
