### PR TITLE
Update tests for Copy-Dba* commands: Only copy from instance2 to instance3

### DIFF
--- a/tests/Copy-DbaBackupDevice.Tests.ps1
+++ b/tests/Copy-DbaBackupDevice.Tests.ps1
@@ -41,8 +41,8 @@ Describe $CommandName -Tag IntegrationTests {
         # Set variables. They are available in all the It blocks.
         $deviceName = "dbatoolsci-backupdevice-$(Get-Random)"
         $backupFileName = "$backupPath\$deviceName.bak"
-        $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance1
-        $destServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+        $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+        $destServer = Connect-DbaInstance -SqlInstance $TestConfig.instance3
 
         # Create the objects.
         $sourceServer.Query("EXEC master.dbo.sp_addumpdevice @devtype = N'disk', @logicalname = N'$deviceName', @physicalname = N'$backupFileName'")
@@ -72,7 +72,7 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "When copying backup device between instances" {
         It "Should copy the backup device successfully or warn about local copy" {
-            $results = Copy-DbaBackupDevice -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -WarningVariable WarnVar -WarningAction SilentlyContinue 3> $null
+            $results = Copy-DbaBackupDevice -Source $TestConfig.instance2 -Destination $TestConfig.instance3 -WarningVariable WarnVar -WarningAction SilentlyContinue 3> $null
 
             if ($WarnVar) {
                 $WarnVar | Should -Match "backup device to destination"
@@ -82,7 +82,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should skip copying when device already exists" {
-            $results = Copy-DbaBackupDevice -Source $TestConfig.instance1 -Destination $TestConfig.instance2
+            $results = Copy-DbaBackupDevice -Source $TestConfig.instance2 -Destination $TestConfig.instance3
             $results.Status | Should -Not -Be "Successful"
         }
     }

--- a/tests/Copy-DbaDbViewData.Tests.ps1
+++ b/tests/Copy-DbaDbViewData.Tests.ps1
@@ -70,8 +70,8 @@ Describe $CommandName -Tag IntegrationTests {
             }
         }
 
-        $db = Get-DbaDatabase -SqlInstance $TestConfig.instance1 -Database tempdb
-        $db2 = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb
+        $db = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -Database tempdb
+        $db2 = Get-DbaDatabase -SqlInstance $TestConfig.instance3 -Database tempdb
         Remove-TempObjects $db, $db2
         $null = $db.Query("CREATE TABLE dbo.dbatoolsci_example (id int);
             INSERT dbo.dbatoolsci_example
@@ -108,35 +108,35 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     It "copies the view data" {
-        $null = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_example2
+        $null = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_example2
         $table1count = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table2count = $db.Query("select id from dbo.dbatoolsci_example2")
         $table1count.Status.Count | Should -Be $table2count.Status.Count
     }
 
     It "copies the view data to another instance" {
-        $null = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Destination $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_example3
+        $null = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Destination $TestConfig.instance3 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_example3
         $table1count = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table2count = $db2.Query("select id from dbo.dbatoolsci_view_example3")
         $table1count.Status.Count | Should -Be $table2count.Status.Count
     }
 
     It "supports piping" {
-        $null = Get-DbaDbView -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example | Copy-DbaDbViewData -DestinationTable dbatoolsci_example2 -Truncate
+        $null = Get-DbaDbView -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example | Copy-DbaDbViewData -DestinationTable dbatoolsci_example2 -Truncate
         $table1count = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table2count = $db.Query("select id from dbo.dbatoolsci_example2")
         $table1count.Status.Count | Should -Be $table2count.Status.Count
     }
 
     It "supports piping more than one view" {
-        $results = Get-DbaDbView -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example2, dbatoolsci_view_example | Copy-DbaDbViewData -DestinationTable dbatoolsci_example3
+        $results = Get-DbaDbView -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example2, dbatoolsci_view_example | Copy-DbaDbViewData -DestinationTable dbatoolsci_example3
         $results.Status.Count | Should -Be 2
         $results.RowsCopied | Measure-Object -Sum | Select-Object -ExpandProperty Sum | Should -Be 20
     }
 
     It "opens and closes connections properly" {
         #regression test, see #3468
-        $results = Get-DbaDbView -SqlInstance $TestConfig.instance1 -Database tempdb -View "dbo.dbatoolsci_view_example", "dbo.dbatoolsci_view_example4" | Copy-DbaDbViewData -Destination $TestConfig.instance2 -DestinationDatabase tempdb -KeepIdentity -KeepNulls -BatchSize 5000 -Truncate
+        $results = Get-DbaDbView -SqlInstance $TestConfig.instance2 -Database tempdb -View "dbo.dbatoolsci_view_example", "dbo.dbatoolsci_view_example4" | Copy-DbaDbViewData -Destination $TestConfig.instance3 -DestinationDatabase tempdb -KeepIdentity -KeepNulls -BatchSize 5000 -Truncate
         $results.Status.Count | Should -Be 2
         $table1dbcount = $db.Query("select id from dbo.dbatoolsci_view_example")
         $table4dbcount = $db2.Query("select id from dbo.dbatoolsci_view_example4")
@@ -151,35 +151,35 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
     It "Should warn and return nothing if Source and Destination are same" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example -Truncate -WarningVariable tablewarning 3> $null
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -Truncate -WarningVariable tablewarning 3> $null
         $result | Should -Be $null
         $tablewarning | Should -Match "Cannot copy dbatoolsci_view_example into itself"
     }
 
     It "Should warn if the destination table doesn't exist" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View tempdb.dbo.dbatoolsci_view_example -DestinationTable dbatoolsci_view_does_not_exist -WarningVariable tablewarning 3> $null
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View tempdb.dbo.dbatoolsci_view_example -DestinationTable dbatoolsci_view_does_not_exist -WarningVariable tablewarning 3> $null
         $result | Should -Be $null
         $tablewarning | Should -Match Auto
     }
 
     It "automatically creates the table" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_will_exist -AutoCreateTable
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -DestinationTable dbatoolsci_view_will_exist -AutoCreateTable
         $result.DestinationTable | Should -Be "dbatoolsci_view_will_exist"
     }
 
     It "Should warn if the source database doesn't exist" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb_invalid -View dbatoolsci_view_example -DestinationTable dbatoolsci_doesntexist -WarningVariable tablewarning 3> $null
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance3 -Database tempdb_invalid -View dbatoolsci_view_example -DestinationTable dbatoolsci_doesntexist -WarningVariable tablewarning 3> $null
         $result | Should -Be $null
         $tablewarning | Should -Match "Failure"
     }
 
     It "Copy data using a query that relies on the default source database" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
         $result.RowsCopied | Should -Be 1
     }
 
     It "Copy data using a query that uses a 3 part query" {
-        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance1 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
+        $result = Copy-DbaDbViewData -SqlInstance $TestConfig.instance2 -Database tempdb -View dbatoolsci_view_example -Query "SELECT TOP (1) Id FROM tempdb.dbo.dbatoolsci_view_example4 ORDER BY Id DESC" -DestinationTable dbatoolsci_example3 -Truncate
         $result.RowsCopied | Should -Be 1
     }
 }

