### PR TITLE
Backup-DbaDatabase: Respect explicit FileCount when using StorageBaseUrl (S3/Azure)

### DIFF
--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -71,6 +71,7 @@ function Backup-DbaDatabase {
         Specifies the number of files to stripe the backup across for improved performance.
         Higher values increase backup speed but require more disk space and coordination during restores.
         Automatically overridden when multiple Path values are provided. Typically use 2-4 files for optimal performance.
+        When using StorageBaseUrl (S3/Azure), an explicit FileCount allows striping multiple backup files into the same bucket/container.
 
     .PARAMETER CreateFolder
         Creates a separate subdirectory for each database within the backup path for better organization.
@@ -669,7 +670,9 @@ function Backup-DbaDatabase {
                         }
                     }
                 }
-                $FileCount = $StorageBaseUrl.count
+                if ($FileCount -eq 0) {
+                    $FileCount = $StorageBaseUrl.count
+                }
                 $Path = $StorageBaseUrl
             }
 


### PR DESCRIPTION
Fixes #10180

Previously, `FileCount` was always overwritten with the count of `StorageBaseUrl` values, ignoring any explicit `-FileCount` value provided by the user. This made it impossible to stripe backups across multiple files within the same S3 bucket or Azure container.

Now `FileCount` is only set from the URL count when the user has not explicitly provided a value. This allows a single StorageBaseUrl with `-FileCount 4` to produce 4 striped backup files in the same bucket.

Generated with [Claude Code](https://claude.ai/code)