### PR TITLE
Copy-DbaLogin - Protect BUILTIN\Administrators on SQL Server on Linux

### DIFF
--- a/public/Copy-DbaLogin.ps1
+++ b/public/Copy-DbaLogin.ps1
@@ -227,6 +227,16 @@ function Copy-DbaLogin {
                 continue
             }
 
+            if ($newUserName -like "BUILTIN\Administrators" -and $sourceServer.HostPlatform -eq "Linux") {
+                if ($Pscmdlet.ShouldProcess($destinstance, "Skipping BUILTIN\Administrators on Linux SQL Server")) {
+                    Write-Message -Level Warning -Message "BUILTIN\Administrators cannot be dropped on SQL Server on Linux as it breaks system stored procedures. Skipping."
+                    $copyLoginStatus.Status = "Skipped"
+                    $copyLoginStatus.Notes = "BUILTIN\Administrators is required on Linux SQL Server"
+                    $copyLoginStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                }
+                continue
+            }
+
             if ($Login.LoginType -like 'Window*' -and $destServer.DatabaseEngineEdition -eq 'SqlManagedInstance' ) {
                 if ($Pscmdlet.ShouldProcess($destinstance, "$Login is a Windows login and not supported on a SQL Managed Instance, skipping on $destInstance")) {
                     Write-Message -Level Verbose -Message "$Login is a Windows login and not supported on a SQL Managed Instance, skipping on $destInstance"
@@ -297,6 +307,16 @@ function Copy-DbaLogin {
                         Write-Message -Level Verbose -Message "$newUserName is the destination service account. Skipping drop."
                         $copyLoginStatus.Status = "Skipped"
                         $copyLoginStatus.Notes = "Destination service account"
+                        $copyLoginStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
+                    }
+                    continue
+                }
+
+                if ($newUserName -like "BUILTIN\Administrators" -and $destServer.HostPlatform -eq "Linux") {
+                    if ($Pscmdlet.ShouldProcess($destinstance, "Skipping BUILTIN\Administrators on Linux SQL Server")) {
+                        Write-Message -Level Warning -Message "BUILTIN\Administrators cannot be dropped on SQL Server on Linux as it breaks system stored procedures. Skipping."
+                        $copyLoginStatus.Status = "Skipped"
+                        $copyLoginStatus.Notes = "BUILTIN\Administrators is required on Linux SQL Server"
                         $copyLoginStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject
                     }
                     continue

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -221,4 +221,35 @@ Describe $CommandName -Tag IntegrationTests {
             $permissions | Should -BeLike '*GRANT CONNECT SQL TO `[port`]*'
         }
     }
+
+    Context "Linux SQL Server protection for BUILTIN\Administrators" {
+        BeforeAll {
+            $linuxInstance = Connect-DbaInstance -SqlInstance $TestConfig.instance3
+            $isLinux = $linuxInstance.HostPlatform -eq "Linux"
+        }
+
+        It "Should skip BUILTIN\Administrators on Linux source with -Force" -Skip:(-not $isLinux) {
+            $splatCopy = @{
+                Source      = $TestConfig.instance3
+                Destination = $TestConfig.instance1
+                Login       = "BUILTIN\Administrators"
+                Force       = $true
+            }
+            $results = Copy-DbaLogin @splatCopy
+            $results.Status | Should -Be "Skipped"
+            $results.Notes | Should -Be "BUILTIN\Administrators is required on Linux SQL Server"
+        }
+
+        It "Should skip BUILTIN\Administrators on Linux destination with -Force" -Skip:(-not $isLinux) {
+            $splatCopy = @{
+                Source      = $TestConfig.instance1
+                Destination = $TestConfig.instance3
+                Login       = "BUILTIN\Administrators"
+                Force       = $true
+            }
+            $results = Copy-DbaLogin @splatCopy
+            $results.Status | Should -Be "Skipped"
+            $results.Notes | Should -Be "BUILTIN\Administrators is required on Linux SQL Server"
+        }
+    }
 }


### PR DESCRIPTION
Fixes #9539

When using `Copy-DbaLogin -Force` on SQL Server on Linux, the `BUILTIN\Administrators` login was being dropped and could not be recreated. This breaks system stored procedures and requires a rebuild of system databases to restore.

### Changes

- Added skip logic to prevent copying BUILTIN\Administrators from Linux source instances
- Added skip logic to prevent dropping BUILTIN\Administrators on Linux destination instances when using -Force
- Uses case-insensitive comparison to handle different casing variations
- Returns clear warning message and marks login as "Skipped" with appropriate notes
- Added integration tests for both source and destination Linux scenarios

### Testing

Tests automatically detect if instance3 is running Linux and skip if not. When Linux is available, tests verify:
- BUILTIN\Administrators is skipped when copying from Linux source
- BUILTIN\Administrators is skipped when copying to Linux destination with -Force

Generated with [Claude Code](https://claude.ai/code)