### PR TITLE
Export-DbaSysDbUserObject - Fix ScriptingOptionsObject parameter being ignored

### DIFF
--- a/public/Export-DbaSysDbUserObject.ps1
+++ b/public/Export-DbaSysDbUserObject.ps1
@@ -133,7 +133,7 @@ function Export-DbaSysDbUserObject {
                         if ((Test-Path -Path $scriptPath) -and $NoClobber) {
                             Stop-Function -Message "File already exists. If you want to overwrite it remove the -NoClobber parameter. If you want to append data, please Use -Append parameter." -Target $scriptPath -Continue
                         }
-                        if (!(Test-Bound -ParameterName ScriptingOption)) {
+                        if (!(Test-Bound -ParameterName ScriptingOptionsObject)) {
                             $ScriptingOptionsObject = New-DbaScriptingOption
                             $ScriptingOptionsObject.IncludeDatabaseContext = $true
                             $ScriptingOptionsObject.ScriptBatchTerminator = $true

--- a/tests/Export-DbaSysDbUserObject.Tests.ps1
+++ b/tests/Export-DbaSysDbUserObject.Tests.ps1
@@ -139,4 +139,18 @@ Describe $CommandName -Tag IntegrationTests {
             $file -match $ruleName | Should -Be $true
         }
     }
+
+    Context "ScriptingOptionsObject parameter works correctly" {
+        It "should respect IncludeIfNotExists scripting option when specified" {
+            $scriptOpts = New-DbaScriptingOption
+            $scriptOpts.IncludeIfNotExists = $true
+            $splatExport = @{
+                SqlInstance           = $TestConfig.instance2
+                ScriptingOptionsObject = $scriptOpts
+                PassThru              = $true
+            }
+            $script = Export-DbaSysDbUserObject @splatExport | Out-String
+            $script -match "IF NOT EXISTS" | Should -Be $true
+        }
+    }
 }


### PR DESCRIPTION
Fixed Test-Bound call to use correct parameter name 'ScriptingOptionsObject' instead of 'ScriptingOption'. This was causing the parameter to be ignored and default scripting options to always be used.

Added integration test to verify ScriptingOptionsObject parameter works correctly.

Fixes #9637

Generated with [Claude Code](https://claude.ai/code)