### PR TITLE
New-DbaDbTable - Handle bracket-quoted names and two-part names

### DIFF
--- a/public/New-DbaDbTable.ps1
+++ b/public/New-DbaDbTable.ps1
@@ -468,6 +468,20 @@ function New-DbaDbTable {
             }
         }
 
+        # Parse the Name parameter to handle bracket-quoted names and two-part names like [schema].[table]
+        if (Test-Bound -ParameterName Name) {
+            $parsedName = Get-ObjectNameParts -ObjectName $Name
+            if ($parsedName.Parsed) {
+                if ($parsedName.Schema -and -not (Test-Bound -ParameterName Schema)) {
+                    $Schema = $parsedName.Schema
+                }
+                $Name = $parsedName.Name
+            } else {
+                Stop-Function -Message "Could not parse -Name '$Name' as a valid object name."
+                return
+            }
+        }
+
         foreach ($instance in $SqlInstance) {
             $InputObject += Get-DbaDatabase -SqlInstance $instance -SqlCredential $SqlCredential -Database $Database
         }

--- a/tests/New-DbaDbTable.Tests.ps1
+++ b/tests/New-DbaDbTable.Tests.ps1
@@ -224,6 +224,37 @@ Describe $CommandName -Tag IntegrationTests {
             $tableWithSchema[2] | Should -Match "$tableName"
         }
     }
+    Context "Should handle bracket-quoted names and two-part names" {
+        BeforeAll {
+            $map = @{
+                Name = "testId"
+                Type = "int"
+            }
+        }
+        It "Strips brackets from a bracket-quoted table name" {
+            $random = Get-Random
+            $tableName = "table_bracket_$random"
+            $result = New-DbaDbTable -SqlInstance $TestConfig.InstanceMulti1 -Database $dbname -Name "[$tableName]" -ColumnMap $map
+            $result.Name | Should -Be $tableName
+            $result.Schema | Should -Be "dbo"
+        }
+        It "Parses schema and table from a two-part bracket-quoted name" {
+            $random = Get-Random
+            $tableName = "table_twopart_$random"
+            $schemaName = "schema_twopart_$random"
+            $result = New-DbaDbTable -SqlInstance $TestConfig.InstanceMulti1 -Database $dbname -Name "[$schemaName].[$tableName]" -ColumnMap $map
+            $result.Name | Should -Be $tableName
+            $result.Schema | Should -Be $schemaName
+        }
+        It "Parses schema and table from a two-part unquoted name" {
+            $random = Get-Random
+            $tableName = "table_unquoted_$random"
+            $schemaName = "schema_unquoted_$random"
+            $result = New-DbaDbTable -SqlInstance $TestConfig.InstanceMulti1 -Database $dbname -Name "$schemaName.$tableName" -ColumnMap $map
+            $result.Name | Should -Be $tableName
+            $result.Schema | Should -Be $schemaName
+        }
+    }
     Context "Should create graph tables with IsNode and IsEdge switches" {
         BeforeAll {
             $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceMulti2


### PR DESCRIPTION
Fixes #8337

Parse the -Name parameter using Get-ObjectNameParts so that bracket-quoted names like [table] are stripped of brackets, and two-part names like [schema].[table] are split into schema and table components.

This brings New-DbaDbTable in line with Get-DbaDbTable which already handles these cases via Get-ObjectNameParts.

Generated with [Claude Code](https://claude.ai/code)