### PR TITLE
Get-DbaRegServer - Fix IncludeSelf to return pipeline-compatible object

### DIFF
--- a/public/Get-DbaRegServer.ps1
+++ b/public/Get-DbaRegServer.ps1
@@ -379,13 +379,21 @@ function Get-DbaRegServer {
             Select-DefaultView -InputObject $server -Property $defaults
         }
 
-        if ($IncludeSelf -and $servers) {
+        if ($IncludeSelf -and $SqlInstance -and $serverstore) {
             Write-Message -Level Verbose -Message "Adding CMS instance"
-            $self = $servers[0].PsObject.Copy() | Select-Object -Property $defaults
-            $self | Add-Member -MemberType NoteProperty -Name Name -Value "CMS Instance" -Force
-            $self.ServerName = $instance
-            $self.Group = $null
-            $self.Description = $null
+            $self = [PSCustomObject]@{
+                Name         = "CMS Instance"
+                ServerName   = $serverstore.SqlInstance
+                Group        = $null
+                Description  = $null
+                Source       = "Central Management Servers"
+                ComputerName = $serverstore.ComputerName
+                InstanceName = $serverstore.InstanceName
+                SqlInstance  = $serverstore.SqlInstance
+                FQDN         = $null
+                IPAddress    = $null
+            }
+            $self | Add-Member -MemberType ScriptMethod -Name ToString -Value { $this.ServerName } -Force
             Select-DefaultView -InputObject $self -Property $defaults
         }
     }

--- a/tests/Get-DbaRegServer.Tests.ps1
+++ b/tests/Get-DbaRegServer.Tests.ps1
@@ -135,6 +135,17 @@ Describe $CommandName -Tag IntegrationTests {
             $results | Where-Object ServerName -match "server1$" | Should -Not -BeNullOrEmpty
         }
 
+        It "Should include CMS instance itself with IncludeSelf and have piping-compatible properties" {
+            $results = Get-DbaRegServer -SqlInstance $TestConfig.InstanceSingle -IncludeSelf
+            $self = $results | Where-Object Name -eq "CMS Instance"
+            $self | Should -Not -BeNullOrEmpty
+            $self.ServerName | Should -Not -BeNullOrEmpty
+            $self.ComputerName | Should -Not -BeNullOrEmpty
+            $self.InstanceName | Should -Not -BeNullOrEmpty
+            $self.SqlInstance | Should -Not -BeNullOrEmpty
+            $self.ToString() | Should -Be $self.ServerName
+        }
+
         # Property Comparisons will come later when we have the commands
     }
 }


### PR DESCRIPTION
Fix `-IncludeSelf` in `Get-DbaRegServer` so the CMS instance itself is returned as a fully-populated object that can be piped to downstream commands like `Get-DbaDefaultPath`.

The previous implementation used `Select-Object` which stripped the `ToString` ScriptMethod and `SqlInstance/ComputerName/InstanceName` properties, causing piped commands to silently skip the CMS server.

Closes #8382

Generated with [Claude Code](https://claude.ai/code)