### PR TITLE
Add Remove-DbaAgentJobSchedule cmdlet

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -539,6 +539,7 @@
         'Remove-DbaAgentAlert',
         'Remove-DbaAgentJob',
         'Remove-DbaAgentJobCategory',
+        'Remove-DbaAgentJobSchedule',
         'Remove-DbaAgentJobStep',
         'Remove-DbaAgentOperator',
         'Remove-DbaAgentSchedule',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -555,6 +555,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Remove-DbaAgentJob',
         'New-DbaAgentJobStep',
         'Set-DbaAgentJobStep',
+        'Remove-DbaAgentJobSchedule',
         'Remove-DbaAgentJobStep',
         'New-DbaAgentSchedule',
         'Set-DbaAgentSchedule',

--- a/public/Remove-DbaAgentJobSchedule.ps1
+++ b/public/Remove-DbaAgentJobSchedule.ps1
@@ -1,0 +1,176 @@
+function Remove-DbaAgentJobSchedule {
+    <#
+    .SYNOPSIS
+        Detaches a schedule from a SQL Server Agent job without removing the schedule.
+
+    .DESCRIPTION
+        Detaches one or more schedules from a SQL Server Agent job without deleting the schedule itself. This is equivalent to executing sp_detach_schedule in T-SQL.
+
+        This is particularly useful when a schedule is shared between multiple jobs and you need to stop a specific job from running on that schedule without affecting other jobs that use the same schedule. The schedule remains in SQL Server Agent and can be reattached to the job or attached to other jobs at any time.
+
+        Use Set-DbaAgentJob with the -Schedule parameter to reattach a schedule to a job after detaching it.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input to allow the function to be executed against multiple SQL Server instances.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Job
+        The name of the SQL Agent job(s) from which to detach the schedule. Required when using -SqlInstance.
+
+    .PARAMETER Schedule
+        The name of the schedule(s) to detach from the job. The schedule itself is not deleted; only the association between the job and schedule is removed.
+
+    .PARAMETER InputObject
+        Accepts job objects from the pipeline, typically from Get-DbaAgentJob output. Use this when you want to filter or retrieve jobs first, then pipe the results for schedule detachment.
+
+    .PARAMETER WhatIf
+        If this switch is enabled, no actions are performed but informational messages will be displayed that explain what would happen if the command were to run.
+
+    .PARAMETER Confirm
+        If this switch is enabled, you will be prompted for confirmation before executing any operations that change state.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object per detach operation, containing the result and details.
+
+        Properties:
+        - ComputerName: The computer name of the SQL Server instance
+        - InstanceName: The SQL Server instance name
+        - SqlInstance: The full SQL Server instance name (computer\instance)
+        - Job: The name of the job from which the schedule was detached
+        - Schedule: The name of the schedule that was detached
+        - ScheduleId: The numeric ID of the schedule
+        - ScheduleUid: The unique GUID identifier of the schedule
+        - Status: Result of the operation ("Detached" for success, or error message for failures)
+        - IsDetached: Boolean indicating if the schedule was successfully detached
+
+    .NOTES
+        Tags: Agent, Job, JobSchedule, Schedule
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaAgentJobSchedule
+
+    .EXAMPLE
+        PS C:\> Remove-DbaAgentJobSchedule -SqlInstance sql1 -Job Job1 -Schedule SharedSchedule
+
+        Detaches the schedule named 'SharedSchedule' from job 'Job1' on sql1. The schedule itself is not deleted and remains available for other jobs.
+
+    .EXAMPLE
+        PS C:\> Remove-DbaAgentJobSchedule -SqlInstance sql1 -Job Job1 -Schedule Schedule1, Schedule2
+
+        Detaches multiple schedules from a single job on sql1.
+
+    .EXAMPLE
+        PS C:\> Remove-DbaAgentJobSchedule -SqlInstance sql1, sql2 -Job Job1 -Schedule SharedSchedule
+
+        Detaches the schedule from job 'Job1' on multiple SQL Server instances.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJob -SqlInstance sql1 -Job Job1 | Remove-DbaAgentJobSchedule -Schedule SharedSchedule
+
+        Detaches the schedule 'SharedSchedule' from job 'Job1' using pipeline input.
+
+    .EXAMPLE
+        PS C:\> Get-DbaAgentJob -SqlInstance sql1 | Where-Object Name -like 'Maintenance*' | Remove-DbaAgentJobSchedule -Schedule SharedSchedule
+
+        Detaches 'SharedSchedule' from all jobs whose names start with 'Maintenance' on sql1.
+
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High")]
+    param (
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [string[]]$Job,
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$Schedule,
+        [Parameter(ValueFromPipeline)]
+        [Microsoft.SqlServer.Management.Smo.Agent.Job[]]$InputObject,
+        [switch]$EnableException
+    )
+    begin {
+        $jobs = @()
+    }
+    process {
+        foreach ($instance in $SqlInstance) {
+            if (-not (Test-Bound -ParameterName Job)) {
+                Stop-Function -Message "Parameter -Job is required when using -SqlInstance" -Target $instance -Continue
+            }
+
+            try {
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            foreach ($jobName in $Job) {
+                if ($server.JobServer.Jobs.Name -notcontains $jobName) {
+                    Stop-Function -Message "Job '$jobName' does not exist on $instance" -Target $instance -Continue
+                }
+                $jobs += $server.JobServer.Jobs[$jobName]
+            }
+        }
+
+        foreach ($jobObject in $InputObject) {
+            $jobs += $jobObject
+        }
+    }
+    end {
+        # We process in the end block to prevent "Collection was modified; enumeration operation may not execute."
+        # if job objects are directly piped from Get-DbaAgentJob.
+        foreach ($jobObject in $jobs) {
+            $server = $jobObject.Parent.Parent
+
+            foreach ($scheduleName in $Schedule) {
+                $jobSchedule = $jobObject.JobSchedules | Where-Object { $_.Name -eq $scheduleName }
+
+                if (-not $jobSchedule) {
+                    Stop-Function -Message "Schedule '$scheduleName' is not attached to job '$($jobObject.Name)' on $($server.Name)" -Target $jobObject -Continue
+                }
+
+                $output = [PSCustomObject]@{
+                    ComputerName = $server.ComputerName
+                    InstanceName = $server.ServiceName
+                    SqlInstance  = $server.DomainInstanceName
+                    Job          = $jobObject.Name
+                    Schedule     = $scheduleName
+                    ScheduleId   = $jobSchedule.Id
+                    ScheduleUid  = $jobSchedule.ScheduleUid
+                    Status       = $null
+                    IsDetached   = $false
+                }
+
+                if ($PSCmdlet.ShouldProcess($server, "Detaching schedule '$scheduleName' from job '$($jobObject.Name)'")) {
+                    try {
+                        Write-Message -Level Verbose -Message "Detaching schedule '$scheduleName' from job '$($jobObject.Name)' on $($server.Name)"
+                        $jobSchedule.Drop($true)
+                        $output.Status = "Detached"
+                        $output.IsDetached = $true
+                    } catch {
+                        Stop-Function -Message "Failed to detach schedule '$scheduleName' from job '$($jobObject.Name)' on $($server.Name)" -ErrorRecord $_ -Target $jobObject -Continue
+                        $output.Status = (Get-ErrorMessage -Record $_)
+                    }
+                }
+
+                $output
+            }
+        }
+    }
+}

--- a/tests/Remove-DbaAgentJobSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentJobSchedule.Tests.ps1
@@ -1,0 +1,118 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Remove-DbaAgentJobSchedule",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Job",
+                "Schedule",
+                "InputObject",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        # We want to run all commands in the BeforeAll block with EnableException to ensure that the test fails if the setup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $jobName = "dbatoolsci_job_$(Get-Random)"
+        $scheduleName = "dbatoolsci_schedule_$(Get-Random)"
+
+        $null = New-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName
+
+        $splatSchedule = @{
+            SqlInstance             = $TestConfig.instance2
+            Schedule                = $scheduleName
+            FrequencyType           = "Daily"
+            FrequencyInterval       = 1
+            StartTime               = "010000"
+        }
+        $null = New-DbaAgentSchedule @splatSchedule
+
+        $splatAttach = @{
+            SqlInstance = $TestConfig.instance2
+            Job         = $jobName
+            Schedule    = $scheduleName
+        }
+        $null = Set-DbaAgentJob @splatAttach
+
+        # We want to run all commands outside of the BeforeAll block without EnableException to be able to test for specific warnings.
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName -Confirm:$false -ErrorAction SilentlyContinue
+        $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule $scheduleName -Confirm:$false -Force -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "When detaching a schedule from a job" {
+        It "Should detach the schedule and return the expected output" {
+            $splatDetach = @{
+                SqlInstance = $TestConfig.instance2
+                Job         = $jobName
+                Schedule    = $scheduleName
+            }
+            $result = Remove-DbaAgentJobSchedule @splatDetach
+            $result.IsDetached | Should -Be $true
+            $result.Job | Should -Be $jobName
+            $result.Schedule | Should -Be $scheduleName
+            $result.Status | Should -Be "Detached"
+        }
+
+        It "Should not remove the schedule itself after detaching" {
+            $schedule = Get-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule $scheduleName
+            $schedule | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should warn when the schedule is not attached to the job" {
+            $splatDetach = @{
+                SqlInstance   = $TestConfig.instance2
+                Job           = $jobName
+                Schedule      = $scheduleName
+                WarningAction = "SilentlyContinue"
+            }
+            $result = Remove-DbaAgentJobSchedule @splatDetach
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When using pipeline input" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            # Reattach the schedule so we can test pipeline detachment
+            $splatAttach = @{
+                SqlInstance = $TestConfig.instance2
+                Job         = $jobName
+                Schedule    = $scheduleName
+            }
+            $null = Set-DbaAgentJob @splatAttach
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        It "Should detach the schedule when job is piped in" {
+            $result = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName | Remove-DbaAgentJobSchedule -Schedule $scheduleName
+            $result.IsDetached | Should -Be $true
+            $result.Job | Should -Be $jobName
+        }
+    }
+}

--- a/tests/Remove-DbaAgentJobSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentJobSchedule.Tests.ps1
@@ -92,7 +92,7 @@ Describe $CommandName -Tag IntegrationTests {
             }
             $result = Remove-DbaAgentJobSchedule @splatDetach
             $result | Should -BeNullOrEmpty
-            $WarnVar | Should -BeLike "Schedule '$scheduleName' is not attached to job '$jobName'*"
+            $WarnVar | Should -BeLike "*Schedule '$scheduleName' is not attached to job '$jobName'*"
         }
     }
 

