### PR TITLE
Copy-DbaAgentOperator, Copy-DbaAgentJob - Fix operator migration SMO cache issue

### DIFF
--- a/public/Copy-DbaAgentJob.ps1
+++ b/public/Copy-DbaAgentJob.ps1
@@ -247,8 +247,8 @@ function Copy-DbaAgentJob {
                 $missingOperators = $operators | Where-Object { $destServer.JobServer.Operators.Name -notcontains $_ }
 
                 if ($missingOperators.Count -gt 0 -and $operators.Count -gt 0) {
+                    $missingOperator = ($missingOperators | Sort-Object | Get-Unique) -join ", "
                     if ($Pscmdlet.ShouldProcess($destinstance, "Operator(s) $($missingOperator) doesn't exist on destination. Skipping job [$jobName]")) {
-                        $missingOperator = ($operators | Sort-Object | Get-Unique) -join ", "
                         $copyJobStatus.Status = "Skipped"
                         $copyJobStatus.Notes = "Job is dependent on operator $missingOperator"
                         $copyJobStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject

--- a/public/Copy-DbaAgentOperator.ps1
+++ b/public/Copy-DbaAgentOperator.ps1
@@ -168,6 +168,7 @@ function Copy-DbaAgentOperator {
                         $sql = $sOperator.Script() | Out-String
                         Write-Message -Level Debug -Message $sql
                         $destServer.Query($sql)
+                        $destServer.JobServer.Operators.Refresh()
 
                         $copyOperatorStatus.Status = "Successful"
                         $copyOperatorStatus | Select-DefaultView -Property DateTime, SourceServer, DestinationServer, Name, Type, Status, Notes -TypeName MigrationObject


### PR DESCRIPTION
## Summary

Fixed issue #9275 where Copy-DbaAgentJob would skip jobs with operators even though the operators were successfully created by Copy-DbaAgentOperator.

## Changes

1. **Copy-DbaAgentOperator.ps1** - Added `$destServer.JobServer.Operators.Refresh()` after creating operators to refresh the SMO cache
2. **Copy-DbaAgentJob.ps1** - Fixed variable logic errors:
   - Moved `$missingOperator` definition before ShouldProcess call
   - Changed from `$operators` to `$missingOperators` when joining missing operator names

## Root Cause

After Copy-DbaAgentOperator created operators via T-SQL, the SMO Operators collection wasn't refreshed. Copy-DbaAgentJob then checked a stale cached collection that didn't include the newly created operators, causing jobs to be incorrectly skipped.

Fixes #9275

---

Generated with [Claude Code](https://claude.ai/code)