### PR TITLE
Explicitly require implicitly required .NET version 4.6.2

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -38,7 +38,7 @@
     PowerShellHostVersion  = ''
 
     # Minimum version of the .NET Framework required by this module
-    DotNetFrameworkVersion = ''
+    DotNetFrameworkVersion = '4.6.2'
 
     # Minimum version of the common language runtime (CLR) required by this module
     CLRVersion             = ''


### PR DESCRIPTION
Issue 7815 mentioned this and I was surprised that it imported with older versions.