### PR TITLE
Test-DbaLastBackup - Add Wait parameter to delay between database restore tests

### DIFF
--- a/tests/Test-DbaLastBackup.Tests.ps1
+++ b/tests/Test-DbaLastBackup.Tests.ps1
@@ -38,7 +38,8 @@ Describe $CommandName -Tag UnitTests {
                 "BufferCount",
                 "IgnoreDiffBackup",
                 "ReuseSourceFolderStructure",
-                "Checksum"
+                "Checksum",
+                "Wait"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }


### PR DESCRIPTION
Fixes #9206

Adds a new `-Wait` parameter to `Test-DbaLastBackup` that allows users to specify a delay in seconds between each database restore test.

## Changes
- Added `-Wait` parameter that accepts an integer value for seconds
- Implemented `Start-Sleep` logic at the end of each database test loop
- Updated help documentation with parameter description and usage example
- Updated parameter validation tests

## Rationale
Users were experiencing I/O errors on checkpoint files (*.CKP) when restoring to NAS network shares. The restore operations were happening too quickly for SQL Server and the storage system to cleanup checkpoint files between databases. This parameter allows users to add a delay between restore tests to prevent these errors.

## Example
```powershell
Test-DbaLastBackup -SqlInstance sql2016 -Wait 5
```

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/dataplat/dbatools/actions/runs/19770172552) | [Branch: claude/issue-9206-20251128-1715](https://github.com/dataplat/dbatools/tree/claude/issue-9206-20251128-1715