### PR TITLE
Replace Get-Service with Get-CimInstance

### DIFF
--- a/functions/Test-DbaDiskAllocation.ps1
+++ b/functions/Test-DbaDiskAllocation.ps1
@@ -96,7 +96,8 @@ function Test-DbaDiskAllocation {
 
             if ($NoSqlCheck -eq $false) {
                 Write-Message -Level Verbose -Message "Checking for SQL Services"
-                $sqlservices = Get-Service -ComputerName $ipaddr | Where-Object { $_.DisplayName -like 'SQL Server (*' }
+                $ClassFilter = "DisplayName like 'SQL Server (%'"
+                $sqlservices = Get-CimInstance -CimSession $CIMsession -ClassName win32_service -Filter $ClassFilter -ErrorAction Stop | Sort-Object -Property Name
                 foreach ($service in $sqlservices) {
                     $instance = $service.DisplayName.Replace('SQL Server (', '')
                     $instance = $instance.TrimEnd(')')


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
"Get-Service -ComputerName" is not available in "PowerShell Core", only in "Windows PowerShell". So, the following line breaks under Core:
$sqlservices = Get-Service -ComputerName $ipaddr | Where-Object { $_.DisplayName -like 'SQL Server (*' }

That line is used in Test-DbaDiskAllocation. The purpose of this fix is to solve that.

I don't know why this gets past the automated tests, but I don't want to spend the time to get Pester/instances/security working. (It took me hours to get a full test environment going last time I did that (a couple of years ago) and this is a two-line change).

This item has been in dbatools for a ++ long time, maybe forever. I wouldn't notice except I use dbachecks and I either need to disable the particular checks that use Test-DbaDiskAllocation or I need to use PowerShell 5.1. Probably not many people are running on Core and prefer to stick to 5.1. I have found that 7.2 is so much faster for my other work that I would like to leave 5.1 behind.

### Approach
Other parts of Test-DbaDiskAllocation cmdlet already use CIM, so this fix should use CIM also. These two lines will replace the single problematic line:

$ClassFilter = "DisplayName like 'SQL Server (%'"
$sqlservices = Get-CimInstance -CimSession $CIMsession -ClassName win32_service -Filter $ClassFilter -ErrorAction Stop | Sort-Object -Property Name

### Commands to test
If you run the Test-DbaDiskAllocation without -NoSqlCheck being true, the old code will fail in Core (7.x) and it will work OK in Windows Powershell (5.1). Any old test would show the failure, here's a example:

Test-DbaDiskAllocation -ComputerName hal9000


### Screenshots
<!-- pictures say a thousand words without typing any of it -->
This shows what a failure looks like, using PowerShell 7.2. Note that the cmdlet still returns useful output, maybe this error is just ignored by users:

![image](https://user-images.githubusercontent.com/11427665/142948456-67d82f27-b48f-4fb9-a8c8-bea39ccbe4ff.png)

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
