### PR TITLE
Get-DbaAgListener: Pass EnableException to used command

### DIFF
--- a/public/Get-DbaAgListener.ps1
+++ b/public/Get-DbaAgListener.ps1
@@ -76,7 +76,7 @@ function Get-DbaAgListener {
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup
+            $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -SqlCredential $SqlCredential -AvailabilityGroup $AvailabilityGroup -EnableException:$EnableException
         }
 
         $agListeners = $InputObject.AvailabilityGroupListeners


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Instead of a try-catch-block we should just pass EnableException to the command. But this is important as we use Get-DbaAgListener inside of other commands as the new Test-DbaKerberos.