### PR TITLE
Update Pester version to 5.7.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,8 @@
    - Install: `Install-Module PSScriptAnalyzer -RequiredVersion 1.18.2`
    - Used by: `Invoke-DbatoolsFormatter` command and CI builds
 
-3. **Pester v5.6.1** - Required for running tests
-   - Install: `Install-Module Pester -RequiredVersion 5.6.1`
+3. **Pester v5.7.1** - Required for running tests
+   - Install: `Install-Module Pester -RequiredVersion 5.7.1`
    - Tests MUST use Pester v5 syntax (no `-ForEach` parameter, strict scoping)
 
 ## PR Summary Guidelines
@@ -151,7 +151,7 @@ When generating PR summaries:
 Install-Module PSScriptAnalyzer -RequiredVersion 1.18.2 -Force
 
 # 3. Install Pester (for testing)
-Install-Module Pester -RequiredVersion 5.6.1 -Force
+Install-Module Pester -RequiredVersion 5.7.1 -Force
 
 # 4. Import the module to verify setup
 Import-Module .\dbatools.psd1

--- a/private/testing/Invoke-ManualPester.ps1
+++ b/private/testing/Invoke-ManualPester.ps1
@@ -201,7 +201,7 @@ function Invoke-ManualPester {
         }
         if ($PesterVersion -gt $MaximumPesterVersion) {
             Write-Warning "Please get Pester to the 5.* release"
-            Write-Warning "     Install-Module -Name Pester  -MaximumVersion '5.6.1' -Force -SkipPublisherCheck"
+            Write-Warning "     Install-Module -Name Pester  -MaximumVersion '5.7.1' -Force -SkipPublisherCheck"
             Write-Warning "     or go to https://github.com/pester/Pester"
         }
 
@@ -296,7 +296,7 @@ function Invoke-ManualPester {
             if ($pesterVersionToUse -eq '5') {
                 Write-DetailedMessage "Running Pester 5 tests $($f.Name)"
                 Remove-Module -Name Pester -ErrorAction SilentlyContinue
-                Import-Module Pester -MinimumVersion 5.6.1 -ErrorAction Stop
+                Import-Module Pester -MinimumVersion 5.7.1 -ErrorAction Stop
                 $pester5Config = New-PesterConfiguration
                 $pester5Config.Run.Path = $f.FullName
                 if ($PassThru) {

--- a/tests/appveyor.pester.ps1
+++ b/tests/appveyor.pester.ps1
@@ -396,7 +396,7 @@ if (-not $Finalize) {
     # Remove any previously loaded pester module
     Remove-Module -Name pester -ErrorAction SilentlyContinue
     # Import pester 5
-    Import-Module pester -RequiredVersion 5.6.1
+    Import-Module pester -RequiredVersion 5.7.1
     Write-Host -Object "appveyor.pester: Running with Pester Version $((Get-Command Invoke-Pester -ErrorAction SilentlyContinue).Version)" -ForegroundColor DarkGreen
 
     # invoking a single invoke-pester consumes too much memory, let's go file by file

--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -51,8 +51,8 @@ if ($installedModule.Version.ToString() -notmatch [regex]::Escape($expectedVersi
 
 ##Get Pester (to run tests)
 Write-Host -Object "appveyor.prep: Install Pester5" -ForegroundColor DarkGreen
-if (-not(Test-Path 'C:\Program Files\WindowsPowerShell\Modules\Pester\5.6.1')) {
-    Install-Module -Name Pester -Force -SkipPublisherCheck -RequiredVersion 5.6.1 | Out-Null
+if (-not(Test-Path 'C:\Program Files\WindowsPowerShell\Modules\Pester\5.7.1')) {
+    Install-Module -Name Pester -Force -SkipPublisherCheck -RequiredVersion 5.7.1 | Out-Null
 }
 
 #Setup DbatoolsConfig Path.DbatoolsExport path


### PR DESCRIPTION
This version is the latest version and about a year old, so probably the last 5.x version and we should use this.
I used this in my lab since we moved to pester 5 without problems.