### PR TITLE
Restore-DbaDatabase, Invoke-DbaAdvancedRestore - Add ErrorBrokerConversations parameter

### DIFF
--- a/public/Invoke-DbaAdvancedRestore.ps1
+++ b/public/Invoke-DbaAdvancedRestore.ps1
@@ -95,6 +95,11 @@ function Invoke-DbaAdvancedRestore {
         Essential when restoring databases where CDC is actively capturing data changes for auditing or ETL processes.
         Cannot be combined with NoRecovery or StandbyDirectory parameters as CDC requires the database to be fully recovered.
 
+    .PARAMETER ErrorBrokerConversations
+        Ends all conversations in the database with an error message when restoring, using the ERROR_BROKER_CONVERSATIONS option.
+        Use this when you want to clean up Service Broker conversations that may be left in an inconsistent state after a restore.
+        Only applied during the final restore step (WITH RECOVERY), not during intermediate log restores.
+
     .PARAMETER PageRestore
         Array of page objects from Get-DbaSuspectPage specifying corrupted pages to restore using page-level restore.
         Use this for targeted repair of specific corrupted pages without restoring the entire database.
@@ -234,6 +239,7 @@ function Invoke-DbaAdvancedRestore {
         [switch]$WithReplace,
         [switch]$KeepReplication,
         [switch]$KeepCDC,
+        [switch]$ErrorBrokerConversations,
         [object[]]$PageRestore,
         [string]$ExecuteAs,
         [switch]$StopBefore,
@@ -406,12 +412,15 @@ function Invoke-DbaAdvancedRestore {
                 if ($Pscmdlet.ShouldProcess($SqlInstance, "Restoring $database to $SqlInstance based on these files: $($backup.FullName -join ', ')")) {
                     try {
                         $restoreComplete = $true
-                        if ($KeepCDC -and $restore.NoRecovery -eq $false) {
+                        if (($KeepCDC -or $ErrorBrokerConversations) -and $restore.NoRecovery -eq $false) {
                             $script = $restore.Script($server)
+                            $withOptions = @()
+                            if ($KeepCDC) { $withOptions += 'KEEP_CDC' }
+                            if ($ErrorBrokerConversations) { $withOptions += 'ERROR_BROKER_CONVERSATIONS' }
                             if ($script -like '*WITH*') {
-                                $script = $script.TrimEnd() + ' , KEEP_CDC'
+                                $script = $script.TrimEnd() + ' , ' + ($withOptions -join ' , ')
                             } else {
-                                $script = $script.TrimEnd() + ' WITH KEEP_CDC'
+                                $script = $script.TrimEnd() + ' WITH ' + ($withOptions -join ' , ')
                             }
                             if ($true -ne $OutputScriptOnly) {
                                 Write-Progress -id 1 -activity "Restoring $database to $SqlInstance - Backup $BackupCnt of $($Backups.count)" -percentcomplete 0 -status ([System.String]::Format("Progress: {0} %", 0))

--- a/public/Restore-DbaDatabase.ps1
+++ b/public/Restore-DbaDatabase.ps1
@@ -216,6 +216,11 @@ function Restore-DbaDatabase {
         Use this when restoring databases with CDC enabled and you need to maintain change tracking functionality.
         Cannot be combined with NoRecovery or Standby modes as CDC requires the database to be fully recovered.
 
+    .PARAMETER ErrorBrokerConversations
+        Ends all conversations in the database with an error message when restoring, using the ERROR_BROKER_CONVERSATIONS option.
+        Use this when you want to clean up Service Broker conversations that may be left in an inconsistent state after a restore.
+        Only applied during the final restore step (WITH RECOVERY), not during intermediate log restores.
+
     .PARAMETER KeepReplication
         Maintains replication settings and objects when restoring databases involved in replication topologies.
         Use this when restoring publisher or subscriber databases where you need to preserve replication configuration.
@@ -485,6 +490,7 @@ function Restore-DbaDatabase {
         [parameter(ParameterSetName = "Restore")][string]$DestinationFileSuffix,
         [parameter(ParameterSetName = "Recovery")][switch]$Recover,
         [parameter(ParameterSetName = "Restore")][switch]$KeepCDC,
+        [parameter(ParameterSetName = "Restore")][switch]$ErrorBrokerConversations,
         [string]$GetBackupInformation,
         [switch]$StopAfterGetBackupInformation,
         [string]$SelectBackupInformation,
@@ -873,28 +879,29 @@ function Restore-DbaDatabase {
             }
             try {
                 $parms = @{
-                    SqlInstance       = $RestoreInstance
-                    WithReplace       = $WithReplace
-                    RestoreTime       = $RestoreTime
-                    StandbyDirectory  = $StandbyDirectory
-                    NoRecovery        = $NoRecovery
-                    Continue          = $Continue
-                    OutputScriptOnly  = $OutputScriptOnly
-                    BlockSize         = $BlockSize
-                    MaxTransferSize   = $MaxTransferSize
-                    BufferCount       = $Buffercount
-                    KeepCDC           = $KeepCDC
-                    VerifyOnly        = $VerifyOnly
-                    PageRestore       = $PageRestore
-                    StorageCredential = $StorageCredential
-                    KeepReplication   = $KeepReplication
-                    StopMark          = $StopMark
-                    StopAfterDate     = $StopAfterDate
-                    StopBefore        = $StopBefore
-                    ExecuteAs         = $ExecuteAs
-                    Checksum          = $Checksum
-                    Restart           = $Restart
-                    EnableException   = $true
+                    SqlInstance              = $RestoreInstance
+                    WithReplace              = $WithReplace
+                    RestoreTime              = $RestoreTime
+                    StandbyDirectory         = $StandbyDirectory
+                    NoRecovery               = $NoRecovery
+                    Continue                 = $Continue
+                    OutputScriptOnly         = $OutputScriptOnly
+                    BlockSize                = $BlockSize
+                    MaxTransferSize          = $MaxTransferSize
+                    BufferCount              = $Buffercount
+                    KeepCDC                  = $KeepCDC
+                    ErrorBrokerConversations = $ErrorBrokerConversations
+                    VerifyOnly               = $VerifyOnly
+                    PageRestore              = $PageRestore
+                    StorageCredential        = $StorageCredential
+                    KeepReplication          = $KeepReplication
+                    StopMark                 = $StopMark
+                    StopAfterDate            = $StopAfterDate
+                    StopBefore               = $StopBefore
+                    ExecuteAs                = $ExecuteAs
+                    Checksum                 = $Checksum
+                    Restart                  = $Restart
+                    EnableException          = $true
                 }
                 $FilteredBackupHistory | Where-Object { $_.IsVerified -eq $true } | Invoke-DbaAdvancedRestore @parms
             } catch {

--- a/tests/Invoke-DbaAdvancedRestore.Tests.ps1
+++ b/tests/Invoke-DbaAdvancedRestore.Tests.ps1
@@ -27,6 +27,7 @@ Describe $CommandName -Tag UnitTests {
                 "WithReplace",
                 "KeepReplication",
                 "KeepCDC",
+                "ErrorBrokerConversations",
                 "PageRestore",
                 "ExecuteAs",
                 "StopBefore",

--- a/tests/Restore-DbaDatabase.Tests.ps1
+++ b/tests/Restore-DbaDatabase.Tests.ps1
@@ -45,6 +45,7 @@ Describe $CommandName -Tag UnitTests {
                 "DestinationFileSuffix",
                 "Recover",
                 "KeepCDC",
+                "ErrorBrokerConversations",
                 "GetBackupInformation",
                 "StopAfterGetBackupInformation",
                 "SelectBackupInformation",


### PR DESCRIPTION
Adds support for the ERROR_BROKER_CONVERSATIONS option when restoring databases (`-ErrorBrokerConversations` switch).

This option ends all Service Broker conversations with an error during a database restore.

Closes #6581

Generated with [Claude Code](https://claude.ai/code)