### PR TITLE
New command: Remove-DbaLinkedServerLogin

### DIFF
--- a/functions/Remove-DbaLinkedServerLogin.ps1
+++ b/functions/Remove-DbaLinkedServerLogin.ps1
@@ -1,0 +1,127 @@
+function Remove-DbaLinkedServerLogin {
+    <#
+    .SYNOPSIS
+        Removes a linked server login.
+
+    .DESCRIPTION
+        Removes a linked server login.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function
+        to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER LinkedServer
+        The name(s) of the linked server(s).
+
+    .PARAMETER LocalLogin
+        The name(s) of the linked server login(s).
+
+    .PARAMETER InputObject
+        Allows piping from Connect-DbaInstance, Get-DbaLinkedServer, and Get-DbaLinkedServerLogin.
+
+    .PARAMETER WhatIf
+        Shows what would happen if the command were to run. No actions are actually performed.
+
+    .PARAMETER Confirm
+        Prompts you for confirmation before executing any changing operations within the command.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Security, Server
+        Author: Adam Lancaster https://github.com/lancasteradam
+
+        dbatools PowerShell module (https://dbatools.io)
+        Copyright: (c) 2021 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaLinkedServerLogin
+
+    .EXAMPLE
+        PS C:\>Remove-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -LocalLogin linkedServerLogin1 -Confirm:$false
+
+        Removes the linkedServerLogin1 from the linkedServer1 linked server on the sql01 instance.
+
+    .EXAMPLE
+        PS C:\>$instance = Connect-DbaInstance -SqlInstance sql01
+        PS C:\>$instance | Remove-DbaLinkedServerLogin -LinkedServer linkedServer1 -LocalLogin linkedServerLogin1 -Confirm:$false
+
+        Passes in a SqlInstance via pipeline and removes the linkedServerLogin1 from the linkedServer1 linked server.
+
+    .EXAMPLE
+        PS C:\>$linkedServer1 = Get-DbaLinkedServer -SqlInstance sql01 -LinkedServer linkedServer1
+        PS C:\>$linkedServer1 | Remove-DbaLinkedServerLogin -LocalLogin linkedServerLogin1 -Confirm:$false
+
+        Passes in a linked server via pipeline and removes the linkedServerLogin1.
+
+    .EXAMPLE
+        PS C:\>$linkedServerLogin1 = Get-DbaLinkedServerLogin -SqlInstance sql01 -LinkedServer linkedServer1 -LocalLogin linkedServerLogin1
+        PS C:\>$linkedServerLogin1 | Remove-DbaLinkedServerLogin -Confirm:$false
+
+        Passes in a linked server login via pipeline and removes it.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$LinkedServer,
+        [string[]]$LocalLogin,
+        [parameter(ValueFromPipeline)]
+        [object[]]$InputObject,
+        [switch]$EnableException
+    )
+    begin {
+        $linkedServerLoginsToDrop = @()
+    }
+    process {
+
+        if ($SqlInstance -and (-not $LinkedServer)) {
+            Stop-Function -Message "LinkedServer is required when SqlInstance is specified"
+            return
+        }
+
+        foreach ($instance in $SqlInstance) {
+            $linkedServerLoginsToDrop += Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential | Get-DbaLinkedServerLogin -LinkedServer $LinkedServer -LocalLogin $LocalLogin
+        }
+
+        foreach ($obj in $InputObject) {
+
+            if ($obj -is [Microsoft.SqlServer.Management.Smo.Server]) {
+
+                if (Test-Bound -Not -ParameterName LinkedServer) {
+                    Stop-Function -Message "LinkedServer is required" -Continue
+                }
+
+                $linkedServerLoginsToDrop += Get-DbaLinkedServerLogin -SqlInstance $obj -LinkedServer $LinkedServer -LocalLogin $LocalLogin
+            } elseif ($obj -is [Microsoft.SqlServer.Management.Smo.LinkedServer]) {
+                $linkedServerLoginsToDrop += $obj | Get-DbaLinkedServerLogin -LocalLogin $LocalLogin
+            } elseif ($obj -is [Microsoft.SqlServer.Management.Smo.LinkedServerLogin]) {
+                $linkedServerLoginsToDrop += $obj
+            }
+        }
+    }
+    end {
+
+        foreach ($lsLoginToDrop in $linkedServerLoginsToDrop) {
+
+            if ($Pscmdlet.ShouldProcess($lsLoginToDrop.Parent.Name, "Removing the linked server login $($lsLoginToDrop.Name) for the linked server $($lsLoginToDrop.Parent.Name) on $($lsLoginToDrop.Parent.Parent.Name)")) {
+                try {
+                    $lsLoginToDrop.Drop()
+                } catch {
+                    Stop-Function -Message "Failure on $($lsLoginToDrop.Parent.Parent.Name) to remove the linked server login $($lsLoginToDrop.Name) for the linked server $($lsLoginToDrop.Parent.Name)" -ErrorRecord $_ -Continue
+                }
+            }
+        }
+    }
+}

