### PR TITLE
import.ps1 - Remove AlwaysBuildLibrary configuration

### DIFF
--- a/private/configurations/settings/import.ps1
+++ b/private/configurations/settings/import.ps1
@@ -19,28 +19,6 @@ Set-DbatoolsConfig -Name 'Import.StrictSecurityMode' -Value $false -Initialize -
 } -Description "Causes the module to import its components only from the module directory. This makes it harder to update the module, but may be required by security policy. This configuration setting persists across all PowerShell consoles for this user."
 
 # Handle dotsourcing on import
-Set-DbatoolsConfig -Name 'Import.AlwaysBuildLibrary' -Value $false -Initialize -Validation bool -Handler {
-    try {
-        if (-not ($isLinux -or $IsMacOS)) {
-            if (-not (Test-Path "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System")) {
-                $null = New-Item "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -ItemType Container -Force -ErrorAction Stop
-            }
-            if ($args[0]) {
-                $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name AlwaysBuildLibrary -PropertyType DWORD -Value 1 -Force -ErrorAction Stop
-            } else {
-                $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name AlwaysBuildLibrary -PropertyType DWORD -Value 1 -Force -ErrorAction Stop
-            } else {
-                $null = New-ItemProperty "HKCU:\SOFTWARE\Microsoft\WindowsPowerShell\dbatools\System" -Name AlwaysBuildLibrary -PropertyType DWORD -Value 0 -Force -ErrorAction Stop
-            }
-        }
-        # Scope Boundary exception: $cfg is defined in Set-DbatoolsConfig
-        Register-DbatoolsConfig -Config $cfg
-    } catch {
-        Write-Message -Level Warning -Message "Failed to apply configuration 'Import.AlwaysBuildLibrary'" -ErrorRecord $_ -Target 'Import.AlwaysBuildLibrary'
-    }
-} -Description "Causes the module to compile the library from source on every import. Of interest for developers only, as this imposes a significant increase in import time. This configuration setting persists across all PowerShell consoles for this user."
-
-# Handle dotsourcing on import
 Set-DbatoolsConfig -Name 'Import.SerialImport' -Value $false -Initialize -Validation bool -Handler {
     try {
         if (-not ($isLinux -or $IsMacOS)) {


### PR DESCRIPTION
Fixes #9382

The Import.AlwaysBuildLibrary configuration is no longer needed since library components are no longer included in the module. This was causing a syntax error due to duplicate else statements in the handler script block.

### Changes
- Removed entire Import.AlwaysBuildLibrary configuration block from `private/configurations/settings/import.ps1`
- Fixes "The term 'else' is not recognized" error on module import

Generated with [Claude Code](https://claude.ai/code)