### PR TITLE
Get-DbaService: Add property SqlInstance when using parameter AdvancedProperties to support Failover Cluster Instances

### DIFF
--- a/public/Get-DbaService.ps1
+++ b/public/Get-DbaService.ps1
@@ -79,6 +79,7 @@ function Get-DbaService {
         - SkuName: The SQL Server edition/SKU name (e.g., Enterprise, Standard)
         - Clustered: Boolean (as numeric or empty) indicating if the service is part of a cluster
         - VSName: The virtual server name if the service is clustered
+        - SqlInstance: The full SQL instance name (including virtual server name if clustered) for engine services
 
         ScriptMethods (callable on returned objects):
         - Stop([bool]$Force): Stops the service, with optional force parameter


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
I need this later for a refctoring of Test-DbaDiskAllocation.

When working with failover cluster instances, the VSName (virtual server name / network name) is needed to connect to the instance instead of the computername that is output by Get-DbaService as the computername is resolved from the input. So `Get-DbaService -SqlInstance FCI01` will output "SQL01" as the computername if the instance is currently running on that computer.

### Approach
When using the parameter AdvancedProperties, the needed information is retrieved, but not well formatted. I changed the code so that for the engine service the SqlInstance property is calculated like in most of our other commands.

<img width="1242" height="213" alt="image" src="https://github.com/user-attachments/assets/112735b7-0965-4edb-b7ae-32a06e8da31d" />
