### PR TITLE
Service commands - Fix credential passing through Update-ServiceStatus

### DIFF
--- a/private/functions/Update-ServiceStatus.ps1
+++ b/private/functions/Update-ServiceStatus.ps1
@@ -190,7 +190,13 @@ process {
         Write-Message -Message "Getting CIM objects from computer $($group.Name)"
         $serviceNames = $group.Group.ServiceName -join "' OR name = '"
         try {
-            $svcCim = Get-DbaCmObject -ComputerName $group.Name -Namespace "root\cimv2" -query "SELECT * FROM Win32_Service WHERE name = '$serviceNames'" -Credential $credential
+            $splatCmObject = @{
+                ComputerName = $group.Name
+                Namespace    = "root\cimv2"
+                Query        = "SELECT * FROM Win32_Service WHERE name = '$serviceNames'"
+            }
+            if ($Credential) { $splatCmObject.Credential = $Credential }
+            $svcCim = Get-DbaCmObject @splatCmObject
         } catch {
             Stop-Function -EnableException $EnableException -FunctionName $callerName -Message ("The attempt to get CIM session for the services on $($group.Name) returned the following error: " + ($_.Exception.Message -join ' ')) -Category ConnectionError -ErrorRecord $_
         }

--- a/public/Restart-DbaService.ps1
+++ b/public/Restart-DbaService.ps1
@@ -153,13 +153,22 @@ function Restart-DbaService {
         }
         if ($processArray) {
             if ($PSCmdlet.ShouldProcess("$ProcessArray", "Restarting Service")) {
-                $services = Update-ServiceStatus -InputObject $processArray -Action 'stop' -Timeout $Timeout -EnableException $EnableException
+                $splatServiceStatus = @{
+                    InputObject     = $processArray
+                    Action          = "stop"
+                    Timeout         = $Timeout
+                    EnableException = $EnableException
+                }
+                if ($Credential) { $splatServiceStatus.Credential = $Credential }
+                $services = Update-ServiceStatus @splatServiceStatus
                 foreach ($service in ($services | Where-Object { $_.Status -eq 'Failed' })) {
                     $service
                 }
                 $services = $services | Where-Object { $_.Status -eq 'Successful' }
                 if ($services) {
-                    Update-ServiceStatus -InputObject $services -Action 'restart' -Timeout $Timeout -EnableException $EnableException
+                    $splatServiceStatus.InputObject = $services
+                    $splatServiceStatus.Action = "restart"
+                    Update-ServiceStatus @splatServiceStatus
                 }
             }
         } else {

--- a/public/Start-DbaService.ps1
+++ b/public/Start-DbaService.ps1
@@ -119,7 +119,14 @@ function Start-DbaService {
         $processArray = $processArray | Where-Object { (!$InstanceName -or $_.InstanceName -in $InstanceName) -and (!$Type -or $_.ServiceType -in $Type) }
         if ($PSCmdlet.ShouldProcess("$ProcessArray", "Starting Service")) {
             if ($processArray) {
-                Update-ServiceStatus -InputObject $processArray -Action 'start' -Timeout $Timeout -EnableException $EnableException
+                $splatServiceStatus = @{
+                    InputObject     = $processArray
+                    Action          = "start"
+                    Timeout         = $Timeout
+                    EnableException = $EnableException
+                }
+                if ($Credential) { $splatServiceStatus.Credential = $Credential }
+                Update-ServiceStatus @splatServiceStatus
             } else {
                 Stop-Function -EnableException $EnableException -Message "No SQL Server services found with current parameters." -Category ObjectNotFound
             }

--- a/public/Stop-DbaService.ps1
+++ b/public/Stop-DbaService.ps1
@@ -153,7 +153,14 @@ function Stop-DbaService {
         }
         if ($PSCmdlet.ShouldProcess("$ProcessArray", "Stopping Service")) {
             if ($processArray) {
-                Update-ServiceStatus -InputObject $processArray -Action 'stop' -Timeout $Timeout -EnableException $EnableException
+                $splatServiceStatus = @{
+                    InputObject     = $processArray
+                    Action          = "stop"
+                    Timeout         = $Timeout
+                    EnableException = $EnableException
+                }
+                if ($Credential) { $splatServiceStatus.Credential = $Credential }
+                Update-ServiceStatus @splatServiceStatus
             } else {
                 Stop-Function -EnableException $EnableException -Message "No SQL Server services found with current parameters." -Category ObjectNotFound
             }


### PR DESCRIPTION
## Summary

This PR fixes issue #9552 where Restart-DbaService, Stop-DbaService, and Start-DbaService were not properly passing the -Credential parameter through to Update-ServiceStatus, which in turn was not passing it to Get-DbaCmObject. This caused authentication failures when users provided credentials.

## Changes

- **Restart-DbaService**: Pass credential to Update-ServiceStatus calls
- **Stop-DbaService**: Pass credential to Update-ServiceStatus call
- **Start-DbaService**: Pass credential to Update-ServiceStatus call
- **Update-ServiceStatus**: Pass credential to Get-DbaCmObject call

All changes use splatting with properly aligned hashtables per dbatools style guide.

Fixes #9552

----

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/dataplat/dbatools/actions/runs/19693417453) | [Branch](https://github.com/dataplat/dbatools/tree/claude/issue-9552-20251126-0520