### PR TITLE
Get-DbaDbView - Use ClearAndInitialize to improve performance

### DIFF
--- a/functions/Get-DbaDbView.ps1
+++ b/functions/Get-DbaDbView.ps1
@@ -131,6 +131,11 @@ function Get-DbaDbView {
 
         foreach ($db in $InputObject) {
             Write-Message -Level Verbose -Message "processing $db"
+
+            # Let the SMO read all properties referenced in this command for all views in the database in one query.
+            # Downside: If some other properties were already read outside of this command in the used SMO, they are cleared.
+            $db.Views.ClearAndInitialize('', [string[]]('Name', 'Schema', 'IsSystemObject', 'CreateDate', 'DateLastModified'))
+
             if ($fqtns) {
                 $views = @()
                 foreach ($fqtn in $fqtns) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

If we run code like `$views = $views | Where-Object { -not $_.IsSystemObject }`, the SMO works on a per view bases, so one view after the other is tested. As IsSystemObject is not one of the default properties, it is empty by default and has to be fetched from the database for every individual view. With say 1000 views in the database, that are 1000 fetches. If we use ClearAndInitialize, then the named properties are all fetched together in one single fetch. After that fetch, the database is not touched anymore and the command runs completely with information inside of the SMO.

About the downside: The Clear in ClearAndInitialize is a clear. So all properties fetched beforehand outside of the command are removed and would have to be fetched again.
So this code would be fast before the cange and slow after the change, because the property Owner would be fetched for every view one at a time when Format-Table runs:
``` 
$db = Get-DbaDatabase -SqlInstance sql01 -Database ViewTest
$db.Views.ClearAndInitialize('', [string[]]('Name', 'Schema', 'IsSystemObject', 'CreateDate', 'DateLastModified', 'Owner'))
$db | Get-DbaDbView -ExcludeSystemView | Format-Table -Property Name, Schema, Owner
```

So the general rule would be: This change helps if the command uses a brand new SMO like when -SqlInstance is used with a string. If someone uses ClearAndInitialize already outside of the command, then it would probably be better to not using the command but:
```
$db = Get-DbaDatabase -SqlInstance sql01 -Database ViewTest
$db.Views.ClearAndInitialize('', [string[]]('Name', 'Schema', 'IsSystemObject', 'CreateDate', 'DateLastModified', 'Owner'))
$db.Views | Where-Object { -not $_.IsSystemObject } | Format-Table -Property Name, Schema, Owner
```