### PR TITLE
Copy-DbaSystemDbUserObject - fix typo

### DIFF
--- a/public/Copy-DbaSystemDbUserObject.ps1
+++ b/public/Copy-DbaSystemDbUserObject.ps1
@@ -82,7 +82,7 @@ function Copy-DbaSystemDbUserObject {
         function get-sqltypename ($type) {
             switch ($type) {
                 "VIEW" { "view" }
-                "SQL_TABLE_VALUED_FUNCTION" { "User table valued fsunction" }
+                "SQL_TABLE_VALUED_FUNCTION" { "User table valued function" }
                 "DEFAULT_CONSTRAINT" { "User default constraint" }
                 "SQL_STORED_PROCEDURE" { "User stored procedure" }
                 "RULE" { "User rule" }


### PR DESCRIPTION
There was a misspelling on function, called fsunction.

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Fix a misspelling of the word function

### Approach
<!-- How does this change solve that purpose -->
Fixes the misspelling

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->

### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
