### PR TITLE
Backup-DbaDbCertificate should warn on missing certificate

### DIFF
--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -241,7 +241,7 @@ function Backup-DbaDbCertificate {
         }
 
         if ($Certificate) {
-            $missingCerts = $Certificate | ? { $InputObject.Name -notcontains $_ }
+            $missingCerts = $Certificate | Where-Object { $InputObject.Name -notcontains $_ }
 
             if ($missingCerts) {
                 Write-Message -Level Warning -Message "Database certificate(s) $missingCerts not found in Database(s)=$Database on Instance(s)=$SqlInstance"

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -237,13 +237,15 @@ function Backup-DbaDbCertificate {
         if (Test-FunctionInterrupt) { return }
 
         if ($SqlInstance) {
-            foreach ($dbCert in $Certificate) {
-                $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
+            foreach ($si in $SqlInstance) {
+                foreach ($dbCert in $Certificate) {
+                    $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $si -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
 
-                if ($databaseCertToBackup) {
-                    $InputObject += $databaseCertToBackup
-                } else {
-                    Stop-Function -Message "Database certificate $dbCert was not found in $Database on $SqlInstance" -Continue
+                    if ($databaseCertToBackup) {
+                        $InputObject += $databaseCertToBackup
+                    } else {
+                        Stop-Function -Message "Database certificate $dbCert was not found in $Database on $si" -Continue
+                    }
                 }
             }
         }

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -237,7 +237,15 @@ function Backup-DbaDbCertificate {
         if (Test-FunctionInterrupt) { return }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $Certificate
+            foreach ($dbCert in $Certificate) {
+                $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
+
+                if ($databaseCertToBackup) {
+                    $InputObject += $databaseCertToBackup
+                } else {
+                    Stop-Function -Message "Database certificate $dbCert was not found in $Database on $SqlInstance" -Continue
+                }
+            }
         }
 
         foreach ($cert in $InputObject) {

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -237,14 +237,14 @@ function Backup-DbaDbCertificate {
         if (Test-FunctionInterrupt) { return }
 
         if ($SqlInstance) {
-            foreach ($si in $SqlInstance) {
+            foreach ($instance in $SqlInstance) {
                 foreach ($dbCert in $Certificate) {
-                    $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $si -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
+                    $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
 
                     if ($databaseCertToBackup) {
                         $InputObject += $databaseCertToBackup
                     } else {
-                        Stop-Function -Message "Database certificate $dbCert was not found in $Database on $si" -Continue
+                        Stop-Function -Message "Database certificate $dbCert was not found in $Database on $instance" -Continue
                     }
                 }
             }

--- a/functions/Backup-DbaDbCertificate.ps1
+++ b/functions/Backup-DbaDbCertificate.ps1
@@ -237,16 +237,14 @@ function Backup-DbaDbCertificate {
         if (Test-FunctionInterrupt) { return }
 
         if ($SqlInstance) {
-            foreach ($instance in $SqlInstance) {
-                foreach ($dbCert in $Certificate) {
-                    $databaseCertToBackup = Get-DbaDbCertificate -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $dbCert
+            $InputObject += Get-DbaDbCertificate -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -ExcludeDatabase $ExcludeDatabase -Certificate $Certificate
+        }
 
-                    if ($databaseCertToBackup) {
-                        $InputObject += $databaseCertToBackup
-                    } else {
-                        Stop-Function -Message "Database certificate $dbCert was not found in $Database on $instance" -Continue
-                    }
-                }
+        if ($Certificate) {
+            $missingCerts = $Certificate | ? { $InputObject.Name -notcontains $_ }
+
+            if ($missingCerts) {
+                Write-Message -Level Warning -Message "Database certificate(s) $missingCerts not found in Database(s)=$Database on Instance(s)=$SqlInstance"
             }
         }
 

--- a/tests/Backup-DbaDbCertificate.Tests.ps1
+++ b/tests/Backup-DbaDbCertificate.Tests.ps1
@@ -19,6 +19,10 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
         if (-not (Get-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb)) {
             $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb -Password $pw -Confirm:$false
         }
+
+        $random = Get-Random
+        $cert = New-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -Confirm:$false -Password $pw -Name dbatoolscli_cert1_$random
+        $cert2 = New-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -Confirm:$false -Password $pw -Name dbatoolscli_cert2_$random
     }
     AfterAll {
         Get-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb | Remove-DbaDbCertificate -Confirm:$false
@@ -26,8 +30,6 @@ Describe "$commandname Integration Tests" -Tag "IntegrationTests" {
     }
 
     Context "Can create and backup a database certificate" {
-        $cert = New-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -Confirm:$false -Password $pw -Name cert1
-        $cert2 = New-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -Confirm:$false -Password $pw -Name cert2
         $results = Backup-DbaDbCertificate -SqlInstance $script:instance1 -Certificate $cert.Name -Database tempdb -EncryptionPassword $pw -DecryptionPassword $pw
         $null = Remove-Item -Path $results.Path -ErrorAction SilentlyContinue -Confirm:$false
 

--- a/tests/Restore-DbaDbCertificate.Tests.ps1
+++ b/tests/Restore-DbaDbCertificate.Tests.ps1
@@ -4,11 +4,11 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
-        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
         [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'Path', 'EncryptionPassword', 'Database', 'DecryptionPassword', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
-            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should Be 0
         }
     }
 }
@@ -19,7 +19,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
             $masterkey = New-DbaDbMasterKey -SqlInstance $script:instance1 -Database tempdb -Password $(ConvertTo-SecureString -String "GoodPass1234!" -AsPlainText -Force) -Confirm:$false
             $password = ConvertTo-SecureString -AsPlainText "GoodPass1234!!" -Force
             $cert = New-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -Confirm:$false
-            $backup = Backup-DbaDbCertificate -SqlInstance $script:instance1 -Database tempdb -EncryptionPassword $password -Confirm:$false
+            $backup = Backup-DbaDbCertificate -SqlInstance $script:instance1 -Certificate $cert.Name -Database tempdb -EncryptionPassword $password -Confirm:$false
             $cert | Remove-DbaDbCertificate -Confirm:$false
         }
         AfterEach {
@@ -27,6 +27,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
         AfterAll {
             $null = $masterkey | Remove-DbaDbMasterKey -Confirm:$false
+            $null = Remove-Item -Path $backup.ExportPath -ErrorAction SilentlyContinue -Confirm:$false
         }
 
         It "restores the db cert when passing in a .cer file" {
@@ -40,7 +41,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "restores the db cert when passing in a folder" {
-            $folder = split-path $backup.ExportPath -Parent
+            $folder = Split-Path $backup.ExportPath -Parent
             $results = Restore-DbaDbCertificate -SqlInstance $script:instance1 -Path $folder -Password $password -Database tempdb -EncryptionPassword $password -Confirm:$false
             $results.Parent.Name | Should Be 'tempdb'
             $results.Name | Should Not BeNullOrEmpty
@@ -49,7 +50,7 @@ Describe "$CommandName Integration Tests" -Tags "IntegrationTests" {
         }
 
         It "restores the db cert and encrypts with master key" {
-            $folder = split-path $backup.ExportPath -Parent
+            $folder = Split-Path $backup.ExportPath -Parent
             $results = Restore-DbaDbCertificate -SqlInstance $script:instance1 -Path $folder -Password $password -Database tempdb -Confirm:$false
             $results.Parent.Name | Should Be 'tempdb'
             $results.Name | Should Not BeNullOrEmpty


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #7918 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Minor change to validate if a certificate was not found.

### Approach
<!-- How does this change solve that purpose -->
Check each db cert and return a warning message if it wasn't found.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See updated Pester tests.