### PR TITLE
Test-DbaAgSpn: Pass EnableException to used command

### DIFF
--- a/public/Test-DbaAgSpn.ps1
+++ b/public/Test-DbaAgSpn.ps1
@@ -90,16 +90,15 @@ function Test-DbaAgSpn {
         }
 
         if ($SqlInstance) {
-            $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -AvailabilityGroup $AvailabilityGroup -SqlCredential $SqlCredential
+            $InputObject += Get-DbaAvailabilityGroup -SqlInstance $SqlInstance -AvailabilityGroup $AvailabilityGroup -SqlCredential $SqlCredential -EnableException:$EnableException
         }
 
         foreach ($ag in $InputObject) {
             Write-Message -Level Verbose -Message "Processing $($ag.Name) on $($ag.Parent.Name)"
-            if (-not $Listener) {
-                $listeners = $ag | Get-DbaAgListener
-            } else {
-                Write-Warning poot
+            if ($Listener) {
                 $listeners = $ag | Get-DbaAgListener -Listener $Listener
+            } else {
+                $listeners = $ag | Get-DbaAgListener
             }
 
             # ([System.Net.Dns]::GetHostEntry($hostEntry)).HostName


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Instead of a try-catch-block we should just pass EnableException to the command. But this is important as we use Get-DbaAgListener inside of other commands as the new Test-DbaKerberos.

Also optimized th if test and removed a false warning message.