### PR TITLE
skip claude-issue* branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,11 @@ configuration: "Debug"
 # skip PR builds when there's already a push build
 skip_branch_with_pr: true
 
-# skip builds on master branch (archival branch)
+# skip builds on master branch (archival branch) and claude/issue-*
 branches:
   except:
     - master
+    - /claude\/-issue/
 
 # skip tag commits entirely
 skip_tags: true


### PR DESCRIPTION
We are skipping builds left and right but currently the issue is that claude doesn't have its own repo.
Branches are created on the main repo using claude/issue-<whatever> format, and then a PR is raised from there.
This change *should* avoid doing builds on branches of the main repo created by claude, which the bot creates but reports the original author as the "creator" instead of itself.
If the bot stays on this naming convention, this will save an unneccessary run on the branch and wait for the proper PR to be raised, as it would happen if claude used its own repo (like an external "human" maintainer) instead of dataplat's one.