### PR TITLE
New-DbaDbSnapshot - Add .Refresh() calls to fix AG secondary snapshots

### DIFF
--- a/public/New-DbaDbSnapshot.ps1
+++ b/public/New-DbaDbSnapshot.ps1
@@ -239,6 +239,10 @@ function New-DbaDbSnapshot {
                 Write-Message -Level Warning -Message "A database named $SnapName already exists, skipping"
                 continue
             }
+            # Refresh database and FileGroups collection to ensure SMO has populated data
+            # This is especially important for AG secondary replicas where collections may not be auto-populated
+            $db.Refresh()
+            $db.FileGroups.Refresh()
             $all_FSD = $db.FileGroups | Where-Object FileGroupType -eq 'FileStreamDataFileGroup'
             $all_MMO = $db.FileGroups | Where-Object FileGroupType -eq 'MemoryOptimizedDataFileGroup'
             $has_FSD = $all_FSD.Count -gt 0


### PR DESCRIPTION
## Summary

Adds `$db.Refresh()` and `$db.FileGroups.Refresh()` calls before accessing the FileGroups collection to fix snapshot creation failures on Availability Group secondary replicas.

## Problem

SMO does not automatically populate the FileGroups collection on AG secondary replicas, causing `New-DbaDbSnapshot` to fail with "Missing the file" errors when trying to create snapshots.

## Solution

Explicitly refresh the database object and its FileGroups collection before enumeration. This is a minimal change approach that:

- Ensures SMO collections are properly populated before access
- Works on both primary and secondary AG replicas
- Follows established dbatools patterns for SMO object handling
- Adds only 2 lines of code with explanatory comments

Fixes #9804

Generated with [Claude Code](https://claude.ai/code)