### PR TITLE
Set-DbaDbCompression - Add SortInTempDB parameter and fix views T-SQL bug

### DIFF
--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -44,6 +44,10 @@ function Set-DbaDbCompression {
         Forces compression operations to use offline rebuilds instead of the default online rebuilds when possible. Online rebuilds keep tables accessible during compression but use more resources.
         Use this switch when you need to minimize resource usage during compression or when experiencing issues with online operations. Offline rebuilds will make tables unavailable during the compression process.
 
+    .PARAMETER SortInTempDB
+        Specifies that intermediate sort operations during index rebuilds should use the tempdb database. This can speed up index creation and reduce space usage in the user database at the expense of tempdb.
+        Use this switch when rebuilding large indexes to avoid filling the user database's log or data files. Requires sufficient space in tempdb for the sort operations.
+
     .PARAMETER InputObject
         Accepts compression recommendations from Test-DbaDbCompression and applies those specific recommendations instead of running a new analysis.
         Use this when you want to review compression recommendations first, then apply only the ones you approve of. This approach gives you more control over which objects get compressed.
@@ -150,6 +154,7 @@ function Set-DbaDbCompression {
         [int]$MaxRunTime = 0,
         [int]$PercentCompression = 0,
         [switch]$ForceOfflineRebuilds,
+        [switch]$SortInTempDB,
         $InputObject,
         [switch]$EnableException
     )
@@ -245,6 +250,7 @@ function Set-DbaDbCompression {
                                     $underlyingObj = $server.Databases[$obj.Database].Tables[$obj.TableName, $obj.Schema].Indexes[$obj.IndexName]
                                     ($underlyingObj.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $obj.Partition }).DataCompression = $obj.CompressionTypeRecommendation
                                     $underlyingObj.OnlineIndexOperation = $CanDoOnlineOperation
+                                    $underlyingObj.SortInTempdb = $SortInTempDB
                                     $underlyingObj.Rebuild()
                                 } catch {
                                     Stop-Function -Message "Compression failed for $instance - $db - table $($obj.Schema).$($obj.TableName) - index $($obj.IndexName) - partition $($obj.Partition)" -Target $db -ErrorRecord $_ -Continue
@@ -310,16 +316,19 @@ function Set-DbaDbCompression {
                                         ## Once this UserVoice item is fixed the workaround can be removed
                                         ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
                                         if ($CompressionType -eq "None") {
-                                            $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH"
+                                            $withOptions = @("DATA_COMPRESSION = $CompressionType")
                                             if ($CanDoOnlineOperation) {
-                                                $query += "(DATA_COMPRESSION = $CompressionType, ONLINE = ON)"
-                                            } else {
-                                                $query += "(DATA_COMPRESSION = $CompressionType)"
+                                                $withOptions += "ONLINE = ON"
                                             }
+                                            if ($SortInTempDB) {
+                                                $withOptions += "SORT_IN_TEMPDB = ON"
+                                            }
+                                            $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH ($($withOptions -join ", "))"
                                             $Server.Query($query, $db.Name)
                                         } else {
                                             $($index.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $P.PartitionNumber }).DataCompression = $CompressionType
                                             $index.OnlineIndexOperation = $CanDoOnlineOperation
+                                            $index.SortInTempdb = $SortInTempDB
                                             $index.Rebuild()
                                         }
                                     } catch {
@@ -357,15 +366,19 @@ function Set-DbaDbCompression {
                                     ## Once this UserVoice item is fixed the workaround can be removed
                                     ## https://feedback.azure.com/forums/908035-sql-server/suggestions/34080112-data-compression-smo-bug
                                     if ($CompressionType -eq "None") {
+                                        $withOptions = @("DATA_COMPRESSION = $CompressionType")
                                         if ($CanDoOnlineOperation) {
-                                            $query += "(DATA_COMPRESSION = $CompressionType, ONLINE = ON)"
-                                        } else {
-                                            $query += "(DATA_COMPRESSION = $CompressionType)"
+                                            $withOptions += "ONLINE = ON"
                                         }
+                                        if ($SortInTempDB) {
+                                            $withOptions += "SORT_IN_TEMPDB = ON"
+                                        }
+                                        $query = "ALTER INDEX [$($index.Name)] ON $($index.Parent) REBUILD PARTITION = ALL WITH ($($withOptions -join ", "))"
                                         $Server.Query($query, $db.Name)
                                     } else {
                                         $($index.PhysicalPartitions | Where-Object { $_.PartitionNumber -eq $P.PartitionNumber }).DataCompression = $CompressionType
                                         $index.OnlineIndexOperation = $CanDoOnlineOperation
+                                        $index.SortInTempdb = $SortInTempDB
                                         $index.Rebuild()
                                     }
                                 } catch {

--- a/tests/Set-DbaDbCompression.Tests.ps1
+++ b/tests/Set-DbaDbCompression.Tests.ps1
@@ -20,6 +20,7 @@ Describe $CommandName -Tag UnitTests {
                 "MaxRunTime",
                 "PercentCompression",
                 "ForceOfflineRebuilds",
+                "SortInTempDB",
                 "InputObject",
                 "EnableException"
             )


### PR DESCRIPTION
Adds a new `-SortInTempDB` switch parameter to `Set-DbaDbCompression` to control the `SORT_IN_TEMPDB` WITH option when rebuilding indexes during compression operations.

Also fixes a pre-existing bug in the views compression T-SQL path where the query string was never initialized before being appended to.

Resolves #6671

Generated with [Claude Code](https://claude.ai/code)