### PR TITLE
Get-DbaDbBackupHistory error 8623

### DIFF
--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -645,8 +645,8 @@ function Get-DbaDbBackupHistory {
                     FROM msdb..backupfile bf
                     join #BackupSetIds bs
                         on bs.backup_set_id = bf.backup_set_id
-                    WHERE [state] <> 8; #Used to eliminate data files that no longer exist
-                    Drop Table #BackupSetIds"
+                    WHERE [state] <> 8; 
+                    Drop Table #BackupSetIds;" # <> 8 Used to eliminate data files that no longer exist
                     Write-Message -Level Debug -Message "FileSQL: $fileAllSql"
                     $fileListResults = $server.Query($fileAllSql)
                 } else {

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -638,10 +638,10 @@ function Get-DbaDbBackupHistory {
                 Write-Message -Level SomewhatVerbose -Message "$($groupedResults.Count) result-groups found."
                 $groupResults = @()
                 $backupSetIds = $groupedResults.Name
-                $backupSetIdsList = '(' + ($backupSetIds -join '),(') + ')'
+                $backupSetIdsList = "Insert into #BackupSetIds( backup_set_id ) Values (" + ($backupSetIds -join ");Insert into #BackupSetIds( backup_set_id ) Values (") + ")"
                 if ($groupedResults.Count -gt 0) {
-                    $TempTable = "Create table #BackupSetIds ( backup_set_id int ); Insert into #BackupSetIds( backup_set_id ) Values $BackupSetIdsList;"
-                    $fileAllSql = "$TempTable SELECT backup_set_id, file_type as FileType, logical_name as LogicalName, physical_name as PhysicalName
+                    $TempTable = "Create table #BackupSetIds ( backup_set_id int ); $backupSetIdsList;"
+                    $fileAllSql = "$TempTable SELECT bf.backup_set_id, file_type as FileType, logical_name as LogicalName, physical_name as PhysicalName
                     FROM msdb..backupfile bf
                     join #BackupSetIds bs
                         on bs.backup_set_id = bf.backup_set_id

--- a/functions/Get-DbaDbBackupHistory.ps1
+++ b/functions/Get-DbaDbBackupHistory.ps1
@@ -645,7 +645,7 @@ function Get-DbaDbBackupHistory {
                     FROM msdb..backupfile bf
                     join #BackupSetIds bs
                         on bs.backup_set_id = bf.backup_set_id
-                    WHERE [state] <> 8; 
+                    WHERE [state] <> 8;
                     Drop Table #BackupSetIds;" # <> 8 Used to eliminate data files that no longer exist
                     Write-Message -Level Debug -Message "FileSQL: $fileAllSql"
                     $fileListResults = $server.Query($fileAllSql)


### PR DESCRIPTION
Changed from In clause to temp table to avoid error 8623 on large sets of backupsetIDs

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ x] Bug fix (non-breaking change, fixes #7916<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Fix  Error 8623 in Get-DbaDbBackupHistory

### Approach
Changes use of IN ( ) to a temporary table
https://docs.microsoft.com/en-us/sql/t-sql/language-elements/in-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15