### PR TITLE
Stop-DbaService, Start-DbaService - Add PolyBase and Launchpad service type support

### DIFF
--- a/private/functions/Update-ServiceStatus.ps1
+++ b/private/functions/Update-ServiceStatus.ps1
@@ -210,7 +210,7 @@ process {
                         $target = "$($_.Service.ServiceName) on $($_.Service.ComputerName)"
                         Write-Message -Level Warning -Message "($target) $($_.Service.Message)" -Target $target
                         if ($_.Service.ServiceType -eq 'Engine' -and $_.ServiceExitCode -eq 3) {
-                            Write-Message -Level Warning -Message "($target) Run the command with '-Force' switch to force the restart of a dependent SQL Agent" -Target $target
+                            Write-Message -Level Warning -Message "($target) Run the command with '-Force' switch to force the restart of dependent services (SQL Agent, PolyBase)" -Target $target
                         }
                     }
                     $_.Service | Select-DefaultView -Property ComputerName, ServiceName, InstanceName, ServiceType, State, Status, Message

--- a/public/Start-DbaService.ps1
+++ b/public/Start-DbaService.ps1
@@ -4,7 +4,7 @@ function Start-DbaService {
         Starts SQL Server related services across multiple computers while respecting service dependencies.
 
     .DESCRIPTION
-        Starts SQL Server services (Engine, Agent, Browser, FullText, SSAS, SSIS, SSRS) on one or more computers following proper dependency order. This function handles the complexity of starting services in the correct sequence so you don't have to manually determine which services depend on others. Commonly used after maintenance windows, server reboots, or when troubleshooting stopped services across an environment.
+        Starts SQL Server services (Engine, Agent, Browser, FullText, SSAS, SSIS, SSRS, PolyBase, Launchpad) on one or more computers following proper dependency order. This function handles the complexity of starting services in the correct sequence so you don't have to manually determine which services depend on others. Commonly used after maintenance windows, server reboots, or when troubleshooting stopped services across an environment.
 
         Requires Local Admin rights on destination computer(s).
 
@@ -25,7 +25,7 @@ function Start-DbaService {
         Credential object used to connect to the computer as a different user.
 
     .PARAMETER Type
-        Filters to specific SQL Server service types rather than starting all services. Valid types: Agent, Browser, Engine, FullText, SSAS, SSIS, SSRS.
+        Filters to specific SQL Server service types rather than starting all services. Valid types: Agent, Browser, Engine, FullText, SSAS, SSIS, SSRS, PolyBase, Launchpad.
         Use this when you need to start only specific service types, such as starting just SQL Agent after maintenance or only SSRS services on reporting servers.
 
     .PARAMETER Timeout
@@ -90,7 +90,7 @@ function Start-DbaService {
         [string[]]$InstanceName,
         [Parameter(ParameterSetName = "Server")]
         [DbaInstanceParameter[]]$SqlInstance,
-        [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS")]
+        [ValidateSet("Agent", "Browser", "Engine", "FullText", "SSAS", "SSIS", "SSRS", "PolyBase", "Launchpad")]
         [string[]]$Type,
         [parameter(ValueFromPipeline, Mandatory, ParameterSetName = "Service")]
         [Alias("ServiceCollection")]


### PR DESCRIPTION
## Summary

Fixes #9443

This PR adds support for PolyBase and Launchpad service types to Stop-DbaService and Start-DbaService, fixing the issue where Enable-DbaAgHadr -Force would fail on servers with PolyBase installed.

## Changes

- **Stop-DbaService**: Added PolyBase and Launchpad to ValidateSet for Type parameter
- **Stop-DbaService**: Enhanced Force logic to automatically include PolyBase services when stopping Engine
- **Start-DbaService**: Added PolyBase and Launchpad to ValidateSet for Type parameter
- **Update-ServiceStatus**: Updated warning message to mention PolyBase dependencies
- Updated help documentation in both functions to reflect new service types

This brings Stop-DbaService and Start-DbaService in line with Get-DbaService and Restart-DbaService which already supported these service types.

## Test Plan

- [ ] Verify Stop-DbaService accepts PolyBase and Launchpad as Type values
- [ ] Verify Start-DbaService accepts PolyBase and Launchpad as Type values
- [ ] Verify Enable-DbaAgHadr -Force works on servers with PolyBase installed
- [ ] Verify Stop-DbaService -Force automatically stops PolyBase dependencies when stopping Engine

Generated with [Claude Code](https://claude.ai/code)