### PR TITLE
Re-enabling pending rename check by default

### DIFF
--- a/functions/Get-DbaComputerSystem.ps1
+++ b/functions/Get-DbaComputerSystem.ps1
@@ -132,7 +132,7 @@ function Get-DbaComputerSystem {
                 $pendingReboot = $null
                 try {
                     Write-Message -Level Verbose -Message "Getting information about pending reboots."
-                    $pendingReboot = Test-PendingReboot -ComputerName $computerResolved -Credential $Credential -PendingRename
+                    $pendingReboot = Test-PendingReboot -ComputerName $computerResolved -Credential $Credential
                 } catch {
                     Write-Message -Level Verbose -Message "Not able to get information about pending reboots."
                 }

--- a/functions/Install-DbaInstance.ps1
+++ b/functions/Install-DbaInstance.ps1
@@ -169,6 +169,9 @@ function Install-DbaInstance {
     .PARAMETER AuthenticationMode
         Chooses authentication mode for SQL Server. Allowed values: Mixed, Windows.
 
+    .PARAMETER NoPendingRenameCheck
+        Disables pending rename validation when checking for a pending reboot.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -276,6 +279,7 @@ function Install-DbaInstance {
         [string]$SaveConfiguration,
         [switch]$PerformVolumeMaintenanceTasks,
         [switch]$Restart,
+        [switch]$NoPendingRenameCheck = (Get-DbatoolsConfigValue -Name 'OS.PendingRename' -Fallback $false),
         [switch]$EnableException
     )
     begin {
@@ -709,6 +713,7 @@ function Install-DbaInstance {
                     SaCredential                  = $SaCredential
                     PerformVolumeMaintenanceTasks = $PerformVolumeMaintenanceTasks
                     Credential                    = $Credential
+                    NoPendingRenameCheck          = $NoPendingRenameCheck
                     EnableException               = $EnableException
                 }
             }

--- a/functions/Invoke-DbaAdvancedInstall.ps1
+++ b/functions/Invoke-DbaAdvancedInstall.ps1
@@ -61,6 +61,9 @@ function Invoke-DbaAdvancedInstall {
     .PARAMETER SaCredential
         Securely provide the password for the sa account when using mixed mode authentication.
 
+    .PARAMETER NoPendingRenameCheck
+        Disables pending rename validation when checking for a pending reboot.
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -103,6 +106,7 @@ function Invoke-DbaAdvancedInstall {
         [string]$Authentication = 'Credssp',
         [pscredential]$Credential,
         [pscredential]$SaCredential,
+        [switch]$NoPendingRenameCheck,
         [switch]$EnableException
     )
     Function Get-SqlInstallSummary {
@@ -180,7 +184,7 @@ function Invoke-DbaAdvancedInstall {
     }
     $activity = "Installing SQL Server ($Version) components on $ComputerName"
     try {
-        $restartNeeded = Test-PendingReboot -ComputerName $ComputerName -Credential $Credential
+        $restartNeeded = Test-PendingReboot -ComputerName $ComputerName -Credential $Credential -NoPendingRename:$NoPendingRenameCheck
     } catch {
         $restartNeeded = $false
         Stop-Function -Message "Failed to get reboot status from $computer" -ErrorRecord $_
@@ -305,7 +309,7 @@ function Invoke-DbaAdvancedInstall {
     }
     # restart if necessary
     try {
-        $restartNeeded = Test-PendingReboot -ComputerName $ComputerName -Credential $Credential
+        $restartNeeded = Test-PendingReboot -ComputerName $ComputerName -Credential $Credential -NoPendingRename:$NoPendingRenameCheck
     } catch {
         $restartNeeded = $false
         Stop-Function -Message "Failed to get reboot status from $($ComputerName)" -ErrorRecord $_

--- a/functions/Invoke-DbaAdvancedUpdate.ps1
+++ b/functions/Invoke-DbaAdvancedUpdate.ps1
@@ -36,6 +36,9 @@ Function Invoke-DbaAdvancedUpdate {
         A list of extra arguments to pass to the execution file. Accepts one or more strings containing command line parameters.
         Example: ... -ArgumentList "/SkipRules=RebootRequiredCheck", "/Q"
 
+    .PARAMETER NoPendingRenameCheck
+        Disables pending rename validation when checking for a pending reboot.
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -77,6 +80,7 @@ Function Invoke-DbaAdvancedUpdate {
         [pscredential]$Credential,
         [string]$ExtractPath,
         [string[]]$ArgumentList,
+        [switch]$NoPendingRenameCheck,
         [switch]$EnableException
 
     )
@@ -94,7 +98,7 @@ Function Invoke-DbaAdvancedUpdate {
         $restartParams.Credential = $Credential
     }
     try {
-        $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential
+        $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential -NoPendingRename:$NoPendingRenameCheck
     } catch {
         $restartNeeded = $false
         Stop-Function -Message "Failed to get reboot status from $computer" -ErrorRecord $_
@@ -203,7 +207,7 @@ Function Invoke-DbaAdvancedUpdate {
         }
         #double check if restart is needed
         try {
-            $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential
+            $restartNeeded = Test-PendingReboot -ComputerName $computer -Credential $Credential -NoPendingRename:$NoPendingRenameCheck
         } catch {
             $restartNeeded = $false
             Stop-Function -Message "Failed to get reboot status from $computer" -ErrorRecord $_

--- a/functions/Update-DbaInstance.ps1
+++ b/functions/Update-DbaInstance.ps1
@@ -94,6 +94,9 @@ function Update-DbaInstance {
         Files would be first downloaded to the local machine (TEMP folder), and then distributed onto remote machines if needed.
         If the Path is a network Path, the files would be downloaded straight to the network folder and executed from there.
 
+    .PARAMETER NoPendingRenameCheck
+        Disables pending rename validation when checking for a pending reboot.
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 
@@ -206,6 +209,7 @@ function Update-DbaInstance {
         [string]$ExtractPath,
         [string[]]$ArgumentList,
         [switch]$Download,
+        [switch]$NoPendingRenameCheck = (Get-DbatoolsConfigValue -Name 'OS.PendingRename' -Fallback $false),
         [switch]$EnableException
 
     )
@@ -578,14 +582,15 @@ function Update-DbaInstance {
         # Declare the installation script
         $installScript = {
             $updateSplat = @{
-                ComputerName    = $_.ComputerName
-                Action          = $_.Actions
-                Restart         = $Restart
-                Credential      = $Credential
-                EnableException = $EnableException
-                ExtractPath     = $ExtractPath
-                Authentication  = $Authentication
-                ArgumentList    = $ArgumentList
+                ComputerName         = $_.ComputerName
+                Action               = $_.Actions
+                Restart              = $Restart
+                Credential           = $Credential
+                EnableException      = $EnableException
+                ExtractPath          = $ExtractPath
+                Authentication       = $Authentication
+                ArgumentList         = $ArgumentList
+                NoPendingRenameCheck = $NoPendingRenameCheck
             }
             Invoke-DbaAdvancedUpdate @updateSplat
         }

--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -60,6 +60,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             'SaveConfiguration',
             'PerformVolumeMaintenanceTasks',
             'Restart',
+            'NoPendingRenameCheck',
             'EnableException'
         )
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters

--- a/tests/Invoke-DbaAdvancedInstall.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedInstall.Tests.ps1
@@ -42,6 +42,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
             'PerformVolumeMaintenanceTasks',
             'Restart',
             'EnableException',
+            'NoPendingRenameCheck',
             'ArgumentList'
         )
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters

--- a/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedUpdate.Tests.ps1
@@ -103,7 +103,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'ComputerName', 'Action', 'Credential', 'Restart', 'Authentication', 'EnableException', 'ExtractPath', 'ArgumentList'
+        [object[]]$knownParameters = 'ComputerName', 'Action', 'Credential', 'Restart', 'Authentication', 'EnableException', 'ExtractPath', 'ArgumentList', 'NoPendingRenameCheck'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0

--- a/tests/Update-DbaInstance.Tests.ps1
+++ b/tests/Update-DbaInstance.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     }
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'Version', 'Type', 'KB', 'InstanceName', 'Path', 'Restart', 'Continue', 'Throttle', 'Authentication', 'EnableException', 'ExtractPath', 'ArgumentList', 'Download'
+        [object[]]$knownParameters = 'ComputerName', 'Credential', 'Version', 'Type', 'KB', 'InstanceName', 'Path', 'Restart', 'Continue', 'Throttle', 'Authentication', 'EnableException', 'ExtractPath', 'ArgumentList', 'Download', 'NoPendingRenameCheck'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7301 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Revert the change introduced in #6432

### Approach
Pending file renames should be checked every time, but if users want to opt out, they can do it now using a switch `-NoPendingRenameCheck ` or by setting a config value `OS.PendingRename`

### Learning
If a user wants a customized behavior, introduce it as a switch/config. Don't change it for everyone.