### PR TITLE
Read-DbaXEFile: Fix database_name and other action columns being empty

### DIFF
--- a/public/Read-DbaXEFile.ps1
+++ b/public/Read-DbaXEFile.ps1
@@ -148,7 +148,7 @@ function Read-DbaXEFile {
                         }
 
                         foreach ($key in $event.Actions.Keys) {
-                            $hash[$key] = $event.Actions[$key]
+                            $hash[($key -Split '\.')[-1]] = $event.Actions[$key]
                         }
 
                         foreach ($key in $event.Fields.Keys) {


### PR DESCRIPTION
Normalize action keys when populating the event hash to match the column name normalization used when building the column list.

Previously, action names like `sqlserver.database_name` were normalized to `database_name` in the column list, but the full key `sqlserver.database_name` was used when setting hash values. This caused the `database_name` property (and all other action-based columns) to remain null.

Fixes #10085

Generated with [Claude Code](https://claude.ai/code)