### PR TITLE
Write-Progress - Add Completed and fix in multiple commands

### DIFF
--- a/private/functions/Write-ProgressHelper.ps1
+++ b/private/functions/Write-ProgressHelper.ps1
@@ -7,7 +7,8 @@ function Write-ProgressHelper {
         [string]$Message,
         [int]$TotalSteps,
         [Alias("NoProgress")]
-        [switch]$ExcludePercent
+        [switch]$ExcludePercent,
+        [switch]$Completed
     )
 
     $caller = (Get-PSCallStack)[1].Command
@@ -47,7 +48,9 @@ function Write-ProgressHelper {
         }
     }
 
-    if ($ExcludePercent) {
+    if ($Completed) {
+        Write-Progress -Activity $Activity -Completed
+    } elseif ($ExcludePercent) {
         Write-Progress -Activity $Activity -Status $Message
     } else {
         if (-not $TotalSteps -and $caller -ne '<ScriptBlock>') {

--- a/public/Install-DbaMaintenanceSolution.ps1
+++ b/public/Install-DbaMaintenanceSolution.ps1
@@ -675,5 +675,6 @@ function Install-DbaMaintenanceSolution {
         }
 
         Write-ProgressHelper -ExcludePercent -Message "Installation complete"
+        Write-ProgressHelper -Completed
     }
 }


### PR DESCRIPTION
Add -Completed parameter to Write-ProgressHelper and call it at the end of Install-DbaMaintenanceSolution to properly close the progress bar.

This fixes the issue where progress bars would persist in VS Code terminals after the function completes.

Fixes #9668

Generated with [Claude Code](https://claude.ai/code)