### PR TITLE
Copy-DbaLogin, Remove-DbaLogin - Add warnings for non-existent logins

### DIFF
--- a/public/Copy-DbaLogin.ps1
+++ b/public/Copy-DbaLogin.ps1
@@ -495,6 +495,16 @@ function Copy-DbaLogin {
             $loginsCollection += Get-DbaLogin -SqlInstance $Source -SqlCredential $SourceSqlCredential -Login $Login -EnableException:$EnableException
         }
 
+        # Warn if specific logins were requested but not found
+        if ($Login -and -not $InputObject) {
+            $foundLogins = $loginsCollection.Name
+            foreach ($requestedLogin in $Login) {
+                if ($requestedLogin -notin $foundLogins) {
+                    Write-Message -Level Warning -Message "Login '$requestedLogin' not found on source instance $Source"
+                }
+            }
+        }
+
         if ($OutFile) {
             return (Export-DbaLogin -SqlInstance $Source -SqlCredential $SourceSqlCredential -FilePath $OutFile -Login $loginsCollection -ObjectLevel:$ObjectLevel -ExcludeLogin $ExcludeLogin -EnableException:$EnableException)
         }

--- a/public/Remove-DbaLogin.ps1
+++ b/public/Remove-DbaLogin.ps1
@@ -90,7 +90,18 @@ function Remove-DbaLogin {
             } catch {
                 Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
             }
-            $InputObject += $server.Logins | Where-Object { $_.Name -in $Login }
+
+            $foundLogins = $server.Logins | Where-Object { $_.Name -in $Login }
+            $foundLoginNames = $foundLogins.Name
+
+            # Warn if specific logins were requested but not found
+            foreach ($requestedLogin in $Login) {
+                if ($requestedLogin -notin $foundLoginNames) {
+                    Write-Message -Level Warning -Message "Login '$requestedLogin' not found on instance $instance"
+                }
+            }
+
+            $InputObject += $foundLogins
         }
 
         foreach ($currentlogin in $InputObject) {


### PR DESCRIPTION
## Summary

When using `-Login` parameter with non-existent login names, these commands now emit warnings instead of silently succeeding with no output.

## Changes

- **Copy-DbaLogin**: Warns when specified logins not found on source instance
- **Remove-DbaLogin**: Warns when specified logins not found on target instance
- Added regression tests for issue #9163 with proper warning validation

## Example

**Before (silent failure):**
```powershell
PS> Copy-DbaLogin -Source serverX -Destination serverY -Login failme
PS>  # No output, no warning, no indication of problem
```

**After (helpful warning):**
```powershell
PS> Copy-DbaLogin -Source serverX -Destination serverY -Login failme
WARNING: Login 'failme' not found on source instance serverX
PS>
```

Fixes #9163

Generated with [Claude Code](https://claude.ai/code)