### PR TITLE
Get-DbaDbRestoreHistory

### DIFF
--- a/functions/Get-DbaDbRestoreHistory.ps1
+++ b/functions/Get-DbaDbRestoreHistory.ps1
@@ -142,11 +142,11 @@ function Get-DbaDbRestoreHistory {
                     bs.backup_start_date AS BackupStartDate,
                     bs.backup_finish_date,
                     bs.backup_finish_date AS BackupFinishDate,
-					rsh.stop_at AS StopAt,
+                    rsh.stop_at AS StopAt,
                     CASE 
-		                WHEN coalesce(rsh.stop_at, '9999-12-31') < bs.backup_start_date THEN stop_at
-		                ELSE bs.backup_start_date
-	                END AS LastRestorePoint
+                        WHEN coalesce(rsh.stop_at, '9999-12-31') < bs.backup_start_date THEN stop_at
+                        ELSE bs.backup_start_date
+                    END AS LastRestorePoint
                     "
                 }
 


### PR DESCRIPTION
Included BackupStartDate along with StopAt & a combination of the two to provide the LastRestorePoint - being either the stopat point or the start of the last restored backup

Type of Change
 Bug fix (non-breaking change, fixes # )
[x ] New feature (non-breaking change, adds functionality, fixes Get-DbaDbRestoreHistory - additional restore point info request #7854 )
 Breaking change (effects multiple commands or functionality, fixes # )
 Ran manual Pester test and has passed (.\tests\manual.pester.ps1)
 Adding code coverage to existing functionality
 Pester test is included
 If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 Unit test is included
 Documentation
 Build system
Purpose
Adds additional information to the output of the function relating to the point in time of the restore.

Approach
Additional fields returned in SQL statement

Commands to test
Same as before just provide additional lines of output

Screenshots
Shows the new output and the LastRestorePoint being the start of the differential backup.

image

This shows the output of the SQL queries used in the script. Demonstrating the LastRestorePoint returned as the stop_at point:

image

The following shows the output with the last file being a transaction log created after the stop at point but covering the required time. The LastRestoredPoint is shown as the stop at point not the .trn file datetime (UTC, rather than BST)

image

Finally the log backup not being after the stop at time therefore the stop at time can't be used and the point in time will be that of the backup file.

image