### PR TITLE
Invoke-DbaQuery - Remove fixed default for QueryTimeout and use global default from Connect-DbaInstance

### DIFF
--- a/functions/Connect-DbaInstance.ps1
+++ b/functions/Connect-DbaInstance.ps1
@@ -646,7 +646,10 @@ function Connect-DbaInstance {
                             $connContext.NonPooledConnection = $true
                         }
                         if ($Database) {
+                            # Save StatementTimeout because it might be reset on GetDatabaseConnection
+                            $savedStatementTimeout = $connContext.StatementTimeout
                             $connContext = $connContext.GetDatabaseConnection($Database)
+                            $connContext.StatementTimeout = $savedStatementTimeout
                         }
                         $server = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Server -ArgumentList $connContext
                     } else {

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -351,9 +351,10 @@ function Invoke-DbaQuery {
             $server = $db.Parent
             $conncontext = $server.ConnectionContext
             if ($conncontext.DatabaseName -ne $db.Name) {
-                #$conncontext = $server.ConnectionContext.Copy()
-                #$conncontext.DatabaseName = $db.Name
-                $conncontext = $server.ConnectionContext.Copy().GetDatabaseConnection($db.Name)
+                # Save StatementTimeout because it might be reset on GetDatabaseConnection
+                $savedStatementTimeout = $conncontext.StatementTimeout
+                $conncontext = $conncontext.Copy().GetDatabaseConnection($db.Name)
+                $conncontext.StatementTimeout = $savedStatementTimeout
             }
             try {
                 if ($File -or $SqlObject) {

--- a/functions/Invoke-DbaQuery.ps1
+++ b/functions/Invoke-DbaQuery.ps1
@@ -153,7 +153,7 @@ function Invoke-DbaQuery {
         [string]$Database,
         [Parameter(Mandatory, ParameterSetName = "Query")]
         [string]$Query,
-        [Int32]$QueryTimeout = 600,
+        [Int32]$QueryTimeout,
         [Parameter(Mandatory, ParameterSetName = "File")]
         [Alias("InputFile")]
         [object[]]$File,

--- a/internal/functions/Invoke-DbaAsync.ps1
+++ b/internal/functions/Invoke-DbaAsync.ps1
@@ -64,7 +64,7 @@ function Invoke-DbaAsync {
         [switch]
         $AppendServerInstance,
 
-        [Int32]$QueryTimeout = 600,
+        [Int32]$QueryTimeout,
 
         [switch]
         $MessagesToOutput,
@@ -79,6 +79,9 @@ function Invoke-DbaAsync {
                 Stop-Function -Message "SqlParameter only accepts a single hashtable or Microsoft.Data.SqlClient.SqlParameter"
                 return
             }
+        }
+        if (-not $PSBoundParameters.QueryTimeout) {
+            $QueryTimeout = $SQLConnection.StatementTimeout
         }
         function Resolve-SqlError {
             param($Err)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Invoke-DbaQuery uses a fixed default of 10 minutes for QueryTimeout which causes problems for long runing queries like index rebuilds.
Most other commands use the default of Connect-DbaInstance. The parameter is named StatementTimeout there and has a default of `Get-DbatoolsConfigValue -FullName 'sql.execution.timeout'` with a default of 0 = unlimited.

### Approach
Removing the fixed default and reading StatementTimeout from ConnectionContext.

### Commands to test
```
# This will fail as it failed before:
Invoke-DbaQuery -SqlInstance sql01 -Query "WAITFOR DELAY '00:00:20'" -QueryTimeout 10

# This now fails as well, so it uses the StatementTimeout from Connect-DbaInstance
$server = Connect-DbaInstance -SqlInstance sql01 -StatementTimeout 10
Invoke-DbaQuery -SqlInstance $server -Query "WAITFOR DELAY '00:00:20'"

# Fails as well, so even if the ConnectionContext is changed to the new database 
Invoke-DbaQuery -SqlInstance $server -Database tempdb -Query "WAITFOR DELAY '00:00:20'" 

# Fails as well, so even when the database SMO is used for pipeline input
$server.Databases['model'] | Invoke-DbaQuery -Query "WAITFOR DELAY '00:00:20'"
```

![image](https://user-images.githubusercontent.com/66946165/146053251-c55c2487-6bff-44d4-9907-0e304f05a472.png)
