### PR TITLE
Get-DbaNetworkConfiguration: Add OutputType Certificate

### DIFF
--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -255,7 +255,7 @@ function Get-DbaNetworkConfiguration {
                         IssuedBy        = $netConf.Certificate.IssuedBy
                         Certificate     = $netConf.Certificate.Certificate
                     }
-                    $defaultView = 'ComputerName', 'InstanceName', 'SqlInstance', 'VSName', 'ServiceAccount', 'ForceEncryption', 'FriendlyName', 'DnsNameList', 'Thumbprint', 'Generated', 'Expires', 'IssuedTo', 'IssuedBy'
+                    $defaultView = 'ComputerName,InstanceName,SqlInstance,VSName,ServiceAccount,ForceEncryption,FriendlyName,DnsNameList,Thumbprint,Generated,Expires,IssuedTo,IssuedBy'.Split(',')
                     if (-not $netConf.Certificate.VSName) {
                         $defaultView = $defaultView | Where-Object { $_ -ne 'VSNAME' }
                     }

--- a/tests/Get-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Get-DbaNetworkConfiguration.Tests.ps1
@@ -23,7 +23,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "has the correct properties" {
-            $ExpectedPropsFull = 'ComputerName,InstanceName,SqlInstance,SharedMemoryEnabled,NamedPipesEnabled,TcpIpEnabled,TcpIpProperties,TcpIpAddresses'.Split(',')
+            $ExpectedPropsFull = 'ComputerName,InstanceName,SqlInstance,SharedMemoryEnabled,NamedPipesEnabled,TcpIpEnabled,TcpIpProperties,TcpIpAddresses,Certificate'.Split(',')
             ($resultsFull.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsFull | Sort-Object)
             $ExpectedPropsTcpIpProperties = 'ComputerName,InstanceName,SqlInstance,Enabled,KeepAlive,ListenAll'.Split(',')
             ($resultsTcpIpProperties.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsTcpIpProperties | Sort-Object)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Long term, I want this command to return all information accessible via SQL Server Configuration Manager.
This step adds all information from Get-DbaNetworkCertificate to be able to refactor that command later.
This change helps to address #6230.
In addition to Get-DbaNetworkCertificate, this command returns the property ForceEncryption as well.

![image](https://user-images.githubusercontent.com/66946165/142380742-2f9be3be-c159-47b6-a5dd-26cebe114688.png)
