### PR TITLE
Get-DbaInstalledPatch: Add Hotfixes that are named GDR

### DIFF
--- a/public/Get-DbaInstalledPatch.ps1
+++ b/public/Get-DbaInstalledPatch.ps1
@@ -72,7 +72,7 @@ function Get-DbaInstalledPatch {
         foreach ($computer in $ComputerName.ComputerName) {
             try {
                 $patches = Invoke-Command2 -ComputerName $computer -Credential $Credential -ScriptBlock {
-                    Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall | Get-ItemProperty | Where-Object { $_.DisplayName -like "Hotfix*SQL*" -or $_.DisplayName -like "Service Pack*SQL*" } | Sort-Object InstallDate
+                    Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall | Get-ItemProperty | Where-Object { $_.DisplayName -like "Hotfix*SQL*" -or $_.DisplayName -like "Service Pack*SQL*" -or $_.DisplayName -like "GDR*SQL*" } | Sort-Object InstallDate
                 }
             } catch {
                 Stop-Function -Message "Failed" -Continue -Target $computer -ErrorRecord $_


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

Some security hotfixes are named "GDR*":

<img width="377" height="95" alt="image" src="https://github.com/user-attachments/assets/83d9a97a-095b-4d6f-93a0-57632ad39510" />

<img width="387" height="138" alt="image" src="https://github.com/user-attachments/assets/a40b1d94-6390-4a25-a114-6efe46a7d8f0" />

So I included them in the filter.