### PR TITLE
New-DbaSqlParameter - Update test comment to reference correct issue number

### DIFF
--- a/tests/New-DbaSqlParameter.Tests.ps1
+++ b/tests/New-DbaSqlParameter.Tests.ps1
@@ -69,7 +69,7 @@ Describe $CommandName -Tag IntegrationTests {
         Invoke-DbaQuery -SqlInstance $TestConfig.instance2 -Database tempdb -CommandType StoredProcedure -Query my_proc -SqlParameters $output
         $output.Value | Should -Be "{""example"":""sample""}"
     }
-    It "binds a ""falsy"" value properly (see #9542)" {
+    It "binds a ""falsy"" value properly (see #9209)" {
         [int]$ZeroInt = 0
         $ZeroSqlParam = New-DbaSqlParameter -ParameterName ZeroInt -Value $ZeroInt -SqlDbType int
         $ZeroSqlParam.Value | Should -Be 0


### PR DESCRIPTION
Fixes #9209

The test file had an incorrect issue number reference. Updated the comment from #9542 to #9209.

No implementation changes needed - the command already correctly handles falsy values using the Test-Bound helper function.

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/dataplat/dbatools/tree/claude/issue-9209-20251128-1720) | [View job run](https://github.com/dataplat/dbatools/actions/runs/19770279378