### PR TITLE
Find-DbaStoredProcedure - Split logic modified

### DIFF
--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -141,8 +141,10 @@ function Find-DbaStoredProcedure {
                     if ($row.TextBody -match $Pattern) {
                         $sp = $db.StoredProcedures | Where-Object { $_.Schema -eq $procSchema -and $_.Name -eq $proc }
 
-                        $StoredProcedureText = $row.TextBody.split("`n")
-                        $spTextFound = $StoredProcedureText | Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
+                        $StoredProcedureText = $row.TextBody
+                        $splitOn = [string[]]@("`r`n", "`r", "`n" )
+                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::RemoveEmptyEntries ) | 
+                            Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                         [PSCustomObject]@{
                             ComputerName             = $server.ComputerName
@@ -154,7 +156,7 @@ function Find-DbaStoredProcedure {
                             IsSystemObject           = $sp.IsSystemObject
                             CreateDate               = $sp.CreateDate
                             LastModified             = $sp.DateLastModified
-                            StoredProcedureTextFound = $spTextFound -join "`n"
+                            StoredProcedureTextFound = $spTextFound -join [System.Environment]::NewLine
                             StoredProcedure          = $sp
                             StoredProcedureFullText  = $StoredProcedureText
                         } | Select-DefaultView -ExcludeProperty StoredProcedure, StoredProcedureFullText

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -143,7 +143,7 @@ function Find-DbaStoredProcedure {
 
                         $StoredProcedureText = $row.TextBody
                         $splitOn = [string[]]@("`r`n", "`r", "`n" )
-                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::RemoveEmptyEntries ) | 
+                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::RemoveEmptyEntries ) |
                             Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                         [PSCustomObject]@{

--- a/functions/Find-DbaStoredProcedure.ps1
+++ b/functions/Find-DbaStoredProcedure.ps1
@@ -143,7 +143,7 @@ function Find-DbaStoredProcedure {
 
                         $StoredProcedureText = $row.TextBody
                         $splitOn = [string[]]@("`r`n", "`r", "`n" )
-                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::RemoveEmptyEntries ) |
+                        $spTextFound = $StoredProcedureText.Split( $splitOn , [System.StringSplitOptions]::None ) |
                             Select-String -Pattern $Pattern | ForEach-Object { "(LineNumber: $($_.LineNumber)) $($_.ToString().Trim())" }
 
                         [PSCustomObject]@{

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -29,7 +29,7 @@ AS
             $DropProcedure = "DROP PROCEDURE dbo.cp_dbatoolsci_sysadmin;"
             $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $DropProcedure
         }
-        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -IncludeSystemDatabases
+        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern 'cp_dbatoolsci_sysadmin' -IncludeSystemDatabases
         It "Should find a specific StoredProcedure named cp_dbatoolsci_sysadmin" {
             $results.Name | Should Be "cp_dbatoolsci_sysadmin"
         }

--- a/tests/Find-DbaStoredProcedure.Tests.ps1
+++ b/tests/Find-DbaStoredProcedure.Tests.ps1
@@ -29,9 +29,9 @@ AS
             $DropProcedure = "DROP PROCEDURE dbo.cp_dbatoolsci_sysadmin;"
             $null = Invoke-DbaQuery -SqlInstance $script:instance2 -Database 'Master' -Query $DropProcedure
         }
-        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern 'cp_dbatoolsci_sysadmin' -IncludeSystemDatabases
+        $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -IncludeSystemDatabases
         It "Should find a specific StoredProcedure named cp_dbatoolsci_sysadmin" {
-            $results.Name | Should Be "cp_dbatoolsci_sysadmin"
+            $results.Name | Should Contain "cp_dbatoolsci_sysadmin"
         }
     }
     Context "Command finds Procedures in a User Database" {
@@ -50,10 +50,10 @@ AS
         }
         $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -Database 'dbatoolsci_storedproceduredb'
         It "Should find a specific StoredProcedure named sp_dbatoolsci_custom" {
-            $results.Name | Should Be "sp_dbatoolsci_custom"
+            $results.Name | Should Contain "sp_dbatoolsci_custom"
         }
         It "Should find sp_dbatoolsci_custom in dbatoolsci_storedproceduredb" {
-            $results.Database | Should Be "dbatoolsci_storedproceduredb"
+            $results.Database | Should Contain "dbatoolsci_storedproceduredb"
         }
         $results = Find-DbaStoredProcedure -SqlInstance $script:instance2 -Pattern dbatools* -ExcludeDatabase 'dbatoolsci_storedproceduredb'
         It "Should find no results when Excluding dbatoolsci_storedproceduredb" {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number-->  )
 - [x] Breaking change (effects multiple commands or functionality, fixes #8036  )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Avoiding `` `r`` output from `StoredProcedureFullText` by outputting as blob of text. Not sure how stored procedure text will be output from SQL Server across platforms. Normalize line endings on `StoredProcedureTextFound` to `[System.Environment]::NewLine`.

### Breaking Changes
Previously output from `StoredProcedureFullText` was a `String[]` ( NOTE: I think it was technically an arraylist ). Now it will return a `string`. Previously output from `StoredProcedureTextFound` was always joined with a hardcodded `` `n``. Now it will be joined with the client's environment new line.

### Approach
<!-- How does this change solve that purpose -->
Removed `.Split` by `` `n`` from `StoredProcedureFullText`. Added `.Split()` to derivation of `$spTextFound`. Deciding to split on `` `n``, `` `r``, and `` `r`n`` because `Get-Content` behavior on PowerShell 7.2.1 is the same. Not sure if the team agrees. Approach for `StoredProcedureTextFound` is self explanatory _i think_.
### Commands to test
<!-- if these are the examples in the help just note it as such -->
`Find-DbaStoredProcedure`
### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
