### PR TITLE
Update Copy-DbaInstanceAudit.ps1 - bug 10113

### DIFF
--- a/public/Copy-DbaInstanceAudit.ps1
+++ b/public/Copy-DbaInstanceAudit.ps1
@@ -210,7 +210,7 @@ function Copy-DbaInstanceAudit {
                         $root = $currentAudit.Filepath.Substring(0, 3)
                         $rootUnc = Join-AdminUnc $resolvedComputerName $root
 
-                        if ((Test-Path $rootUnc) -eq $true ) {
+                        if ((Test-Path $rootUnc) -eq $true) {
                             if ($Pscmdlet.ShouldProcess($destinstance, "Creating directory $($currentAudit.Filepath)")) {
                                 try {
                                     $null = New-DbaDirectory -SqlInstance $destServer -Path $currentAudit.Filepath -EnableException


### PR DESCRIPTION
Path is only needed to be tested when using audit to file, other types like security log, app log, url, external monitor we don't need to check the path

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #10113)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) -->
Fix substring errors when copying audits which don't go to files

### Approach
<!-- How does this change solve that purpose -->
Checks the destination type and only checks file path on file dest types

### Commands to test
<!-- if these are the examples in the help just note it as such -->

### Screenshots
<!-- pictures say a thousand words without typing any of it -->
Works with -force but throws errors about test-path and substring
<img width="2166" height="1416" alt="image" src="https://github.com/user-attachments/assets/1a9ada6a-45c3-4ba5-8c9b-07244a4dd7eb" />

After modification, checking the test-path for only $surrentAudit.DestinationType -eq "File" works in both Force and Non-Forced modes
<img width="1898" height="1206" alt="image" src="https://github.com/user-attachments/assets/3e1db431-1c11-4888-ab3a-e87af84e15fa" />


### Learning
<!-- Optional -->
<!--
	Include:
	 - blog post that may have assisted in writing the code
	 - blog post that were initial source
	 - special or unique approach made to solve the problem
-->
