### PR TITLE
ConvertTo-DbaXESession - Add SqlCredential parameter for cross-domain support

### DIFF
--- a/tests/ConvertTo-DbaXESession.Tests.ps1
+++ b/tests/ConvertTo-DbaXESession.Tests.ps1
@@ -13,6 +13,7 @@ Describe $CommandName -Tag UnitTests {
             $expectedParameters += @(
                 "InputObject",
                 "Name",
+                "SqlCredential",
                 "OutputScriptOnly",
                 "EnableException"
             )


### PR DESCRIPTION
Fixes #8413

Adds SqlCredential parameter to ConvertTo-DbaXESession to support cross-domain scenarios where alternate credentials are required.

## Changes
- Added SqlCredential parameter with proper help documentation
- Updated all three Get-DbaXESession calls to use splats with SqlCredential support
- Updated parameter validation test to include SqlCredential
- Followed dbatools style guide throughout

## Testing
Users can now pass credentials for cross-domain scenarios:
```powershell
Get-DbaTrace -SqlInstance [TargetServer].[OtherDomain] -SqlCredential (Get-Credential) | 
    ConvertTo-DbaXESession -SqlCredential (Get-Credential) -OutputScriptOnly
```

Generated with [Claude Code](https://claude.ai/code)