### PR TITLE
Backup-DbaDatabase - Add extra caution

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -741,6 +741,10 @@ function Backup-DbaDatabase {
             }
 
             $headerinfo | Select-DefaultView -ExcludeProperty $OutputExclude
+
+            if (-not $ReplaceInName) {
+                $FilePath = $null
+            }
         }
     }
 }


### PR DESCRIPTION
In a [previous PR](https://github.com/sqlcollaborative/dbatools/pull/7858), `$FilePath = $null` was removed in all cases. Because I don't know why the line existed, I'm going to add it back for all cases except the one where it broke (using `$ReplaceInName`)