### PR TITLE
Add secure credential storage guidance to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,20 @@ $cred = Get-Credential ad\winadmin
 Get-DbaDiskSpace -ComputerName sql01 -Credential $cred
 ```
 
+#### Storing Credentials Securely
+PowerShell's `Export-CliXml` provides a fast and secure way to store credentials to disk. The credentials are encrypted using Windows Data Protection API (DPAPI) and can only be decrypted by the same user on the same machine.
+
+```powershell
+# Save credentials to disk (one-time setup)
+Get-Credential | Export-CliXml -Path "$HOME\sql-credentials.xml"
+
+# Reuse saved credentials in scripts
+$cred = Import-CliXml -Path "$HOME\sql-credentials.xml"
+Get-DbaDatabase -SqlInstance sql01 -SqlCredential $cred
+```
+
+For more advanced credential management approaches including the Secrets Management module, see [Rob Sewell's guide](https://blog.robsewell.com/blog/good-bye-import-clixml-use-the-secrets-management-module-for-your-labs-and-demos/).
+
 ### Custom Ports
 ```powershell
 # Using colon or comma for non-default ports


### PR DESCRIPTION
Resolves #9619

The broken link to Jaap Brasser's blog was already removed from readme.md. However, the Authentication section lacked guidance on securely storing credentials to disk, which was the purpose of the original link.

### Changes
- Added "Storing Credentials Securely" section under Advanced Usage > Authentication
- Explains Export-CliXml/Import-CliXml for credential storage
- Notes DPAPI encryption for security
- Links to Rob Sewell's guide for advanced approaches

This follows @niphlod's suggestion to keep it simple for quick-start users while providing a path to more advanced credential management.

🤖 Generated with [Claude Code](https://claude.ai/code)