--- a/tests/Copy-DbaInstanceTrigger.Tests.ps1
+++ b/tests/Copy-DbaInstanceTrigger.Tests.ps1
@@ -38,7 +38,7 @@ Describe $CommandName -Tag IntegrationTests {
                 PRINT 'hello'"
 
         # Create the server trigger on the source instance.
-        $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance1
+        $sourceServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
         $sourceServer.Query($sql)
 
         # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
@@ -53,7 +53,7 @@ Describe $CommandName -Tag IntegrationTests {
         $sourceServer.Query("DROP TRIGGER [$triggerName] ON ALL SERVER")
 
         try {
-            $destServer = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+            $destServer = Connect-DbaInstance -SqlInstance $TestConfig.instance3
             $destServer.Query("DROP TRIGGER [$triggerName] ON ALL SERVER")
         } catch {
             # Ignore cleanup errors
@@ -65,8 +65,8 @@ Describe $CommandName -Tag IntegrationTests {
     Context "When copying server triggers between instances" {
         It "Should report successful copy operation" {
             $splatCopy = @{
-                Source        = $TestConfig.instance1
-                Destination   = $TestConfig.instance2
+                Source        = $TestConfig.instance2
+                Destination   = $TestConfig.instance3
                 WarningAction = "SilentlyContinue"
             }
             $results = Copy-DbaInstanceTrigger @splatCopy

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -54,7 +54,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
         $logins = "claudio", "port", "tester", "tester_new"
         $dropTableQuery = "IF EXISTS (SELECT * FROM sys.tables WHERE name = 'tester_table') DROP TABLE tester_table"
-        foreach ($instance in $TestConfig.instance1, $TestConfig.instance2) {
+        foreach ($instance in $TestConfig.instance2, $TestConfig.instance3) {
             foreach ($login in $logins) {
                 Initialize-TestLogin -Instance $instance -Login $login
             }
@@ -63,19 +63,19 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         # create objects
-        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -InputFile "$($TestConfig.appveyorlabrepo)\sql2008-scripts\logins.sql"
+        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -InputFile "$($TestConfig.appveyorlabrepo)\sql2008-scripts\logins.sql"
 
         $tableQuery = @("CREATE TABLE tester_table (a int)", "CREATE USER tester FOR LOGIN tester", "GRANT INSERT ON tester_table TO tester;")
-        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance1 -Database tempdb -Query ($tableQuery -join '; ')
-        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database tempdb -Query $tableQuery[0]
+        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database tempdb -Query ($tableQuery -join '; ')
+        $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance3 -Database tempdb -Query $tableQuery[0]
 
         # we want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
     BeforeEach {
         # cleanup targets
-        Initialize-TestLogin -Instance $TestConfig.instance2 -Login tester
-        Initialize-TestLogin -Instance $TestConfig.instance1 -Login tester_new
+        Initialize-TestLogin -Instance $TestConfig.instance3 -Login tester
+        Initialize-TestLogin -Instance $TestConfig.instance2 -Login tester_new
     }
     AfterAll {
         # we want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
@@ -84,24 +84,24 @@ Describe $CommandName -Tag IntegrationTests {
         # cleanup everything
         $logins = "claudio", "port", "tester", "tester_new"
 
-        foreach ($instance in $TestConfig.instance1, $TestConfig.instance2) {
+        foreach ($instance in $TestConfig.instance2, $TestConfig.instance3) {
             foreach ($login in $logins) {
                 Initialize-TestLogin -Instance $instance -Login $login
             }
             $null = Invoke-DbaQuery -SqlInstance $instance -Database tempdb -Query $dropTableQuery
         }
 
-        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1, $TestConfig.instance2 -Login 'claudio', 'port', 'tester'
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2, $TestConfig.instance3 -Login 'claudio', 'port', 'tester'
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "Copy login with the same properties." {
         It "Should copy successfully" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login Tester
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Destination $TestConfig.instance3 -Login Tester
             $results.Status | Should -Be "Successful"
-            $login1 = Get-DbaLogin -SqlInstance $TestConfig.instance1 -login Tester
-            $login2 = Get-DbaLogin -SqlInstance $TestConfig.instance2 -login Tester
+            $login1 = Get-DbaLogin -SqlInstance $TestConfig.instance2 -login Tester
+            $login2 = Get-DbaLogin -SqlInstance $TestConfig.instance3 -login Tester
 
             $login2 | Should -Not -BeNullOrEmpty
 
@@ -122,15 +122,15 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should login with newly created Sql Login (also tests credential login) and gets name" {
             $password = ConvertTo-SecureString -Force -AsPlainText tester1
             $cred = New-Object System.Management.Automation.PSCredential ("tester", $password)
-            $s = Connect-DbaInstance -SqlInstance $TestConfig.instance1 -SqlCredential $cred
-            $s.Name | Should -Be $TestConfig.instance1
+            $s = Connect-DbaInstance -SqlInstance $TestConfig.instance2 -SqlCredential $cred
+            $s.Name | Should -Be $TestConfig.instance2
         }
     }
 
     Context "No overwrite" {
         It "Should say skipped" {
-            $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -InputFile "$($TestConfig.appveyorlabrepo)\sql2008-scripts\logins.sql"
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login tester
+            $null = Invoke-DbaQuery -SqlInstance $TestConfig.instance3 -InputFile "$($TestConfig.appveyorlabrepo)\sql2008-scripts\logins.sql"
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Destination $TestConfig.instance3 -Login tester
             $results.Status | Should -Be "Skipped"
             $results.Notes | Should -Be "Already exists on destination"
         }
@@ -138,15 +138,18 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "ExcludeSystemLogins Parameter" {
         It "Should say skipped" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -ExcludeSystemLogins
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Destination $TestConfig.instance3 -ExcludeSystemLogins
             $results.Status.Contains('Skipped') | Should -Be $true
-            $results.Notes.Contains('System login') | Should -Be $true
+            # Notes is "Local machine name" if ComputerName is different, so we skip the test in this case
+            if (([DbaInstanceParameter]$TestConfig.instance2).ComputerName -eq ([DbaInstanceParameter]$TestConfig.instance3).ComputerName) {
+                $results.Notes.Contains('System login') | Should -Be $true
+            }
         }
     }
 
     Context "Supports pipe" {
         It "migrates the one tester login" {
-            $results = Get-DbaLogin -SqlInstance $TestConfig.instance1 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance2 -Force
+            $results = Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance3 -Force
             $results.Name | Should -Be "tester"
             $results.Status | Should -Be "Successful"
         }
@@ -154,25 +157,25 @@ Describe $CommandName -Tag IntegrationTests {
 
     Context "Supports cloning" {
         It "clones the one tester login" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Login tester -Destination $TestConfig.instance1 -Force -LoginRenameHashtable @{ tester = 'tester_new' } -NewSid
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Login tester -Destination $TestConfig.instance2 -Force -LoginRenameHashtable @{ tester = 'tester_new' } -NewSid
             $results.Name | Should -Be "tester_new"
             $results.Status | Should -Be "Successful"
-            Get-DbaLogin -SqlInstance $TestConfig.instance1 -Login tester_new | Should -Not -BeNullOrEmpty
+            Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login tester_new | Should -Not -BeNullOrEmpty
         }
         It "clones the one tester login using pipe" {
-            $results = Get-DbaLogin -SqlInstance $TestConfig.instance1 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance1 -Force -LoginRenameHashtable @{ tester = 'tester_new' } -NewSid
+            $results = Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance2 -Force -LoginRenameHashtable @{ tester = 'tester_new' } -NewSid
             $results.Name | Should -Be "tester_new"
             $results.Status | Should -Be "Successful"
-            Get-DbaLogin -SqlInstance $TestConfig.instance1 -Login tester_new | Should -Not -BeNullOrEmpty
+            Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login tester_new | Should -Not -BeNullOrEmpty
         }
         It "clones the one tester login to a different server with a new name" {
             'tester', 'tester_new' | ForEach-Object {
-                Initialize-TestLogin -Instance $TestConfig.instance2 -Login $_
+                Initialize-TestLogin -Instance $TestConfig.instance3 -Login $_
             }
-            $results = Get-DbaLogin -SqlInstance $TestConfig.instance1 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance2 -LoginRenameHashtable @{ tester = 'tester_new' }
+            $results = Get-DbaLogin -SqlInstance $TestConfig.instance2 -Login tester | Copy-DbaLogin -Destination $TestConfig.instance3 -LoginRenameHashtable @{ tester = 'tester_new' }
             $results.Name | Should -Be "tester_new"
             $results.Status | Should -Be "Successful"
-            $login = (Connect-DbaInstance -SqlInstance $TestConfig.instance2).Logins['tester_new']
+            $login = (Connect-DbaInstance -SqlInstance $TestConfig.instance3).Logins['tester_new']
             $login | Should -Not -BeNullOrEmpty
             $login | Remove-DbaLogin -Force
         }
@@ -184,34 +187,34 @@ Describe $CommandName -Tag IntegrationTests {
         }
         BeforeEach {
             'tester', 'tester_new' | ForEach-Object {
-                Initialize-TestLogin -Instance $TestConfig.instance2 -Login $_
+                Initialize-TestLogin -Instance $TestConfig.instance3 -Login $_
             }
         }
         AfterAll {
             Remove-Item -Path $tempExportFile -Force
         }
         It "clones the one tester login with sysadmin permissions" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Login tester -Destination $TestConfig.instance2 -LoginRenameHashtable @{ tester = 'tester_new' }
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Login tester -Destination $TestConfig.instance3 -LoginRenameHashtable @{ tester = 'tester_new' }
             $results.Name | Should -Be "tester_new"
             $results.Status | Should -Be "Successful"
-            $i2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+            $i2 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
             $login = $i2.Logins['tester_new']
             $login | Should -Not -BeNullOrEmpty
             $role = $i2.Roles['sysadmin']
             $role.EnumMemberNames() | Should -Contain $results.Name
         }
         It "clones the one tester login with object permissions" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Login tester -Destination $TestConfig.instance2 -LoginRenameHashtable @{ tester = 'tester_new' } -ObjectLevel
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Login tester -Destination $TestConfig.instance3 -LoginRenameHashtable @{ tester = 'tester_new' } -ObjectLevel
             $results.Name | Should -Be "tester_new"
             $results.Status | Should -Be "Successful"
-            $i2 = Connect-DbaInstance -SqlInstance $TestConfig.instance2
+            $i2 = Connect-DbaInstance -SqlInstance $TestConfig.instance3
             $login = $i2.Logins['tester_new']
             $login | Should -Not -BeNullOrEmpty
-            $permissions = Export-DbaUser -SqlInstance $TestConfig.instance2 -Database tempdb -User tester_new -Passthru
+            $permissions = Export-DbaUser -SqlInstance $TestConfig.instance3 -Database tempdb -User tester_new -Passthru
             $permissions | Should -BeLike '*GRANT INSERT ON OBJECT::`[dbo`].`[tester_table`] TO `[tester_new`]*'
         }
         It "scripts out two tester login with object permissions" {
-            $results = Copy-DbaLogin -Source $TestConfig.instance1 -Login tester, port -OutFile $tempExportFile -ObjectLevel
+            $results = Copy-DbaLogin -Source $TestConfig.instance2 -Login tester, port -OutFile $tempExportFile -ObjectLevel
             $results | Should -Be $tempExportFile
             $permissions = Get-Content $tempExportFile -Raw
             $permissions | Should -BeLike '*CREATE LOGIN `[tester`]*'

--- a/tests/Copy-DbaRegServer.Tests.ps1
+++ b/tests/Copy-DbaRegServer.Tests.ps1
@@ -61,7 +61,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         # Cleanup all created objects.
         $newGroup.Drop()
-        $destServer = Connect-DbaInstance $TestConfig.instance1
+        $destServer = Connect-DbaInstance $TestConfig.instance3
         $destRegStore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($destServer.ConnectionContext.SqlConnectionObject)
         $destDbStore = $destRegStore.DatabaseEngineServerGroup
         $destGroupStore = $destDbStore.ServerGroups[$groupName]
@@ -74,7 +74,7 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should complete successfully" {
             $splatCopy = @{
                 Source      = $TestConfig.instance2
-                Destination = $TestConfig.instance1
+                Destination = $TestConfig.instance3
                 CMSGroup    = $groupName
             }
             $results = Copy-DbaRegServer @splatCopy

--- a/tests/Copy-DbaSpConfigure.Tests.ps1
+++ b/tests/Copy-DbaSpConfigure.Tests.ps1
@@ -27,43 +27,43 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "When copying configuration with the same properties" {
         BeforeAll {
-            $sourceConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance1 -ConfigName RemoteQueryTimeout
-            $destConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $sourceConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $destConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance3 -ConfigName RemoteQueryTimeout
             $sourceConfigValue = $sourceConfig.ConfiguredValue
             $destConfigValue = $destConfig.ConfiguredValue
 
             # Set different values to ensure they don't match
             if ($sourceConfigValue -and $destConfigValue) {
                 $newValue = $sourceConfigValue + $destConfigValue
-                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout -Value $newValue
+                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance3 -ConfigName RemoteQueryTimeout -Value $newValue
             }
         }
 
         AfterAll {
             if ($destConfigValue -and $destConfigValue -ne $sourceConfigValue) {
-                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout -Value $destConfigValue
+                $null = Set-DbaSpConfigure -SqlInstance $TestConfig.instance3 -ConfigName RemoteQueryTimeout -Value $destConfigValue
             }
         }
 
         It "Should start with different values" {
-            $config1 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance1 -ConfigName RemoteQueryTimeout
-            $config2 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $config1 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $config2 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance3 -ConfigName RemoteQueryTimeout
             $config1.ConfiguredValue | Should -Not -Be $config2.ConfiguredValue
         }
 
         It "Should copy successfully" {
-            $results = Copy-DbaSpConfigure -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $results = Copy-DbaSpConfigure -Source $TestConfig.instance2 -Destination $TestConfig.instance3 -ConfigName RemoteQueryTimeout
             $results.Status | Should -Be "Successful"
         }
 
         It "Should retain the same properties after copy" {
-            $config1 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance1 -ConfigName RemoteQueryTimeout
-            $config2 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $config1 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
+            $config2 = Get-DbaSpConfigure -SqlInstance $TestConfig.instance3 -ConfigName RemoteQueryTimeout
             $config1.ConfiguredValue | Should -Be $config2.ConfiguredValue
         }
 
         It "Should not modify the source configuration" {
-            $newConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance1 -ConfigName RemoteQueryTimeout
+            $newConfig = Get-DbaSpConfigure -SqlInstance $TestConfig.instance2 -ConfigName RemoteQueryTimeout
             $newConfig.ConfiguredValue | Should -Be $sourceConfigValue
         }
     }


### PR DESCRIPTION
I now have a lab on azure with a domain and a client and two sql servers to test the Copy-Dba* commands in a better scenario.

I changed the instances that are used in the tests so that we always copy from instance2 to instance3. This way I only need two instances in that lab.

All Copy-Dba* tests run successful in that lab.