### PR TITLE
Sync-DbaAvailabilityGroup - Exclude MSX jobs from syncing

### DIFF
--- a/tests/Get-DbaAgentJob.Tests.ps1
+++ b/tests/Get-DbaAgentJob.Tests.ps1
@@ -18,7 +18,6 @@ Describe $CommandName -Tag UnitTests {
                 "Database",
                 "Category",
                 "ExcludeDisabledJobs",
-                "IncludeMsxJobs",
                 "EnableException",
                 "ExcludeCategory",
                 "IncludeExecution",


### PR DESCRIPTION
Resolves #9273

Added `-ExcludeMsxJobs` parameter to `Get-DbaAgentJob` to filter out MSX (Master Server) jobs (CategoryID = 1). Modified `Sync-DbaAvailabilityGroup` to automatically exclude MSX jobs when syncing agent jobs to prevent errors on secondary replicas.

### Changes
- Added `-ExcludeMsxJobs` switch to `Get-DbaAgentJob`
- Updated `Sync-DbaAvailabilityGroup` to use the new parameter when syncing jobs
- Updated parameter validation test

Generated with [Claude Code](https://claude.ai/code)