### PR TITLE
Get-DbaAgentJob and Sync-DbaAvailabilityGroup: Move filter for MSX jobs to the command that needs it

### DIFF
--- a/public/Get-DbaAgentJob.ps1
+++ b/public/Get-DbaAgentJob.ps1
@@ -207,8 +207,6 @@ function Get-DbaAgentJob {
             if ($ExcludeDisabledJobs) {
                 $jobs = $Jobs | Where-Object IsEnabled -eq $true
             }
-            # Always exclude MSX jobs (CategoryID = 1) - they cannot be synced to secondary replicas
-            $jobs = $jobs | Where-Object CategoryID -ne 1
             if ($Database) {
                 $dbLookup = @{}
                 foreach ($db in $Database) {

--- a/public/Sync-DbaAvailabilityGroup.ps1
+++ b/public/Sync-DbaAvailabilityGroup.ps1
@@ -374,7 +374,6 @@ function Sync-DbaAvailabilityGroup {
 
             if ($Exclude -notcontains "AgentJob") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing Agent Jobs"
-                # MSX jobs are automatically excluded by Get-DbaAgentJob to avoid errors
                 $splatGetJob = @{
                     SqlInstance = $server
                 }
@@ -385,6 +384,9 @@ function Sync-DbaAvailabilityGroup {
                     $splatGetJob['ExcludeJob'] = $ExcludeJob
                 }
                 $jobsToSync = Get-DbaAgentJob @splatGetJob
+
+                # Always exclude MSX jobs (CategoryID = 1) - they cannot be synced to secondary replicas
+                $jobsToSync = $jobsToSync | Where-Object CategoryID -ne 1
 
                 $splatCopyJob = @{
                     Destination          = $secondaries


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #10138 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

See issue for details.