### PR TITLE
Removes the comment that was overlooked

### DIFF
--- a/functions/Remove-DbaDbSequence.ps1
+++ b/functions/Remove-DbaDbSequence.ps1
@@ -68,7 +68,7 @@ function Remove-DbaDbSequence {
     param (
         [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
-        #[Parameter(ParameterSetName = 'NonPipeline')]
+        [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Database,


### PR DESCRIPTION
The comment should be removed as that was used for the development phase.