### PR TITLE
Get-DbaCmObject - Add configurable CIM operation timeout

### DIFF
--- a/private/configurations/settings/computermanagement.ps1
+++ b/private/configurations/settings/computermanagement.ps1
@@ -5,6 +5,9 @@ This is designed for all things that control how anything that caches acts
 # Sets the default timeout on bad connections
 Set-DbatoolsConfig -FullName 'ComputerManagement.BadConnectionTimeout' -Value (New-TimeSpan -Minutes 15) -Initialize -Validation timespan -Handler { [Dataplat.Dbatools.Connection.ConnectionHost]::BadConnectionTimeout = $args[0] } -Description 'The timeout used on bad computer management connections. When a connection using a protocol fails, it will not be reattempted for this timespan.'
 
+# Sets the default CIM operation timeout
+Set-DbatoolsConfig -FullName 'ComputerManagement.CimOperationTimeout' -Value (New-TimeSpan -Seconds 60) -Initialize -Validation timespan -Description 'The timeout for individual CIM operations (CimRM and CimDCOM). When a CIM connection attempt does not complete within this timespan, it will be aborted. Lower values speed up failure detection but may cause issues with slow networks.'
+
 # Disable the management cache entire
 Set-DbatoolsConfig -FullName 'ComputerManagement.Cache.Disable.All' -Value $false -Initialize -Validation bool -Handler { [Dataplat.Dbatools.Connection.ConnectionHost]::DisableCache = $args[0] } -Description 'Globally disables all caching done by the Computer Management functions'
 

--- a/private/functions/New-DbaCimSessionOptionWithTimeout.ps1
+++ b/private/functions/New-DbaCimSessionOptionWithTimeout.ps1
@@ -1,0 +1,53 @@
+function New-DbaCimSessionOptionWithTimeout {
+    <#
+    .SYNOPSIS
+        Creates CIM session options with a configured operation timeout.
+
+    .DESCRIPTION
+        Internal helper function that creates CIM session options (WSManSessionOptions or DComSessionOptions)
+        with the operation timeout configured from ComputerManagement.CimOperationTimeout setting.
+
+        This ensures that CIM operations will timeout according to user configuration instead of
+        using the system default timeout values.
+
+    .PARAMETER Protocol
+        The protocol to use for the CIM session options. Valid values are "Default" (WSMan), "Dcom".
+
+    .NOTES
+        Tags: ComputerManagement, CIM, Internal
+        Author: dbatools team
+
+        This is an internal function and should not be called directly by users.
+
+    .EXAMPLE
+        PS C:\> New-DbaCimSessionOptionWithTimeout -Protocol Default
+
+        Creates WSManSessionOptions with the configured operation timeout.
+
+    .EXAMPLE
+        PS C:\> New-DbaCimSessionOptionWithTimeout -Protocol Dcom
+
+        Creates DComSessionOptions with the configured operation timeout.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateSet("Default", "Dcom")]
+        [string]$Protocol
+    )
+
+    $operationTimeout = Get-DbatoolsConfigValue -FullName "ComputerManagement.CimOperationTimeout" -Fallback (New-TimeSpan -Seconds 60)
+
+    switch ($Protocol) {
+        "Default" {
+            $options = New-CimSessionOption -Protocol Default
+            $options.Timeout = $operationTimeout
+            return $options
+        }
+        "Dcom" {
+            $options = New-CimSessionOption -Protocol Dcom
+            $options.Timeout = $operationTimeout
+            return $options
+        }
+    }
+}

--- a/public/New-DbaCmConnection.ps1
+++ b/public/New-DbaCmConnection.ps1
@@ -178,8 +178,16 @@ function New-DbaCmConnection {
                 if (Test-Bound "DisableCredentialAutoRegister") { $connection.DisableCredentialAutoRegister = $DisableCredentialAutoRegister }
                 if (Test-Bound "EnableCredentialFailover") { $connection.DisableCredentialAutoRegister = $EnableCredentialFailover }
                 if (Test-Bound "WindowsCredentialsAreBad") { $connection.WindowsCredentialsAreBad = $WindowsCredentialsAreBad }
-                if (Test-Bound "CimWinRMOptions") { $connection.CimWinRMOptions = $CimWinRMOptions }
-                if (Test-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
+                if (Test-Bound "CimWinRMOptions") {
+                    $connection.CimWinRMOptions = $CimWinRMOptions
+                } else {
+                    $connection.CimWinRMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Default
+                }
+                if (Test-Bound "CimDCOMOptions") {
+                    $connection.CimDCOMOptions = $CimDCOMOptions
+                } else {
+                    $connection.CimDCOMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Dcom
+                }
 
                 if (-not $disable_cache) {
                     Write-Message -Level Verbose -Message "Writing connection to cache"

--- a/public/Set-DbaCmConnection.ps1
+++ b/public/Set-DbaCmConnection.ps1
@@ -236,8 +236,16 @@ function Set-DbaCmConnection {
                 if (Test-Bound "DisableCredentialAutoRegister") { $connection.DisableCredentialAutoRegister = $DisableCredentialAutoRegister }
                 if (Test-Bound "EnableCredentialFailover") { $connection.DisableCredentialAutoRegister = $EnableCredentialFailover }
                 if (Test-Bound "WindowsCredentialsAreBad") { $connection.WindowsCredentialsAreBad = $WindowsCredentialsAreBad }
-                if (Test-Bound "CimWinRMOptions") { $connection.CimWinRMOptions = $CimWinRMOptions }
-                if (Test-Bound "CimDCOMOptions") { $connection.CimDCOMOptions = $CimDCOMOptions }
+                if (Test-Bound "CimWinRMOptions") {
+                    $connection.CimWinRMOptions = $CimWinRMOptions
+                } elseif ($null -eq $connection.CimWinRMOptions) {
+                    $connection.CimWinRMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Default
+                }
+                if (Test-Bound "CimDCOMOptions") {
+                    $connection.CimDCOMOptions = $CimDCOMOptions
+                } elseif ($null -eq $connection.CimDCOMOptions) {
+                    $connection.CimDCOMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Dcom
+                }
                 if (Test-Bound "OverrideConnectionPolicy") { $connection.OverrideConnectionPolicy = $OverrideConnectionPolicy }
 
                 if (-not $disable_cache) {


### PR DESCRIPTION
## Summary

Adds configurable timeout for CIM/DCOM operations to fix issue where `Get-DbaService` and other commands using `Get-DbaCmObject` would timeout after ~5 minutes regardless of configuration settings.

Fixes #9420

## Changes

- Add `ComputerManagement.CimOperationTimeout` configuration setting (default 60s)
- Create `New-DbaCimSessionOptionWithTimeout` helper function to apply timeout
- Update `New-DbaCmConnection` to use configured timeout by default
- Update `Set-DbaCmConnection` to use configured timeout by default

## Usage

```powershell
Set-DbatoolsConfig -FullName 'ComputerManagement.CimOperationTimeout' -Value (New-TimeSpan -Seconds 10)
Get-DbaService -ComputerName 'serverX' -AdvancedProperties
```

This reduces total timeout from ~5 minutes to ~20 seconds (10s per protocol).

🤖 Generated with [Claude Code](https://claude.ai/code)