### PR TITLE
Update-DbaInstance - Fix NoPendingRenameCheck parameter not being passed to Test-PendingReboot

### DIFF
--- a/public/Update-DbaInstance.ps1
+++ b/public/Update-DbaInstance.ps1
@@ -434,7 +434,12 @@ function Update-DbaInstance {
                 $components = $components | Where-Object { $_.InstanceName -eq $InstanceName }
             }
             try {
-                $restartNeeded = Test-PendingReboot -ComputerName $resolvedName -Credential $Credential
+                $splatPendingReboot = @{
+                    ComputerName    = $resolvedName
+                    Credential      = $Credential
+                    NoPendingRename = $NoPendingRenameCheck
+                }
+                $restartNeeded = Test-PendingReboot @splatPendingReboot
             } catch {
                 Stop-Function -Message "Failed to get reboot status from $resolvedName" -Continue -ErrorRecord $_
             }


### PR DESCRIPTION
## Summary

The `-NoPendingRenameCheck` switch was not being passed through to `Test-PendingReboot`, causing the function to always check the `PendingFileRenameOperations` registry key even when users explicitly requested to skip this check.

This PR fixes the issue by:
- Mapping the `-NoPendingRenameCheck` parameter from `Update-DbaInstance` to the `-NoPendingRename` parameter expected by `Test-PendingReboot`
- Using a splat for 3+ parameters following dbatools style guide
- Maintaining proper hashtable alignment per coding standards

Fixes #9219

---

Generated with [Claude Code](https://claude.ai/code)