### PR TITLE
Get-DbaCmObject - Apply CimOperationTimeout to all CIM connections

### DIFF
--- a/public/Get-DbaCmObject.ps1
+++ b/public/Get-DbaCmObject.ps1
@@ -255,6 +255,14 @@ function Get-DbaCmObject {
 
             $connection = $connectionObject.Connection
 
+            # Ensure CIM session options are initialized with the configured operation timeout
+            if ($null -eq $connection.CimWinRMOptions) {
+                $connection.CimWinRMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Default
+            }
+            if ($null -eq $connection.CimDCOMOptions) {
+                $connection.CimDCOMOptions = New-DbaCimSessionOptionWithTimeout -Protocol Dcom
+            }
+
             # Ensure using the right credentials
             try { $cred = $connection.GetCredential($Credential) }
             catch {


### PR DESCRIPTION
Ensures CimWinRMOptions and CimDCOMOptions are initialized with the `ComputerManagement.CimOperationTimeout` config value (default: 60s) whenever Get-DbaCmObject retrieves a connection, not only when New-DbaCmConnection or Set-DbaCmConnection are explicitly called. This prevents indefinite hangs when querying servers with hung or corrupted WMI.

Fixes #6498

Generated with [Claude Code](https://claude.ai/code)