### PR TITLE
Save-DbaCommunitySoftware - Add file with version information for SQLWATCH

### DIFF
--- a/functions/Save-DbaCommunitySoftware.ps1
+++ b/functions/Save-DbaCommunitySoftware.ps1
@@ -246,6 +246,8 @@ function Save-DbaCommunitySoftware {
                 # As this software is downloaded as a release, the directory has a different name.
                 # Rename the directory from like 'SQLWATCH 4.3.0.23725 20210721131116' to 'SQLWATCH' to be able to handle this like the other software.
                 if ($sourceDirectoryName -like 'SQLWATCH*') {
+                    # Write a file with version info, to be able to check if version is outdated
+                    Set-Content -Path "$sourceDirectory\version.txt" -Value $sourceDirectoryName
                     Rename-Item -Path $sourceDirectory.FullName -NewName 'SQLWATCH'
                     $sourceDirectory = Get-ChildItem -Path $zipFolder -Directory
                     $sourceDirectoryName = $sourceDirectory.Name


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

As we rename the original directory, we loose the information of the version that is inside.
So we save the original directory name in a new file version.txt.
That way, we can write a script to give us the versions of all community software that is currently in the cache. I will post a first version of such a script in a comment.