### PR TITLE
Removes output from Examples that break the docs

### DIFF
--- a/functions/Add-DbaAgListener.ps1
+++ b/functions/Add-DbaAgListener.ps1
@@ -1,7 +1,7 @@
 
 function Add-DbaAgListener {
     <#
-    .SYNOPSIS
+        .SYNOPSIS
         Adds a listener to an availability group on a SQL Server instance.
 
     .DESCRIPTION

--- a/functions/Add-DbaAgListener.ps1
+++ b/functions/Add-DbaAgListener.ps1
@@ -1,7 +1,7 @@
 
 function Add-DbaAgListener {
     <#
-        .SYNOPSIS
+    .SYNOPSIS
         Adds a listener to an availability group on a SQL Server instance.
 
     .DESCRIPTION

--- a/functions/Backup-DbaDbMasterKey.ps1
+++ b/functions/Backup-DbaDbMasterKey.ps1
@@ -58,14 +58,6 @@ function Backup-DbaDbMasterKey {
 
     .EXAMPLE
         PS C:\> Backup-DbaDbMasterKey -SqlInstance server1\sql2016
-        ```
-        ComputerName : SERVER1
-        InstanceName : SQL2016
-        SqlInstance  : SERVER1\SQL2016
-        Database     : master
-        Filename     : E:\MSSQL13.SQL2016\MSSQL\Backup\server1$sql2016-master-20170614162311.key
-        Status       : Success
-        ```
 
         Prompts for export password, then logs into server1\sql2016 with Windows credentials then backs up all database keys to the default backup directory.
 

--- a/functions/Backup-DbaDbMasterKey.ps1
+++ b/functions/Backup-DbaDbMasterKey.ps1
@@ -58,6 +58,11 @@ function Backup-DbaDbMasterKey {
 
     .EXAMPLE
         PS C:\> Backup-DbaDbMasterKey -SqlInstance server1\sql2016
+        >> ComputerName : SERVER1
+        >> InstanceName : SQL2016
+        >> SqlInstance  : SERVER1\SQL2016
+        >> Filename     : E:\MSSQL13.SQL2016\MSSQL\Backup\server1$sql2016-SMK-20170614162311.key
+        >> Status       : Success
 
         Prompts for export password, then logs into server1\sql2016 with Windows credentials then backs up all database keys to the default backup directory.
 

--- a/functions/Backup-DbaServiceMasterKey.ps1
+++ b/functions/Backup-DbaServiceMasterKey.ps1
@@ -49,6 +49,11 @@ function Backup-DbaServiceMasterKey {
 
     .EXAMPLE
         PS C:\> Backup-DbaServiceMasterKey -SqlInstance server1\sql2016
+        >> ComputerName : SERVER1
+        >> InstanceName : SQL2016
+        >> SqlInstance  : SERVER1\SQL2016
+        >> Filename     : E:\MSSQL13.SQL2016\MSSQL\Backup\server1$sql2016-SMK-20170614162311.key
+        >> Status       : Success
 
         Prompts for export password, then logs into server1\sql2016 with Windows credentials then backs up the service master key to the default backup directory.
 

--- a/functions/Backup-DbaServiceMasterKey.ps1
+++ b/functions/Backup-DbaServiceMasterKey.ps1
@@ -49,13 +49,6 @@ function Backup-DbaServiceMasterKey {
 
     .EXAMPLE
         PS C:\> Backup-DbaServiceMasterKey -SqlInstance server1\sql2016
-        ```
-        ComputerName : SERVER1
-        InstanceName : SQL2016
-        SqlInstance  : SERVER1\SQL2016
-        Filename     : E:\MSSQL13.SQL2016\MSSQL\Backup\server1$sql2016-SMK-20170614162311.key
-        Status       : Success
-        ```
 
         Prompts for export password, then logs into server1\sql2016 with Windows credentials then backs up the service master key to the default backup directory.
 

--- a/functions/Invoke-DbaPfRelog.ps1
+++ b/functions/Invoke-DbaPfRelog.ps1
@@ -100,30 +100,6 @@ function Invoke-DbaPfRelog {
 
     .EXAMPLE
         PS C:\> Invoke-DbaPfRelog -Path C:\temp\perfmon.blg -Destination C:\temp\a\b\c -Raw
-        ```
-        [Invoke-DbaPfRelog][21:21:35] relog "C:\temp\perfmon.blg" -f csv -o C:\temp\a\b\c
-
-        Input
-        ----------------
-        File(s):
-        C:\temp\perfmon.blg (Binary)
-
-        Begin:    1/13/2018 5:13:23
-        End:      1/13/2018 14:29:55
-        Samples:  2227
-
-        100.00%
-
-        Output
-        ----------------
-        File:     C:\temp\a\b\c.csv
-
-        Begin:    1/13/2018 5:13:23
-        End:      1/13/2018 14:29:55
-        Samples:  2227
-
-        The command completed successfully.
-        ```
 
         Creates the temp, a, and b directories if needed, then generates c.tsv (tab separated) from C:\temp\perfmon.blg then outputs the raw results of the relog command.
 

--- a/functions/Invoke-DbaPfRelog.ps1
+++ b/functions/Invoke-DbaPfRelog.ps1
@@ -100,6 +100,22 @@ function Invoke-DbaPfRelog {
 
     .EXAMPLE
         PS C:\> Invoke-DbaPfRelog -Path C:\temp\perfmon.blg -Destination C:\temp\a\b\c -Raw
+        >> [Invoke-DbaPfRelog][21:21:35] relog "C:\temp\perfmon.blg" -f csv -o C:\temp\a\b\c
+        >> Input
+        >> ----------------
+        >> File(s):
+        >> C:\temp\perfmon.blg (Binary)
+        >> Begin:    1/13/2018 5:13:23
+        >> End:      1/13/2018 14:29:55
+        >> Samples:  2227
+        >> 100.00%
+        >> Output
+        >> ----------------
+        >> File:     C:\temp\a\b\c.csv
+        >> Begin:    1/13/2018 5:13:23
+        >> End:      1/13/2018 14:29:55
+        >> Samples:  2227
+        >> The command completed successfully.
 
         Creates the temp, a, and b directories if needed, then generates c.tsv (tab separated) from C:\temp\perfmon.blg then outputs the raw results of the relog command.
 


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
The docs are broken by this format, plus other examples do not include outputs.

<img width="535" alt="image" src="https://user-images.githubusercontent.com/13431760/144883135-82c4e0b1-b0bc-4013-a124-412febb97a9e.png">


### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
