### PR TITLE
Sync-DbaLoginPermission - Fix login disabled state not being synced

### DIFF
--- a/private/functions/Update-SqlPermission.ps1
+++ b/private/functions/Update-SqlPermission.ps1
@@ -42,6 +42,19 @@ function Update-SqlPermission {
 
     $saname = Get-SaLoginName -SqlInstance $DestServer
 
+    # Sync login enabled/disabled state
+    if ($SourceLogin.IsDisabled -ne $DestLogin.IsDisabled) {
+        if ($Pscmdlet.ShouldProcess($destination, "Setting login $newLoginName IsDisabled to $($SourceLogin.IsDisabled).")) {
+            try {
+                $DestLogin.IsDisabled = $SourceLogin.IsDisabled
+                $DestLogin.Alter()
+                Write-Message -Level Verbose -Message "Setting login $newLoginName IsDisabled to $($SourceLogin.IsDisabled) on $destination successfully performed."
+            } catch {
+                Stop-Function -Message "Failed to set login $newLoginName IsDisabled to $($SourceLogin.IsDisabled) on $destination." -Target $DestLogin -ErrorRecord $_
+            }
+        }
+    }
+
     # gotta close because enum repeatedly causes problems with the datareader
     $null = $SourceServer.ConnectionContext.SqlConnectionObject.Close()
     $null = $DestServer.ConnectionContext.SqlConnectionObject.Close()


### PR DESCRIPTION
## Summary

Fixes #9208 - Sync-DbaLoginPermission now properly syncs login enabled/disabled state from source to destination.

## Changes

- Modified `Update-SqlPermission.ps1` to sync the `IsDisabled` property of logins
- Added integration test to verify login state synchronization

## Testing

New integration test verifies that when a login is disabled on source, it is properly disabled on destination after running Sync-DbaLoginPermission.

----

Generated with [Claude Code](https://claude.ai/code)