### PR TITLE
Sync-DbaAvailabilityGroup: Enhance handling of dedicated admin connections

### DIFF
--- a/tests/Sync-DbaAvailabilityGroup.Tests.ps1
+++ b/tests/Sync-DbaAvailabilityGroup.Tests.ps1
@@ -15,6 +15,7 @@ Describe $CommandName -Tag UnitTests {
                 "PrimarySqlCredential",
                 "Secondary",
                 "SecondarySqlCredential",
+                "Credential",
                 "AvailabilityGroup",
                 "Exclude",
                 "Login",
@@ -23,6 +24,7 @@ Describe $CommandName -Tag UnitTests {
                 "ExcludeJob",
                 "DisableJobOnDestination",
                 "InputObject",
+                "ExcludePassword",
                 "Force",
                 "EnableException"
             )


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [x] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

When opening a connection we test if we need a DAC and we test if we already have a DAC. We reuse a DAC when possible. We remember if we opened a DAC to later be able to close it.

`Get-DecryptedObject` needs two things:
* A Dedicated Admin Connection (DAC) to select master.sys.syslnklgns
* A WinRM connection to read "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$serviceInstanceId\Security\"

That's why `Get-DecryptedObject` needs `$Credential` which it used all the time, but the parameter was missing. So every command that calls `Get-DecryptedObject` needs `$Credential` as well. And every command that calls one of those commands as well.