### PR TITLE
Find-DbaDbGrowthEvent: remove wrong filter

### DIFF
--- a/public/Find-DbaDbGrowthEvent.ps1
+++ b/public/Find-DbaDbGrowthEvent.ps1
@@ -181,7 +181,6 @@ function Find-DbaDbGrowthEvent {
                         FROM::fn_trace_gettable( @base_tracefilename, DEFAULT )
                         WHERE
                             [EventClass] IN ($eventClassFilter)
-                            AND [ServerName] = @@SERVERNAME
                             AND [DatabaseName] IN (_DatabaseList_)
                         ORDER BY [StartTime] DESC;
                     END


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

This filter is not needed and in the (special?) case of Azure virtual maschines [ServerName] is some random value and not the @@SERVERNAME - so the test failes.