### PR TITLE
Connect-DbaInstance - Set NonPooledConnection on ServerConnection for…

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -1075,6 +1075,10 @@ function Connect-DbaInstance {
                 }
                 Write-Message -Level Debug -Message "Setting ConnectionContext.StatementTimeout to '$StatementTimeout'"
                 $server.ConnectionContext.StatementTimeout = $StatementTimeout
+                if ($NonPooledConnection) {
+                    Write-Message -Level Debug -Message "Setting ConnectionContext.NonPooledConnection to 'True'"
+                    $server.ConnectionContext.NonPooledConnection = $true
+                }
             }
 
             $maskedConnString = Hide-ConnectionString $server.ConnectionContext.ConnectionString


### PR DESCRIPTION
<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [x] Bug fix (non-breaking change, fixes #10259, #10256 )
 - [ ] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (affects multiple commands or functionality, fixes #<!--issue number--> )
 - [x] Ran manual Pester test and has passed (`Invoke-ManualPester`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/dataplat/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Fix SQL Server error 17810 ("maximum number of dedicated administrator connections already exists") when using `Connect-DbaInstance -DedicatedAdminConnection`. The DAC connection is not kept open between SMO operations because `ServerConnection.NonPooledConnection` is never set in the String input path, causing rapid connect/disconnect cycling that races against SQL Server's DAC slot release.

### Approach
Added `$server.ConnectionContext.NonPooledConnection = $true` in the String input path of `Connect-DbaInstance`, alongside the existing `ConnectionContext` property assignments (BatchSeparator, LockTimeout, etc.). This is gated on `$NonPooledConnection` which covers both `-DedicatedAdminConnection` and explicit `-NonPooledConnection` usage.

The same pattern already exists in the Server/copy-context path (line ~711) and in `New-DbaConnectionString` (line ~465) — this change brings the String input path in line with both.

### Commands to test
```powershell
# Clear the error log first so results are unambiguous
Invoke-DbaQuery -SqlInstance localhost -Query "EXEC sp_cycle_errorlog"

# Connect via DAC, run a query, disconnect
$server = Connect-DbaInstance -SqlInstance localhost -DedicatedAdminConnection
Invoke-DbaQuery -SqlInstance $server -Query "SELECT @@servername"
$server | Disconnect-DbaInstance

# Check SQL Server error log for 17810 - should return no rows
Invoke-DbaQuery -SqlInstance localhost -Query "EXEC xp_readerrorlog 0, 1, N'17810'"
```

**Before fix:** `xp_readerrorlog` returns rows showing error 17810 logged during the DAC session (sometimes, depending on how quickly your particular SQL Server cleaned up the closing DAC connection - its an intermittant race condition).
**After fix:** No 17810 entries — the DAC connection stays open for the duration instead of cycling.

### Learning
- `SqlConnectionInfo.Pooled` and `ServerConnection.NonPooledConnection` are independent settings. `Pooled = $false` controls SqlClient connection pooling (`Pooling=false` in the connection string), while `NonPooledConnection = $true` controls whether SMO auto-disconnects after each operation. Both are required for DAC connections to work correctly.
