### PR TITLE
Fix Set-DbaDbFileGrowth when multiple files within file group

### DIFF
--- a/functions/Set-DbaDbFileGrowth.ps1
+++ b/functions/Set-DbaDbFileGrowth.ps1
@@ -101,7 +101,8 @@ function Set-DbaDbFileGrowth {
         }
 
         foreach ($db in $InputObject) {
-            $allfiles = @($db.FileGroups.Files + $db.LogFiles)
+            $allfiles = @($db.FileGroups.Files)
+            $allfiles += $db.LogFiles
             foreach ($file in $allfiles) {
                 if ($PSCmdlet.ShouldProcess($db.Parent.Name, "Setting filegrowth for $($file.Name) in $($db.name) to $($Growth)$($GrowthType)")) {
                     # SMO gave me some weird errors so I'm just gonna go with T-SQL

--- a/functions/Set-DbaDbFileGrowth.ps1
+++ b/functions/Set-DbaDbFileGrowth.ps1
@@ -101,7 +101,7 @@ function Set-DbaDbFileGrowth {
         }
 
         foreach ($db in $InputObject) {
-            $allfiles = @($db.FileGroups.Files, $db.LogFiles)
+            $allfiles = @($db.FileGroups.Files + $db.LogFiles)
             foreach ($file in $allfiles) {
                 if ($PSCmdlet.ShouldProcess($db.Parent.Name, "Setting filegrowth for $($file.Name) in $($db.name) to $($Growth)$($GrowthType)")) {
                     # SMO gave me some weird errors so I'm just gonna go with T-SQL


### PR DESCRIPTION
Issue when multiple file exist within the file group.
For example tempdb

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
fix issue with multiple files within file group

### Approach
changed the array creation

### Commands to test
Set-DbaDbFileGrowth -sqlInstance $instance -Database tempdb -Growth 0 -ErrorAction Stop -Verbose

### Screenshots
![image](https://user-images.githubusercontent.com/23144316/148790917-91138864-245e-4d31-8a18-e93e3d93bc41.png)

### Learning
[combining two arrays](https://devblogs.microsoft.com/scripting/powertip-add-two-powershell-arrays-together/)
