### PR TITLE
Update-DbaInstance: Fall back to computer name if Resolve-DbaNetworkName fails

### DIFF
--- a/public/Update-DbaInstance.ps1
+++ b/public/Update-DbaInstance.ps1
@@ -445,8 +445,13 @@ function Update-DbaInstance {
                 Write-Message -Level Warning -Message "Explicit -Credential might be required when running against remote hosts and -Path is a network folder"
                 $notifiedCredentials = $true
             }
-            if ($resolvedComputer = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential) {
-                $resolvedComputers += $resolvedComputer.FullComputerName
+            try {
+                if ($resolvedComputer = Resolve-DbaNetworkName -ComputerName $computer.ComputerName -Credential $Credential -EnableException) {
+                    $resolvedComputers += $resolvedComputer.FullComputerName
+                }
+            } catch {
+                Write-Message -Level Verbose -Message "Could not resolve $($computer.ComputerName) via CIM (this may occur with CredSSP or workgroup environments). Using provided name directly."
+                $resolvedComputers += $computer.ComputerName
             }
         }
         #Leave only unique computer names


### PR DESCRIPTION
When using CredSSP or workgroup environments, the early CIM-based Resolve-DbaNetworkName call fails because CredSSP delegation is not available at that point. Wrap the call in try/catch and use the provided computer name directly when resolution fails, allowing the rest of the command (which uses proper PSRemoting with Authentication) to proceed normally.

Fixes #9134

Generated with [Claude Code](https://claude.ai/code)