### PR TITLE
Improve clarity in docs

### DIFF
--- a/functions/Get-DbaMaintenanceSolutionLog.ps1
+++ b/functions/Get-DbaMaintenanceSolutionLog.ps1
@@ -17,7 +17,7 @@ function Get-DbaMaintenanceSolutionLog {
         For MFA support, please use Connect-DbaInstance.
 
     .PARAMETER LogType
-        Accepts 'IndexOptimize', 'DatabaseBackup', 'DatabaseIntegrityCheck'. ATM only IndexOptimize parsing is available
+        Accepts 'IndexOptimize', 'DatabaseBackup', 'DatabaseIntegrityCheck'. Only IndexOptimize parsing is available at the moment
 
     .PARAMETER Since
         Consider only files generated since this date


### PR DESCRIPTION
The acronym/abbreviation ATM is being used instead of a clearer alternative, "at the moment". 