### PR TITLE
Restore-DbaDatabase - Add WITH RESTART option

### DIFF
--- a/public/Invoke-DbaAdvancedRestore.ps1
+++ b/public/Invoke-DbaAdvancedRestore.ps1
@@ -130,6 +130,11 @@ function Invoke-DbaAdvancedRestore {
         Use this to ensure backup files contain checksums and validate them during restore, following backup best practices.
         Without this parameter, SQL Server verifies checksums if present but doesn't fail if checksums are missing. With this parameter, the operation fails if checksums are not present in the backup.
 
+    .PARAMETER Restart
+        Instructs the restore operation to restart an interrupted restore sequence.
+        Use this when a previous restore operation was interrupted due to a reboot, service failure, or other system event.
+        Allows resuming large transaction log restores that were partially completed before interruption.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -186,6 +191,7 @@ function Invoke-DbaAdvancedRestore {
         [string]$StopMark,
         [datetime]$StopAfterDate,
         [switch]$Checksum,
+        [switch]$Restart,
         [switch]$EnableException
     )
     begin {
@@ -305,6 +311,9 @@ function Invoke-DbaAdvancedRestore {
                 }
                 if ($Checksum) {
                     $restore.Checksum = $Checksum
+                }
+                if ($Restart) {
+                    $restore.Restart = $Restart
                 }
                 if ($KeepReplication) {
                     $restore.KeepReplication = $KeepReplication

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -242,6 +242,11 @@ function Restore-DbaDatabase {
         Use this to ensure backup files contain checksums and validate them during restore, following backup best practices.
         Without this parameter, SQL Server verifies checksums if present but doesn't fail if checksums are missing. With this parameter, the operation fails if checksums are not present in the backup.
 
+    .PARAMETER Restart
+        Instructs the restore operation to restart an interrupted restore sequence.
+        Use this when a previous restore operation was interrupted due to a reboot, service failure, or other system event.
+        Allows resuming large transaction log restores that were partially completed before interruption.
+
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -450,7 +455,8 @@ function Restore-DbaDatabase {
         [string]$StopMark,
         [datetime]$StopAfterDate = (Get-Date '01/01/1971'),
         [int]$StatementTimeout = 0,
-        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][switch]$Checksum
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][switch]$Checksum,
+        [parameter(ParameterSetName = "Restore")][parameter(ParameterSetName = "RestorePage")][switch]$Restart
     )
     begin {
         Write-Message -Level InternalComment -Message "Starting"
@@ -843,6 +849,7 @@ function Restore-DbaDatabase {
                     StopBefore       = $StopBefore
                     ExecuteAs        = $ExecuteAs
                     Checksum         = $Checksum
+                    Restart          = $Restart
                     EnableException  = $true
                 }
                 $FilteredBackupHistory | Where-Object { $_.IsVerified -eq $true } | Invoke-DbaAdvancedRestore @parms

--- a/tests/Invoke-DbaAdvancedRestore.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedRestore.Tests.ps1
@@ -33,6 +33,7 @@ Describe $CommandName -Tag UnitTests {
                 "StopMark",
                 "StopAfterDate",
                 "Checksum",
+                "Restart",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -62,6 +62,7 @@ Describe $CommandName -Tag UnitTests {
                 "StopAfterDate",
                 "ExecuteAs",
                 "Checksum",
+                "Restart",
                 "NoXpDirRecurse"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty


### PR DESCRIPTION
Implements `-Restart` switch parameter for Restore-DbaDatabase and Invoke-DbaAdvancedRestore to support restarting interrupted restore operations. This allows resuming large transaction log restores that were interrupted due to system failures or reboots.

Fixes #9296

Generated with [Claude Code](https://claude.ai/code)