### PR TITLE
Remove-DbaDbRole - Add schema ownership handling and Force parameter

### DIFF
--- a/tests/Remove-DbaDbRole.Tests.ps1
+++ b/tests/Remove-DbaDbRole.Tests.ps1
@@ -19,6 +19,7 @@ Describe $CommandName -Tag UnitTests {
                 "ExcludeRole",
                 "IncludeSystemDbs",
                 "InputObject",
+                "Force",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
@@ -102,6 +103,93 @@ Describe $CommandName -Tag IntegrationTests {
 
             $result0.Count | Should -BeGreaterThan $result1.Count
             $result1.Name -contains $role1 | Should -Be $false
+        }
+    }
+
+    Context "Schema ownership handling" {
+        BeforeEach {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Create a unique role and schema for each test
+            $testRole = "dbatoolssci_role_$(Get-Random)"
+            $diffSchema = "dbatoolssci_diffsch_$(Get-Random)"
+        }
+
+        AfterEach {
+            # Cleanup - remove any leftover objects
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Drop any test tables first
+            $null = $server.Query("IF EXISTS (SELECT * FROM sys.tables WHERE name = 'TestTable' AND schema_id = SCHEMA_ID('$diffSchema')) DROP TABLE [$diffSchema].[TestTable]", $dbname1)
+
+            # Drop schemas if they exist
+            $null = $server.Query("IF EXISTS (SELECT * FROM sys.schemas WHERE name = '$testRole') DROP SCHEMA [$testRole]", $dbname1)
+            $null = $server.Query("IF EXISTS (SELECT * FROM sys.schemas WHERE name = '$diffSchema') DROP SCHEMA [$diffSchema]", $dbname1)
+
+            # Drop role if it exists
+            $null = $server.Query("IF EXISTS (SELECT * FROM sys.database_principals WHERE name = '$testRole' AND type = 'R') DROP ROLE [$testRole]", $dbname1)
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Removes role with empty schema of same name" {
+            # Create role and schema with same name
+            $null = $server.Query("CREATE ROLE [$testRole]", $dbname1)
+            $null = $server.Query("CREATE SCHEMA [$testRole] AUTHORIZATION [$testRole]", $dbname1)
+
+            # Remove the role (schema should be dropped automatically)
+            Remove-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole -Confirm:$false
+
+            # Verify role is removed
+            $result = Get-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole
+            $result | Should -BeNullOrEmpty
+
+            # Verify schema is also removed
+            $splatQuery = @{
+                SqlInstance = $TestConfig.instance2
+                Database    = $dbname1
+                Query       = "SELECT name FROM sys.schemas WHERE name = '$testRole'"
+            }
+            $schemaExists = Invoke-DbaQuery @splatQuery
+            $schemaExists | Should -BeNullOrEmpty
+        }
+
+        It "Does not remove role with schema containing objects without -Force" {
+            # Create role and different schema with objects
+            $null = $server.Query("CREATE ROLE [$testRole]", $dbname1)
+            $null = $server.Query("CREATE SCHEMA [$diffSchema] AUTHORIZATION [$testRole]", $dbname1)
+            $null = $server.Query("CREATE TABLE [$diffSchema].[TestTable] (ID INT)", $dbname1)
+
+            # Try to remove the role without Force (should fail with warning)
+            $result = Remove-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole -Confirm:$false -WarningVariable warn -WarningAction SilentlyContinue
+
+            # Verify role still exists
+            $roleCheck = Get-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole
+            $roleCheck | Should -Not -BeNullOrEmpty
+            $roleCheck.Name | Should -Be $testRole
+        }
+
+        It "Removes role and reassigns schema ownership with -Force" {
+            # Create role and different schema with objects
+            $null = $server.Query("CREATE ROLE [$testRole]", $dbname1)
+            $null = $server.Query("CREATE SCHEMA [$diffSchema] AUTHORIZATION [$testRole]", $dbname1)
+            $null = $server.Query("CREATE TABLE [$diffSchema].[TestTable] (ID INT)", $dbname1)
+
+            # Remove the role with Force (should reassign schema to dbo and remove role)
+            Remove-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole -Force -Confirm:$false
+
+            # Verify role is removed
+            $roleCheck = Get-DbaDbRole -SqlInstance $TestConfig.instance2 -Database $dbname1 -Role $testRole
+            $roleCheck | Should -BeNullOrEmpty
+
+            # Verify schema ownership changed to dbo
+            $splatQuery = @{
+                SqlInstance = $TestConfig.instance2
+                Database    = $dbname1
+                Query       = "SELECT SCHEMA_NAME(schema_id) AS SchemaName, USER_NAME(principal_id) AS Owner FROM sys.schemas WHERE name = '$diffSchema'"
+            }
+            $schemaOwner = Invoke-DbaQuery @splatQuery
+            $schemaOwner.Owner | Should -Be "dbo"
         }
     }
 }


### PR DESCRIPTION
This enhancement allows Remove-DbaDbRole to handle schema ownership similar to Remove-DbaDbUser:

- Drops empty schemas with same name as role
- Reassigns schema ownership to dbo for other schemas (requires -Force if schemas contain objects)
- Provides clear warning messages when schemas prevent role removal

Fixes #9457

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/dataplat/dbatools/actions/runs/19770875045) | [Branch](https://github.com/dataplat/dbatools/tree/claude/issue-9457-20251128-1755