### PR TITLE
Get-DbaMemoryCondition - Remove outdated Microsoft KB URL reference

### DIFF
--- a/public/Get-DbaMemoryCondition.ps1
+++ b/public/Get-DbaMemoryCondition.ps1
@@ -9,7 +9,6 @@ function Get-DbaMemoryCondition {
         The function returns detailed memory statistics including physical memory usage, page file utilization, virtual address space consumption, and SQL Server-specific memory allocation metrics. Each record includes the exact timestamp when memory conditions were recorded, making it valuable for correlating memory pressure with performance degradation during specific time periods.
 
         This command is based on a query provided by Microsoft support and queries the sys.dm_os_ring_buffers DMV to extract resource monitor notifications.
-        Reference KB article: https://support.microsoft.com/en-us/help/918483/how-to-reduce-paging-of-buffer-pool-memory-in-the-64-bit-version-of-sq
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.


### PR DESCRIPTION
Fixes #8449

The URL https://support.microsoft.com/en-us/help/918483/ redirects to an unrelated error page and is no longer relevant. This PR removes the reference line from the command documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)