### PR TITLE
Backup-DbaDatabase: Prevent duplicate dbname when using CreateFolder with ReplaceInName

### DIFF
--- a/public/Backup-DbaDatabase.ps1
+++ b/public/Backup-DbaDatabase.ps1
@@ -870,6 +870,21 @@ function Backup-DbaDatabase {
                 $FinalBackupPath[0] = $FinalBackupPath[0] + $slash + $BackupFinalName
             }
 
+            # Auto-detect dbname token to prevent duplication when using CreateFolder + ReplaceInName
+            if ($CreateFolder -and $ReplaceInName -and -not $NoAppendDbNameInPath) {
+                $containsDbNameToken = $false
+                foreach ($pathToCheck in $FinalBackupPath) {
+                    if ($pathToCheck -match "\bdbname\b") {
+                        $containsDbNameToken = $true
+                        break
+                    }
+                }
+                if ($containsDbNameToken) {
+                    Write-Message -Level Verbose -Message "Path contains 'dbname' token with ReplaceInName. Automatically skipping database folder creation to prevent duplication."
+                    $NoAppendDbNameInPath = $true
+                }
+            }
+
             if ($CreateFolder -and $FinalBackupPath[0] -ne 'NUL:') {
                 for ($i = 0; $i -lt $FinalBackupPath.Count; $i++) {
                     $parent = [IO.Path]::GetDirectoryName($FinalBackupPath[$i])

--- a/tests/Backup-DbaDatabase.Tests.ps1
+++ b/tests/Backup-DbaDatabase.Tests.ps1
@@ -485,6 +485,16 @@ go
         }
     }
 
+    Context "Test CreateFolder with ReplaceInName prevents duplicate dbname (issue 9135)" {
+        It "Should not duplicate database name when path contains dbname token" {
+            $results = Backup-DbaDatabase -SqlInstance $TestConfig.InstanceCopy1 -Database master -Path "$DestBackupDir\servername\instancename\dbname\backuptype" -BackupFileName "servername_dbname_backuptype_timestamp.bak" -ReplaceInName -CreateFolder -BuildPath
+            $instanceName = ([DbaInstanceParameter]$TestConfig.InstanceCopy1).InstanceName
+            $serverName = ([DbaInstanceParameter]$TestConfig.InstanceCopy1).ComputerName
+            $results.BackupPath | Should -BeLike "$DestBackupDir\$serverName\$instanceName\master\Full\*"
+            $results.BackupPath | Should -Not -BeLike "*\master\master\*"
+        }
+    }
+
     Context "Test Backup Encryption with Certificate" {
         # TODO: Should the master key be created at lab startup like in instance3?
         BeforeAll {


### PR DESCRIPTION
Fixes #9135

## Summary
Automatically detects when path contains 'dbname' token with -ReplaceInName and skips database folder creation to prevent duplication.

## Changes
- Added auto-detection logic in Backup-DbaDatabase.ps1 (lines 712-725)
- Uses word boundary regex `\bdbname\b` to match only the token, not substrings
- Automatically sets `$NoAppendDbNameInPath = $true` when dbname token detected
- Includes verbose logging for transparency
- Added regression test coverage

## Backward Compatibility
- Only affects cases that currently produce wrong results (duplicate dbname)
- Respects explicit -NoAppendDbNameInPath if set by user
- No breaking changes

Generated with [Claude Code](https://claude.ai/code)


Recreated based on #10217 because base branch was very old.