### PR TITLE
New-DbaDatabase: Fix issues with generated filenames

### DIFF
--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -74,7 +74,7 @@ function New-DbaDatabase {
         The data file suffix.
 
     .PARAMETER LogFileSuffix
-        The log file suffix.
+        The log file suffix. Defaults to "_log"
 
     .PARAMETER SecondaryDataFileSuffix
         The secondary data file suffix.
@@ -176,7 +176,7 @@ function New-DbaDatabase {
         [ValidateSet('Primary', 'Secondary')]
         [string]$DefaultFileGroup,
         [string]$DataFileSuffix,
-        [string]$LogFileSuffix,
+        [string]$LogFileSuffix = '_log',
         [string]$SecondaryDataFileSuffix,
         [switch]$EnableException
     )

--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -173,7 +173,7 @@ function New-DbaDatabase {
 
     begin {
         # do some checks to see if the advanced config settings will be invoked
-        if (Test-Bound -ParameterName DataFilePath, DefaultFileGroup, LogFilePath, LogGrowth, LogMaxSize, LogSize, PrimaryFileGrowth, PrimaryFileMaxSize, PrimaryFilesize, SecondaryFileCount, SecondaryFileGrowth, SecondaryFileMaxSize, SecondaryFilesize) {
+        if (Test-Bound -ParameterName DataFilePath, DefaultFileGroup, LogFilePath, LogGrowth, LogMaxSize, LogSize, PrimaryFileGrowth, PrimaryFileMaxSize, PrimaryFilesize, SecondaryFileCount, SecondaryFileGrowth, SecondaryFileMaxSize, SecondaryFilesize, DataFileSuffix, LogFileSuffix, SecondaryDataFileSuffix) {
             $advancedconfig = $true
             Write-Message -Message "Advanced data file configuration will be invoked" -Level Verbose
         }
@@ -258,7 +258,7 @@ function New-DbaDatabase {
                     $newdb.RecoveryModel = $RecoveryModel
                 }
 
-                if ($advancedconfig) {
+                if ($server.VersionMajor -gt 8) {
                     try {
                         Write-Message -Message "Creating PRIMARY filegroup" -Level Verbose
                         $primaryfg = New-Object Microsoft.SqlServer.Management.Smo.Filegroup($newdb, "PRIMARY")

--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -165,9 +165,9 @@ function New-DbaDatabase {
         [int32]$SecondaryFileCount,
         [ValidateSet('Primary', 'Secondary')]
         [string]$DefaultFileGroup,
-        [string]$DataFileSuffix = "_PRIMARY",
-        [string]$LogFileSuffix = "_Log",
-        [string]$SecondaryDataFileSuffix = "_MainData",
+        [string]$DataFileSuffix,
+        [string]$LogFileSuffix,
+        [string]$SecondaryDataFileSuffix,
         [switch]$EnableException
     )
 
@@ -258,7 +258,7 @@ function New-DbaDatabase {
                     $newdb.RecoveryModel = $RecoveryModel
                 }
 
-                if ($server.VersionMajor -gt 8) {
+                if ($advancedconfig) {
                     try {
                         Write-Message -Message "Creating PRIMARY filegroup" -Level Verbose
                         $primaryfg = New-Object Microsoft.SqlServer.Management.Smo.Filegroup($newdb, "PRIMARY")

--- a/functions/New-DbaDatabase.ps1
+++ b/functions/New-DbaDatabase.ps1
@@ -8,12 +8,6 @@ function New-DbaDatabase {
 
         It allows creation with multiple files, and sets all growth settings to be fixed size rather than percentage growth. The autogrowth settings are obtained from the modeldev file in the model database when not supplied as command line arguments.
 
-        The generated database filenames take the form:
-
-        <db name>_PRIMARY
-        <db name>_Log
-        <db name>_MainData_1  (Secondary filegroup files)
-
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 
@@ -77,13 +71,13 @@ function New-DbaDatabase {
         Sets the default file group. Either primary or secondary.
 
     .PARAMETER DataFileSuffix
-        The data file suffix. Defaults to "_PRIMARY"
+        The data file suffix.
 
     .PARAMETER LogFileSuffix
-        The log file suffix. Defaults to "_Log"
+        The log file suffix.
 
     .PARAMETER SecondaryDataFileSuffix
-        The secondary data file suffix. Defaults to "_MainData"
+        The secondary data file suffix.
 
     .PARAMETER WhatIf
         If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
@@ -130,7 +124,23 @@ function New-DbaDatabase {
         Creates a secondary group with 2 files in the Secondary filegroup.
 
     .EXAMPLE
-        New-DbaDatabase -SqlInstance sql1 -Name newDb -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64
+        $databaseParams = @{
+            SqlInstance             = "sql1"
+            Name                    = "newDb"
+            LogSize                 = 32
+            LogMaxSize              = 512
+            PrimaryFilesize         = 64
+            PrimaryFileMaxSize      = 512
+            SecondaryFilesize       = 64
+            SecondaryFileMaxSize    = 512
+            LogGrowth               = 32
+            PrimaryFileGrowth       = 64
+            SecondaryFileGrowth     = 64
+            DataFileSuffix          = "_PRIMARY"
+            LogFileSuffix           = "_Log"
+            SecondaryDataFileSuffix = "_MainData"
+        }
+        New-DbaDatabase @databaseParams
 
         Creates a new database named newDb on the sql1 instance and sets the file sizes, max sizes, and growth as specified. The resulting filenames will take the form:
 

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -46,7 +46,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates one new database on two servers" {
-            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64
+            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
             $newDbOnTwoServers.Count | Should -Be 2
             $newDbOnTwoServers[0].Name | Should -Be $newDbName
             $newDbOnTwoServers[1].Name | Should -Be $newDbName
@@ -90,7 +90,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "bug 6780 autogrowth params" {
-            $db6780 = New-DbaDatabase -SqlInstance $instance2 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1
+            $db6780 = New-DbaDatabase -SqlInstance $instance2 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
             $db6780.Count | Should -Be 1
 
             $instance2.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].Growth | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
@@ -116,13 +116,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "SecondaryFilesize is specified but not the SecondaryFileCount" {
-            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10
+            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
             $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files.Count | Should -Be 1
             $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files[0].Size | Should -Be 10240
         }
 
         It "SecondaryFileCount is specified but not the other secondary file params" {
-            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2
+            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files.Count | Should -Be 2
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[0].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[1].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
@@ -143,7 +143,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $primaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $primaryFileGroupDbName -DefaultFileGroup "Primary"
             $primaryFileGroupDb.DefaultFileGroup | Should -Be "PRIMARY"
 
-            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary"
+            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary" -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
             $secondaryFileGroupDb.DefaultFileGroup | Should -Be "$($secondaryFileGroupDbName)_MainData"
         }
     }

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -46,7 +46,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "creates one new database on two servers" {
-            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
+            $newDbOnTwoServers = New-DbaDatabase -SqlInstance $instance2, $instance3 -Name $newDbName -LogSize 32 -LogMaxSize 512 -PrimaryFilesize 64 -PrimaryFileMaxSize 512 -SecondaryFilesize 64 -SecondaryFileMaxSize 512 -LogGrowth 32 -PrimaryFileGrowth 64 -SecondaryFileGrowth 64 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $newDbOnTwoServers.Count | Should -Be 2
             $newDbOnTwoServers[0].Name | Should -Be $newDbName
             $newDbOnTwoServers[1].Name | Should -Be $newDbName

--- a/tests/New-DbaDatabase.Tests.ps1
+++ b/tests/New-DbaDatabase.Tests.ps1
@@ -90,7 +90,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "bug 6780 autogrowth params" {
-            $db6780 = New-DbaDatabase -SqlInstance $instance2 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
+            $db6780 = New-DbaDatabase -SqlInstance $instance2 -Name $bug6780DbName -Recoverymodel Simple -DataFilePath $randomDb.PrimaryFilePath -LogFilePath $randomDb.PrimaryFilePath -SecondaryFileCount 1 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $db6780.Count | Should -Be 1
 
             $instance2.Databases[$bug6780DbName].FileGroups["PRIMARY"].Files["$($bug6780DbName)_PRIMARY"].Growth | Should -Be $instance2.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Growth
@@ -116,13 +116,13 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
         }
 
         It "SecondaryFilesize is specified but not the SecondaryFileCount" {
-            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
+            $secondaryFileTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileTestDbName -SecondaryFilesize 10 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files.Count | Should -Be 1
             $instance3.Databases[$secondaryFileTestDbName].FileGroups["$($secondaryFileTestDbName)_MainData"].Files[0].Size | Should -Be 10240
         }
 
         It "SecondaryFileCount is specified but not the other secondary file params" {
-            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2 -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
+            $secondaryFileCountTestDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileCountTestDbName -SecondaryFileCount 2 -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files.Count | Should -Be 2
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[0].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
             $instance3.Databases[$secondaryFileCountTestDbName].FileGroups["$($secondaryFileCountTestDbName)_MainData"].Files[1].Size | Should -Be $instance3.Databases["model"].FileGroups["PRIMARY"].Files["modeldev"].Size
@@ -143,7 +143,7 @@ Describe "$CommandName Integration Tests" -Tag "IntegrationTests" {
             $primaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $primaryFileGroupDbName -DefaultFileGroup "Primary"
             $primaryFileGroupDb.DefaultFileGroup | Should -Be "PRIMARY"
 
-            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary" -DataFileSuffix = "_PRIMARY" -LogFileSuffix = "_Log" -SecondaryDataFileSuffix = "_MainData"
+            $secondaryFileGroupDb = New-DbaDatabase -SqlInstance $instance3 -Name $secondaryFileGroupDbName -DefaultFileGroup "Secondary" -DataFileSuffix "_PRIMARY" -LogFileSuffix "_Log" -SecondaryDataFileSuffix "_MainData"
             $secondaryFileGroupDb.DefaultFileGroup | Should -Be "$($secondaryFileGroupDbName)_MainData"
         }
     }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7981 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Fixes for the linked issue.

But this will also effect the filenames when used without advanced parameters, as now the "special" filenames are created always:
![image](https://user-images.githubusercontent.com/66946165/143573744-a7180271-4fb9-4b64-af51-3da473846dc8.png)

![image](https://user-images.githubusercontent.com/66946165/143573814-b36484c5-5d19-4a19-988f-16f8deb6e4c2.png)
