### PR TITLE
Rename-DbaDatabase - Fix ReplaceBefore parameter error with empty strings

### DIFF
--- a/public/Rename-DbaDatabase.ps1
+++ b/public/Rename-DbaDatabase.ps1
@@ -432,8 +432,14 @@ function Rename-DbaDatabase {
                         $Orig_Placeholder = $Orig_LGName
                         if ($ReplaceBefore) {
                             # at Logical Name level, we need to worry about database name and filegroup name
-                            $Orig_Placeholder = $Orig_Placeholder.Replace((Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name), '').Replace(
-                                (Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name), '')
+                            $dbKey = Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name
+                            $fgKey = Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name
+                            if ($dbKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($dbKey, '')
+                            }
+                            if ($fgKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($fgKey, '')
+                            }
                         }
                         $NewLGName = $LogicalName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', $fg.Name).Replace(
                             '<FT>', $FileType).Replace('<LGN>', $Orig_Placeholder)
@@ -476,8 +482,14 @@ function Rename-DbaDatabase {
                         $Orig_Placeholder = $Orig_LGName
                         if ($ReplaceBefore) {
                             # at Logical Name level, we need to worry about database name and filegroup name, but for logfiles filegroup is not there
-                            $Orig_Placeholder = $Orig_Placeholder.Replace((Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name), '').Replace(
-                                (Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name), '')
+                            $dbKey = Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name
+                            $fgKey = Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name
+                            if ($dbKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($dbKey, '')
+                            }
+                            if ($fgKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($fgKey, '')
+                            }
                         }
                         $NewLGName = $LogicalName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', '').Replace(
                             '<FT>', 'LOG').Replace('<LGN>', $Orig_Placeholder)
@@ -572,9 +584,18 @@ function Rename-DbaDatabase {
                         $Orig_Placeholder = $Orig_FNNameLeaf
                         if ($ReplaceBefore) {
                             # at Filename level, we need to worry about database name, filegroup name and logical file name
-                            $Orig_Placeholder = $Orig_Placeholder.Replace((Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name), '').Replace(
-                                (Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name), '').Replace(
-                                (Get-DbaKeyByValue -HashTable $Entities_Before['LGN'] -Value $logical.Name), '')
+                            $dbKey = Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name
+                            $fgKey = Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name
+                            $lgKey = Get-DbaKeyByValue -HashTable $Entities_Before['LGN'] -Value $logical.Name
+                            if ($dbKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($dbKey, '')
+                            }
+                            if ($fgKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($fgKey, '')
+                            }
+                            if ($lgKey) {
+                                $Orig_Placeholder = $Orig_Placeholder.Replace($lgKey, '')
+                            }
                         }
                         $NewFNName = $FileName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', $fg.Name).Replace(
                             '<FT>', $FileType).Replace('<LGN>', $logical.Name).Replace('<FNN>', $Orig_Placeholder)
@@ -623,9 +644,18 @@ function Rename-DbaDatabase {
                             $Orig_Placeholder = $Orig_FNNameLeaf
                             if ($ReplaceBefore) {
                                 # at Filename level, we need to worry about database name, filegroup name and logical file name
-                                $Orig_Placeholder = $Orig_Placeholder.Replace((Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name), '').Replace(
-                                    (Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name), '').Replace(
-                                    (Get-DbaKeyByValue -HashTable $Entities_Before['LGN'] -Value $logical.Name), '')
+                                $dbKey = Get-DbaKeyByValue -HashTable $Entities_Before['DBN'] -Value $db.Name
+                                $fgKey = Get-DbaKeyByValue -HashTable $Entities_Before['FGN'] -Value $fg.Name
+                                $lgKey = Get-DbaKeyByValue -HashTable $Entities_Before['LGN'] -Value $logical.Name
+                                if ($dbKey) {
+                                    $Orig_Placeholder = $Orig_Placeholder.Replace($dbKey, '')
+                                }
+                                if ($fgKey) {
+                                    $Orig_Placeholder = $Orig_Placeholder.Replace($fgKey, '')
+                                }
+                                if ($lgKey) {
+                                    $Orig_Placeholder = $Orig_Placeholder.Replace($lgKey, '')
+                                }
                             }
                             $NewFNName = $FileName.Replace('<DBN>', $db.Name).Replace('<DATE>', $CurrentDate).Replace('<FGN>', '').Replace(
                                 '<FT>', 'LOG').Replace('<LGN>', $logical.Name).Replace('<FNN>', $Orig_Placeholder)

--- a/tests/Rename-DbaDatabase.Tests.ps1
+++ b/tests/Rename-DbaDatabase.Tests.ps1
@@ -312,4 +312,28 @@ Describe $CommandName -Tag IntegrationTests {
             $fileGroupResults.FGN.Keys | Should -Be @("Dbatoolsci_filegroupname")
         }
     }
+
+    Context "Regression tests" {
+        It "Should not throw an error when using ReplaceBefore with LogicalName and FileName (issue #9069)" {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $testDbName = "dbatoolsci_replaceBefore_$(Get-Random)"
+            $null = New-DbaDatabase -SqlInstance $TestConfig.instance2 -Name $testDbName
+
+            $splatReplaceBefore = @{
+                SqlInstance   = $TestConfig.instance2
+                Database      = $testDbName
+                DatabaseName  = "$($testDbName)_renamed"
+                LogicalName   = "<DBN><LGN>"
+                FileName      = "<DBN><FNN>"
+                ReplaceBefore = $true
+                Preview       = $true
+            }
+
+            { $result = Rename-DbaDatabase @splatReplaceBefore } | Should -Not -Throw
+
+            $null = Remove-DbaDatabase -SqlInstance $TestConfig.instance2 -Database $testDbName
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+    }
 }


### PR DESCRIPTION
Fixed issue where Rename-DbaDatabase throws an error when ReplaceBefore is specified due to attempting to call .Replace() with empty string values.

The Get-DbaKeyByValue function can return empty strings when no matching key is found. When these empty strings were passed as the first argument to the .Replace() method, PowerShell attempted to convert them to a char type, resulting in an error.

**Changes:**
- Modified all four ReplaceBefore code sections to check if the key value is not null/empty before calling .Replace()
- Added regression test to prevent this issue from recurring

Fixes #9069

Generated with [Claude Code](https://claude.ai/code)