### PR TITLE
Fix Set-DbaAgentJobStep: Add proxy removal support and prevent unwanted parameter resets

### DIFF
--- a/public/Set-DbaAgentJobStep.ps1
+++ b/public/Set-DbaAgentJobStep.ps1
@@ -343,12 +343,12 @@ function Set-DbaAgentJobStep {
                         }
                     }
 
-                    if ($PSBoundParameters.ContainsKey('RetryAttempts')) {
+                    if (Test-Bound -ParameterName 'RetryAttempts') {
                         Write-Message -Message "Setting job step retry attempts to $RetryAttempts" -Level Verbose
                         $jobStep.RetryAttempts = $RetryAttempts
                     }
 
-                    if ($PSBoundParameters.ContainsKey('RetryInterval')) {
+                    if (Test-Bound -ParameterName 'RetryInterval') {
                         Write-Message -Message "Setting job step retry interval to $RetryInterval" -Level Verbose
                         $jobStep.RetryInterval = $RetryInterval
                     }
@@ -358,7 +358,7 @@ function Set-DbaAgentJobStep {
                         $jobStep.OutputFileName = $OutputFileName
                     }
 
-                    if ($PSBoundParameters.ContainsKey('ProxyName')) {
+                    if (Test-Bound -ParameterName 'ProxyName') {
                         if ([string]::IsNullOrEmpty($ProxyName)) {
                             # Remove proxy from job step
                             Write-Message -Message "Removing proxy from job step" -Level Verbose


### PR DESCRIPTION


## Type of Change
 - Bug fix (non-breaking change )
 - New feature (adds functionality)

### Purpose
This PR addresses two issues in Set-DbaAgentJobStep:

Bug: RetryAttempts and RetryInterval parameters were incorrectly being set to 0 when not explicitly provided by the user, overwriting existing job step values.

Missing feature: There was no way to remove a proxy from a job step once it was assigned. Users could only add or change proxies, but not remove them.

### Approach
The fix uses $PSBoundParameters.ContainsKey() to properly distinguish between:

- A parameter that was not provided (should leave existing value unchanged)
- A parameter that was explicitly provided with a value (including 0, $null, or empty string)

For ProxyName:
- Now accepts $null or empty string to remove the proxy from a job step
- Uses [string]::IsNullOrEmpty($ProxyName) to handle both $null and empty string cases
- Sets $jobStep.ProxyName = '' to clear the proxy
- Adds verbose message "Removing proxy from job step" when proxy is removed

For RetryAttempts and RetryInterval:
- Changed from if ($null -ne $RetryAttempts) to if ($PSBoundParameters.ContainsKey('RetryAttempts'))
- This prevents the unintended reset to 0 when these parameters are not specified
- Now only updates these values when explicitly provided by the user

### Commands to test

Test 1: Remove proxy from a job step
```
# Setup: Create a job step with a proxy
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -ProxyName "MyProxy"

# Remove the proxy by passing $null
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -ProxyName $null -Verbose

# Or remove by passing empty string
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -ProxyName "" -Verbose

# Verify proxy is removed
Get-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" | Select-Object Name, ProxyName
```

Test 2: Verify RetryAttempts and RetryInterval are not reset
```
# Setup: Create a job step with retry values
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -RetryAttempts 5 -RetryInterval 10

# Update another property WITHOUT specifying retry parameters
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -Command "SELECT 1" -Verbose

# Verify RetryAttempts and RetryInterval remain at 5 and 10 (not reset to 0)
Get-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" | Select-Object Name, RetryAttempts, RetryInterval
```

Test 3: Explicitly set retry values to 0
```
# This should still work - explicitly setting to 0
Set-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" -RetryAttempts 0 -RetryInterval 0 -Verbose

# Verify values are set to 0
Get-DbaAgentJobStep -SqlInstance localhost -Job "TestJob" -StepName "Step1" | Select-Object Name, RetryAttempts, RetryInterval

```