### PR TITLE
Reset-DbaAdmin - Use TrustServerCertificate

### DIFF
--- a/functions/Reset-DbaAdmin.ps1
+++ b/functions/Reset-DbaAdmin.ps1
@@ -133,7 +133,7 @@ function Reset-DbaAdmin {
                 [switch]$EnableException
             )
             try {
-                $connstring = "Data Source=$instance;Integrated Security=True;Connect Timeout=20;Application Name=Reset-DbaAdmin"
+                $connstring = "Data Source=$instance;Integrated Security=True;TrustServerCertificate=true;Connect Timeout=20;Application Name=Reset-DbaAdmin"
                 $conn = New-Object Microsoft.Data.SqlClient.SqlConnection $connstring
                 $conn.Open()
                 $cmd = New-Object Microsoft.Data.sqlclient.sqlcommand($null, $conn)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7792 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Reset-DbAdmin should be as resilient as possible. The new library always tests the server certificate.

### Approach
Use TrustServerCertificate to be able to connect even if certificatename does not match the given server name.

@potatoqualitee - Is this what you have planned?