### PR TITLE
New-DbaAvailabilityGroup - add a test before attempting to add database

### DIFF
--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -663,6 +663,19 @@ function New-DbaAvailabilityGroup {
                 if ($SeedingMode) { $addDatabaseParams['SeedingMode'] = $SeedingMode }
                 if ($SharedPath) { $addDatabaseParams['SharedPath'] = $SharedPath }
                 try {
+                    do {
+                        Start-Sleep -Milliseconds 500
+                        $states = Get-DbaAgReplica -SqlInstance $secondaries | Where-Object Role -notin "Primary", "Unknown"
+                        $wait++
+                        $ready = $true
+                        foreach ($state in $states) {
+                            if ($state.ConnectionState -ne "Connected") {
+                                $ready = $false
+                            }
+                        }
+                    }
+                    until ($ready -or $wait -gt 10)
+                    $wait = 0
                     $null = Add-DbaAgDatabase @addDatabaseParams
                 } catch {
                     Stop-Function -Message "Failed to add databases to Availability Group." -ErrorRecord $_

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -652,7 +652,12 @@ function New-DbaAvailabilityGroup {
                     $ready = $false
                 }
             }
-        } until ($ready -or $wait -gt 20) # wait up to 10 seconds (500ms * 20)
+        } until ($ready -or $wait -gt 40) # wait up to 20 seconds (500ms * 40)
+
+        if (-not $ready -or $wait -gt 40) {
+            Write-Message -Level Warning -Message "One or more replicas are still not connected and ready. If you encounter this error often, please let us know and we'll increase the timeout. Moving on and trying the next step."
+        }
+
         $wait = 0
 
         # Add databases

--- a/functions/New-DbaAvailabilityGroup.ps1
+++ b/functions/New-DbaAvailabilityGroup.ps1
@@ -673,8 +673,7 @@ function New-DbaAvailabilityGroup {
                                 $ready = $false
                             }
                         }
-                    }
-                    until ($ready -or $wait -gt 10)
+                    } until ($ready -or $wait -gt 20) # wait up to 10 seconds (500ms * 20)
                     $wait = 0
                     $null = Add-DbaAgDatabase @addDatabaseParams
                 } catch {


### PR DESCRIPTION
Sometimes this awesome command would be too darn fast and the ag wasn't ready to accept a database. This waits until the state is connected before attempting to add.