### PR TITLE
Install-DbaInstance - Add ASAdminAccount parameter for Analysis Services administrators

### DIFF
--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -29,6 +29,7 @@ Describe $CommandName -Tag UnitTests {
                 "BackupPath",
                 "UpdateSourcePath",
                 "AdminAccount",
+                "ASAdminAccount",
                 "Port",
                 "Throttle",
                 "ProductID",


### PR DESCRIPTION
## Summary

Adds missing ASAdminAccount parameter to Install-DbaInstance to specify Analysis Services administrator accounts.

Fixes #9935

## Changes

- Added ASAdminAccount parameter that maps to ASSYSADMINACCOUNTS SQL Server setup parameter
- Added parameter documentation explaining its purpose and usage
- Added usage example demonstrating Analysis Services installation with separate admin accounts
- Updated parameter validation test to include new parameter

This parameter is required when installing Analysis Services feature, as SQL Server setup requires at least one administrator account to be specified via ASSYSADMINACCOUNTS.

## Testing

- Updated parameter validation test in Install-DbaInstance.Tests.ps1
- Follows same pattern as existing AdminAccount parameter

---

Generated with [Claude Code](https://claude.ai/code)