### PR TITLE
Test-DbaLsnChain: Fix bug in case log backup is taken during full backup

### DIFF
--- a/private/functions/Test-DbaLsnChain.ps1
+++ b/private/functions/Test-DbaLsnChain.ps1
@@ -103,10 +103,10 @@ function Test-DbaLsnChain {
         $TranLogBackups = $TestHistory | Where-Object {
             $isLogBackup = $_.$TypeName -in ('Transaction Log', 'Log')
             $isBasedOnAnchor = $_.DatabaseBackupLsn -eq $FullDBAnchor.CheckPointLsn
-            $hasGreaterFirstLsn = $_.FirstLsn -gt $FullDBAnchor.CheckPointLsn
+            $hasGreaterLastLsn = $_.LastLsn -gt $FullDBAnchor.CheckPointLsn
 
-            Write-Message -Level Verbose -Message "Checking $($_.FullName) - isLogBackup $isLogBackup, isBasedOnAnchor $isBasedOnAnchor, hasGreaterFirstLsn $hasGreaterFirstLsn, FullDBAnchor.CheckPointLsn $($FullDBAnchor.CheckPointLsn), DatabaseBackupLsn $($_.DatabaseBackupLsn), FirstLsn $($_.FirstLsn) LastLsn $($_.LastLsn)"
-            $isLogBackup -and ($isBasedOnAnchor -or $hasGreaterFirstLsn)
+            Write-Message -Level Verbose -Message "Checking $($_.FullName) - isLogBackup $isLogBackup, isBasedOnAnchor $isBasedOnAnchor, hasGreaterLastLsn $hasGreaterLastLsn, FullDBAnchor.CheckPointLsn $($FullDBAnchor.CheckPointLsn), DatabaseBackupLsn $($_.DatabaseBackupLsn), FirstLsn $($_.FirstLsn) LastLsn $($_.LastLsn)"
+            $isLogBackup -and ($isBasedOnAnchor -or $hasGreaterLastLsn)
         } | Sort-Object -Property LastLsn, FirstLsn
 
         for ($i = 0; $i -lt ($TranLogBackups.count)) {


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

I have a customer facing this issue, so I did some analysis.

Here is the new logging before the fix:

```
AUSFÜHRLICH: [15:47:45][Test-DbaLsnChain] Testing LSN Chain
AUSFÜHRLICH: [15:47:45][Test-DbaLsnChain] Testing LSN Chain - Type Type
AUSFÜHRLICH: [15:47:45][<Unknown>] Checking C:\Temp\FULL_20260202_020339.bak - isLogBackup False, isBasedOnAnchor False, hasGreaterFirstLsn False, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000148382400046, FirstLsn 34246000021188000002 LastLsn 34347000156420000001
AUSFÜHRLICH: [15:47:45][<Unknown>] Checking C:\Temp\LOG_20260202_020500.trn - isLogBackup True, isBasedOnAnchor False, hasGreaterFirstLsn False, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000148382400046, FirstLsn 34347000156393600001 LastLsn 34347000156428000001
AUSFÜHRLICH: [15:47:45][<Unknown>] Checking C:\Temp\LOG_20260202_021002.trn - isLogBackup True, isBasedOnAnchor True, hasGreaterFirstLsn True, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000156416000046, FirstLsn 34347000156428000001 LastLsn 34347000156458400001
WARNUNG: [15:47:45][Test-DbaLsnChain] Break in LSN Chain between C:\Temp\FULL_20260202_020339.bak and C:\Temp\LOG_20260202_021002.trn 
AUSFÜHRLICH: [15:47:45][Test-DbaLsnChain] Anchor 34347000156420000001 - FirstLSN 34347000156428000001
AUSFÜHRLICH: [15:47:45][Test-DbaBackupInformation] LSN Check failed
```

And here is the logging after the fix:

```
AUSFÜHRLICH: [15:56:24][Test-DbaLsnChain] Testing LSN Chain
AUSFÜHRLICH: [15:56:24][Test-DbaLsnChain] Testing LSN Chain - Type Type
AUSFÜHRLICH: [15:56:24][<Unknown>] Checking C:\Temp\FULL_20260202_020339.bak - isLogBackup False, isBasedOnAnchor False, hasGreaterLastLsn True, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000148382400046, FirstLsn 34246000021188000002 LastLsn 34347000156420000001
AUSFÜHRLICH: [15:56:24][<Unknown>] Checking C:\Temp\LOG_20260202_020500.trn - isLogBackup True, isBasedOnAnchor False, hasGreaterLastLsn True, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000148382400046, FirstLsn 34347000156393600001 LastLsn 34347000156428000001
AUSFÜHRLICH: [15:56:24][<Unknown>] Checking C:\Temp\LOG_20260202_021002.trn - isLogBackup True, isBasedOnAnchor True, hasGreaterLastLsn True, FullDBAnchor.CheckPointLsn 34347000156416000046, DatabaseBackupLsn 34347000156416000046, FirstLsn 34347000156428000001 LastLsn 34347000156458400001
AUSFÜHRLICH: [15:56:24][Test-DbaLsnChain] Passed LSN Chain checks
```

The bug is that a log backup must have a higher FirstLsn than the anchor backup. This is true in most cases so we have not seen this issue. But here in this case, the first log backup that is needed for restore is still based on the "older" full backup, but has a higher LastLsn that the anchor backup and thus needs to be restored as the first log backup.

I also fixed a formatting issue and made the test more readable including a log message for future analysis. That's why I spilt the change into multiple commits for easier review of the change.