### PR TITLE
Connect-DbaInstance: Auto-retry with Initial Catalog=master for mirrored SQL Server instances

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -1130,6 +1130,37 @@ function Connect-DbaInstance {
                     }
                 }
 
+                # Check if the error is about Failover Partner requiring Initial Catalog.
+                # This happens when connecting to a SQL Server instance configured for database mirroring.
+                # The .NET SqlClient sends Failover Partner info from the server's TDS handshake to the
+                # connection pool, and the pool then requires Initial Catalog to be set in the connection string.
+                $isFailoverPartnerError = $errorMessage -match "Failover Partner" -and $errorMessage -match "Initial Catalog"
+                if ($isNewConnection -and $isFailoverPartnerError -and -not $connectionSucceeded -and $inputObjectType -eq 'String') {
+                    Write-Message -Level Verbose -Message "Connection failed because the server is configured for database mirroring (Failover Partner requires Initial Catalog). Retrying with Initial Catalog=master."
+                    Write-Message -Level Debug -Message "Original error: $errorMessage"
+
+                    try {
+                        # Add Initial Catalog=master to satisfy the Failover Partner connection string requirement
+                        if ($server.ConnectionContext.SqlConnectionObject.ConnectionString -notmatch "Initial Catalog" -and $server.ConnectionContext.SqlConnectionObject.ConnectionString -notmatch "Database=") {
+                            if ($server.ConnectionContext.SqlConnectionObject.ConnectionString -match ";$") {
+                                $server.ConnectionContext.SqlConnectionObject.ConnectionString += "Initial Catalog=master;"
+                            } else {
+                                $server.ConnectionContext.SqlConnectionObject.ConnectionString += ";Initial Catalog=master;"
+                            }
+                        }
+
+                        # Retry the connection
+                        Write-Message -Level Debug -Message "Retrying connection with Initial Catalog=master for server with database mirroring"
+                        $null = $server.ConnectionContext.ExecuteWithResults("SELECT 'dbatools is opening a new connection with Initial Catalog'")
+                        Write-Message -Level Verbose -Message "Connection succeeded with Initial Catalog=master for server with database mirroring"
+                        $connectionSucceeded = $true
+                    } catch {
+                        Write-Message -Level Debug -Message "Retry with Initial Catalog=master also failed: $($_.Exception.Message)"
+                        # Keep the original error for reporting
+                        $connectionError = $_
+                    }
+                }
+
                 if (-not $connectionSucceeded) {
                     Stop-Function -Target $instance -Message "Failure" -Category ConnectionError -ErrorRecord $connectionError -Continue
                 }


### PR DESCRIPTION
Fixes #9853

Adds automatic retry logic in Connect-DbaInstance when connecting to SQL Server instances configured for database mirroring. The .NET SqlClient records the Failover Partner from the TDS handshake and requires Initial Catalog to be set in the connection string. When this error is detected, the connection is retried with Initial Catalog=master added transparently.

Generated with [Claude Code](https://claude.ai/code)