### PR TITLE
Connect-DbaInstance - Exclude ActiveConnections for SQL Server 2022+ to fix performance issue

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -1134,8 +1134,18 @@ function Connect-DbaInstance {
                             # 2005 and 2008
                             [void]$initFieldsDb.AddRange($Fields200x_Db)
                             [void]$initFieldsLogin.AddRange($Fields200x_Login)
+                        } elseif ($server.VersionMajor -ge 16) {
+                            # 2022 and above - exclude ActiveConnections due to performance issue #9282
+                            $fields = New-Object System.Collections.Specialized.StringCollection
+                            foreach ($field in $Fields201x_Db) {
+                                if ($field -ne "ActiveConnections") {
+                                    [void]$fields.Add($field)
+                                }
+                            }
+                            [void]$initFieldsDb.AddRange($fields)
+                            [void]$initFieldsLogin.AddRange($Fields201x_Login)
                         } else {
-                            # 2012 and above
+                            # 2012 to 2019
                             [void]$initFieldsDb.AddRange($Fields201x_Db)
                             [void]$initFieldsLogin.AddRange($Fields201x_Login)
                         }


### PR DESCRIPTION
## Summary

This PR fixes the severe performance degradation in `Get-DbaDatabase` on SQL Server 2022+ by excluding `ActiveConnections` from the default init fields.

## Problem

On SQL Server 2022, SMO's query for `ActiveConnections` uses the deprecated `sys.sysprocesses` view which has significant performance problems. With 190+ databases, `Get-DbaDatabase` takes 4+ minutes instead of 12 seconds seen on SQL Server 2016.

## Solution

For SQL Server 2022 and above (VersionMajor >= 16), `ActiveConnections` is not eagerly fetched during connection initialization. Users can still access this property, but it will be fetched on-demand per database rather than in bulk upfront.

## Impact

- SQL Server 2000-2019: No behavior change
- SQL Server 2022+: Significantly faster database enumeration
- Trade-off: Accessing `ActiveConnections` on SQL 2022+ will fetch per-database (slower if accessing for all databases, faster for single database queries)

Fixes #9282

---

Generated with [Claude Code](https://claude.ai/code)