### PR TITLE
Get-DbaDbRestoreHistory - Fixes tiny bug with selecting restored backup #8019

### DIFF
--- a/functions/Get-DbaDbRestoreHistory.ps1
+++ b/functions/Get-DbaDbRestoreHistory.ps1
@@ -166,8 +166,8 @@ function Get-DbaDbRestoreHistory {
 
 
                 if ($last) {
-                    $wherearray += "rsh.backup_set_id in
-                        (select max(backup_set_id) from msdb.dbo.restorehistory
+                    $wherearray += "rsh.restore_history_id in
+                        (select max(restore_history_id) from msdb.dbo.restorehistory
                         group by destination_database_name
                         )"
                 }


### PR DESCRIPTION
Fixes wrong determination of Last restored backup - #8019

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #8019  )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose

### Approach
Use key field `restorehistory.restore_history_id` instead of `backup_set_id` which contains duplicates when you restore same backups 
### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
