### PR TITLE
Copy-DbaAgentJob and Copy-DbaAgentServer - Fix alert-to-job link loss with -Force

### DIFF
--- a/public/Copy-DbaAgentServer.ps1
+++ b/public/Copy-DbaAgentServer.ps1
@@ -133,9 +133,6 @@ function Copy-DbaAgentServer {
             # extra reconnect to force refresh
             $destServer = Connect-DbaInstance -SqlInstance $destinstance -SqlCredential $DestinationSqlCredential
 
-            Copy-DbaAgentAlert -Source $sourceServer -Destination $destinstance -DestinationSqlCredentia $DestinationSqlCredential -Force:$force -IncludeDefaults
-            $destServer.JobServer.Alerts.Refresh()
-
             Copy-DbaAgentProxy -Source $sourceServer -Destination $destinstance -DestinationSqlCredentia $DestinationSqlCredential -Force:$force
             $destServer.JobServer.ProxyAccounts.Refresh()
 
@@ -144,7 +141,11 @@ function Copy-DbaAgentServer {
 
             $destServer.JobServer.Refresh()
             $destServer.Refresh()
+            # Copy jobs BEFORE alerts to ensure jobs exist when alerts with job associations are created
             Copy-DbaAgentJob -Source $sourceServer -Destination $destinstance -DestinationSqlCredentia $DestinationSqlCredential -Force:$force -DisableOnDestination:$DisableJobsOnDestination -DisableOnSource:$DisableJobsOnSource
+
+            Copy-DbaAgentAlert -Source $sourceServer -Destination $destinstance -DestinationSqlCredentia $DestinationSqlCredential -Force:$force -IncludeDefaults
+            $destServer.JobServer.Alerts.Refresh()
 
             # To do
             <#


### PR DESCRIPTION
Fixes issue #9316

When using `-Force` to drop and recreate jobs, alerts that referenced those jobs would lose their job associations. This occurred because SQL Server automatically removes job associations from alerts when the referenced job is dropped.

## Changes

- **Copy-DbaAgentJob**: Before dropping a job, query which alerts reference it and restore those links after the job is recreated using `sp_update_alert`
- **Copy-DbaAgentServer**: Changed order to copy jobs BEFORE alerts, ensuring jobs exist when alerts with job associations are created
- **Tests**: Added regression test for issue #9316 to verify alert links are preserved

## Testing

Added integration test that:
1. Creates a job on both source and destination
2. Creates an alert on destination that references the job
3. Copies the job with `-Force` (drops and recreates)
4. Verifies the alert-to-job link is still intact

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/dataplat/dbatools/tree/claude/issue-9316-20251128-1643) | [View job run](https://github.com/dataplat/dbatools/actions/runs/19769559523