### PR TITLE
Move-DbaDbFile - Return on failed status change

### DIFF
--- a/functions/Move-DbaDbFile.ps1
+++ b/functions/Move-DbaDbFile.ps1
@@ -6,7 +6,6 @@ function Move-DbaDbFile {
     .DESCRIPTION
         Moves database files from one local drive or folder to another.
         It will put database offline, update metadata and set it online again.
-        It can also be used to move database files on an AG secondary.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -148,7 +147,7 @@ function Move-DbaDbFile {
 
             $dbStatus = (Get-DbaDbState -SqlInstance $server -Database $Database).Status
             if ($dbStatus -ne 'ONLINE') {
-                Write-Message -Level Verbose -Message "Database $Database is already Offline. Getting file strucutre from sys.master_files."
+                Write-Message -Level Verbose -Message "Database $Database is not ONLINE. Getting file strucutre from sys.master_files."
                 if ($fileTypeFilter -eq -1) {
                     $DataFiles = Get-DbaDbPhysicalFile -SqlInstance $server | Where-Object Name -eq $Database | Select-Object LogicalName, PhysicalName
                 } else {
@@ -185,12 +184,14 @@ function Move-DbaDbFile {
                         try {
                             $SetState = Set-DbaDbState -SqlInstance $server -Database $Database -Offline -Force:$Force
                             if ($SetState.Status -ne 'Offline') {
-                                Write-Message -Level Warning -Message "Setting database Offline failed!"
+                                Stop-Function -Message "Setting database Offline failed!"
+                                return
                             } else {
                                 Write-Message -Level Verbose -Message "Database $Database was set to Offline status."
                             }
                         } catch {
-                            Stop-Function -Message "Setting database Offline failed! : $($_.Exception.InnerException.InnerException.InnerException)" -ErrorRecord $_ -Target $server.DomainInstanceName -OverrideExceptionMessage
+                            Stop-Function -Message "Setting database Offline failed!" -ErrorRecord $_ -Target $SqlInstance
+                            return
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7698  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

To get a starting point, I had a look at the code and tried to address the problems related to the linked issue.

But I think there are more problems in the code. In general, the usage of try-catch and Stop-Function should be generally revisited. A lot of "return" are missing, as without -EnableException only a warning is displayed and it is up to the author of the commands to issue a return to stop the further processing of the command.