--- a/tests/Remove-DbaAgentJobSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentJobSchedule.Tests.ps1
@@ -39,6 +39,7 @@ Describe $CommandName -Tag IntegrationTests {
             FrequencyType     = "Daily"
             FrequencyInterval = 1
             StartTime         = "010000"
+            Force             = $true
         }
         $null = New-DbaAgentSchedule @splatSchedule
 

--- a/tests/Remove-DbaAgentJobSchedule.Tests.ps1
+++ b/tests/Remove-DbaAgentJobSchedule.Tests.ps1
@@ -31,19 +31,19 @@ Describe $CommandName -Tag IntegrationTests {
         $jobName = "dbatoolsci_job_$(Get-Random)"
         $scheduleName = "dbatoolsci_schedule_$(Get-Random)"
 
-        $null = New-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName
+        $null = New-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $jobName
 
         $splatSchedule = @{
-            SqlInstance             = $TestConfig.instance2
-            Schedule                = $scheduleName
-            FrequencyType           = "Daily"
-            FrequencyInterval       = 1
-            StartTime               = "010000"
+            SqlInstance       = $TestConfig.InstanceSingle
+            Schedule          = $scheduleName
+            FrequencyType     = "Daily"
+            FrequencyInterval = 1
+            StartTime         = "010000"
         }
         $null = New-DbaAgentSchedule @splatSchedule
 
         $splatAttach = @{
-            SqlInstance = $TestConfig.instance2
+            SqlInstance = $TestConfig.InstanceSingle
             Job         = $jobName
             Schedule    = $scheduleName
         }
@@ -57,8 +57,8 @@ Describe $CommandName -Tag IntegrationTests {
         # We want to run all commands in the AfterAll block with EnableException to ensure that the test fails if the cleanup fails.
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName -Confirm:$false -ErrorAction SilentlyContinue
-        $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule $scheduleName -Confirm:$false -Force -ErrorAction SilentlyContinue
+        $null = Remove-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $jobName
+        $null = Remove-DbaAgentSchedule -SqlInstance $TestConfig.InstanceSingle -Schedule $scheduleName -Force
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -66,7 +66,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "When detaching a schedule from a job" {
         It "Should detach the schedule and return the expected output" {
             $splatDetach = @{
-                SqlInstance = $TestConfig.instance2
+                SqlInstance = $TestConfig.InstanceSingle
                 Job         = $jobName
                 Schedule    = $scheduleName
             }
@@ -78,19 +78,20 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should not remove the schedule itself after detaching" {
-            $schedule = Get-DbaAgentSchedule -SqlInstance $TestConfig.instance2 -Schedule $scheduleName
+            $schedule = Get-DbaAgentSchedule -SqlInstance $TestConfig.InstanceSingle -Schedule $scheduleName
             $schedule | Should -Not -BeNullOrEmpty
         }
 
         It "Should warn when the schedule is not attached to the job" {
             $splatDetach = @{
-                SqlInstance   = $TestConfig.instance2
+                SqlInstance   = $TestConfig.InstanceSingle
                 Job           = $jobName
                 Schedule      = $scheduleName
                 WarningAction = "SilentlyContinue"
             }
             $result = Remove-DbaAgentJobSchedule @splatDetach
             $result | Should -BeNullOrEmpty
+            $WarnVar | Should -BeLike "Schedule '$scheduleName' is not attached to job '$jobName'*"
         }
     }
 
@@ -100,7 +101,7 @@ Describe $CommandName -Tag IntegrationTests {
 
             # Reattach the schedule so we can test pipeline detachment
             $splatAttach = @{
-                SqlInstance = $TestConfig.instance2
+                SqlInstance = $TestConfig.InstanceSingle
                 Job         = $jobName
                 Schedule    = $scheduleName
             }
@@ -110,7 +111,7 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should detach the schedule when job is piped in" {
-            $result = Get-DbaAgentJob -SqlInstance $TestConfig.instance2 -Job $jobName | Remove-DbaAgentJobSchedule -Schedule $scheduleName
+            $result = Get-DbaAgentJob -SqlInstance $TestConfig.InstanceSingle -Job $jobName | Remove-DbaAgentJobSchedule -Schedule $scheduleName
             $result.IsDetached | Should -Be $true
             $result.Job | Should -Be $jobName
         }


### PR DESCRIPTION
Implements `sp_detach_schedule` equivalent: removes the association between a job and a schedule without deleting the shared schedule itself.

Closes #9687

Generated with [Claude Code](https://claude.ai/code)