### PR TITLE
Backup-DbaDatabase - Skip backup for inaccessible databases

### DIFF
--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -534,6 +534,11 @@ function Backup-DbaDatabase {
                 Stop-Function -Message "Backing up tempdb not supported" -Continue
             }
 
+            if (-not $db.IsAccessible) {
+                Write-Progress -Id $topProgressId -Activity 'Backup' -Completed
+                Stop-Function -Message "Database $dbName is not accessible. Cannot perform backup." -Continue -Target $db
+            }
+
             if ('Normal' -notin ($db.Status -split ',')) {
                 Write-Progress -Id $topProgressId -Activity 'Backup' -Completed
                 Stop-Function -Message "Database status not Normal. $dbName skipped." -Continue


### PR DESCRIPTION
Added a check to prevent backup attempts on databases that are not accessible. The function now stops and reports if a database cannot be accessed before proceeding with the backup.

fixes #10064