### PR TITLE
Invoke-DbaDbDataMasking: Fix Deterministic masking not applied with multiple columns

### DIFF
--- a/public/Invoke-DbaDbDataMasking.ps1
+++ b/public/Invoke-DbaDbDataMasking.ps1
@@ -883,8 +883,6 @@ function Invoke-DbaDbDataMasking {
 
                                             if ($lookupResult.NewValue) {
                                                 $newValue = $lookupResult.NewValue
-                                                # Skip further processing for this column
-                                                continue
                                             }
                                         } catch {
                                             Stop-Function -Message "Something went wrong retrieving the deterministic values" -Target $query -ErrorRecord $_ -continue


### PR DESCRIPTION
Fix for issue #7503 where the Deterministic property was not honored when a config had 2+ columns.

A spurious `continue` statement after finding a deterministic lookup value caused the column to be skipped when building the UPDATE statement. The looked-up value was found but never written back to the database.

Generated with [Claude Code](https://claude.ai/code)

Fixes #7503