### PR TITLE
Issue template config addition - docs and dbatools.io issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,9 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Issues found with dbatools.io?
     url: https://github.com/sqlcollaborative/web/issues/new
-    about: Primary website is hosted via GitHub Pages
+    about: Website is hosted via GitHub Pages under sqlcollaborative/web
   - name: Issues found with docs.dbatools.io?
     url: https://github.com/sqlcollaborative/docs/issues/new
+    about: Website is hosted under sqlcollaborative/docs
   - name: Ask a question about dbatools or get support
     url: https://github.com/sqlcollaborative/dbatools/discussions/new
     about: Get support via forums

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,10 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Issues found with dbatools.io?
+    url: https://github.com/sqlcollaborative/web/issues/new
+    about: Primary website is hosted via GitHub Pages
+  - name: Issues found with docs.dbatools.io?
+    url: https://github.com/sqlcollaborative/docs/issues/new
   - name: Ask a question about dbatools or get support
     url: https://github.com/sqlcollaborative/dbatools/discussions/new
     about: Get support via forums


### PR DESCRIPTION
Adding additional short links for the dbatools.io and docs.dbatools.io repositories for issues to be created there instead of this repository.