### PR TITLE
Remove-DbaLinkedServer: Add option to drop logins along with the linked server

### DIFF
--- a/functions/Remove-DbaLinkedServer.ps1
+++ b/functions/Remove-DbaLinkedServer.ps1
@@ -116,11 +116,7 @@ function Remove-DbaLinkedServer {
 
             if ($Pscmdlet.ShouldProcess($lsToDrop.Parent.Name, "Removing the linked server $($lsToDrop.Name) on $($lsToDrop.Parent.Name)")) {
                 try {
-                    if (Test-Bound Force) {
-                        $lsToDrop.Drop($true)
-                    } else {
-                        $lsToDrop.Drop()
-                    }
+                    $lsToDrop.Drop([boolean]$Force)
                 } catch {
                     Stop-Function -Message "Failure on $($lsToDrop.Parent.Name) to remove the linked server $($lsToDrop.Name)" -ErrorRecord $_ -Continue
                 }

--- a/functions/Remove-DbaLinkedServer.ps1
+++ b/functions/Remove-DbaLinkedServer.ps1
@@ -29,6 +29,9 @@ function Remove-DbaLinkedServer {
     .PARAMETER Confirm
         Prompts you for confirmation before executing any changing operations within the command.
 
+    .PARAMETER Force
+        Drops the linked server login(s) associated with the linked server and then drops the linked server.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -51,6 +54,11 @@ function Remove-DbaLinkedServer {
         Removes the linked server "linkedServer1" from the sql01 instance.
 
     .EXAMPLE
+        PS C:\>Remove-DbaLinkedServer -SqlInstance sql01 -LinkedServer linkedServer1 -Confirm:$false -Force
+
+        Removes the linked server "linkedServer1" and the associated linked server logins from the sql01 instance.
+
+    .EXAMPLE
         PS C:\>$linkedServer1 = Get-DbaLinkedServer -SqlInstance sql01 -LinkedServer linkedServer1
         PS C:\>$linkedServer1 | Remove-DbaLinkedServer -Confirm:$false
 
@@ -68,6 +76,7 @@ function Remove-DbaLinkedServer {
         [string[]]$LinkedServer,
         [parameter(ValueFromPipeline)]
         [object[]]$InputObject,
+        [switch]$Force,
         [switch]$EnableException
     )
     begin {
@@ -107,7 +116,11 @@ function Remove-DbaLinkedServer {
 
             if ($Pscmdlet.ShouldProcess($lsToDrop.Parent.Name, "Removing the linked server $($lsToDrop.Name) on $($lsToDrop.Parent.Name)")) {
                 try {
-                    $lsToDrop.Drop()
+                    if (Test-Bound Force) {
+                        $lsToDrop.Drop($true)
+                    } else {
+                        $lsToDrop.Drop()
+                    }
                 } catch {
                     Stop-Function -Message "Failure on $($lsToDrop.Parent.Name) to remove the linked server $($lsToDrop.Name)" -ErrorRecord $_ -Continue
                 }

--- a/tests/Remove-DbaLinkedServer.Tests.ps1
+++ b/tests/Remove-DbaLinkedServer.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'InputObject', 'Force', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
@@ -17,56 +17,85 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
     BeforeAll {
         $random = Get-Random
         $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
 
-        $instance2.Query("EXEC sp_addlinkedserver @server=N'LS1_$random'")
-        $instance2.Query("EXEC sp_addlinkedserver @server=N'LS2_$random'")
-        $instance2.Query("EXEC sp_addlinkedserver @server=N'LS3_$random'")
+        $linkedServerName1 = "LS1_$random"
+        $linkedServerName2 = "LS2_$random"
+        $linkedServerName3 = "LS3_$random"
+        $linkedServerName4 = "LS4_$random"
 
-        $ls1 = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS1_$random"
-        $ls2 = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS2_$random"
-        $ls3 = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS3_$random"
+        $linkedServer1 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName1
+        $linkedServer2 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName2
+        $linkedServer3 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName3
+        $linkedServer4 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName4
+
+        $securePassword = ConvertTo-SecureString -String 's3cur3P4ssw0rd?' -AsPlainText -Force
+        $loginName = "test_$random"
+        New-DbaLogin -SqlInstance $instance2, $instance3 -Login $loginName -SecurePassword $securePassword
+
+        $newLinkedServerLogin = New-Object Microsoft.SqlServer.Management.Smo.LinkedServerLogin
+        $newLinkedServerLogin.Parent = $linkedServer4
+        $newLinkedServerLogin.Name = $loginName
+        $newLinkedServerLogin.RemoteUser = $loginName
+        $newLinkedServerLogin.SetRemotePassword(($securePassword | ConvertFrom-SecurePass))
+        $newLinkedServerLogin.Create()
     }
     AfterAll {
-        if ($instance2.LinkedServers.Name -contains "LS1_$random") {
-            $instance2.LinkedServers["LS1_$random"].Drop()
+        if ($instance2.LinkedServers.Name -contains $linkedServerName1) {
+            $instance2.LinkedServers[$linkedServerName1].Drop()
         }
 
-        if ($instance2.LinkedServers.Name -contains "LS2_$random") {
-            $instance2.LinkedServers["LS2_$random"].Drop()
+        if ($instance2.LinkedServers.Name -contains $linkedServerName2) {
+            $instance2.LinkedServers[$linkedServerName2].Drop()
         }
 
-        if ($instance2.LinkedServers.Name -contains "LS3_$random") {
-            $instance2.LinkedServers["LS3_$random"].Drop()
+        if ($instance2.LinkedServers.Name -contains $linkedServerName3) {
+            $instance2.LinkedServers[$linkedServerName3].Drop()
         }
+
+        if ($instance2.LinkedServers.Name -contains $linkedServerName4) {
+            $instance2.LinkedServers[$linkedServerName4].Drop($true)
+        }
+
+        Remove-DbaLogin -SqlInstance $instance2, $instance3 -Login $loginName -Confirm:$false
     }
 
     Context "ensure command works" {
 
         It "Removes a linked server" {
-            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS1_$random"
+            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName1
             $results.Length | Should -Be 1
-            Remove-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS1_$random" -Confirm:$false
-            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS1_$random"
+            Remove-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer $linkedServerName1 -Confirm:$false
+            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName1
             $results | Should -BeNullOrEmpty
         }
 
         It "Tries to remove a non-existent linked server" {
-            Remove-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS1_$random" -Confirm:$false -WarningVariable warnings
-            $warnings | Should -BeLike "*Linked server LS1_$random does not exist on $($instance2.Name)"
+            Remove-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer $linkedServerName1 -Confirm:$false -WarningVariable warnings
+            $warnings | Should -BeLike "*Linked server $linkedServerName1 does not exist on $($instance2.Name)"
         }
 
         It "Removes a linked server using a server from a pipeline and a linked server from a pipeline" {
-            $results = Get-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS2_$random"
+            $results = Get-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer $linkedServerName2
             $results.Length | Should -Be 1
-            Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS2_$random" | Remove-DbaLinkedServer -WarningVariable warn -Confirm:$false
+            Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName2 | Remove-DbaLinkedServer -WarningVariable warn -Confirm:$false
             $warn | Should -BeNullOrEmpty
-            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS2_$random"
+            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName2
             $results | Should -BeNullOrEmpty
 
-            $results = Get-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer "LS3_$random"
+            $results = Get-DbaLinkedServer -SqlInstance $script:instance2 -LinkedServer $linkedServerName3
             $results.Length | Should -Be 1
-            $instance2 | Remove-DbaLinkedServer -LinkedServer "LS3_$random" -Confirm:$false
-            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer "LS3_$random"
+            $instance2 | Remove-DbaLinkedServer -LinkedServer $linkedServerName3 -Confirm:$false
+            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName3
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Removes a linked server that requires the -Force param" {
+            Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName4 | Remove-DbaLinkedServer -Confirm:$false -WarningVariable warnings
+            $warnings | Should -BeLike "*There are still remote logins or linked logins for the server*"
+
+            Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName4 | Remove-DbaLinkedServer -Confirm:$false -Force
+            $results = Get-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServerName4
             $results | Should -BeNullOrEmpty
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7951 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Add a -Force param so that the logins for a linked server can be dropped at the same time as the linked server.

### Approach
<!-- How does this change solve that purpose -->
Minor change to use a new param.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the new pester test.