### PR TITLE
Correct help text to correctly reflect Duration units

### DIFF
--- a/public/Find-DbaDbGrowthEvent.ps1
+++ b/public/Find-DbaDbGrowthEvent.ps1
@@ -81,7 +81,7 @@ function Find-DbaDbGrowthEvent {
         - EventClass: The trace event class (92 = Data File Auto Grow, 93 = Log File Auto Grow, 94 = Data File Auto Shrink, 95 = Log File Auto Shrink)
         - DatabaseName: The name of the database that experienced the growth/shrink event
         - Filename: The path and name of the database file that was resized
-        - Duration: The duration of the event in seconds (milliseconds converted to seconds)
+        - Duration: The duration of the event in milliseconds
         - StartTime: The date and time when the event started (UTC by default, local time if -UseLocalTime is specified)
         - EndTime: The date and time when the event ended (UTC by default, local time if -UseLocalTime is specified)
         - ChangeInSize: The size change during the event in megabytes (MB)


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [X] Bug fix (non-breaking change, fixes #10170 
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [X] Documentation
 - [ ] Build system

<!-- Below this line you can erase anything that is not applicable -->
### Purpose
Correct documentation

### Approach
Corrects units reported in `.OUTPUTS` documentation

### Commands to test
`Find-DbaDbGrowthEvent`