### PR TITLE
Get-RestoreContinuableDatabase - Fix duplicate rows for databases with Memory Optimized filegroups

### DIFF
--- a/private/functions/Get-RestoreContinuableDatabase.ps1
+++ b/private/functions/Get-RestoreContinuableDatabase.ps1
@@ -23,7 +23,7 @@ function Get-RestoreContinuableDatabase {
         return
     }
     if ($server.VersionMajor -ge 9) {
-        $sql = "SELECT DISTINCT DB_NAME(database_id) AS 'Database', differential_base_lsn, redo_start_lsn, redo_start_fork_guid AS 'FirstRecoveryForkID' FROM sys.master_files WHERE redo_start_lsn IS NOT NULL"
+        $sql = "SELECT DB_NAME(database_id) AS 'Database', MIN(differential_base_lsn) AS differential_base_lsn, MIN(redo_start_lsn) AS redo_start_lsn, redo_start_fork_guid AS 'FirstRecoveryForkID' FROM sys.master_files WHERE redo_start_lsn IS NOT NULL GROUP BY database_id, redo_start_fork_guid"
     } else {
         $sql = "
               CREATE TABLE #db_info


### PR DESCRIPTION
Fixes #9385

This PR fixes an issue where `Restore-DbaDatabase` with `-Continue` fails when databases have Memory Optimized File Groups with different LSN values.

### The Problem
The `Get-RestoreContinuableDatabase` function used `DISTINCT` in its SQL query, which returned multiple rows for the same database when Memory Optimized filegroups had different `differential_base_lsn` values. This caused restore continuation to fail with "Failed to find LSN or RecoveryForkID" errors.

### The Solution
Changed the query to use `MIN()` aggregation with `GROUP BY` instead of `DISTINCT`, ensuring exactly one row per database with the minimum LSN values.

### Changes
- Modified `private/functions/Get-RestoreContinuableDatabase.ps1`
- Used the approach suggested by @OD-DanielWDrake in the original issue

Generated with [Claude Code](https://claude.ai/code)