### PR TITLE
New-DbaDbSnapshot: Add Basic Availability Group Support

### DIFF
--- a/public/New-DbaDbSnapshot.ps1
+++ b/public/New-DbaDbSnapshot.ps1
@@ -188,6 +188,10 @@ function New-DbaDbSnapshot {
                     Write-Message -Level Warning -Message "$($db.name) is a snapshot, skipping"
                 } elseif ($db.name -in $NoSupportForSnap) {
                     Write-Message -Level Warning -Message "$($db.name) snapshots are prohibited"
+                } elseif ($db.IsAccessible -ne $true -and ($server.AvailabilityGroups | Where-Object Name -eq $db.AvailabilityGroupName).LocalReplicaRole -eq 'Secondary') {
+                    # Readable secondaries are considered accessible.
+                    # This accounts for every other valid state of an AG (e.g. a database in a Basic Availability Group is a valid target).
+                    $InputObject += $db
                 } elseif ($db.IsAccessible -ne $true) {
                     Write-Message -Level Verbose -Message "$($db.name) is not accessible, skipping"
                 } else {


### PR DESCRIPTION
Should close #9631... In theory. This is just my quick best guess made in the GitHub GUI. I don't have PowerShell installed on this machine and, to be embarrassingly honest, I don't think that I ever learned how to build dbatools correctly even on my proper machine.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #9631  )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Test for BAGs, then snapshot if so.

### Approach
<!-- How does this change solve that purpose -->
As above.

### Commands to test
<!-- if these are the examples in the help just note it as such -->
Just `New-DbaDbSnapshot`. However, once this is working, I should see if the other snapshot commands support BAGs.
### Screenshots
<!-- pictures say a thousand words without typing any of it -->
N/A
### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
N/A