### PR TITLE
*-DbaDbTable - Add parameter aliases to standardize table name parameter

### DIFF
--- a/public/Get-DbaDbTable.ps1
+++ b/public/Get-DbaDbTable.ps1
@@ -99,6 +99,7 @@ function Get-DbaDbTable {
         [string[]]$Database,
         [string[]]$ExcludeDatabase,
         [switch]$IncludeSystemDBs,
+        [Alias("Name")]
         [string[]]$Table,
         [string[]]$Schema,
         [parameter(ValueFromPipeline)]

--- a/public/New-DbaDbTable.ps1
+++ b/public/New-DbaDbTable.ps1
@@ -371,6 +371,7 @@ function New-DbaDbTable {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [String[]]$Database,
+        [Alias("Table")]
         [String]$Name,
         [String]$Schema = "dbo",
         [hashtable[]]$ColumnMap,

--- a/public/Remove-DbaDbTable.ps1
+++ b/public/Remove-DbaDbTable.ps1
@@ -67,6 +67,7 @@ function Remove-DbaDbTable {
         [DbaInstanceParameter[]]$SqlInstance,
         [PSCredential]$SqlCredential,
         [string[]]$Database,
+        [Alias("Name")]
         [string[]]$Table,
         [Parameter(ValueFromPipeline)]
         [Microsoft.SqlServer.Management.Smo.Table[]]$InputObject,


### PR DESCRIPTION
## Summary
Adds parameter aliases to ensure all three `*-DbaDbTable` commands support both `Table` and `Name` parameters.

## Changes
- Get-DbaDbTable: Added 'Name' alias to 'Table' parameter
- New-DbaDbTable: Added 'Table' alias to 'Name' parameter
- Remove-DbaDbTable: Added 'Name' alias to 'Table' parameter
- Test files remain unchanged (no aliases in parameter validation)

This allows users to use the same splat for all three commands regardless of which parameter name they choose.

Fixes #9470

🤖 Generated with [Claude Code](https://claude.ai/code)