### PR TITLE
Sync-DbaAvailabilityGroup - Fix null reference errors when syncing empty Agent objects

### DIFF
--- a/public/Sync-DbaAvailabilityGroup.ps1
+++ b/public/Sync-DbaAvailabilityGroup.ps1
@@ -287,15 +287,23 @@ function Sync-DbaAvailabilityGroup {
             if ($Exclude -notcontains "AgentCategory") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing Agent Categories"
                 Copy-DbaAgentJobCategory -Source $server -Destination $secondaries -Force:$force
-                $secondaries.JobServer.JobCategories.Refresh()
-                $secondaries.JobServer.OperatorCategories.Refresh()
-                $secondaries.JobServer.AlertCategories.Refresh()
+                foreach ($sec in $secondaries) {
+                    if ($sec.JobServer) {
+                        $sec.JobServer.JobCategories.Refresh()
+                        $sec.JobServer.OperatorCategories.Refresh()
+                        $sec.JobServer.AlertCategories.Refresh()
+                    }
+                }
             }
 
             if ($Exclude -notcontains "AgentOperator") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing Agent Operators"
                 Copy-DbaAgentOperator -Source $server -Destination $secondaries -Force:$force
-                $secondaries.JobServer.Operators.Refresh()
+                foreach ($sec in $secondaries) {
+                    if ($sec.JobServer) {
+                        $sec.JobServer.Operators.Refresh()
+                    }
+                }
             }
 
             if ($Exclude -notcontains "AgentAlert") {
@@ -306,15 +314,23 @@ function Sync-DbaAvailabilityGroup {
             if ($Exclude -notcontains "AgentProxy") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing Agent Proxy Accounts"
                 Copy-DbaAgentProxy -Source $server -Destination $secondaries -Force:$force
-                $secondaries.JobServer.ProxyAccounts.Refresh()
+                foreach ($sec in $secondaries) {
+                    if ($sec.JobServer) {
+                        $sec.JobServer.ProxyAccounts.Refresh()
+                    }
+                }
             }
 
             if ($Exclude -notcontains "AgentSchedule") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing Agent Schedules"
                 Copy-DbaAgentSchedule -Source $server -Destination $secondaries -Force:$force
-                $secondaries.JobServer.SharedSchedules.Refresh()
-                $secondaries.JobServer.Refresh()
-                $secondaries.Refresh()
+                foreach ($sec in $secondaries) {
+                    if ($sec.JobServer) {
+                        $sec.JobServer.SharedSchedules.Refresh()
+                        $sec.JobServer.Refresh()
+                    }
+                    $sec.Refresh()
+                }
             }
 
             if ($Exclude -notcontains "AgentJob") {


### PR DESCRIPTION
## Summary

Fixes #9684

Wrapped JobServer.Refresh() calls in foreach loops with null checks to prevent "You cannot call a method on a null-valued expression" errors when:
- No Agent Operators exist on primary
- No Agent Proxies exist on primary
- Agent service is unavailable on secondary replicas

## Changes

- AgentCategory: Added foreach loop with JobServer null check (lines 290-296)
- AgentOperator: Added foreach loop with JobServer null check (lines 302-306)
- AgentProxy: Added foreach loop with JobServer null check (lines 317-321)
- AgentSchedule: Added foreach loop with JobServer null check (lines 327-333)

This follows the same pattern used for DatabaseOwner sync (line 256) and prevents one secondary's issues from blocking the entire sync operation.

Generated with [Claude Code](https://claude.ai/code)