### PR TITLE
Save-DbaKbUpdate - Add parameter Language

### DIFF
--- a/functions/Save-DbaKbUpdate.ps1
+++ b/functions/Save-DbaKbUpdate.ps1
@@ -15,8 +15,13 @@ function Save-DbaKbUpdate {
     .PARAMETER FilePath
         The exact file name to save to, otherwise, it uses the name given by the webserver
 
-     .PARAMETER Architecture
+    .PARAMETER Architecture
         Defaults to x64. Can be x64, x86, ia64 or "All"
+
+    .PARAMETER Language
+        Cumulative Updates come in one file for all languages, but Service Packs have a file for every language.
+        If you want to download only a specific language, use this parameter.
+        You have to use the three letter code that is part of the filename, e. g. "enu" for english or "deu" for german.
 
     .PARAMETER InputObject
         Enables piping from Get-DbaKbUpdate
@@ -58,6 +63,11 @@ function Save-DbaKbUpdate {
         PS C:\> Save-DbaKbUpdate -Name KB4057114 -Architecture All -Path C:\temp
 
         Downloads the x64 version of KB4057114 and the x86 version of KB4057114 to C:\temp. This works for SQL Server or any other KB.
+
+    .EXAMPLE
+        PS C:\> Save-DbaKbUpdate -Name KB5003279 -Language enu -Path C:\temp
+
+        Downloads only the english version of KB5003279, which is the Service Pack 3 for SQL Server 2016, to C:\temp.
     #>
     [CmdletBinding()]
     param(
@@ -66,6 +76,7 @@ function Save-DbaKbUpdate {
         [string]$FilePath,
         [ValidateSet("x64", "x86", "ia64", "All")]
         [string]$Architecture = "x64",
+        [string]$Language,
         [parameter(ValueFromPipeline)]
         [object[]]$InputObject,
         [switch]$EnableException
@@ -91,7 +102,10 @@ function Save-DbaKbUpdate {
         }
 
         foreach ($link in $InputObject.Link) {
-            if ($Architecture -ne "All" -and $link -notmatch "$($Architecture)_") {
+            if ($Architecture -ne "All" -and $link -notmatch "$($Architecture)[-_]") {
+                continue
+            }
+            if ($Language -and $link -notmatch "-$($Language)_") {
                 continue
             }
 

--- a/tests/Save-DbaKbUpdate.Tests.ps1
+++ b/tests/Save-DbaKbUpdate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandpath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'Name', 'Path', 'FilePath', 'InputObject', 'Architecture', 'EnableException'
+        [object[]]$knownParameters = 'Name', 'Path', 'FilePath', 'InputObject', 'Architecture', 'Language', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7825 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I want to be able to download only the needed language of the SQL Server 2016 Sercice Pack 3.

### Approach
New parameter Language to be able to filter.

### Commands to test
See new example.

### Screenshots
![image](https://user-images.githubusercontent.com/66946165/138899199-1073035c-e9a2-4e1d-9edd-3db9449e243a.png)