--- a/tests/Remove-DbaLinkedServerLogin.Tests.ps1
+++ b/tests/Remove-DbaLinkedServerLogin.Tests.ps1
@@ -1,0 +1,117 @@
+$CommandName = $MyInvocation.MyCommand.Name.Replace(".Tests.ps1", "")
+Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
+. "$PSScriptRoot\constants.ps1"
+
+Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
+    Context "Validate parameters" {
+        [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object { $_ -notin ('whatif', 'confirm') }
+        [object[]]$knownParameters = 'SqlInstance', 'SqlCredential', 'LinkedServer', 'LocalLogin', 'InputObject', 'EnableException'
+        $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
+        It "Should only contain our specific parameters" {
+            (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object { $_ }) -DifferenceObject $params).Count ) | Should -Be 0
+        }
+    }
+}
+
+Describe "$commandname Integration Tests" -Tags "IntegrationTests" {
+    BeforeAll {
+        $random = Get-Random
+        $instance2 = Connect-DbaInstance -SqlInstance $script:instance2
+        $instance3 = Connect-DbaInstance -SqlInstance $script:instance3
+
+        $securePassword = ConvertTo-SecureString -String 'securePassword' -AsPlainText -Force
+        $localLogin1Name = "dbatoolscli_localLogin1_$random"
+        $localLogin2Name = "dbatoolscli_localLogin2_$random"
+        $localLogin3Name = "dbatoolscli_localLogin3_$random"
+        $localLogin4Name = "dbatoolscli_localLogin4_$random"
+        $localLogin5Name = "dbatoolscli_localLogin5_$random"
+        $localLogin6Name = "dbatoolscli_localLogin6_$random"
+        $localLogin7Name = "dbatoolscli_localLogin7_$random"
+        $remoteLoginName = "dbatoolscli_remoteLogin_$random"
+
+        $linkedServer1Name = "dbatoolscli_linkedServer1_$random"
+        $linkedServer2Name = "dbatoolscli_linkedServer2_$random"
+
+        New-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name, $localLogin3Name, $localLogin4Name, $localLogin5Name, $localLogin6Name, $localLogin7Name -SecurePassword $securePassword
+        New-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -SecurePassword $securePassword
+
+        $linkedServer1 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+        $linkedServer2 = New-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer2Name -ServerProduct mssql -Provider sqlncli -DataSource $instance3
+
+        $linkedServerLogin1 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin2 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin2Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin3 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin3Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin4 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin4Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin5 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin5Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin6 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin6Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+        $linkedServerLogin7 = New-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -LocalLogin $localLogin7Name -RemoteUser $remoteLoginName -RemoteUserPassword $securePassword
+    }
+    AfterAll {
+        Remove-DbaLinkedServer -SqlInstance $instance2 -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false -Force
+        Remove-DbaLogin -SqlInstance $instance2 -Login $localLogin1Name, $localLogin2Name, $localLogin3Name, $localLogin4Name, $localLogin5Name, $localLogin6Name, $localLogin7Name -Confirm:$false
+        Remove-DbaLogin -SqlInstance $instance3 -Login $remoteLoginName -Confirm:$false
+    }
+
+    Context "ensure command works" {
+
+        It "Check the validation for a linked server" {
+            $results = Remove-DbaLinkedServerLogin -SqlInstance $instance2 -LocalLogin $localLogin1Name -Confirm:$false -WarningVariable warningMessage
+            $results | Should -BeNullOrEmpty
+            $warningMessage | Should -Match "LinkedServer is required"
+        }
+
+        It "Remove a linked server login" {
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name
+            $results.length | Should -Be 1
+
+            $results = Remove-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name -Confirm:$false
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin1Name
+            $results | Should -BeNullOrEmpty
+
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin2Name, $localLogin3Name
+            $results.length | Should -Be 2
+
+            $results = Remove-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin2Name, $localLogin3Name -Confirm:$false
+            $results = Get-DbaLinkedServerLogin -SqlInstance $instance2 -LinkedServer $linkedServer1Name -LocalLogin $localLogin2Name, $localLogin3Name
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Remove a linked server login via pipeline with a server instance passed in" {
+            $results = $instance2 | Get-DbaLinkedServerLogin -LinkedServer $linkedServer1Name -LocalLogin $localLogin4Name
+            $results.length | Should -Be 1
+
+            $results = $instance2 | Remove-DbaLinkedServerLogin -LinkedServer $linkedServer1Name -LocalLogin $localLogin4Name -Confirm:$false
+            $results = $instance2 | Get-DbaLinkedServerLogin -LinkedServer $linkedServer1Name -LocalLogin $localLogin4Name
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Remove a linked server login via pipeline with a linked server passed in" {
+            $results = $linkedServer1 | Get-DbaLinkedServerLogin -LocalLogin $localLogin5Name
+            $results.length | Should -Be 1
+
+            $results = $linkedServer1 | Remove-DbaLinkedServerLogin -LocalLogin $localLogin5Name -Confirm:$false
+            $results = $linkedServer1 | Get-DbaLinkedServerLogin -LocalLogin $localLogin5Name
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Remove a linked server login via pipeline with a linked server login passed in" {
+            $results = $linkedServer1 | Get-DbaLinkedServerLogin -LocalLogin $localLogin6Name
+            $results.length | Should -Be 1
+
+            $results = $linkedServerLogin6 | Remove-DbaLinkedServerLogin -Confirm:$false
+            $results = $linkedServer1 | Get-DbaLinkedServerLogin -LocalLogin $localLogin6Name
+            $results | Should -BeNullOrEmpty
+        }
+
+        It "Remove linked server logins for multiple linked servers and omit the LocalLogin param" {
+            $results = $instance2 | Get-DbaLinkedServerLogin -LinkedServer $linkedServer1Name, $linkedServer2Name
+            $results.Parent.Name | Should -Contain $linkedServer1Name
+            $results.Parent.Name | Should -Contain $linkedServer2Name
+            $results.Name | Should -Contain $localLogin7Name
+
+            $results = $instance2 | Remove-DbaLinkedServerLogin -LinkedServer $linkedServer1Name, $linkedServer2Name -Confirm:$false
+            $results = $instance2 | Get-DbaLinkedServerLogin -LinkedServer $linkedServer1Name, $linkedServer2Name
+            $results.Name | Should -Not -Contain $localLogin7Name
+        }
+    }
+}


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #8026 )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [x] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [x] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Basic command for removing a linked login from a linked server. Part of a series of PRs related to linked servers:

1. Update for Remove-DbaLinkedServer (#7952)
2. New command for Get-DbaLinkedServerLogin	(#7965)
3. New command for New-DbaLinkedServerLogin (#7983)
4. New command for Remove-DbaLinkedServerLogin (This PR)
5. Update for New-DbaLinkedServer
6. New command for Set-DbaLinkedServer

### Approach
<!-- How does this change solve that purpose -->
Basic command that allows for multiple input object types.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
See the Pester tests.