### PR TITLE
DbaAvailabilityGroup - Add ClusterConnectionOption parameter with TLS 1.3 encryption support

### DIFF
--- a/tests/New-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/New-DbaAvailabilityGroup.Tests.ps1
@@ -44,6 +44,7 @@ Describe $CommandName -Tag UnitTests {
                 "SubnetMask",
                 "Port",
                 "Dhcp",
+                "ClusterConnectionOption",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty

--- a/tests/Set-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Set-DbaAvailabilityGroup.Tests.ps1
@@ -23,6 +23,7 @@ Describe $CommandName -Tag UnitTests {
                 "BasicAvailabilityGroup",
                 "DatabaseHealthTrigger",
                 "IsDistributedAvailabilityGroup",
+                "ClusterConnectionOption",
                 "InputObject",
                 "EnableException"
             )


### PR DESCRIPTION
Adds ClusterConnectionOption parameter to New-DbaAvailabilityGroup and Set-DbaAvailabilityGroup for configuring cluster-to-instance ODBC connections with TLS 1.3 encryption support.

(do *AvailabilityGroup*)

Requested by: https://github.com/microsoft/SQLServerPSModule/issues/116