### PR TITLE
Get-DbaDbUdf, Remove-DbaDbUdf - Fix UserDefinedAggregate IsSystemObject error

### DIFF
--- a/public/Remove-DbaDbUdf.ps1
+++ b/public/Remove-DbaDbUdf.ps1
@@ -1,10 +1,10 @@
 function Remove-DbaDbUdf {
     <#
     .SYNOPSIS
-        Removes user-defined functions from SQL Server databases.
+        Removes user-defined functions and user-defined aggregates from SQL Server databases.
 
     .DESCRIPTION
-        Removes user-defined functions from specified databases, providing a clean way to drop obsolete or unwanted UDFs without manual T-SQL scripting. This function is particularly useful during database cleanup operations, code refactoring projects, or when removing deprecated functions that are no longer needed. Supports filtering by schema and function name, and can exclude system UDFs to prevent accidental removal of built-in functions. Works seamlessly with Get-DbaDbUdf for pipeline operations.
+        Removes user-defined functions and user-defined aggregates from specified databases, providing a clean way to drop obsolete or unwanted UDFs and UDAs without manual T-SQL scripting. This function is particularly useful during database cleanup operations, code refactoring projects, or when removing deprecated functions that are no longer needed. Supports filtering by schema and function name, and can exclude system UDFs to prevent accidental removal of built-in functions. Works seamlessly with Get-DbaDbUdf for pipeline operations.
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -45,8 +45,8 @@ function Remove-DbaDbUdf {
         Use this to protect specific functions from deletion while removing others that match your criteria.
 
     .PARAMETER InputObject
-        Accepts UDF objects directly from Get-DbaDbUdf pipeline operations.
-        Use this when you need to filter or examine UDFs first before removal, enabling complex selection logic not possible with simple name matching.
+        Accepts UDF and UDA objects directly from Get-DbaDbUdf pipeline operations.
+        Use this when you need to filter or examine UDFs or UDAs first before removal, enabling complex selection logic not possible with simple name matching.
 
     .PARAMETER WhatIf
         Shows what would happen if the command were to run. No actions are actually performed.
@@ -103,7 +103,7 @@ function Remove-DbaDbUdf {
         [Parameter(ParameterSetName = 'NonPipeline')]
         [string[]]$ExcludeName,
         [parameter(ValueFromPipeline, ParameterSetName = 'Pipeline', Mandatory = $true)]
-        [Microsoft.SqlServer.Management.Smo.UserDefinedFunction[]]$InputObject,
+        [object[]]$InputObject,
         [Parameter(ParameterSetName = 'NonPipeline')][Parameter(ParameterSetName = 'Pipeline')]
         [switch]$EnableException
     )


### PR DESCRIPTION
## Summary

Fixed test failures by properly handling UserDefinedFunctions and UserDefinedAggregates separately, since UserDefinedAggregate objects don't have the IsSystemObject property.

## Changes

- ✅ Initialize UserDefinedFunctions and UserDefinedAggregates separately with appropriate properties
- ✅ Filter UserDefinedFunctions by IsSystemObject only when supported
- ✅ Combine both collections after filtering
- ✅ Update Remove-DbaDbUdf InputObject type to accept both object types
- ✅ Update help documentation for both commands

## Tests Fixed

- Get-DbaDbUdf integration tests (6 failures)
- Remove-DbaDbUdf integration tests (2 failures)
- Set-DbaResourceGovernor test (1 failure)

Fixes #9092

🤖 Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/dataplat/dbatools/actions/runs/19787826121) • [`claude/issue-9092-20251129-1842`](https://github.com/dataplat/dbatools/tree/claude/issue-9092-20251129-1842