### PR TITLE
Update-DbaServiceAccount - Update permissions on certificate

### DIFF
--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -228,7 +228,8 @@ function Update-DbaServiceAccount {
                                 if ($svc.ServiceName -ne 'MSSQLSERVER') {
                                     $sqlInstance += '\' + $svc.ServiceName
                                 }
-                                $certificate = Get-DbaNetworkConfiguration -SqlInstance $sqlInstance -Credential $Credential -OutputType Certificate -EnableException
+                                # We try to get the certificate, but don't fail in case we are not able to.
+                                $certificate = Get-DbaNetworkConfiguration -SqlInstance $sqlInstance -Credential $Credential -OutputType Certificate
                                 if ($certificate.Thumbprint) {
                                     Write-Message -Level Verbose -Message "Removing certificate from service $($svc.ServiceName) on $($svc.ComputerName)"
                                     $null = Remove-DbaNetworkCertificate -SqlInstance $sqlInstance -Credential $Credential -EnableException

--- a/functions/Update-DbaServiceAccount.ps1
+++ b/functions/Update-DbaServiceAccount.ps1
@@ -221,24 +221,25 @@ function Update-DbaServiceAccount {
                 if ($PsCmdlet.ShouldProcess($serviceObject, "Changing account information for service $($svc.ServiceName) on $($svc.ComputerName)")) {
                     try {
                         if ($actionType -eq 'Account') {
-                            Write-Message -Level Verbose -Message "Attempting an account change for service $($svc.ServiceName) on $($svc.ComputerName)"
-                            $null = Invoke-ManagedComputerCommand -ComputerName $svc.ComputerName -Credential $Credential -ScriptBlock $scriptAccountChange -ArgumentList @($svc.ServiceName, $currentCredential.UserName, $currentCredential.GetNetworkCredential().Password) -EnableException:$EnableException
-                            $outMessage = "The login account for the service has been successfully set."
+                            # Test if a certificate is used. If so, remove it and set it again later.
+                            $certificate = $null
                             if ($serviceObject.ServiceType -eq 'Engine') {
-                                # Test if a certificate is used. If so, update permissions on the certificate for the new service account.
                                 $sqlInstance = $svc.ComputerName
                                 if ($svc.ServiceName -ne 'MSSQLSERVER') {
                                     $sqlInstance += '\' + $svc.ServiceName
                                 }
-                                try {
-                                    $certificate = Get-DbaNetworkConfiguration -SqlInstance $sqlInstance -Credential $Credential -OutputType Certificate -EnableException
-                                    if ($certificate.Thumbprint) {
-                                        $setCertOutput = Set-DbaNetworkCertificate -SqlInstance $sqlInstance -Credential $Credential -Thumbprint $certificate.Thumbprint -EnableException
-                                        $outMessage += ' ' + $setCertOutput.Notes
-                                    }
-                                } catch {
-                                    $outMessage += " Failed to update permissions on the certificate."
+                                $certificate = Get-DbaNetworkConfiguration -SqlInstance $sqlInstance -Credential $Credential -OutputType Certificate -EnableException
+                                if ($certificate.Thumbprint) {
+                                    Write-Message -Level Verbose -Message "Removing certificate from service $($svc.ServiceName) on $($svc.ComputerName)"
+                                    $null = Remove-DbaNetworkCertificate -SqlInstance $sqlInstance -Credential $Credential -EnableException
                                 }
+                            }
+                            Write-Message -Level Verbose -Message "Attempting an account change for service $($svc.ServiceName) on $($svc.ComputerName)"
+                            $null = Invoke-ManagedComputerCommand -ComputerName $svc.ComputerName -Credential $Credential -ScriptBlock $scriptAccountChange -ArgumentList @($svc.ServiceName, $currentCredential.UserName, $currentCredential.GetNetworkCredential().Password) -EnableException:$EnableException
+                            $outMessage = "The login account for the service has been successfully set."
+                            if ($certificate.Thumbprint) {
+                                Write-Message -Level Verbose -Message "Setting certificate for service $($svc.ServiceName) on $($svc.ComputerName)"
+                                $null = Set-DbaNetworkCertificate -SqlInstance $sqlInstance -Credential $Credential -Thumbprint $certificate.Thumbprint -EnableException
                             }
                         } elseif ($actionType -eq 'Password') {
                             Write-Message -Level Verbose -Message "Attempting a password change for service $($svc.ServiceName) on $($svc.ComputerName)"
@@ -249,6 +250,10 @@ function Update-DbaServiceAccount {
                     } catch {
                         $outStatus = 'Failed'
                         $outMessage = $_.Exception.Message
+                        if ($certificate.Thumbprint) {
+                            # Depending on where the process failed, the certificate might be already removed but not yet set again.
+                            $outMessage += " Please check if certificate with thumbprint $($certificate.Thumbprint) is still in place."
+                        }
                         Stop-Function -Message $outMessage -Continue
                     }
                 } else {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #6230 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
For instances with a network certificate, changing the account is only possible if the certificate is temporarily removed. Setting it  again after the account change also sets the ACLs on the certificate to the new account.

### Approach
<!-- How does this change solve that purpose -->

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
