### PR TITLE
Fix Remove-DbaAgentJob to continue processing when jobs don't exist

### DIFF
--- a/public/Remove-DbaAgentJob.ps1
+++ b/public/Remove-DbaAgentJob.ps1
@@ -96,7 +96,7 @@ function Remove-DbaAgentJob {
 
             foreach ($j in $Job) {
                 if ($Server.JobServer.Jobs.Name -notcontains $j) {
-                    Stop-Function -Message "Job $j doesn't exist on $instance." -Continue -ContinueLabel main -Target $instance -Category InvalidData
+                    Stop-Function -Message "Job $j doesn't exist on $instance." -Continue -Target $instance -Category InvalidData
                 }
                 $InputObject += ($Server.JobServer.Jobs | Where-Object Name -eq $j)
             }


### PR DESCRIPTION
## Type of Change
 Bug fix (non-breaking change, fixes)

### Purpose
Fix an issue where `Remove-DbaAgentJob` would stop processing remaining jobs when encountering a non-existent job name, preventing valid jobs from being removed.

### Approach
Removed the `-ContinueLabel main` parameter from `Stop-Function` call when a job is not found (line 99). This parameter was causing the function to break out of the outer instance loop entirely. Without it, only the current job iteration is skipped, allowing all valid jobs to be processed and removed as expected.

### Commands to test
```powershell
# Test with mixed valid and invalid job names
Remove-DbaAgentJob -SqlInstance sql1 -Job 'ValidJob1', 'InvalidJob', 'ValidJob2'

# Expected: Warning for InvalidJob, but ValidJob1 and ValidJob2 are both removed