### PR TITLE
Invoke-DbaDiagnosticQuery - Fix Azure SQL DB query execution with limited permissions

### DIFF
--- a/public/Invoke-DbaDiagnosticQuery.ps1
+++ b/public/Invoke-DbaDiagnosticQuery.ps1
@@ -411,7 +411,14 @@ function Invoke-DbaDiagnosticQuery {
 
                             Write-Message -Level Verbose -Message "Collecting diagnostic query data from $($currentDb) for $($scriptpart.QueryName) on $instance"
                             try {
-                                $result = $server.Query($scriptpart.Text, $currentDb)
+                                # Azure SQL Database connections are already scoped to a specific database
+                                # Using the 2-parameter Query() overload can fail with limited permissions
+                                # For Azure SQL DB, use the 1-parameter overload even for DBSpecific queries
+                                if ($server.DatabaseEngineType -eq "SqlAzureDatabase") {
+                                    $result = $server.Query($scriptpart.Text)
+                                } else {
+                                    $result = $server.Query($scriptpart.Text, $currentDb)
+                                }
                                 if (-not $result) {
                                     [PSCustomObject]@{
                                         ComputerName     = $server.ComputerName


### PR DESCRIPTION
Resolves issue where database-specific queries fail on Azure SQL Database with lower permissions, even though the T-SQL runs fine in SSMS.

The problem occurred when using the 2-parameter Query() overload which attempts a new connection context. For Azure SQL DB, connections are already scoped to a specific database, so the 1-parameter overload works correctly even for DBSpecific queries.

Fixes #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)