### PR TITLE
Backup-DbaDatabase - Remove usage of [IO.Path]::GetFullPath for MacOS

### DIFF
--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -533,7 +533,12 @@ function Backup-DbaDatabase {
                 $suffix = $file.extension -Replace '^\.', ''
                 if ( '' -ne (Split-Path $FilePath)) {
                     Write-Message -Level Verbose -Message "Fully qualified path passed in"
-                    $FinalBackupPath += $file.DirectoryName
+                    # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
+                    if ($IsMacOS) {
+                        $FinalBackupPath += $file.DirectoryName
+                    } else {
+                        $FinalBackupPath += [IO.Path]::GetFullPath($file.DirectoryName)
+                    }
                 }
             } else {
                 Write-Message -Level VeryVerbose -Message "Setting filename - $timestamp"
@@ -599,6 +604,10 @@ function Backup-DbaDatabase {
                 }
             }
 
+            # Because of #7860, don't use [IO.Path]::GetFullPath on MacOS
+            if ($null -eq $AzureBaseUrl -and $Path -and -not $IsMacOS) {
+                $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
+            }
 
             $script = $null
             $backupComplete = $false

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -533,7 +533,7 @@ function Backup-DbaDatabase {
                 $suffix = $file.extension -Replace '^\.', ''
                 if ( '' -ne (Split-Path $FilePath)) {
                     Write-Message -Level Verbose -Message "Fully qualified path passed in"
-                    $FinalBackupPath += [IO.Path]::GetFullPath($file.DirectoryName)
+                    $FinalBackupPath += $file.DirectoryName
                 }
             } else {
                 Write-Message -Level VeryVerbose -Message "Setting filename - $timestamp"
@@ -597,11 +597,6 @@ function Backup-DbaDatabase {
                         }
                     }
                 }
-            }
-
-
-            if ($null -eq $AzureBaseUrl -and $Path) {
-                $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
             }
 
 

--- a/functions/Backup-DbaDatabase.ps1
+++ b/functions/Backup-DbaDatabase.ps1
@@ -609,6 +609,7 @@ function Backup-DbaDatabase {
                 $FinalBackupPath = $FinalBackupPath | ForEach-Object { [IO.Path]::GetFullPath($_) }
             }
 
+
             $script = $null
             $backupComplete = $false
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7860 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Support mixed os environment, so using dbatools on MacOS for an instance on windows.

### Approach
Removed [IO.Path]::GetFullPath as I think it is not necessary. But it may be needed in some situations, so please @Stuart-Moore have a look at this.
