### PR TITLE
Invoke-DbaDbPiiScan - Fix TEXT, NTEXT, XML column handling

### DIFF
--- a/public/Invoke-DbaDbPiiScan.ps1
+++ b/public/Invoke-DbaDbPiiScan.ps1
@@ -349,7 +349,7 @@ function Invoke-DbaDbPiiScan {
                                 Write-Message -Level Verbose -Message "Scanning the top $SampleCount values for [$($columnobject.Name)] from [$($tableobject.Schema)].[$($tableobject.Name)]"
 
                                 # Set the text data types
-                                $textDataTypes = 'char', 'varchar', 'text', 'nchar', 'nvarchar', 'ntext', 'xml'
+                                $textDataTypes = "char", "varchar", "nchar", "nvarchar"
 
                                 # Setup the query
                                 if ($columnobject.DataType.Name -in $textDataTypes) {


### PR DESCRIPTION
### Summary

Fixes #9889 by removing TEXT, NTEXT, and XML from the `$textDataTypes` array. These data types don't support LTRIM/RTRIM functions in SQL Server, which was causing the command to fail when scanning tables with these column types.

### Changes

- Updated `$textDataTypes` array to only include compatible types: char, varchar, nchar, nvarchar
- Applied dbatools style guide (double quotes)

### Testing

The fix resolves the error when scanning tables containing TEXT, NTEXT, or XML columns. These columns will now be scanned without applying TRIM functions.

---

Generated with [Claude Code](https://claude.ai/code)