### PR TITLE
speedup dependency detection for integration tests

### DIFF
--- a/tests/appveyor.common.ps1
+++ b/tests/appveyor.common.ps1
@@ -2,6 +2,7 @@ function Get-TestsForScenario {
     param($Scenario, $AllTests, [switch]$Silent)
 
     # does this scenario run an 'autodetect' ?
+
     if ($TestsRunGroups[$Scenario].StartsWith('autodetect_')[0]) {
         # exclude any test specifically tied to a non-autodetect or version specific scenario
         $TiedFunctions = ($TestsRunGroups.GetEnumerator() | Where-Object { $_.Value -notlike 'autodetect_*' -and $_.Name -notlike '20*' }).Value


### PR DESCRIPTION
(do Join-DbaPath)

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [x] Build system


### Purpose
Someone told me code was slow. It kinda was, for huge dependency trees .... now it's an order of magnitude faster, and has little helpers to avoid spending time re-analyzing the correctness of the code in the future.

### Approach
Basically re-use everything as much as possible, computing the lookup beforehand and memoizing each result at each step.
Since this is a "recursive by design" approach (we're finding the dependencies of the tests... which is counterintuitive since our goal is finding what has the altered command(s) AS A DEPENDENCY, and then follow those branches out for each one, till eventually all the tree is resolved ) the memoization pattern is the most appropriate.
For "usual" PRs this shaves maybe 3 seconds, for PRs involving "well connected" functions, it may shave off maybe one or two mins.

I'm including Join-DbaPath in the "special commit" message just to see a mildly-well-connected function to be worked on.
