### PR TITLE
Install-DbaMaintenanceSolution.Tests: make the additional backup parameters tests run

### DIFF
--- a/tests/Install-DbaMaintenanceSolution.Tests.ps1
+++ b/tests/Install-DbaMaintenanceSolution.Tests.ps1
@@ -127,16 +127,17 @@ Describe $CommandName -Tag IntegrationTests {
 
             # Clean up any leftover Hallengren procedures in tempdb from the first Context
             $cleanupTempdb = "
-                IF OBJECT_ID('tempdb.dbo.CommandExecute', 'P') IS NOT NULL DROP PROCEDURE tempdb.dbo.CommandExecute;
-                IF OBJECT_ID('tempdb.dbo.DatabaseBackup', 'P') IS NOT NULL DROP PROCEDURE tempdb.dbo.DatabaseBackup;
-                IF OBJECT_ID('tempdb.dbo.DatabaseIntegrityCheck', 'P') IS NOT NULL DROP PROCEDURE tempdb.dbo.DatabaseIntegrityCheck;
-                IF OBJECT_ID('tempdb.dbo.IndexOptimize', 'P') IS NOT NULL DROP PROCEDURE tempdb.dbo.IndexOptimize;
-                IF OBJECT_ID('tempdb.dbo.CommandLog', 'U') IS NOT NULL DROP TABLE tempdb.dbo.CommandLog;
-                IF OBJECT_ID('tempdb.dbo.Queue', 'U') IS NOT NULL DROP TABLE tempdb.dbo.Queue;
-                IF OBJECT_ID('tempdb.dbo.QueueDatabase', 'U') IS NOT NULL DROP TABLE tempdb.dbo.QueueDatabase;
+                IF OBJECT_ID('dbo.CommandExecute', 'P') IS NOT NULL DROP PROCEDURE dbo.CommandExecute;
+                IF OBJECT_ID('dbo.DatabaseBackup', 'P') IS NOT NULL DROP PROCEDURE dbo.DatabaseBackup;
+                IF OBJECT_ID('dbo.DatabaseIntegrityCheck', 'P') IS NOT NULL DROP PROCEDURE dbo.DatabaseIntegrityCheck;
+                IF OBJECT_ID('dbo.IndexOptimize', 'P') IS NOT NULL DROP PROCEDURE dbo.IndexOptimize;
+                IF OBJECT_ID('dbo.CommandLog', 'U') IS NOT NULL DROP TABLE dbo.CommandLog;
+                IF OBJECT_ID('dbo.Queue', 'U') IS NOT NULL DROP TABLE dbo.Queue;
+                IF OBJECT_ID('dbo.QueueDatabase', 'U') IS NOT NULL DROP TABLE dbo.QueueDatabase;
             "
             $splatCleanupTempdb = @{
                 SqlInstance = $TestConfig.InstanceMulti2
+                Database    = "tempdb"
                 Query       = $cleanupTempdb
             }
             Invoke-DbaQuery @splatCleanupTempdb
@@ -185,7 +186,11 @@ Describe $CommandName -Tag IntegrationTests {
             $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
         }
 
-        It "Should add ChangeBackupType parameter to DIFF backup job" -Skip:(-not $script:installationSucceeded) {
+        It "Should add ChangeBackupType parameter to DIFF backup job" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - DIFF"
@@ -194,7 +199,11 @@ Describe $CommandName -Tag IntegrationTests {
             $jobStep.Command | Should -Match "@ChangeBackupType = 'Y'"
         }
 
-        It "Should add ChangeBackupType parameter to LOG backup job" -Skip:(-not $script:installationSucceeded) {
+        It "Should add ChangeBackupType parameter to LOG backup job" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - LOG"
@@ -203,7 +212,11 @@ Describe $CommandName -Tag IntegrationTests {
             $jobStep.Command | Should -Match "@ChangeBackupType = 'Y'"
         }
 
-        It "Should NOT add ChangeBackupType parameter to FULL backup job" -Skip:(-not $script:installationSucceeded) {
+        It "Should NOT add ChangeBackupType parameter to FULL backup job" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - FULL"
@@ -212,7 +225,11 @@ Describe $CommandName -Tag IntegrationTests {
             $jobStep.Command | Should -Not -Match "@ChangeBackupType = 'Y'"
         }
 
-        It "Should add Compress parameter to all backup jobs" -Skip:(-not $script:installationSucceeded) {
+        It "Should add Compress parameter to all backup jobs" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - FULL"
@@ -221,7 +238,11 @@ Describe $CommandName -Tag IntegrationTests {
             $jobStep.Command | Should -Match "@Compress = 'Y'"
         }
 
-        It "Should have Verify parameter set to Y in backup jobs" -Skip:(-not $script:installationSucceeded) {
+        It "Should have Verify parameter set to Y in backup jobs" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - FULL"
@@ -230,7 +251,11 @@ Describe $CommandName -Tag IntegrationTests {
             $jobStep.Command | Should -Match "@Verify = 'Y'"
         }
 
-        It "Should have CheckSum parameter set to Y in backup jobs" -Skip:(-not $script:installationSucceeded) {
+        It "Should have CheckSum parameter set to Y in backup jobs" {
+            if (-not $script:installationSucceeded) {
+                Set-ItResult -Skipped -Because "Installation failed"
+                return
+            }
             $splatJobStep = @{
                 SqlInstance = $TestConfig.InstanceMulti2
                 Job         = "DatabaseBackup - USER_DATABASES - FULL"


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes part of #10144)
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [X] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [X] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
As mentioned in passing in #10144, I'm struggling to convince myself that the "Additional backup parameters" in [`Install-DbaMaintenanceSolution.Tests.ps1`](https://github.com/dataplat/dbatools/blob/development/tests/Install-DbaMaintenanceSolution.Tests.ps1#L112) run. I can [see warnings](https://ci.appveyor.com/project/dataplat/dbatools/builds/53504593/job/3i18881vnwkxh7w7) in appveyor
> Running C:\github\dbatools\tests\Install-DbaMaintenanceSolution.Tests.ps1 ...
> 
> [00:38:26][Install-DbaMaintenanceSolution] Could not execute DatabaseIntegrityCheck.sql in tempdb on appveyor-vm\sql2022 | Log entry string is too long. A string written to the event log cannot exceed 32766 characters.
> 
> [00:38:26][Install-DbaMaintenanceSolution] Could not execute IndexOptimize.sql in tempdb on appveyor-vm\sql2022 | Log entry string is too long. A string written to the event log cannot exceed 32766 characters.

and `Invoke-ManualPester -Path tests/Install-DbaMaintenanceSolution.Tests.ps1 -ScriptAnalyzer -Show Detailed -TestIntegration` skipped them on my machine as well.

These tests were introduced in [this commit](https://github.com/dataplat/dbatools/commit/f72a50e736ecaf42c2ca1002c4d14a987a0563a2) and the PR suggests some difficulty with  appveyor at the time. That said, I can believe that this is all just me being confused. Today is the first day that I've had to get serious about `Invoke-ManualPester`.

Once this has been looked at, I'll be able to approach #10133 with more confidence. #10133 will require me adding more tests to this file, so I would like to be confident in this file's code before I start copy and pasting it.

### Approach
I'm really not a Pester expert, but my assessment is that `-Skip:(-not $script:installationSucceeded)` in the original code runs before `$script:installationSucceeded` is defined, so these tests are always skipped. Refactoring to use `Set-ItResult` is, as far as I know, idiomatic Pester.

I also made the tempdb block match the earlier one. All signs are that `DROP PROCEDURE` does not work with 3-part names.

### Commands to test
Run `Invoke-ManualPester -Path tests/Install-DbaMaintenanceSolution.Tests.ps1  -Show Diagnostic -TestIntegration` on this branch and on the current development branch. If I'm right, only my branch will run this test.