### PR TITLE
Restore-DbaDatabase - Fix ReplaceDbNameInFile to only replace filename, not directory path

### DIFF
--- a/public/Format-DbaBackupInformation.ps1
+++ b/public/Format-DbaBackupInformation.ps1
@@ -186,14 +186,14 @@ function Format-DbaBackupInformation {
                         $_.PhysicalName = $FileMapping[$_.LogicalName]
                     }
                 } else {
-                    if ($ReplaceDbNameInFile -eq $true) {
-                        $_.PhysicalName = $_.PhysicalName -Replace $History.OriginalDatabase, $History.Database
-                    }
                     Write-Message -Message " 1 PhysicalName = $($_.PhysicalName) " -Level Verbose
                     $Pname = [System.Io.FileInfo]$_.PhysicalName
                     $RestoreDir = $Pname.DirectoryName
                     # Handle MacOS returning full path for BaseName
                     $baseName = $Pname.BaseName.Split($PathSep)[-1]
+                    if ($ReplaceDbNameInFile -eq $true) {
+                        $baseName = $baseName -Replace $History.OriginalDatabase, $History.Database
+                    }
                     if ($_.Type -eq 'D' -or $_.FileType -eq 'D') {
                         if ('' -ne $DataFileDirectory) {
                             $RestoreDir = $DataFileDirectory

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -220,6 +220,24 @@ Describe $CommandName -Tag IntegrationTests {
     }
 
 
+    Context "ReplaceDbNameInFile regression test for #9656" {
+        BeforeAll {
+            $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException
+        }
+
+        It "Should replace database name in file basename only, not in directory path" {
+            $scriptOutput = Restore-DbaDatabase -SqlInstance $TestConfig.instance2 -Path "$($TestConfig.appveyorlabrepo)\singlerestore\singlerestore.bak" -DatabaseName "NewDatabaseName" -ReplaceDbNameInFile -WithReplace -OutputScriptOnly
+            $scriptOutput | Should -BeLike "*NewDatabaseName*"
+            $scriptOutput | Should -Not -BeLike "*singlerestore\NewDatabaseName\*"
+        }
+
+        It "Should generate valid MOVE statements with replaced database name" {
+            $scriptOutput = Restore-DbaDatabase -SqlInstance $TestConfig.instance2 -Path "$($TestConfig.appveyorlabrepo)\singlerestore\singlerestore.bak" -DatabaseName "ReplacedDbName" -ReplaceDbNameInFile -WithReplace -OutputScriptOnly
+            $scriptOutput | Should -Match "MOVE.*ReplacedDbName"
+        }
+    }
+
+
     Context "Test restoring as other login #6992" {
         BeforeAll {
             $null = Get-DbaDatabase -SqlInstance $TestConfig.instance2 -ExcludeSystem -EnableException | Remove-DbaDatabase -EnableException


### PR DESCRIPTION
Fixes #9656

The issue was that ReplaceDbNameInFile was replacing the database name in the full file path (including directory), which caused the directory path to be incorrectly modified. This led to "file already exists and owned by another database" errors.

The fix moves the database name replacement to apply only to the basename (filename without directory), after extracting the directory path and before reconstructing the full path.

**Changes:**
- Modified Format-DbaBackupInformation.ps1 to replace database name in basename only
- Added regression test for #9656

Generated with [Claude Code](https://claude.ai/code)

@niphlod and @andreasjordan can you pls review this change to a very important command?