### PR TITLE
Get-DbaReplSubscription: Also check distribution DB for pull subscriptions missing from syssubscriptions

### DIFF
--- a/public/Get-DbaReplSubscription.ps1
+++ b/public/Get-DbaReplSubscription.ps1
@@ -6,6 +6,8 @@ function Get-DbaReplSubscription {
     .DESCRIPTION
         Retrieves detailed information about replication subscriptions, showing which subscriber instances are receiving data from publications. This is essential for monitoring replication topology, troubleshooting subscription issues, and auditing data distribution across your SQL Server environment. You can filter results by database, publication name, subscriber instance, subscription database, or subscription type (Push/Pull) to focus on specific replication relationships.
 
+        Pull subscriptions that exist only in the distribution database (but not in the publisher's syssubscriptions) are also returned, to handle cases where subscriptions were set up outside the normal creation process.
+
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
 
@@ -149,6 +151,9 @@ function Get-DbaReplSubscription {
                 Stop-Function -Message "Error occurred while getting publications from $instance" -ErrorRecord $_ -Target $instance -Continue
             }
 
+            # Track subscriptions already emitted to avoid duplicates from the distribution DB check
+            $foundSubscriptionKeys = @{}
+
             try {
                 foreach ($subs in $publications.Subscriptions) {
                     Write-Message -Level Verbose -Message ('Get subscriptions for {0}' -f $sub.PublicationName)
@@ -166,6 +171,9 @@ function Get-DbaReplSubscription {
                     }
 
                     foreach ($sub in $subs) {
+                        $subKey = "$($sub.SubscriberName)|$($sub.SubscriptionDBName)|$($sub.PublicationName)|$($sub.DatabaseName)"
+                        $foundSubscriptionKeys[$subKey] = $true
+
                         Add-Member -Force -InputObject $sub -MemberType NoteProperty -Name ComputerName -Value $server.ComputerName
                         Add-Member -Force -InputObject $sub -MemberType NoteProperty -Name InstanceName -Value $server.ServiceName
                         Add-Member -Force -InputObject $sub -MemberType NoteProperty -Name SqlInstance -Value $server.DomainInstanceName
@@ -175,6 +183,95 @@ function Get-DbaReplSubscription {
                 }
             } catch {
                 Stop-Function -Message "Error occurred while getting subscriptions from $instance" -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            # Also check distribution database for pull subscriptions that may be missing from publisher's syssubscriptions.
+            # This handles cases where pull subscriptions were created outside the normal process and only exist in distribution.dbo.MSsubscriptions.
+            if (-not $Type -or "Pull" -in $Type) {
+                try {
+                    $replServer = New-Object Microsoft.SqlServer.Replication.ReplicationServer
+                    $replServer.ConnectionContext = $server.ConnectionContext
+
+                    if ($replServer.IsPublisher -and $replServer.DistributorInstalled -and $replServer.DistributorAvailable) {
+                        $distributorName = $replServer.DistributionServer
+                        $distributionDbName = $replServer.DistributionDatabase
+
+                        try {
+                            # Reuse the existing connection if the distributor is the same server
+                            if ($distributorName -eq $server.ComputerName -or $distributorName -eq $server.DomainInstanceName) {
+                                $distributorServer = $server
+                            } else {
+                                $distributorServer = Connect-DbaInstance -SqlInstance $distributorName -SqlCredential $SqlCredential
+                            }
+
+                            $distQuery = "
+                                SELECT DISTINCT
+                                    a.subscriber_name AS SubscriberName,
+                                    a.subscriber_db   AS SubscriptionDBName,
+                                    p.publisher_db    AS DatabaseName,
+                                    p.publication     AS PublicationName
+                                FROM MSdistribution_agents a
+                                INNER JOIN MSsubscriptions s ON s.agent_id = a.id AND s.subscription_type = 1
+                                INNER JOIN MSpublications p ON p.publication_id = s.publication_id
+                            "
+
+                            $splatDistQuery = @{
+                                SqlInstance = $distributorServer
+                                Database    = $distributionDbName
+                                Query       = $distQuery
+                            }
+                            $distPullSubs = Invoke-DbaQuery @splatDistQuery
+
+                            # Build a lookup of the publications we queried so we only include relevant subscriptions
+                            $publicationKeys = @{}
+                            foreach ($pub in $publications) {
+                                $pubKey = "$($pub.DatabaseName)|$($pub.Name)"
+                                $publicationKeys[$pubKey] = $true
+                            }
+
+                            # Convert SubscriberName filter to strings for comparison
+                            $subscriberNameStrings = @()
+                            if ($SubscriberName) {
+                                $subscriberNameStrings = $SubscriberName | ForEach-Object { $_.ToString() }
+                            }
+
+                            foreach ($distSub in $distPullSubs) {
+                                # Only process subscriptions for publications we already queried
+                                $pubKey = "$($distSub.DatabaseName)|$($distSub.PublicationName)"
+                                if (-not $publicationKeys.ContainsKey($pubKey)) { continue }
+
+                                # Apply subscriber name filter
+                                if ($subscriberNameStrings -and $distSub.SubscriberName -notin $subscriberNameStrings) { continue }
+
+                                # Apply subscription database filter
+                                if ($SubscriptionDatabase -and $distSub.SubscriptionDBName -notin $SubscriptionDatabase) { continue }
+
+                                # Skip subscriptions already returned via SMO
+                                $subKey = "$($distSub.SubscriberName)|$($distSub.SubscriptionDBName)|$($distSub.PublicationName)|$($distSub.DatabaseName)"
+                                if ($foundSubscriptionKeys.ContainsKey($subKey)) { continue }
+
+                                # Emit subscriptions found only in the distribution database
+                                $subObj = [PSCustomObject]@{
+                                    ComputerName       = $server.ComputerName
+                                    InstanceName       = $server.ServiceName
+                                    SqlInstance        = $server.DomainInstanceName
+                                    DatabaseName       = $distSub.DatabaseName
+                                    PublicationName    = $distSub.PublicationName
+                                    Name               = "$($distSub.PublicationName)-$($distSub.SubscriberName)-$($distSub.SubscriptionDBName)"
+                                    SubscriberName     = $distSub.SubscriberName
+                                    SubscriptionDBName = $distSub.SubscriptionDBName
+                                    SubscriptionType   = "Pull"
+                                }
+
+                                Select-DefaultView -InputObject $subObj -Property ComputerName, InstanceName, SqlInstance, DatabaseName, PublicationName, Name, SubscriberName, SubscriptionDBName, SubscriptionType
+                            }
+                        } catch {
+                            Write-Message -Level Warning -Message "Could not query distribution database on $distributorName for additional pull subscriptions from $instance"
+                        }
+                    }
+                } catch {
+                    Write-Message -Level Verbose -Message "Unable to check distribution database for additional pull subscriptions from $instance"
+                }
             }
         }
     }


### PR DESCRIPTION
Pull subscriptions that exist only in the distribution database (distribution.dbo.MSsubscriptions) but not in the publisher's syssubscriptions table are now also returned.

This handles cases where subscriptions were set up outside the normal creation process or have inconsistencies between the publisher and distributor.

Fixes #10077

Generated with [Claude Code](https://claude.ai/code)