### PR TITLE
New command: Get-DbaLinkedServerLogin

### DIFF
--- a/functions/Get-DbaLinkedServerLogin.ps1
+++ b/functions/Get-DbaLinkedServerLogin.ps1
@@ -29,6 +29,12 @@ function Get-DbaLinkedServerLogin {
     .PARAMETER InputObject
         Allows piping from Connect-DbaInstance and Get-DbaLinkedServer
 
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.

--- a/functions/Get-DbaLinkedServerLogin.ps1
+++ b/functions/Get-DbaLinkedServerLogin.ps1
@@ -1,0 +1,123 @@
+function Get-DbaLinkedServerLogin {
+    <#
+    .SYNOPSIS
+        Obtains linked server login(s).
+
+    .DESCRIPTION
+        Obtains linked server login(s).
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER LinkedServer
+        The name(s) of the linked server(s).
+
+    .PARAMETER LocalLogin
+        The name(s) of the linked server login(s) to include.
+
+    .PARAMETER ExcludeLocalLogin
+        The name(s) of the linked server login(s) to exclude
+
+    .PARAMETER InputObject
+        Allows piping from Connect-DbaInstance and Get-DbaLinkedServer
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Security, Server
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaLinkedServerLogin
+
+    .EXAMPLE
+        PS C:\>Get-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -LocalLogin login1
+
+        Gets the linked server login "login1" from the linked server "linkedServer1" on sql01.
+
+    .EXAMPLE
+        PS C:\>Get-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -ExcludeLocalLogin login2
+
+        Gets the linked server login(s) from the linked server "linkedServer1" on sql01 and excludes the login2 linked server login.
+
+    .EXAMPLE
+        PS C:\>(Get-DbaLinkedServer -SqlInstance sql01 -LinkedServer linkedServer1) | Get-DbaLinkedServerLogin -LocalLogin login1
+
+        Gets the linked server login "login1" from the linked server "linkedServer1" on sql01 using a pipeline with the linked server passed in.
+
+    .EXAMPLE
+        PS C:\>(Connect-DbaInstance -SqlInstance sql01) | Get-DbaLinkedServerLogin -LinkedServer linkedServer1 -LocalLogin login1
+
+        Gets the linked server login "login1" from the linked server "linkedServer1" on sql01 using a pipeline with the instance passed in.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$LinkedServer,
+        [string[]]$LocalLogin,
+        [string[]]$ExcludeLocalLogin,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        foreach ($instance in $SqlInstance) {
+
+            if (Test-Bound -Not -ParameterName LinkedServer) {
+                Stop-Function -Message "LinkedServer is required" -Continue
+            }
+
+            $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential | Get-DbaLinkedServer -LinkedServer $LinkedServer
+        }
+
+        foreach ($obj in $InputObject) {
+
+            if ($obj -is [Microsoft.SqlServer.Management.Smo.Server]) {
+
+                if (Test-Bound -Not -ParameterName LinkedServer) {
+                    Stop-Function -Message "LinkedServer is required" -Continue
+                }
+
+                $ls = Get-DbaLinkedServer -SqlInstance $obj -LinkedServer $LinkedServer
+
+            } elseif ($obj -is [Microsoft.SqlServer.Management.Smo.LinkedServer]) {
+                $ls = $obj
+            }
+
+            $linkedServerLogins = $ls.LinkedServerLogins
+
+            if ($LocalLogin) {
+                $linkedServerLogins = $linkedServerLogins | Where-Object { $_.Name -in $LocalLogin }
+            }
+
+            if ($ExcludeLocalLogin) {
+                $linkedServerLogins = $linkedServerLogins | Where-Object { $_.Name -notin $ExcludeLocalLogin }
+            }
+
+            foreach ($lsLogin in $linkedServerLogins) {
+                Add-Member -Force -InputObject $lsLogin -MemberType NoteProperty -Name ComputerName -value $ls.parent.ComputerName
+                Add-Member -Force -InputObject $lsLogin -MemberType NoteProperty -Name InstanceName -value $ls.parent.ServiceName
+                Add-Member -Force -InputObject $lsLogin -MemberType NoteProperty -Name SqlInstance -value $ls.parent.DomainInstanceName
+
+                Select-DefaultView -InputObject $lsLogin -Property ComputerName, InstanceName, SqlInstance, Name, RemoteUser, Impersonate
+            }
+        }
+    }
+}

