### PR TITLE
Get-DbaRegistryRoot: Fix for named clustered instance

### DIFF
--- a/functions/Get-DbaRegistryRoot.ps1
+++ b/functions/Get-DbaRegistryRoot.ps1
@@ -68,17 +68,17 @@ function Get-DbaRegistryRoot {
                         $regRoot = ($regRoot -Split 'Value\=')[1]
                         $vsname = ($vsname -Split 'Value\=')[1]
                     } else {
-                        Write-Message -Level Warning -Message "Can't find instance $vsname on $env:COMPUTERNAME"
-                        return
+                        Stop-Function -Message "Can't find instance $instanceName on $env:COMPUTERNAME" -Continue
                     }
                 }
 
-                # vsname takes care of clusters
-                if ([System.String]::IsNullOrEmpty($vsname)) {
-                    $vsname = $computer
-                    if ($instanceName -ne "MSSQLSERVER") {
-                        $vsname = "$($computer.ComputerName)\$instanceName"
-                    }
+                $sqlInstance = $computer.ComputerName
+                # vsname is the virtual server name for a failover cluster instance
+                if ($vsname) {
+                    $sqlInstance = $vsname
+                }
+                if ($instanceName -ne "MSSQLSERVER") {
+                    $sqlInstance = "$sqlInstance\$instanceName"
                 }
 
                 Write-Message -Level Verbose -Message "Regroot: $regRoot"
@@ -88,7 +88,7 @@ function Get-DbaRegistryRoot {
                 [PSCustomObject]@{
                     ComputerName = $computer.ComputerName
                     InstanceName = $instanceName
-                    SqlInstance  = $vsname
+                    SqlInstance  = $sqlInstance
                     Hive         = "HKLM"
                     Path         = $regRoot
                     RegistryRoot = "HKLM:\$regRoot"

--- a/functions/Get-DbaRegistryRoot.ps1
+++ b/functions/Get-DbaRegistryRoot.ps1
@@ -72,9 +72,10 @@ function Get-DbaRegistryRoot {
                     }
                 }
 
-                $sqlInstance = $computer.ComputerName
                 # vsname is the virtual server name for a failover cluster instance
-                if ($vsname) {
+                if ([System.String]::IsNullOrEmpty($vsname)) {
+                    $sqlInstance = $computer.ComputerName
+                } else {
                     $sqlInstance = $vsname
                 }
                 if ($instanceName -ne "MSSQLSERVER") {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #7994 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Fixed the issue but also changed variable names and building of SqlInstance to better readability.
I think "[System.String]::IsNullOrEmpty" is not needed, a bit oversized and hard to read in this code - but I can add it back in if requested.