### PR TITLE
Set-FileSystemSetting: Force array to always get count

### DIFF
--- a/private/functions/Set-FileSystemSetting.ps1
+++ b/private/functions/Set-FileSystemSetting.ps1
@@ -60,7 +60,7 @@ function Set-FileSystemSetting {
 
                 Write-Message -Level Verbose -Message "Attempting to connect to $computerName's CIM"
                 $namespaces = Get-DbaCmObject -ComputerName $computerName -Credential $Credential -Namespace root\Microsoft\SQLServer -Query "SELECT NAME FROM __NAMESPACE WHERE NAME LIKE 'ComputerManagement%'" -EnableException
-                $fileStreamNamespace = $namespaces | Where-Object { (Get-DbaCmObject -ComputerName $computerName -Credential $Credential -Namespace "root\Microsoft\SQLServer\$($PSItem.Name)" -ClassName FilestreamSettings -EnableException).Count -gt 0 } | Sort-Object Name -Descending | Select-Object -First 1
+                $fileStreamNamespace = $namespaces | Where-Object { (@(Get-DbaCmObject -ComputerName $computerName -Credential $Credential -Namespace "root\Microsoft\SQLServer\$($PSItem.Name)" -ClassName FilestreamSettings -EnableException)).Count -gt 0 } | Sort-Object Name -Descending | Select-Object -First 1
                 if ($fileStreamNamespace) {
                     $fileStreamCim = Get-DbaCmObject -ComputerName $computerName -Credential $Credential -Namespace root\Microsoft\SQLServer\$($fileStreamNamespace.Name) -ClassName FilestreamSettings | Where-Object { $PSItem.InstanceName -eq $instanceName }
                     if ($fileStreamCim) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

When using ".count" we need to fore an array if we only have one element.
