### PR TITLE
Remove-DbaAgentAlertCategory to support pipeline from Get-* function

### DIFF
--- a/functions/Get-DbaAgentAlert.ps1
+++ b/functions/Get-DbaAgentAlert.ps1
@@ -58,8 +58,7 @@ function Get-DbaAgentAlert {
     param (
         [parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
-        [PSCredential]
-        $SqlCredential,
+        [PSCredential]$SqlCredential,
         [string[]]$Alert,
         [string[]]$ExcludeAlert,
         [switch]$EnableException

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -70,7 +70,7 @@ function Remove-DbaAgentAlertCategory {
     param (
         [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
-        #[Parameter(ParameterSetName = 'NonPipeline')]
+        [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Category,

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -96,7 +96,7 @@ function Remove-DbaAgentAlertCategory {
     }
 
     end {
-        # We have to delete in the end block to prevent "Collection was modified; enumeration operation may not execute." if directly piped from Get-DbaAgentAlert.
+        # We have to delete in the end block to prevent "Collection was modified; enumeration operation may not execute." if directly piped from Get-DbaAgentAlertCategory.
         foreach ($agentCategory in $agentCategories) {
             if ($PSCmdlet.ShouldProcess($agentCategory.Parent.Parent.Name, "Removing the SQL Agent alert category $($agentCategory.Name) on $($agentCategory.Parent.Parent.Name)")) {
                 $output = [pscustomobject]@{

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -60,6 +60,11 @@ function Remove-DbaAgentAlertCategory {
 
         Remove multiple alert categories from the multiple instances.
 
+    .EXAMPLE
+        PS C:\> Get-DbaAgentAlertCategory -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent alert category(-ies) to drop' -OutputMode Multiple | Remove-DbaAgentAlertCategory
+
+        Using a pipeline this command gets all SQL Agent alert category(-ies) on SRV1, lets the user select those to remove and then removes the selected SQL Agent alert category(-ies).
+
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (

--- a/functions/Remove-DbaAgentAlertCategory.ps1
+++ b/functions/Remove-DbaAgentAlertCategory.ps1
@@ -20,8 +20,8 @@ function Remove-DbaAgentAlertCategory {
     .PARAMETER Category
         The name of the category
 
-    .PARAMETER Force
-        The force parameter will ignore some errors in the parameters and assume defaults.
+    .PARAMETER InputObject
+        Allows piping from Get-DbaAgentAlertCategory.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.

--- a/tests/Get-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Get-DbaAgentAlertCategory.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         AfterAll {
-            $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+            $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2 -Confirm:$false
         }
         $results = Get-DbaAgentAlertCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get at least 2 categories" {

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         AfterAll {
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2 -Confirm:$false
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get at least 2 categories" {

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         AfterAll {
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2 -Confirm:$false
         }
         $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get at least 2 categories" {

--- a/tests/New-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/New-DbaAgentAlertCategory.Tests.ps1
@@ -38,6 +38,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         # Cleanup and ignore all output
-        $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2
+        $null = Remove-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 -Confirm:$false
     }
 }

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -38,10 +38,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "supports piping SQL Agent alert category" {
             $categoryName = "dbatoolsci_test_$(get-random)"
-            $results2 = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName
-            (Get-DbaAgentAlertCategory -SqlInstance $server -Category $categoryName ) | Should -Not -BeNullOrEmpty
-            Get-DbaAgentAlertCategory -SqlInstance $server -Category $categoryName | Remove-DbaAgentAlertCategory -Confirm:$false
-            (Get-DbaAgentAlertCategory -SqlInstance $server -Category $categoryName ) | Should -BeNullOrEmpty
+            $null = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName
+            (Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName ) | Should -Not -BeNullOrEmpty
+            Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName | Remove-DbaAgentAlertCategory -Confirm:$false
+            (Get-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName ) | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Remove-DbaAgentAlertCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentAlertCategory.Tests.ps1
@@ -36,7 +36,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $newresults.Count | Should Be 0
         }
 
-        It "supports piping SQL Agent alert" {
+        It "supports piping SQL Agent alert category" {
             $categoryName = "dbatoolsci_test_$(get-random)"
             $results2 = New-DbaAgentAlertCategory -SqlInstance $script:instance2 -Category $categoryName
             (Get-DbaAgentAlertCategory -SqlInstance $server -Category $categoryName ) | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
To support pipeline from Get-* function

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Get-DbaAgentAlertCategory -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent alert category(-ies) to drop' -OutputMode Multiple | Remove-DbaAgentAlertCategory`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
