### PR TITLE
Fixing memory leak

### DIFF
--- a/internal/scripts/logfilescript.ps1
+++ b/internal/scripts/logfilescript.ps1
@@ -91,7 +91,7 @@ $scriptBlock = {
                 $num_Error++
 
                 $Record = $null
-                [Sqlcollaborative.Dbatools.Message.LogHost]::OutQueueError.TryDequeue([ref]$Record)
+                $null = [Sqlcollaborative.Dbatools.Message.LogHost]::OutQueueError.TryDequeue([ref]$Record)
 
                 if ($Record) {
                     $Record | Export-Clixml -Path "$($root.FullName)\dbatools_$($pid)_error_$($num_Error).xml" -Depth 3
@@ -113,7 +113,7 @@ $scriptBlock = {
                 }
 
                 $Entry = $null
-                [Sqlcollaborative.Dbatools.Message.LogHost]::OutQueueLog.TryDequeue([ref]$Entry)
+                $null = [Sqlcollaborative.Dbatools.Message.LogHost]::OutQueueLog.TryDequeue([ref]$Entry)
                 if ($Entry) {
                     Add-Content -Path $CurrentFile -Value (ConvertTo-Csv -InputObject $Entry -NoTypeInformation)[1]
                 }


### PR DESCRIPTION
## Type of Change

 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose

Fixes memory leak in the logging system (only noticeable in long-running processes such as services).
Resolves #8035 

### Details

The background logging is running in an infinite loop. This causes any unhandled output within that loop being queued in the output buffer, waiting for the loop to finish (which it never will).
The `TryDequeue(...)` method returns a `$true` on success, or `$false` on failure (= Queue is empty) which were not handled.
This would then - _very, very slowly_ - accumulate in memory.