--- a/tests/Get-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Get-DbaLinkedServerLogin.Tests.ps1
@@ -1,0 +1,113 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'LocalLogin', 'ExcludeLocalLogin', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $random = Get-Random
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
+
+        $securePassword = ConvertTo-SecureString -String 's3cur3P4ssw0rd?' -AsPlainText -Force
+        $localLogin1Name = "dbatoolscli_localLogin1_$random"
+        $localLogin2Name = "dbatoolscli_localLogin2_$random"
+        $remoteLoginName = "dbatoolscli_remoteLogin_$random"
+
+        $linkedServer1Name = "dbatoolscli_linkedServer1_$random"
+        $linkedServer2Name = "dbatoolscli_linkedServer2_$random"
+
+        New-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name -SecurePassword $securePassword
+        New-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -SecurePassword $securePassword
+
+        $linkedServer1 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+        $linkedServer2 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer2Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+
+        $newLinkedServerLogin1 = New-Object Microsoft.SqlServer.Management.Smo.LinkedServerLogin
+        $newLinkedServerLogin1.Parent = $linkedServer1
+        $newLinkedServerLogin1.Name = $localLogin1Name
+        $newLinkedServerLogin1.RemoteUser = $remoteLoginName
+        $newLinkedServerLogin1.Impersonate = $false
+        $newLinkedServerLogin1.SetRemotePassword(($securePassword | ConvertFrom-SecurePass))
+        $newLinkedServerLogin1.Create()
+
+        $newLinkedServerLogin2 = New-Object Microsoft.SqlServer.Management.Smo.LinkedServerLogin
+        $newLinkedServerLogin2.Parent = $linkedServer1
+        $newLinkedServerLogin2.Name = $localLogin2Name
+        $newLinkedServerLogin2.RemoteUser = $remoteLoginName
+        $newLinkedServerLogin2.Impersonate = $false
+        $newLinkedServerLogin2.SetRemotePassword(($securePassword | ConvertFrom-SecurePass))
+        $newLinkedServerLogin2.Create()
+
+        $newLinkedServerLogin3 = New-Object Microsoft.SqlServer.Management.Smo.LinkedServerLogin
+        $newLinkedServerLogin3.Parent = $linkedServer2
+        $newLinkedServerLogin3.Name = $localLogin1Name
+        $newLinkedServerLogin3.RemoteUser = $remoteLoginName
+        $newLinkedServerLogin3.Impersonate = $false
+        $newLinkedServerLogin3.SetRemotePassword(($securePassword | ConvertFrom-SecurePass))
+        $newLinkedServerLogin3.Create()
+    }
+    AfterAll {
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false -Force
+        Remove-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name -Confirm:$false
+        Remove-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -Confirm:$false
+    }
+
+    Context "ensure command works" {
+
+        It "Check the validation for a linked server" {
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LocalLogin $localLogin1Name -WarningVariable warnings
+            $warnings | Should -BeLike "*LinkedServer is required*"
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Get a linked server login" {
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Be $localLogin1Name
+            $results.RemoteUser | Should -Be $remoteLoginName
+            $results.Impersonate | Should -Be $false
+
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name, $localLogin2Name
+            $results.length | Should -Be 2
+            $results.Name | Should -Be $localLogin1Name, $localLogin2Name
+            $results.RemoteUser | Should -Be $remoteLoginName, $remoteLoginName
+            $results.Impersonate | Should -Be $false, $false
+        }
+
+        It "Get a linked server login and exclude a login" {
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -ExcludeLocalLogin $localLogin1Name
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Contain $localLogin2Name
+            $results.Name | Should -Not -Contain $localLogin1Name
+        }
+
+        It "Get a linked server login by passing in a server via pipeline" {
+            $results = $instance2 | Get-DbaLinkedServerLogin -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Be $localLogin1Name
+        }
+
+        It "Get a linked server login by passing in a linked server via pipeline" {
+            $results = $linkedServer1 | Get-DbaLinkedServerLogin -LocalLogin $localLogin1Name
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Be $localLogin1Name
+        }
+
+        It "Get a linked server login from multiple linked servers" {
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -LocalLogin $localLogin1Name
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Be $localLogin1Name, $localLogin1Name
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #)
 - [x] New feature (non-breaking change, adds functionality, fixes #7964 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [x] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
New command for obtaining linked server logins.

### Approach
<!-- How does this change solve that purpose -->
Basic approach that allows for instance, linked server, login name, and login exclusion list to be passed in.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the examples and the pester tests.