### PR TITLE
Compare-DbaAgReplica* commands - Remove invalid EnableException parameter

### DIFF
--- a/public/Compare-DbaAgReplicaAgentJob.ps1
+++ b/public/Compare-DbaAgReplicaAgentJob.ps1
@@ -127,9 +127,8 @@ function Compare-DbaAgReplicaAgentJob {
                 foreach ($replicaInstance in $replicaInstances) {
                     try {
                         $splatConnection = @{
-                            SqlInstance     = $replicaInstance
-                            SqlCredential   = $SqlCredential
-                            EnableException = $true
+                            SqlInstance   = $replicaInstance
+                            SqlCredential = $SqlCredential
                         }
                         $replicaServer = Connect-DbaInstance @splatConnection
 

--- a/public/Compare-DbaAgReplicaCredential.ps1
+++ b/public/Compare-DbaAgReplicaCredential.ps1
@@ -98,9 +98,8 @@ function Compare-DbaAgReplicaCredential {
                 foreach ($replicaInstance in $replicaInstances) {
                     try {
                         $splatConnection = @{
-                            SqlInstance     = $replicaInstance
-                            SqlCredential   = $SqlCredential
-                            EnableException = $true
+                            SqlInstance   = $replicaInstance
+                            SqlCredential = $SqlCredential
                         }
                         $replicaServer = Connect-DbaInstance @splatConnection
 

--- a/public/Compare-DbaAgReplicaLogin.ps1
+++ b/public/Compare-DbaAgReplicaLogin.ps1
@@ -118,9 +118,8 @@ function Compare-DbaAgReplicaLogin {
                 foreach ($replicaInstance in $replicaInstances) {
                     try {
                         $splatConnection = @{
-                            SqlInstance     = $replicaInstance
-                            SqlCredential   = $SqlCredential
-                            EnableException = $true
+                            SqlInstance   = $replicaInstance
+                            SqlCredential = $SqlCredential
                         }
                         $replicaServer = Connect-DbaInstance @splatConnection
 

--- a/public/Compare-DbaAgReplicaOperator.ps1
+++ b/public/Compare-DbaAgReplicaOperator.ps1
@@ -98,9 +98,8 @@ function Compare-DbaAgReplicaOperator {
                 foreach ($replicaInstance in $replicaInstances) {
                     try {
                         $splatConnection = @{
-                            SqlInstance     = $replicaInstance
-                            SqlCredential   = $SqlCredential
-                            EnableException = $true
+                            SqlInstance   = $replicaInstance
+                            SqlCredential = $SqlCredential
                         }
                         $replicaServer = Connect-DbaInstance @splatConnection
 


### PR DESCRIPTION
Fixes #9992

Removed the invalid `EnableException` parameter from `Connect-DbaInstance` calls in four Compare-DbaAgReplica* commands.

**Files fixed:**
- Compare-DbaAgReplicaCredential.ps1
- Compare-DbaAgReplicaOperator.ps1
- Compare-DbaAgReplicaLogin.ps1
- Compare-DbaAgReplicaAgentJob.ps1

**Issue:** `Connect-DbaInstance` does not support the `EnableException` parameter, causing warnings when these commands tried to connect to AG replicas.

---

Generated with [Claude Code](https://claude.ai/code)