### PR TITLE
Get-DbaNetworkCertificate - Use SqlInstance and Get-DbaNetworkConfiguration

### DIFF
--- a/functions/Get-DbaNetworkCertificate.ps1
+++ b/functions/Get-DbaNetworkCertificate.ps1
@@ -47,6 +47,6 @@ function Get-DbaNetworkCertificate {
         [switch]$EnableException
     )
     process {
-        Get-DbaNetworkConfiguration -SqlInstance $SqlInstance -OutputType Certificate | Where-Object FriendlyName
+        Get-DbaNetworkConfiguration -SqlInstance $SqlInstance -OutputType Certificate | Where-Object Thumbprint
     }
 }

--- a/functions/Get-DbaNetworkCertificate.ps1
+++ b/functions/Get-DbaNetworkCertificate.ps1
@@ -47,6 +47,6 @@ function Get-DbaNetworkCertificate {
         [switch]$EnableException
     )
     process {
-        Get-DbaNetworkConfiguration -SqlInstance $SqlInstance -OutputType Certificate
+        Get-DbaNetworkConfiguration -SqlInstance $SqlInstance -OutputType Certificate | Where-Object FriendlyName
     }
 }

--- a/functions/Get-DbaNetworkCertificate.ps1
+++ b/functions/Get-DbaNetworkCertificate.ps1
@@ -6,8 +6,8 @@ function Get-DbaNetworkCertificate {
     .DESCRIPTION
         Gets the computer certificates that is assigned to the SQL Server instance for enabling network encryption.
 
-    .PARAMETER ComputerName
-        The target SQL Server instance or instances. Defaults to localhost. If target is a cluster, you must specify the distinct nodes.
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. Defaults to standard instance on localhost. If target is a cluster, you must specify the distinct nodes.
 
     .PARAMETER Credential
         Alternate credential object to use for accessing the target computer(s).
@@ -29,99 +29,24 @@ function Get-DbaNetworkCertificate {
         https://dbatools.io/Get-DbaNetworkCertificate
 
     .EXAMPLE
-        PS C:\> Get-DbaNetworkCertificate
+        PS C:\> Get-DbaNetworkCertificate -SqlInstance sql2016
 
-        Gets computer certificates on localhost that are candidates for using with SQL Server's network encryption
+        Gets computer certificate for the standard instance on sql2016 that is being used for SQL Server network encryption
 
     .EXAMPLE
-        PS C:\> Get-DbaNetworkCertificate -ComputerName sql2016
+        PS C:\> Get-DbaNetworkCertificate -SqlInstance server1\sql2017
 
-        Gets computer certificates on sql2016 that are being used for SQL Server network encryption
+        Gets computer certificate for the named instance sql2017 on server1 that is being used for SQL Server network encryption
     #>
     [CmdletBinding()]
     param (
         [parameter(ValueFromPipeline)]
-        [DbaInstanceParameter[]]$ComputerName = $env:COMPUTERNAME,
+        [Alias("ComputerName")]
+        [DbaInstanceParameter[]]$SqlInstance = $env:COMPUTERNAME,
         [PSCredential]$Credential,
         [switch]$EnableException
     )
     process {
-        # Registry access
-        foreach ($computer in $computername) {
-            try {
-                $sqlwmis = Invoke-ManagedComputerCommand -ComputerName $computer.ComputerName -ScriptBlock { $wmi.Services } -Credential $Credential -ErrorAction Stop | Where-Object DisplayName -match "SQL Server \("
-            } catch {
-                Stop-Function -Message $_ -Target $sqlwmi -Continue
-            }
-
-            foreach ($sqlwmi in $sqlwmis) {
-                $regRoot = ($sqlwmi.AdvancedProperties | Where-Object Name -eq REGROOT).Value
-                $vsname = ($sqlwmi.AdvancedProperties | Where-Object Name -eq VSNAME).Value
-                $instanceName = $sqlwmi.DisplayName.Replace('SQL Server (', '').Replace(')', '') # Don't clown, I don't know regex :(
-                $serviceAccount = $sqlwmi.ServiceAccount
-
-                if ([System.String]::IsNullOrEmpty($regRoot)) {
-                    $regRoot = $sqlwmi.AdvancedProperties | Where-Object { $_ -match 'REGROOT' }
-                    $vsname = $sqlwmi.AdvancedProperties | Where-Object { $_ -match 'VSNAME' }
-
-                    if (![System.String]::IsNullOrEmpty($regRoot)) {
-                        $regRoot = ($regRoot -Split 'Value\=')[1]
-                        $vsname = ($vsname -Split 'Value\=')[1]
-                    } else {
-                        Write-Message -Level Warning -Message "Can't find instance $vsname on $env:COMPUTERNAME"
-                        return
-                    }
-                }
-
-                if ([System.String]::IsNullOrEmpty($vsname)) { $vsname = $computer }
-
-                Write-Message -Level Verbose -Message "Regroot: $regRoot"
-                Write-Message -Level Verbose -Message "ServiceAcct: $serviceAccount"
-                Write-Message -Level Verbose -Message "InstanceName: $instanceName"
-                Write-Message -Level Verbose -Message "VSNAME: $vsname"
-
-                $scriptBlock = {
-                    $regRoot = $args[0]
-                    $serviceAccount = $args[1]
-                    $instanceName = $args[2]
-                    $vsname = $args[3]
-
-                    $regPath = "Registry::HKEY_LOCAL_MACHINE\$regRoot\MSSQLServer\SuperSocketNetLib"
-
-                    $thumbprint = (Get-ItemProperty -Path $regPath -Name Certificate -ErrorAction SilentlyContinue).Certificate
-
-                    try {
-                        $cert = Get-ChildItem Cert:\LocalMachine -Recurse -ErrorAction Stop | Where-Object Thumbprint -eq $Thumbprint
-                    } catch {
-                        # Don't care - sometimes there's errors that are thrown for apparent good reason
-                        # here to avoid an empty catch
-                        $null = 1
-                    }
-
-                    if (!$cert) { continue }
-
-                    [pscustomobject]@{
-                        ComputerName   = $env:COMPUTERNAME
-                        InstanceName   = $instanceName
-                        SqlInstance    = $vsname
-                        ServiceAccount = $serviceAccount
-                        FriendlyName   = $cert.FriendlyName
-                        DnsNameList    = $cert.DnsNameList
-                        Thumbprint     = $cert.Thumbprint
-                        Generated      = $cert.NotBefore
-                        Expires        = $cert.NotAfter
-                        IssuedTo       = $cert.Subject
-                        IssuedBy       = $cert.Issuer
-                        Certificate    = $cert
-                    }
-                }
-
-                try {
-                    Invoke-Command2 -ComputerName $computer.ComputerName -Credential $Credential -ArgumentList $regRoot, $serviceAccount, $instanceName, $vsname -ScriptBlock $scriptBlock -ErrorAction Stop | Select-DefaultView -ExcludeProperty Certificate
-                } catch {
-                    Stop-Function -Message $_ -ErrorRecord $_ -Target $ComputerName -Continue
-                }
-            }
-        }
+        Get-DbaNetworkConfiguration -SqlInstance $SqlInstance -OutputType Certificate
     }
 }

--- a/tests/Get-DbaNetworkCertificate.Tests.ps1
+++ b/tests/Get-DbaNetworkCertificate.Tests.ps1
@@ -5,7 +5,7 @@ Write-Host -Object "Running $PSCommandPath" -ForegroundColor Cyan
 Describe "$CommandName Unit Tests" -Tag 'UnitTests' {
     Context "Validate parameters" {
         [object[]]$params = (Get-Command $CommandName).Parameters.Keys | Where-Object {$_ -notin ('whatif', 'confirm')}
-        [object[]]$knownParameters = 'ComputerName', 'Credential', 'EnableException'
+        [object[]]$knownParameters = 'SqlInstance', 'Credential', 'EnableException'
         $knownParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
         It "Should only contain our specific parameters" {
             (@(Compare-Object -ReferenceObject ($knownParameters | Where-Object {$_}) -DifferenceObject $params).Count ) | Should Be 0


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Get-DbaNetworkCertificate listed all certificates used for any instance on the target computer. With this change, it is possible to get the certificate for a single instance.
And as we have Get-DbaNetworkConfiguration to get all kind of network replated information, the command is now only a wrapper to reduce duplicate code.