### PR TITLE
Install-DbaInstance - Add SQL Server 2025 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ When in doubt about version compatibility, use the `New-Object` cmdlet approach.
 - SQL Server 2017 = Version 14
 - SQL Server 2019 = Version 15
 - SQL Server 2022 = Version 16
+- SQL Server 2025 = Version 17
 
 **Philosophy:**
 - **Support SQL Server 2000 when it is not complex or does not add significantly to the codebase**

--- a/public/Install-DbaInstance.ps1
+++ b/public/Install-DbaInstance.ps1
@@ -93,7 +93,7 @@ function Install-DbaInstance {
 
     .PARAMETER Version
         Specifies the SQL Server version to install using the year-based identifier.
-        Valid values are 2008, 2008R2, 2012, 2014, 2016, 2017, 2019, and 2022.
+        Valid values are 2008, 2008R2, 2012, 2014, 2016, 2017, 2019, 2022, and 2025.
         This parameter determines which setup.exe file to locate in the installation media and configures version-specific features like tempdb file optimization (SQL 2016+).
 
     .PARAMETER InstanceName
@@ -319,7 +319,7 @@ function Install-DbaInstance {
         [DbaInstanceParameter[]]$SqlInstance = $env:COMPUTERNAME,
         [parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("2008", "2008R2", "2012", "2014", "2016", "2017", "2019", "2022")]
+        [ValidateSet("2008", "2008R2", "2012", "2014", "2016", "2017", "2019", "2022", "2025")]
         [string]$Version,
         [string]$InstanceName,
         [PSCredential]$SaCredential,
@@ -469,6 +469,7 @@ function Install-DbaInstance {
             2017 { '14.0' }
             2019 { '15.0' }
             2022 { '16.0' }
+            2025 { '17.0' }
             default {
                 Stop-Function -Message "Version $Version is not supported"
                 return

--- a/tests/Install-DbaInstance.Tests.ps1
+++ b/tests/Install-DbaInstance.Tests.ps1
@@ -90,6 +90,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             # Create a dummy Configuration.ini
@@ -113,7 +116,7 @@ Describe $CommandName -Tag IntegrationTests {
             $result.Restarted | Should -Be $false
             $result.Installer | Should -Be "$TestDrive\dummy.exe"
             $result.Notes | Should -BeNullOrEmpty
-            if ($version -in "2016", "2017") {
+            if ($version -in "2016", "2017", "2019", "2022", "2025") {
                 $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
             }
         }
@@ -125,6 +128,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             $params = @{
@@ -166,7 +172,7 @@ Describe $CommandName -Tag IntegrationTests {
             $result.Configuration.$mainNode.SAPWD | Should -Be "foo"
             $result.Configuration.$mainNode.SQLSVCACCOUNT | Should -Be "foo"
             $result.Configuration.$mainNode.SQLSYSADMINACCOUNTS | Should -Be """local\foo"" ""local\bar"""
-            if ($version -in "2016", "2017") {
+            if ($version -in "2016", "2017", "2019", "2022", "2025") {
                 $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
             }
         }
@@ -178,6 +184,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             # Create a dummy Configuration.ini
@@ -210,7 +219,7 @@ Describe $CommandName -Tag IntegrationTests {
             $result.Notes | Should -BeNullOrEmpty
             $result.Configuration.$mainNode.FEATURES | Should -Be "SQLEngine,AS"
             $result.Configuration.$mainNode.SQLSVCACCOUNT | Should -Be "foo\bar"
-            if ($version -in "2016", "2017") {
+            if ($version -in "2016", "2017", "2019", "2022", "2025") {
                 $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
             }
         }
@@ -222,6 +231,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             $result = Install-DbaInstance -Version $version -Path TestDrive: -EnableException -UpdateSourcePath TestDrive:
@@ -248,6 +260,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             # temporary replacing that mock with exit code 3010
@@ -271,7 +286,7 @@ Describe $CommandName -Tag IntegrationTests {
             $result.Installer | Should -Be "$TestDrive\dummy.exe"
             $result.Notes | Should -BeNullOrEmpty
             $result.Configuration.$mainNode.FEATURES -join "," | Should -BeLike *SQLEngine*
-            if ($version -in "2016", "2017") {
+            if ($version -in "2016", "2017", "2019", "2022", "2025") {
                 $result.Configuration.$mainNode.SQLTEMPDBFILECOUNT | Should -Be 8
             }
 
@@ -286,6 +301,9 @@ Describe $CommandName -Tag IntegrationTests {
             @{ version = "2014"; canonicVersion = "12.0"; mainNode = "OPTIONS" }
             @{ version = "2016"; canonicVersion = "13.0"; mainNode = "OPTIONS" }
             @{ version = "2017"; canonicVersion = "14.0"; mainNode = "OPTIONS" }
+            @{ version = "2019"; canonicVersion = "15.0"; mainNode = "OPTIONS" }
+            @{ version = "2022"; canonicVersion = "16.0"; mainNode = "OPTIONS" }
+            @{ version = "2025"; canonicVersion = "17.0"; mainNode = "OPTIONS" }
         ) {
             param($version, $canonicVersion, $mainNode)
             Mock -CommandName Invoke-Program -MockWith { [PSCustomObject]@{ Successful = $true; ExitCode = [uint32[]]0 } } -ModuleName dbatools


### PR DESCRIPTION
## Summary

Adds SQL Server 2025 support to Install-DbaInstance command.

## Changes

- Added "2025" to ValidateSet in Version parameter
- Added version 17.0 mapping for SQL Server 2025
- Updated parameter help documentation
- Added SQL 2025 test cases to all test scenarios
- Updated CLAUDE.md with SQL Server 2025 version mapping

Fixes #9993

🤖 Generated with [Claude Code](https://claude.ai/code)