### PR TITLE
Copy-DbaLinkedServer - Add DAC connection to prevent multiple DAC connection attempts

### DIFF
--- a/public/Copy-DbaLinkedServer.ps1
+++ b/public/Copy-DbaLinkedServer.ps1
@@ -282,8 +282,8 @@ function Copy-DbaLinkedServer {
             Write-Message -Level Verbose -Message "You are using a SQL Credential. Note that this script requires Windows Administrator access on the source server. Attempting with $($SourceSqlCredential.Username)."
         }
         try {
-            $sourceServer = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
-            return
+            Write-Message -Level Verbose -Message "We will try to open a dedicated admin connection."
+            $sourceServer = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential -DedicatedAdminConnection -WarningAction SilentlyContinue
         } catch {
             Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $Source
             return
@@ -318,5 +318,10 @@ function Copy-DbaLinkedServer {
             # Magic happens here
             Copy-DbaLinkedServers $LinkedServer -Force:$force
         }
+    }
+    end {
+        # Disconnect is important because it is a DAC
+        # Disconnect in case of WhatIf, as we opened the connection
+        $null = $sourceServer | Disconnect-DbaInstance -WhatIf:$false
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #9204 where `Sync-DbaAvailabilityGroup` was causing 3 failed DAC connection errors in SQL Server logs.

## Root Cause

`Copy-DbaLinkedServer` was not opening a DAC connection like `Copy-DbaCredential` does. When `Get-DecryptedObject` was called without an existing DAC connection, it attempted to open its own DAC connection, causing conflicts when both credentials and linked servers needed to be synced.

## Changes

- Added `-DedicatedAdminConnection` parameter to `Connect-DbaInstance` call in Copy-DbaLinkedServer.ps1 (line 286)
- Added verbose message about opening DAC connection (line 285)
- Added `end` block to properly disconnect DAC connection (lines 322-326)

This ensures `Copy-DbaLinkedServer` follows the same pattern as `Copy-DbaCredential`, opening a DAC connection upfront that `Get-DecryptedObject` will detect and reuse.

Fixes #9204

🤖 Generated with [Claude Code](https://claude.ai/code)