### PR TITLE
Invoke-DbaAdvancedInstall - Add /q switch for Server Core compatibility

### DIFF
--- a/public/Invoke-DbaAdvancedInstall.ps1
+++ b/public/Invoke-DbaAdvancedInstall.ps1
@@ -262,6 +262,7 @@ function Invoke-DbaAdvancedInstall {
         }
     }
     $installParams = $ArgumentList
+    $installParams += "/q"
     $installParams += "/CONFIGURATIONFILE=`"$remoteConfig`""
     Write-Message -Level Verbose -Message "Setup starting from $($InstallationPath)"
     $execParams = @{


### PR DESCRIPTION
## Summary

Adds the /q (quiet mode) command-line switch to SQL Server setup.exe invocation to fix installations on Windows Server Core.

## Changes

- Modified `Invoke-DbaAdvancedInstall.ps1` to include `/q` parameter in the setup.exe command line
- This supplements the existing `QUIET = "True"` setting in the configuration file

## Fixes

Closes #9707

Windows Server Core requires the /q or /qs command-line parameter to be passed directly to setup.exe, not just in the configuration file. Per Microsoft's documentation:

> When running SQL Server Setup on Server Core, you must use the /q (quiet mode) or /qs (quiet simple mode) parameter.

----

🤖 Generated with [Claude Code](https://claude.ai/code)