### PR TITLE
InvokeDbaDBLogShipping: Modified restore alert threshold default to 45 minutes

### DIFF
--- a/functions/Invoke-DbaDbLogShipping.ps1
+++ b/functions/Invoke-DbaDbLogShipping.ps1
@@ -298,7 +298,7 @@ function Invoke-DbaDbLogShipping {
 
     .PARAMETER RestoreThreshold
         The number of minutes allowed to elapse between restore operations before an alert is generated.
-        The default value = 0
+        The default value = 45
 
     .PARAMETER SecondaryDatabasePrefix
         The secondary database can be renamed to include a prefix.
@@ -623,7 +623,7 @@ function Invoke-DbaDbLogShipping {
             Write-Message -Message "Restore retention set to $RestoreRetention" -Level Verbose
         }
         if (-not $RestoreThreshold) {
-            $RestoreThreshold = 0
+            $RestoreThreshold = 45
             Write-Message -Message "Restore Threshold set to $RestoreThreshold" -Level Verbose
         }
         if (-not $PrimaryMonitorServerSecurityMode) {


### PR DESCRIPTION
A RestoreThreshold of 0 minutes will always put the secondary replica
in an alert state. Therefore, it is not optimal as a default setting.

The transaction log shipping scripts generated by SSMS are using 45
minutes as default value.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
The new default value will ensure that the secondary will not always be in an alert state. 

### Approach
Investigated the default used by SSMS (2008 SP3, 2012 and 18.10).
