### PR TITLE
Fix credential passing in replication commands

### DIFF
--- a/private/functions/Connect-ReplicationDB.ps1
+++ b/private/functions/Connect-ReplicationDB.ps1
@@ -11,7 +11,7 @@ function Connect-ReplicationDB {
     $repDB = New-Object Microsoft.SqlServer.Replication.ReplicationDatabase
 
     $repDB.Name = $Database.Name
-    $repDB.ConnectionContext = $Server.ConnectionContext.SqlConnectionObject
+    $repDB.ConnectionContext = $Server.ConnectionContext
 
     if (-not $repDB.LoadProperties()) {
         Write-Message -Level Verbose -Message "Skipping $($Database.Name). Failed to load properties correctly."

--- a/public/Get-DbaReplServer.ps1
+++ b/public/Get-DbaReplServer.ps1
@@ -62,7 +62,7 @@ function Get-DbaReplServer {
             try {
                 $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
                 $replServer = New-Object Microsoft.SqlServer.Replication.ReplicationServer
-                $replServer.ConnectionContext = $Server.ConnectionContext.SqlConnectionObject
+                $replServer.ConnectionContext = $Server.ConnectionContext
                 $replServer | Add-Member -Type NoteProperty -Name ComputerName -Value $server.ComputerName -Force
                 $replServer | Add-Member -Type NoteProperty -Name InstanceName -Value $server.ServiceName -Force
                 $replServer | Add-Member -Type NoteProperty -Name SqlInstance -Value $server.DomainInstanceName -Force


### PR DESCRIPTION
## Summary

Fixes #9593 - Get-DbaReplArticle and other replication commands were not properly using the `-SqlCredential` parameter.

## Root Cause

When using alternative Windows credentials, the authentication information (ConnectAsUser, ConnectAsUserName, ConnectAsUserPassword) is stored on the ServerConnection object, not on the underlying SqlConnection.

Connect-ReplicationDB and Get-DbaReplServer were extracting just the SqlConnectionObject, which lost the credential information and caused commands to fall back to the current user's credentials.

## Changes

- `private/functions/Connect-ReplicationDB.ps1`: Changed to pass full ConnectionContext instead of SqlConnectionObject
- `public/Get-DbaReplServer.ps1`: Changed to pass full ConnectionContext instead of SqlConnectionObject

## Testing

- Affects Get-DbaReplArticle, Get-DbaReplPublication, Get-DbaReplServer, and Get-DbaReplSubscription
- Credential should now be properly passed to replication objects

🤖 Generated with [Claude Code](https://claude.ai/code)