### PR TITLE
Get-DbaDb[StoredProcedure|Table|Udf|View]: Wrap all ClearAndInitialize in try-catch-block

### DIFF
--- a/public/Get-DbaDbStoredProcedure.ps1
+++ b/public/Get-DbaDbStoredProcedure.ps1
@@ -185,7 +185,11 @@ function Get-DbaDbStoredProcedure {
 
             # Let the SMO read all properties referenced in this command for all stored procedures in the database in one query.
             # Downside: If some other properties were already read outside of this command in the used SMO, they are cleared.
-            $db.StoredProcedures.ClearAndInitialize('', [string[]]('Schema', 'Name', 'ID', 'CreateDate', 'DateLastModified', 'ImplementationType', 'Startup', 'IsSystemObject'))
+            try {
+                $db.StoredProcedures.ClearAndInitialize('', [string[]]('Schema', 'Name', 'ID', 'CreateDate', 'DateLastModified', 'ImplementationType', 'Startup', 'IsSystemObject'))
+            } catch {
+                Write-Message -Level Verbose -Message "ClearAndInitialize failed: $_"
+            }
 
             if ($db.StoredProcedures.Count -eq 0) {
                 Write-Message -Message "No Stored Procedures exist in the $db database on $instance" -Target $db -Level Output

--- a/public/Get-DbaDbTable.ps1
+++ b/public/Get-DbaDbTable.ps1
@@ -284,7 +284,11 @@ function Get-DbaDbTable {
                 }
             }
 
-            $db.Tables.ClearAndInitialize($urnFilter, [string[]]$properties)
+            try {
+                $db.Tables.ClearAndInitialize($urnFilter, [string[]]$properties)
+            } catch {
+                Write-Message -Level Verbose -Message "ClearAndInitialize failed: $_"
+            }
 
             if ($fqTns) {
                 $tables = @()

--- a/public/Get-DbaDbUdf.ps1
+++ b/public/Get-DbaDbUdf.ps1
@@ -151,10 +151,18 @@ function Get-DbaDbUdf {
 
                 # Let the SMO read all properties referenced in this command for all user defined functions in the database in one query.
                 # Downside: If some other properties were already read outside of this command in the used SMO, they are cleared.
-                $db.UserDefinedFunctions.ClearAndInitialize('', [string[]]('Schema', 'Name', 'CreateDate', 'DateLastModified', 'DataType', 'IsSystemObject'))
+                try {
+                    $db.UserDefinedFunctions.ClearAndInitialize('', [string[]]('Schema', 'Name', 'CreateDate', 'DateLastModified', 'DataType', 'IsSystemObject'))
+                } catch {
+                    Write-Message -Level Verbose -Message "ClearAndInitialize failed: $_"
+                }
 
                 # UserDefinedAggregates don't have IsSystemObject property, so initialize separately
-                $db.UserDefinedAggregates.ClearAndInitialize('', [string[]]('Schema', 'Name', 'CreateDate', 'DateLastModified', 'DataType'))
+                try {
+                    $db.UserDefinedAggregates.ClearAndInitialize('', [string[]]('Schema', 'Name', 'CreateDate', 'DateLastModified', 'DataType'))
+                } catch {
+                    Write-Message -Level Verbose -Message "ClearAndInitialize failed: $_"
+                }
 
                 $userDefinedFunctions = $db.UserDefinedFunctions
 

--- a/public/Get-DbaDbView.ps1
+++ b/public/Get-DbaDbView.ps1
@@ -164,7 +164,11 @@ function Get-DbaDbView {
 
             # Let the SMO read all properties referenced in this command for all views in the database in one query.
             # Downside: If some other properties were already read outside of this command in the used SMO, they are cleared.
-            $db.Views.ClearAndInitialize('', [string[]]('Name', 'Schema', 'IsSystemObject', 'CreateDate', 'DateLastModified'))
+            try {
+                $db.Views.ClearAndInitialize('', [string[]]('Name', 'Schema', 'IsSystemObject', 'CreateDate', 'DateLastModified'))
+            } catch {
+                Write-Message -Level Verbose -Message "ClearAndInitialize failed: $_"
+            }
 
             if ($fqtns) {
                 $views = @()


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #10134 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

This is a workaround for a bug in SMO where the method ClearAndInitialize does not use the connection provided by the object the method is called on, but instead opens a new connection. In case SqlCredential is an AD account, the credentials are not part of the connection string SMO is using and so it uses current windows context and fails.

As ClearAndInitialize is only to enhance performance and not a critical part of the command, we only log a verbose message if the call failes.