### PR TITLE
New-DbaAgentJobStep - Fix OnFailAction ValidateSet order to match actual default

### DIFF
--- a/public/New-DbaAgentJobStep.ps1
+++ b/public/New-DbaAgentJobStep.ps1
@@ -212,7 +212,7 @@ function New-DbaAgentJobStep {
         [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
         [string]$OnSuccessAction = 'QuitWithSuccess',
         [int]$OnSuccessStepId = 0,
-        [ValidateSet('QuitWithSuccess', 'QuitWithFailure', 'GoToNextStep', 'GoToStep')]
+        [ValidateSet('QuitWithFailure', 'QuitWithSuccess', 'GoToNextStep', 'GoToStep')]
         [string]$OnFailAction = 'QuitWithFailure',
         [int]$OnFailStepId = 0,
         [string]$Database,


### PR DESCRIPTION
Fix the documentation inconsistency where the ValidateSet for OnFailAction listed QuitWithSuccess first, causing doc generators to display it as "(default)" even though the actual default is QuitWithFailure.

Reorder the ValidateSet so QuitWithFailure comes first, matching the actual parameter default.

Fixes #9695

Generated with [Claude Code](https://claude.ai/code)