### PR TITLE
Copy-DbaDbMail - Fix InvalidCastException by explicitly casting SMO name properties to string

### DIFF
--- a/public/Copy-DbaDbMail.ps1
+++ b/public/Copy-DbaDbMail.ps1
@@ -140,7 +140,7 @@ function Copy-DbaDbMail {
 
             Write-Message -Message "Migrating accounts." -Level Verbose
             foreach ($account in $sourceAccounts) {
-                $accountName = $account.name
+                $accountName = [string]$account.name
                 $newAccountName = $accountName -replace [Regex]::Escape($source), $destinstance
                 Write-Message -Message "Updating account name from '$accountName' to '$newAccountName'." -Level Verbose
                 $copyMailAccountStatus = [PSCustomObject]@{
@@ -209,7 +209,7 @@ function Copy-DbaDbMail {
             Write-Message -Message "Migrating mail profiles." -Level Verbose
             foreach ($profile in $sourceProfiles) {
 
-                $profileName = $profile.name
+                $profileName = [string]$profile.name
                 $newProfileName = $profileName -replace [Regex]::Escape($source), $destinstance
                 Write-Message -Message "Updating profile name from '$profileName' to '$newProfileName'." -Level Verbose
                 $copyMailProfileStatus = [PSCustomObject]@{
@@ -286,7 +286,7 @@ function Copy-DbaDbMail {
 
             Write-Message -Message "Migrating mail servers." -Level Verbose
             foreach ($mailServer in $sourceMailServers) {
-                $mailServerName = $mailServer.name
+                $mailServerName = [string]$mailServer.name
                 $copyMailServerStatus = [PSCustomObject]@{
                     SourceServer      = $sourceServer.Name
                     DestinationServer = $destServer.Name


### PR DESCRIPTION
## Summary

Fixes InvalidCastException error in Copy-DbaDbMail when migrating database mail configurations.

## Changes

Explicitly cast SMO object .name properties to [string] to prevent type casting errors:
- Line 143: `$accountName = [string]$account.name`
- Line 212: `$profileName = [string]$profile.name`
- Line 289: `$mailServerName = [string]$mailServer.name`

## Root Cause

SMO object properties may return non-string types that cause InvalidCastException when used in Write-Message string interpolation. The issue varies by:
- SMO library versions (SQL Server 2017 vs 2022)
- .NET Framework versions
- Object name content

Fixes #9662

🤖 Generated with [Claude Code](https://claude.ai/code)