### PR TITLE
New-DbaAvailabilityGroup - Warn when ConnectionModeInSecondaryRole is used on Standard Edition

### DIFF
--- a/public/New-DbaAvailabilityGroup.ps1
+++ b/public/New-DbaAvailabilityGroup.ps1
@@ -499,6 +499,16 @@ function New-DbaAvailabilityGroup {
             return
         }
 
+        # Check if ConnectionModeInSecondaryRole is set on Standard Edition
+        if ($ConnectionModeInSecondaryRole -and $ConnectionModeInSecondaryRole -ne "AllowNoConnections") {
+            $instances = @($server) + $secondaries
+            foreach ($instance in $instances) {
+                if ($instance.EngineEdition -eq "Standard") {
+                    Write-Message -Level Warning -Message "ConnectionModeInSecondaryRole is not supported on Standard Edition. The setting will be ignored on $($instance.Name). Consider using Enterprise or Developer Edition for read-only secondary replicas."
+                }
+            }
+        }
+
         # database checks
         if ($Database) {
             $dbs += Get-DbaDatabase -SqlInstance $Primary -SqlCredential $PrimarySqlCredential -Database $Database


### PR DESCRIPTION
Fixes #9986

Adds a warning when users try to set `ConnectionModeInSecondaryRole` on Standard Edition instances. Standard Edition does not support readable secondary replicas, and previously the setting was silently ignored with no user feedback.

The warning is shown when:
- `ConnectionModeInSecondaryRole` is set to anything other than `AllowNoConnections`
- Any instance (primary or secondary) is running Standard Edition

Generated with [Claude Code](https://claude.ai/code)