### PR TITLE
Copy-DbaAgentJob - Fix incorrect escaping of @server variable in job steps

### DIFF
--- a/public/Copy-DbaAgentJob.ps1
+++ b/public/Copy-DbaAgentJob.ps1
@@ -363,10 +363,10 @@ function Copy-DbaAgentJob {
 
                         if ($missingLogin.Count -gt 0 -and $force) {
                             $saLogin = Get-SqlSaLogin -SqlInstance $destServer
-                            $sql = $sql -replace [Regex]::Escape("@owner_login_name=N'$missingLogin'"), [Regex]::Escape("@owner_login_name=N'$saLogin'")
+                            $sql = $sql -replace [Regex]::Escape("@owner_login_name=N'$missingLogin'"), "@owner_login_name=N'$saLogin'"
                         }
 
-                        $sql = $sql -replace [Regex]::Escape("@server=N'$($sourceserver.DomainInstanceName)'"), [Regex]::Escape("@server=N'$($destServer.DomainInstanceName)'")
+                        $sql = $sql -replace [Regex]::Escape("@server=N'$($sourceserver.DomainInstanceName)'"), "@server=N'$($destServer.DomainInstanceName)'"
 
                         Write-Message -Message $sql -Level Debug
                         $destServer.Query($sql)


### PR DESCRIPTION
Fixes #9086

Removed `[Regex]::Escape()` from the replacement side of `-replace` operations on lines 366 and 369. This fixes the issue where instance names with backslashes (e.g., s0560\POWERBI) were being double-escaped to s0560\\POWERBI, causing sp_helpserver to reject the value.

The replacement string in PowerShell's `-replace` operator should not be escaped - only the pattern (left side) needs `[Regex]::Escape()` to match literal characters.

**Historical Context:**
This issue was previously fixed in PR #1322 (2017) but was re-introduced in PR #5979 (2019).

Generated with [Claude Code](https://claude.ai/code)