### PR TITLE
Get-DbaNetworkConfiguration: Output advanced properties

### DIFF
--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -164,10 +164,10 @@ function Get-DbaNetworkConfiguration {
                         ExtendedProtection = $extendedProtection
                     }
                 } catch {
-                    $outputCertificate = "Failed to get information from registry: $_"
+                    $outputCertificate = $outputAdvanced = "Failed to get information from registry: $_"
                 }
             } else {
-                $outputCertificate = "Failed to get information from registry: Path not found"
+                $outputCertificate = $outputAdvanced = "Failed to get information from registry: Path not found"
             }
 
             [PSCustomObject]@{

--- a/functions/Get-DbaNetworkConfiguration.ps1
+++ b/functions/Get-DbaNetworkConfiguration.ps1
@@ -136,7 +136,7 @@ function Get-DbaNetworkConfiguration {
             if ($regRoot) {
                 $regPath = "Registry::HKEY_LOCAL_MACHINE\$regRoot\MSSQLServer\SuperSocketNetLib"
                 try {
-                    $acceptedNtlmSpns = (Get-ItemProperty -Path $regPath -Name AcceptedSPNs).AcceptedSPNs
+                    $acceptedSPNs = (Get-ItemProperty -Path $regPath -Name AcceptedSPNs).AcceptedSPNs
                     $thumbprint = (Get-ItemProperty -Path $regPath -Name Certificate).Certificate
                     $cert = Get-ChildItem Cert:\LocalMachine -Recurse -ErrorAction SilentlyContinue | Where-Object Thumbprint -eq $thumbprint | Select-Object -First 1
                     $extendedProtection = switch ((Get-ItemProperty -Path $regPath -Name ExtendedProtection).ExtendedProtection) { 0 { $false } 1 { $true } }
@@ -160,7 +160,7 @@ function Get-DbaNetworkConfiguration {
                     $outputAdvanced = [PSCustomObject]@{
                         ForceEncryption    = $forceEncryption
                         HideInstance       = $hideInstance
-                        AcceptedNtlmSpns   = $acceptedNtlmSpns
+                        AcceptedSPNs       = $acceptedSPNs
                         ExtendedProtection = $extendedProtection
                     }
                 } catch {

--- a/tests/Get-DbaNetworkConfiguration.Tests.ps1
+++ b/tests/Get-DbaNetworkConfiguration.Tests.ps1
@@ -23,7 +23,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "has the correct properties" {
-            $ExpectedPropsFull = 'ComputerName,InstanceName,SqlInstance,SharedMemoryEnabled,NamedPipesEnabled,TcpIpEnabled,TcpIpProperties,TcpIpAddresses,Certificate'.Split(',')
+            $ExpectedPropsFull = 'ComputerName,InstanceName,SqlInstance,SharedMemoryEnabled,NamedPipesEnabled,TcpIpEnabled,TcpIpProperties,TcpIpAddresses,Certificate,Advanced'.Split(',')
             ($resultsFull.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsFull | Sort-Object)
             $ExpectedPropsTcpIpProperties = 'ComputerName,InstanceName,SqlInstance,Enabled,KeepAlive,ListenAll'.Split(',')
             ($resultsTcpIpProperties.PsObject.Properties.Name | Sort-Object) | Should Be ($ExpectedPropsTcpIpProperties | Sort-Object)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Output advanced properties to now have all information accessable via SQL Server Configuration Manager under Properties of the SQL Server Network Configuration.

![image](https://user-images.githubusercontent.com/66946165/143223992-26810ff2-04b8-4d27-ba1c-f5301117d6a3.png)

![image](https://user-images.githubusercontent.com/66946165/143224058-012f36c8-a102-45db-947b-7be5d01ea61e.png)

Will later update the Set-DbaNetworkConfiguration command to be able to change these settings.

But first let's have a look at the naming of variables and properties of the output - any suggestions for changing them? I have tried to name them like they appear on the GUI which is sometimes different than the name of the registry item property.
