### PR TITLE
Add server name to removal message in Remove-DbaDbUser for WhatIf clarity

### DIFF
--- a/public/Remove-DbaDbUser.ps1
+++ b/public/Remove-DbaDbUser.ps1
@@ -119,7 +119,7 @@ function Remove-DbaDbUser {
                 $dropSchemas = @()
                 Write-Message -Level Verbose -Message "Removing User $user from Database $db on target $server"
 
-                if ($Pscmdlet.ShouldProcess($user, "Removing user from Database $db")) {
+                if ($Pscmdlet.ShouldProcess($user, "Removing user from Database $db on target $server")) {
                     # Drop Schemas owned by the user before dropping the user
                     $schemaUrns = $user.EnumOwnedObjects() | Where-Object Type -EQ Schema
                     if ($schemaUrns) {


### PR DESCRIPTION
## Type of Change
 - [x] Bug fix (non-breaking change)

### Purpose
Improve clarity when using `Remove-DbaDbUser` with the `-WhatIf` switch: the server name is now explicitly shown in the main message indicating which instance is targeted for user removal. This ensures that, when running with `-WhatIf` or `-Confirm`, users can easily distinguish actions per target instance, making multi-instance operations clearer and safer.