### PR TITLE
Remove-DbaAgentJobCategory to support pipeline from Get-* function 

### DIFF
--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -24,6 +24,9 @@ function Remove-DbaAgentJobCategory {
         The type of category. This can be "LocalJob", "MultiServerJob" or "None".
         If no category is used all categories types will be removed.
 
+    .PARAMETER InputObject
+        Allows piping from Get-DbaAgentJobCategory.
+
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
 

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -71,7 +71,7 @@ function Remove-DbaAgentJobCategory {
     param (
         [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
-        #[Parameter(ParameterSetName = 'NonPipeline')]
+        [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Category,

--- a/functions/Remove-DbaAgentJobCategory.ps1
+++ b/functions/Remove-DbaAgentJobCategory.ps1
@@ -18,10 +18,11 @@ function Remove-DbaAgentJobCategory {
         For MFA support, please use Connect-DbaInstance.
 
     .PARAMETER Category
-        The name of the category
+        The name of the category.
 
-    .PARAMETER Force
-        The force parameter will ignore some errors in the parameters and assume defaults.
+    .PARAMETER CategoryType
+        The type of category. This can be "LocalJob", "MultiServerJob" or "None".
+        If no category is used all categories types will be removed.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
@@ -60,45 +61,66 @@ function Remove-DbaAgentJobCategory {
 
         Remove multiple job categories from the multiple instances.
 
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJobCategory -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent job category(-ies) to drop' -OutputMode Multiple | Remove-DbaAgentJobCategory
+
+        Using a pipeline this command gets all SQL Agent job category(-ies) on SRV1, lets the user select those to remove and then removes the selected SQL Agent job category(-ies).
+
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "Low")]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
-        [parameter(Mandatory, ValueFromPipeline)]
+        [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
+        #[Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
-        [ValidateNotNullOrEmpty()]
+        [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Category,
-        [switch]$Force,
+        [Parameter(ParameterSetName = 'NonPipeline')]
+        [ValidateSet("LocalJob", "MultiServerJob", "None")]
+        [string[]]$CategoryType,
+        [parameter(ValueFromPipeline, ParameterSetName = 'Pipeline', Mandatory = $true)]
+        [Microsoft.SqlServer.Management.Smo.Agent.JobCategory[]]$InputObject,
+        [Parameter(ParameterSetName = 'NonPipeline')][Parameter(ParameterSetName = 'Pipeline')]
         [switch]$EnableException
     )
+
     begin {
-        if ($Force) { $ConfirmPreference = 'none' }
+        $jobCategories = @( )
     }
+
     process {
+        if ($SqlInstance) {
+            $params = $PSBoundParameters
+            $null = $params.Remove('WhatIf')
+            $null = $params.Remove('Confirm')
+            $jobCategories = Get-DbaAgentJobCategory @params
+        } else {
+            $jobCategories += $InputObject
+        }
+    }
 
-        foreach ($instance in $SqlInstance) {
-            try {
-                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
-
-            foreach ($cat in $Category) {
-                if ($cat -notin $server.JobServer.JobCategories.Name) {
-                    Stop-Function -Message "Job category $cat doesn't exist on $instance" -Target $instance -Continue
+    end {
+        # We have to delete in the end block to prevent "Collection was modified; enumeration operation may not execute." if directly piped from Get-DbaAgentJobCategory.
+        foreach ($jobCategory in $jobCategories) {
+            if ($PSCmdlet.ShouldProcess($jobCategory.Parent.Parent.Name, "Removing the SQL Agent category(-ies) $($jobCategory.Name) on $($jobCategory.Parent.Parent.Name)")) {
+                $output = [pscustomobject]@{
+                    ComputerName = $jobCategory.Parent.Parent.ComputerName
+                    InstanceName = $jobCategory.Parent.Parent.ServiceName
+                    SqlInstance  = $jobCategory.Parent.Parent.DomainInstanceName
+                    Name         = $jobCategory.Name
+                    Status       = $null
+                    IsRemoved    = $false
                 }
-
-                if ($PSCmdlet.ShouldProcess($instance, "Removing the job category $Category")) {
-                    try {
-                        $currentCategory = $server.JobServer.JobCategories[$cat]
-
-                        Write-Message -Message "Removing job category $cat" -Level Verbose
-
-                        $currentCategory.Drop()
-                    } catch {
-                        Stop-Function -Message "Something went wrong removing the job category $cat on $instance" -Target $cat -Continue -ErrorRecord $_
-                    }
+                try {
+                    $jobCategory.Drop()
+                    $output.Status = "Dropped"
+                    $output.IsRemoved = $true
+                } catch {
+                    Stop-Function -Message "Failed removing the SQL Agent job category(-ies) $($jobCategory.Name) on $($jobCategory.Parent.Parent.Name)" -ErrorRecord $_
+                    $output.Status = (Get-ErrorMessage -Record $_)
+                    $output.IsRemoved = $false
                 }
+                $output
             }
         }
     }

--- a/tests/Copy-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Copy-DbaAgentJobCategory.Tests.ps1
@@ -18,7 +18,7 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci test category'
     }
     AfterAll {
-        $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci test category'
+        $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci test category' -Confirm:$false
     }
 
     Context "Command copies jobs properly" {

--- a/tests/Find-DbaAgentJob.Tests.ps1
+++ b/tests/Find-DbaAgentJob.Tests.ps1
@@ -25,7 +25,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
         }
         AfterAll {
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob, dbatoolsci_testjob_disabled
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci_job_category'
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'dbatoolsci_job_category' -Confirm:$false
         }
 
         $results = Find-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob

--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -67,7 +67,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = New-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob_cat2 -Category 'Cat2'
         }
         AfterAll {
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'Cat1', 'Cat2'
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category 'Cat1', 'Cat2' -Confirm:$false
 
             $null = Remove-DbaAgentJob -SqlInstance $script:instance2 -Job dbatoolsci_testjob_cat1, dbatoolsci_testjob_cat2
         }

--- a/tests/Get-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Get-DbaAgentJobCategory.Tests.ps1
@@ -19,7 +19,7 @@ Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
             $null = New-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
         }
         AfterAll {
-            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2
+            $null = Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category dbatoolsci_testcategory, dbatoolsci_testcategory2 -Confirm:$false
         }
         $results = Get-DbaAgentJobCategory -SqlInstance $script:instance2 | Where-Object {$_.Name -match "dbatoolsci"}
         It "Should get at least 2 categories" {

--- a/tests/New-DbaAgentJobCategory.Tests.ps1
+++ b/tests/New-DbaAgentJobCategory.Tests.ps1
@@ -42,6 +42,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         # Cleanup and ignore all output
-        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 *> $null
+        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2 -Confirm:$false *> $null
     }
 }

--- a/tests/Remove-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Remove-DbaAgentJobCategory.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'Force', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Category', 'CategoryType', 'InputObject', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
@@ -32,7 +32,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "Remove the job categories" {
-            Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3
+            Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, Categorytest3 -Confirm:$false
 
             $newresults = Get-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest1, CategoryTest2, CategoryTest3
 

--- a/tests/Set-DbaAgentJobCategory.Tests.ps1
+++ b/tests/Set-DbaAgentJobCategory.Tests.ps1
@@ -34,6 +34,6 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         # Cleanup and ignore all output
-        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 *> $null
+        Remove-DbaAgentJobCategory -SqlInstance $script:instance2 -Category CategoryTest2 -Confirm:$false *> $null
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [x] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
To support pipeline from Get-* function

Removed the `-Force` parameter, so it can be used with the pattern from other Remove-* commands with `-Confirm:$false `instead.

### Approach
<!-- How does this change solve that purpose -->

Similar to #7997 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

`Get-DbaAgentJobCategory -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent job category(-ies) to drop' -OutputMode Multiple | Remove-DbaAgentJobCategory`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
