### PR TITLE
New command: New-DbaLinkedServerLogin

### DIFF
--- a/functions/New-DbaLinkedServerLogin.ps1
+++ b/functions/New-DbaLinkedServerLogin.ps1
@@ -1,0 +1,135 @@
+function New-DbaLinkedServerLogin {
+    <#
+    .SYNOPSIS
+        Creates a new linked server login.
+
+    .DESCRIPTION
+        Creates a new linked server login. See the Microsoft documentation for sp_addlinkedsrvlogin for more details on the parameters.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER LinkedServer
+        The name(s) of the linked server(s).
+
+    .PARAMETER LocalLogin
+        Specifies the local login name.
+
+    .PARAMETER RemoteUser
+        Specifies the remote login name.
+
+    .PARAMETER RemoteUserPassword
+        Specifies the remote login password as a secure string. NOTE: passwords are sent to the SQL Server instance in plain text. Check with your security administrator before using this parameter. View the documentation for sp_addlinkedsrvlogin for more details.
+
+    .PARAMETER Impersonate
+        Specifies if the local login credentials should be used instead of the remote login credentials.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaLinkedServer.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Security, Server
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/New-DbaLinkedServerLogin
+
+    .EXAMPLE
+        PS C:\>New-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -LocalLogin localUser1 -RemoteUser remoteUser1 -RemoteUserPassword <password>
+
+        Creates a new linked server login and maps the local login testuser1 to the remote login testuser2. This linked server login is created on the sql01 instance for the linkedServer1 linked server.
+
+        NOTE: passwords are sent to the SQL Server instance in plain text. Check with your security administrator before using the command with the RemoteUserPassword parameter. View the documentation for sp_addlinkedsrvlogin for more details.
+
+    .EXAMPLE
+        PS C:\>New-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -Impersonate
+
+        Creates a mapping for all local logins on sql01 to connect using their own credentials to the linked server linkedServer1.
+
+    .EXAMPLE
+        PS C:\>Get-DbaLinkedServer -SqlInstance sql01 -LinkedServer linkedServer1 | New-DbaLinkedServerLogin -LinkedServer linkedServer1 -LocalLogin testuser1 -RemoteUser testuser2 -RemoteUserPassword <password>
+
+        Creates a new linked server login and maps the local login testuser1 to the remote login testuser2. This linked server login is created on the sql01 instance for the linkedServer1 linked server. The linkedServer1 instance is passed in via pipeline.
+
+        NOTE: passwords are sent to the SQL Server instance in plain text. Check with your security administrator before using the command with the RemoteUserPassword parameter. View the documentation for sp_addlinkedsrvlogin for more details.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$LinkedServer,
+        [string]$LocalLogin,
+        [string]$RemoteUser,
+        [Security.SecureString]$RemoteUserPassword,
+        [switch]$Impersonate,
+        [parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.LinkedServer[]]$InputObject,
+        [switch]$EnableException
+    )
+    process {
+
+        foreach ($instance in $SqlInstance) {
+
+            if (Test-Bound -Not -ParameterName LinkedServer) {
+                Stop-Function -Message "LinkedServer is required"
+                return
+            }
+
+            $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential | Get-DbaLinkedServer -LinkedServer $LinkedServer
+        }
+
+        foreach ($lnkSrv in $InputObject) {
+
+            if ($Pscmdlet.ShouldProcess($($lnkSrv.Parent.Name), "Creating the linked server login on $($lnkSrv.Parent.Name)")) {
+                try {
+                    $newLinkedServerLogin = New-Object Microsoft.SqlServer.Management.Smo.LinkedServerLogin
+                    $newLinkedServerLogin.Parent = $lnkSrv
+
+                    if (Test-Bound LocalLogin) {
+                        $newLinkedServerLogin.Name = $LocalLogin
+                    }
+
+                    if (Test-Bound RemoteUser) {
+                        $newLinkedServerLogin.RemoteUser = $RemoteUser
+                    }
+
+                    if (Test-Bound RemoteUserPassword) {
+                        $newLinkedServerLogin.SetRemotePassword(($RemoteUserPassword | ConvertFrom-SecurePass))
+                    }
+
+                    $newLinkedServerLogin.Impersonate = [boolean]$Impersonate
+
+                    $newLinkedServerLogin.Create()
+
+                    $lnkSrv | Get-DbaLinkedServerLogin -LocalLogin $LocalLogin
+
+                } catch {
+                    Stop-Function -Message "Failure on $($lnkSrv.Parent.Name) to create the linked server login for $lnkSrv" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/functions/New-DbaLinkedServerLogin.ps1
+++ b/functions/New-DbaLinkedServerLogin.ps1
@@ -21,7 +21,7 @@ function New-DbaLinkedServerLogin {
         The name(s) of the linked server(s).
 
     .PARAMETER LocalLogin
-        Specifies the local login name.
+        Specifies the local login name. This parameter is required in all scenarios.
 
     .PARAMETER RemoteUser
         Specifies the remote login name.
@@ -90,15 +90,18 @@ function New-DbaLinkedServerLogin {
         [switch]$EnableException
     )
     process {
+        if ($SqlInstance -and (-not $LinkedServer)) {
+            Stop-Function -Message "LinkedServer is required when SqlInstance is specified"
+            return
+        }
+
+        if (-not $LocalLogin) {
+            Stop-Function -Message "LocalLogin is required in all scenarios"
+            return
+        }
 
         foreach ($instance in $SqlInstance) {
-
-            if (Test-Bound -Not -ParameterName LinkedServer) {
-                Stop-Function -Message "LinkedServer is required"
-                return
-            }
-
-            $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential | Get-DbaLinkedServer -LinkedServer $LinkedServer
+            $InputObject += Get-DbaLinkedServer -SqlInstance $instance -SqlCredential $SqlCredential -LinkedServer $LinkedServer
         }
 
         foreach ($lnkSrv in $InputObject) {

--- a/tests/New-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/New-DbaLinkedServerLogin.Tests.ps1
@@ -1,0 +1,71 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'LocalLogin', 'RemoteUser', 'RemoteUserPassword', 'Impersonate', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $random = Get-Random
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
+
+        $securePassword = ConvertTo-SecureString -String 'securePassword' -AsPlainText -Force
+        $localLogin1Name = "dbatoolscli_localLogin1_$random"
+        $localLogin2Name = "dbatoolscli_localLogin2_$random"
+        $remoteLoginName = "dbatoolscli_remoteLogin_$random"
+
+        $linkedServer1Name = "dbatoolscli_linkedServer1_$random"
+        $linkedServer2Name = "dbatoolscli_linkedServer2_$random"
+
+        New-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name -SecurePassword $securePassword
+        New-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -SecurePassword $securePassword
+
+        $linkedServer1 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+        $linkedServer2 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer2Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+    }
+    AfterAll {
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false -Force
+        Remove-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name -Confirm:$false
+        Remove-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -Confirm:$false
+    }
+
+    Context "ensure command works" {
+
+        It "Check the validation for an invalid linked server" {
+            $results = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer "dbatoolscli_invalidServer_$random" -LocalLogin $localLogin1Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Check the validation for a linked server" {
+            $results = New-DbaLinkedServerLogin -SqlInstance $instance2 -LocalLogin $localLogin1Name -WarningVariable warnings
+            $warnings | Should -BeLike "*LinkedServer is required*"
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Creates a linked server login with the local login to remote user mapping on two different linked servers" {
+            $results = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -LocalLogin $localLogin1Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+            $results.length | Should -Be 2
+            $results.Name | Should -Be $localLogin1Name, $localLogin1Name
+            $results.RemoteUser | Should -Be $remoteLoginName, $remoteLoginName
+            $results.Impersonate | Should -Be $false, $false
+        }
+
+        It "Creates a linked server login with impersonation using a linked server from a pipeline" {
+            $results = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin2Name -Impersonate
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Be $localLogin2Name
+            $results.RemoteUser | Should -BeNullOrEmpty
+            $results.Impersonate | Should -Be $true
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7982 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [x] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Adding a new command for a login to be added to a linked server.

This is the 3rd in a series of PRs related to linked servers:

1. Update for Remove-DbaLinkedServer (PR 7952, already merged)
2. New command for Get-DbaLinkedServerLogin	(PR 7965, already merged)
3. New command for New-DbaLinkedServerLogin (This PR)
4. New command for Remove-DbaLinkedServerLogin
5. Update for New-DbaLinkedServer
6. New command for Set-DbaLinkedServer



### Approach
<!-- How does this change solve that purpose -->
Basic command to accept the param values for a linked server login and then update the linked server.


### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the examples and the pester tests.