### PR TITLE
Remove-DbaAgentOperator to support pipeline from Get-* function 

### DIFF
--- a/functions/Remove-DbaAgentOperator.ps1
+++ b/functions/Remove-DbaAgentOperator.ps1
@@ -65,7 +65,7 @@ function Remove-DbaAgentOperator {
     param (
         [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
-        #[Parameter(ParameterSetName = 'NonPipeline')]
+        [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
         [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Operator,

--- a/functions/Remove-DbaAgentOperator.ps1
+++ b/functions/Remove-DbaAgentOperator.ps1
@@ -1,7 +1,7 @@
 function Remove-DbaAgentOperator {
     <#
     .SYNOPSIS
-        Removes a new operator on an instance.
+        Removes an operator from an instance.
 
     .DESCRIPTION
         Drop an operator from SQL Agent.
@@ -18,6 +18,12 @@ function Remove-DbaAgentOperator {
 
     .PARAMETER Operator
         Name of the operator in SQL Agent.
+
+    .PARAMETER ExcludeOperator
+        The operator(s) to exclude.
+
+    .PARAMETER InputObject
+        Allows piping from Get-DbaAgentOperator.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
@@ -49,42 +55,65 @@ function Remove-DbaAgentOperator {
 
         This removes an operator named DBA from the instance.
 
+    .EXAMPLE
+        PS C:\>  Get-DbaAgentOperator -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent operator(s) to drop' -OutputMode Multiple | Remove-DbaAgentOperator
+
+        Using a pipeline this command gets all SQL Agent operator(s) on SRV1, lets the user select those to remove and then removes the selected SQL Agent alert category(-ies).
+
     #>
-    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess, ConfirmImpact = "High")]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
+        [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
+        #[Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
-        [parameter(Mandatory)]
-        [string]$Operator,
-        [parameter(ValueFromPipeline)]
-        [Microsoft.SqlServer.Management.Smo.Server[]]$InputObject,
+        [Parameter(ParameterSetName = 'NonPipeline')]
+        [string[]]$Operator,
+        [Parameter(ParameterSetName = 'NonPipeline')]
+        [string[]]$ExcludeOperator,
+        [parameter(ValueFromPipeline, ParameterSetName = 'Pipeline', Mandatory = $true)]
+        [Microsoft.SqlServer.Management.Smo.Agent.Operator[]]$InputObject,
+        [Parameter(ParameterSetName = 'NonPipeline')][Parameter(ParameterSetName = 'Pipeline')]
         [switch]$EnableException
     )
 
     begin {
+        $dbOperators = @( )
     }
 
     process {
-        foreach ($instance in $SqlInstance) {
-            try {
-                $InputObject += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
-            } catch {
-                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
-            }
+        if ($SqlInstance) {
+            $params = $PSBoundParameters
+            $null = $params.Remove('WhatIf')
+            $null = $params.Remove('Confirm')
+            $dbOperators = Get-DbaAgentOperator @params
+        } else {
+            $dbOperators += $InputObject
         }
+    }
 
-        foreach ($server in $InputObject) {
-            if ((Get-DbaAgentOperator -SqlInstance $server -Operator $Operator).Count -ne 0) {
-                if ($Pscmdlet.ShouldProcess($server, "Dropping operator $operator")) {
-                    try {
-                        Write-Message -Level Verbose -Message "Dropping Operator $operator"
-                        $server.JobServer.Operators[$operator].Drop()
-
-                        Get-DbaAgentOperator -SqlInstance $server -Operator $Operator
-                    } catch {
-                        Stop-Function -Message "Issue dropping operator" -Category InvalidOperation -ErrorRecord $_ -Target $server
-                    }
+    end {
+        # We have to delete in the end block to prevent "Collection was modified; enumeration operation may not execute." if directly piped from Get-DbaAgentOperator.
+        foreach ($dbOperator in $dbOperators) {
+            if ($PSCmdlet.ShouldProcess($dbOperator.Parent.Parent.Name, "Removing the SQL Agent operator $($dbOperator.Name) on $($dbOperator.Parent.Parent.Name)")) {
+                $output = [pscustomobject]@{
+                    ComputerName = $dbOperator.Parent.Parent.ComputerName
+                    InstanceName = $dbOperator.Parent.Parent.ServiceName
+                    SqlInstance  = $dbOperator.Parent.Parent.DomainInstanceName
+                    Name         = $dbOperator.Name
+                    Status       = $null
+                    IsRemoved    = $false
                 }
+                try {
+                    $dbOperator.Drop()
+                    $output.Status = "Dropped"
+                    $output.IsRemoved = $true
+                } catch {
+                    Stop-Function -Message "Failed removing the SQL Agent operator $($dbOperator.Name) on $($dbOperator.Parent.Parent.Name)" -ErrorRecord $_
+                    $output.Status = (Get-ErrorMessage -Record $_)
+                    $output.IsRemoved = $false
+                }
+                $output
             }
         }
     }

--- a/functions/Remove-DbaAgentOperator.ps1
+++ b/functions/Remove-DbaAgentOperator.ps1
@@ -61,19 +61,15 @@ function Remove-DbaAgentOperator {
         Using a pipeline this command gets all SQL Agent operator(s) on SRV1, lets the user select those to remove and then removes the selected SQL Agent alert category(-ies).
 
     #>
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Default', ConfirmImpact = 'High')]
     param (
-        [Parameter(ParameterSetName = 'NonPipeline', Mandatory = $true, Position = 0)]
         [DbaInstanceParameter[]]$SqlInstance,
-        [Parameter(ParameterSetName = 'NonPipeline')]
         [PSCredential]$SqlCredential,
-        [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$Operator,
-        [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$ExcludeOperator,
         [parameter(ValueFromPipeline, ParameterSetName = 'Pipeline', Mandatory = $true)]
         [Microsoft.SqlServer.Management.Smo.Agent.Operator[]]$InputObject,
-        [Parameter(ParameterSetName = 'NonPipeline')][Parameter(ParameterSetName = 'Pipeline')]
+        [Parameter(ParameterSetName = 'Pipeline')]
         [switch]$EnableException
     )
 

--- a/tests/Remove-DbaAgentOperator.Tests.ps1
+++ b/tests/Remove-DbaAgentOperator.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [array]$params = ([Management.Automation.CommandMetaData]$ExecutionContext.SessionState.InvokeCommand.GetCommand($CommandName, 'Function')).Parameters.Keys
-        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Operator', 'InputObject', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Operator', 'ExcludeOperator', 'InputObject', 'EnableException'
         It "Should only contain our specific parameters" {
             Compare-Object -ReferenceObject $knownParameters -DifferenceObject $params | Should -BeNullOrEmpty
         }
@@ -32,9 +32,12 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $results | Should Be 0
         }
 
-        It "Pipeline command" {
-            $results = $instance2 | Remove-DbaAgentOperator -Operator $email2 -Confirm:$false
-            $results | Should -BeNullOrEmpty
+        It "supports piping SQL Agent operator" {
+            $operatorName = "dbatoolsci_test_$(get-random)"
+            $null = New-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName
+            (Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName ) | Should -Not -BeNullOrEmpty
+            Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName | Remove-DbaAgentOperator -Confirm:$false
+            (Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName ) | Should -BeNullOrEmpty
         }
     }
 }

--- a/tests/Remove-DbaAgentOperator.Tests.ps1
+++ b/tests/Remove-DbaAgentOperator.Tests.ps1
@@ -34,10 +34,10 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
 
         It "supports piping SQL Agent operator" {
             $operatorName = "dbatoolsci_test_$(get-random)"
-            $null = New-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName
-            (Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName ) | Should -Not -BeNullOrEmpty
-            Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName | Remove-DbaAgentOperator -Confirm:$false
-            (Get-DbaAgentOperator -SqlInstance $script:instance2 -Operator $operatorName ) | Should -BeNullOrEmpty
+            $null = New-DbaAgentOperator -SqlInstance $instance2 -Operator $operatorName
+            (Get-DbaAgentOperator -SqlInstance $instance2 -Operator $operatorName ) | Should -Not -BeNullOrEmpty
+            Get-DbaAgentOperator -SqlInstance $instance2 -Operator $operatorName | Remove-DbaAgentOperator -Confirm:$false
+            (Get-DbaAgentOperator -SqlInstance $instance2 -Operator $operatorName ) | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
To support pipeline from Get-* function, as it was not working properly. 

### Approach
<!-- How does this change solve that purpose -->

Similar to #7997 

### Commands to test
<!-- if these are the examples in the help just note it as such -->

`Get-DbaAgentOperator -SqlInstance SRV1 | Out-GridView -Title 'Select SQL Agent operator(s) to drop' -OutputMode Multiple | Remove-DbaAgentOperator`

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
