### PR TITLE
New-DbaFirewallRule - Add RuleType parameter

### DIFF
--- a/tests/New-DbaFirewallRule.Tests.ps1
+++ b/tests/New-DbaFirewallRule.Tests.ps1
@@ -14,6 +14,7 @@ Describe $CommandName -Tag UnitTests {
                 "SqlInstance",
                 "Credential",
                 "Type",
+                "RuleType",
                 "Configuration",
                 "Force",
                 "EnableException"
@@ -24,78 +25,139 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    BeforeAll {
-        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+    Context "RuleType Program (default - executable-based rules)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
 
-        # Create firewall rules and get results for testing
-        $resultsNew = New-DbaFirewallRule -SqlInstance $TestConfig.instance2
-        $resultsGet = Get-DbaFirewallRule -SqlInstance $TestConfig.instance2
-        $resultsRemoveBrowser = $resultsGet | Where-Object Type -eq "Browser" | Remove-DbaFirewallRule
-        $resultsRemove = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2 -Type AllInstance
+            # Create firewall rules with default RuleType (Program)
+            $resultsNew = New-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $resultsGet = Get-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $resultsRemoveBrowser = $resultsGet | Where-Object Type -eq "Browser" | Remove-DbaFirewallRule
+            $resultsRemove = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2 -Type AllInstance
 
-        $instanceName = ([DbaInstanceParameter]$TestConfig.instance2).InstanceName
+            $instanceName = ([DbaInstanceParameter]$TestConfig.instance2).InstanceName
 
-        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "creates at least two firewall rules" {
+            $resultsNew.Count | Should -BeGreaterOrEqual 2
+        }
+
+        It "creates first firewall rule for SQL Server instance" {
+            $resultsNew[0].Successful | Should -Be $true
+            $resultsNew[0].Type | Should -Be "Engine"
+            $resultsNew[0].DisplayName | Should -Be "SQL Server instance $instanceName"
+            $resultsNew[0].Status | Should -Be "The rule was successfully created."
+        }
+
+        It "creates second firewall rule for SQL Server Browser" {
+            $resultsNew[1].Successful | Should -Be $true
+            $resultsNew[1].Type | Should -Be "Browser"
+            $resultsNew[1].DisplayName | Should -Be "SQL Server Browser"
+            $resultsNew[1].Status | Should -Be "The rule was successfully created."
+        }
+
+        It "returns at least two firewall rules" {
+            $resultsGet.Count | Should -BeGreaterOrEqual 2
+        }
+
+        It "returns firewall rule for SQL Server instance with Program" {
+            $resultInstance = $resultsGet | Where-Object Type -eq "Engine"
+            $resultInstance.Protocol | Should -Be "TCP"
+            $resultInstance.Program | Should -BeLike "*sqlservr.exe"
+        }
+
+        It "returns firewall rule for SQL Server Browser with Program" {
+            $resultBrowser = $resultsGet | Where-Object Type -eq "Browser"
+            # Browser in Program mode should have Protocol = Any and Program path
+            if ($resultBrowser.Program) {
+                $resultBrowser.Program | Should -BeLike "*sqlbrowser.exe"
+                $resultBrowser.Protocol | Should -Be "Any"
+            } else {
+                # Fallback to port-based if Program couldn't be determined
+                $resultBrowser.Protocol | Should -Be "UDP"
+                $resultBrowser.LocalPort | Should -Be "1434"
+            }
+        }
+
+        It "removes firewall rule for Browser" {
+            $resultsRemoveBrowser.Type | Should -Be "Browser"
+            $resultsRemoveBrowser.IsRemoved | Should -Be $true
+            $resultsRemoveBrowser.Status | Should -Be "The rule was successfully removed."
+        }
+
+        It "removes other firewall rules" {
+            $resultsRemove.Type | Should -Contain "Engine"
+            $resultsRemove.IsRemoved | Should -Contain $true
+            $resultsRemove.Status | Should -Contain "The rule was successfully removed."
+        }
     }
 
-    AfterAll {
-        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+    Context "RuleType Port (traditional port-based rules)" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
 
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
+            # Create firewall rules with RuleType Port
+            $resultsNewPort = New-DbaFirewallRule -SqlInstance $TestConfig.instance2 -RuleType Port
+            $resultsGetPort = Get-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $resultsRemovePort = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2 -Type AllInstance
 
-    # If remote DAC is enabled, also creates rule for DAC.
-    It "creates at least two firewall rules" {
-        $resultsNew.Count | Should -BeGreaterOrEqual 2
-    }
+            $instanceName = ([DbaInstanceParameter]$TestConfig.instance2).InstanceName
 
-    It "creates first firewall rule for SQL Server instance" {
-        $resultsNew[0].Successful | Should -Be $true
-        $resultsNew[0].Type | Should -Be "Engine"
-        $resultsNew[0].DisplayName | Should -Be "SQL Server instance $instanceName"
-        $resultsNew[0].Status | Should -Be "The rule was successfully created."
-    }
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
 
-    It "creates second firewall rule for SQL Server Browser" {
-        $resultsNew[1].Successful | Should -Be $true
-        $resultsNew[1].Type | Should -Be "Browser"
-        $resultsNew[1].DisplayName | Should -Be "SQL Server Browser"
-        $resultsNew[1].Status | Should -Be "The rule was successfully created."
-    }
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+            $null = Remove-DbaFirewallRule -SqlInstance $TestConfig.instance2
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
 
-    # If remote DAC is enabled, also creates rule for DAC.
-    It "returns at least two firewall rules" {
-        $resultsGet.Count | Should -BeGreaterOrEqual 2
-    }
+        It "creates at least two firewall rules" {
+            $resultsNewPort.Count | Should -BeGreaterOrEqual 2
+        }
 
-    It "returns one firewall rule for SQL Server instance" {
-        $resultInstance = $resultsGet | Where-Object Type -eq "Engine"
-        $resultInstance.Protocol | Should -Be "TCP"
-    }
+        It "creates first firewall rule for SQL Server instance" {
+            $resultsNewPort[0].Successful | Should -Be $true
+            $resultsNewPort[0].Type | Should -Be "Engine"
+            $resultsNewPort[0].DisplayName | Should -Be "SQL Server instance $instanceName"
+            $resultsNewPort[0].Status | Should -Be "The rule was successfully created."
+        }
 
-    It "returns one firewall rule for SQL Server Browser" {
-        $resultBrowser = $resultsGet | Where-Object Type -eq "Browser"
-        $resultBrowser.Protocol | Should -Be "UDP"
-        $resultBrowser.LocalPort | Should -Be "1434"
-    }
+        It "creates second firewall rule for SQL Server Browser" {
+            $resultsNewPort[1].Successful | Should -Be $true
+            $resultsNewPort[1].Type | Should -Be "Browser"
+            $resultsNewPort[1].DisplayName | Should -Be "SQL Server Browser"
+            $resultsNewPort[1].Status | Should -Be "The rule was successfully created."
+        }
 
-    It "removes firewall rule for Browser" {
-        $resultsRemoveBrowser.Type | Should -Be "Browser"
-        $resultsRemoveBrowser.IsRemoved | Should -Be $true
-        $resultsRemoveBrowser.Status | Should -Be "The rule was successfully removed."
-    }
+        It "returns firewall rule for SQL Server instance with LocalPort" {
+            $resultInstance = $resultsGetPort | Where-Object Type -eq "Engine"
+            $resultInstance.Protocol | Should -Be "TCP"
+            $resultInstance.LocalPort | Should -Not -BeNullOrEmpty
+        }
 
-    # If remote DAC is enabled, removed Engine and DAC. Use foreach when moved to pester5.
-    It "removes other firewall rules" {
-        $resultsRemove.Type | Should -Contain "Engine"
-        $resultsRemove.IsRemoved | Should -Contain $true
-        $resultsRemove.Status | Should -Contain "The rule was successfully removed."
+        It "returns firewall rule for SQL Server Browser with port 1434" {
+            $resultBrowser = $resultsGetPort | Where-Object Type -eq "Browser"
+            $resultBrowser.Protocol | Should -Be "UDP"
+            $resultBrowser.LocalPort | Should -Be "1434"
+        }
+
+        It "removes firewall rules" {
+            $resultsRemovePort.Type | Should -Contain "Engine"
+            $resultsRemovePort.IsRemoved | Should -Contain $true
+            $resultsRemovePort.Status | Should -Contain "The rule was successfully removed."
+        }
     }
 }


### PR DESCRIPTION
This pull request adds a new `-RuleType` parameter to the `New-DbaFirewallRule` function, allowing users to choose between program-based (executable) and traditional port-based firewall rules for SQL Server and SQL Server Browser. The default is now program-based, which improves flexibility when port configurations change. The implementation and documentation have been updated accordingly, and new integration tests verify both modes.

### Feature Addition: RuleType Parameter
* Added `-RuleType` parameter to `New-DbaFirewallRule`, allowing selection between `Program` (default, executable-based) and `Port` (traditional port-based) firewall rules. This enables easier management when SQL Server instances change ports. [[1]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R97-R103) [[2]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R177-R178) [[3]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R289-R328) [[4]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45L290-R374)

### Documentation and Help Updates
* Updated function help and parameter descriptions to explain the new `-RuleType` parameter, including details on rule behavior for both modes and example usage. [[1]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45L10-R12) [[2]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45L23-R53) [[3]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R97-R103) [[4]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R140-R146)

### Implementation Changes
* Refactored rule creation logic to support both program-based and port-based rules, including fallback mechanisms if executable paths cannot be determined. [[1]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45R289-R328) [[2]](diffhunk://#diff-a40c4dfa1c547c3ab2f8c912f7d90b854165e408baa88f4d23e7bf30270e8c45L290-R374)

### Testing Improvements
* Added and expanded integration tests in `New-DbaFirewallRule.Tests.ps1` to verify both `Program` and `Port` modes, including assertions for rule properties and removal. [[1]](diffhunk://#diff-45993927dd434d8bb1f5a8166eaf20f0cac597bdb5eb1c22737bbc4c432ab7a7R28-L54) [[2]](diffhunk://#diff-45993927dd434d8bb1f5a8166eaf20f0cac597bdb5eb1c22737bbc4c432ab7a7L73-R163)
* Updated unit tests to include the new `RuleType` parameter.