### PR TITLE
Connect-DbaInstance - Trust server certificate for localhost DAC connections

### DIFF
--- a/public/Connect-DbaInstance.ps1
+++ b/public/Connect-DbaInstance.ps1
@@ -648,6 +648,8 @@ function Connect-DbaInstance {
                         $serverName = "ADMIN:localhost"
                     }
                     Write-Message -Level Debug -Message "IsLocalHost is true, using '$serverName' for DAC to avoid multi-IP resolution."
+                    # Trust the server certificate because 'localhost' may not match the certificate CN (e.g., FQDN), issue #10254
+                    $TrustServerCertificate = $true
                 } else {
                     $serverName = "ADMIN:$serverName"
                 }
@@ -721,6 +723,8 @@ function Connect-DbaInstance {
                             } else {
                                 $connContext.ServerInstance = "ADMIN:localhost"
                             }
+                            # Trust the server certificate because 'localhost' may not match the certificate CN (e.g., FQDN), issue #10254
+                            $connContext.TrustServerCertificate = $true
                         } else {
                             $connContext.ServerInstance = 'ADMIN:' + $connContext.ServerInstance
                         }


### PR DESCRIPTION
Fixes #10254

When using DedicatedAdminConnection with a localhost instance, the server name is changed to `ADMIN:localhost` to avoid multi-IP resolution issues (#10151). However, if TLS encryption is enabled, the SQL Server certificate (issued to the FQDN) doesn't match `localhost`, causing "The target principal name is incorrect".

Automatically set TrustServerCertificate=true when connecting via DAC to localhost, since the hostname mismatch is expected and acceptable in this context.

Generated with [Claude Code](https://claude.ai/code)