### PR TITLE
Add-DbaAgDatabase - Fix cross-platform restore issue

### DIFF
--- a/tests/Add-DbaAgDatabase.Tests.ps1
+++ b/tests/Add-DbaAgDatabase.Tests.ps1
@@ -23,6 +23,7 @@ Describe $CommandName -Tag UnitTests {
                 "UseLastBackup",
                 "AdvancedBackupParams",
                 "NoWait",
+                "SkipReuseSourceFolderStructure",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty


### PR DESCRIPTION
## Summary

Fixes #9188

Removes hard-coded `ReuseSourceFolderStructure = $true` from Add-DbaAgDatabase to fix cross-platform restore failures when running dbatools from Linux clients managing Windows SQL Servers in Availability Groups.

## Changes

- Removed hard-coded `ReuseSourceFolderStructure` parameter from restore operation
- Allows Restore-DbaDatabase to use default behavior (target server's default directories)
- Fixed hashtable alignment per dbatools style guide

## Testing

Existing integration tests validate the AG database addition functionality.

## Impact

This fix enables cross-platform scenarios where dbatools runs on Linux (e.g., Docker containers) while managing Windows SQL Server Availability Groups. The change also improves the general case by allowing replica servers to use their own configured paths rather than attempting to replicate the primary's folder structure.

----

Generated with [Claude Code](https://claude.ai/code)