### PR TITLE
Get-DbaDbMailAccount, Get-DbaDbMailProfile - Add Account-Profile link details

### DIFF
--- a/public/Get-DbaDbMailAccount.ps1
+++ b/public/Get-DbaDbMailAccount.ps1
@@ -61,6 +61,7 @@ function Get-DbaDbMailAccount {
         - ReplyToAddress: The reply-to email address for emails sent from this account
         - IsBusyAccount: Boolean indicating if the account is currently busy sending messages
         - MailServers: Collection of SMTP servers configured for this account
+        - MailProfile: Collection of Database Mail profile names associated with this account
 
         Additional properties available (from SMO SqlMailAccount object):
         - Account: The account owner or associated account information
@@ -128,10 +129,13 @@ function Get-DbaDbMailAccount {
                     $accounts = $accounts | Where-Object Name -notin $ExcludeAccount
                 }
 
-                $accounts | Add-Member -Force -MemberType NoteProperty -Name ComputerName -value $mailserver.ComputerName
-                $accounts | Add-Member -Force -MemberType NoteProperty -Name InstanceName -value $mailserver.InstanceName
-                $accounts | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -value $mailserver.SqlInstance
-                $accounts | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, ID, Name, DisplayName, Description, EmailAddress, ReplyToAddress, IsBusyAccount, MailServers
+                foreach ($acct in $accounts) {
+                    $acct | Add-Member -Force -MemberType NoteProperty -Name ComputerName -value $mailserver.ComputerName
+                    $acct | Add-Member -Force -MemberType NoteProperty -Name InstanceName -value $mailserver.InstanceName
+                    $acct | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -value $mailserver.SqlInstance
+                    $acct | Add-Member -Force -MemberType NoteProperty -Name MailProfile -value $acct.GetAccountProfileNames()
+                    $acct | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, ID, Name, DisplayName, Description, EmailAddress, ReplyToAddress, IsBusyAccount, MailServers, MailProfile
+                }
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
             }

--- a/public/Get-DbaDbMailProfile.ps1
+++ b/public/Get-DbaDbMailProfile.ps1
@@ -47,6 +47,7 @@ function Get-DbaDbMailProfile {
         - Description: Text description of the profile's purpose or intended use
         - ForceDeleteForActiveProfiles: Boolean indicating if the profile will be forcefully deleted even if actively used
         - IsBusyProfile: Boolean indicating if the profile is currently busy processing mail messages
+        - MailAccount: Collection of Database Mail account names associated with this profile
 
         Additional properties available (from SMO MailProfile object):
         - Parent: Reference to the parent SqlMail object
@@ -131,11 +132,13 @@ function Get-DbaDbMailProfile {
 
                 }
 
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value $mailserver.ComputerName
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name InstanceName -Value $mailserver.InstanceName
-                $profiles | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -Value $mailserver.SqlInstance
-
-                $profiles | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, ID, Name, Description, ForceDeleteForActiveProfiles, IsBusyProfile
+                foreach ($prof in $profiles) {
+                    $prof | Add-Member -Force -MemberType NoteProperty -Name ComputerName -Value $mailserver.ComputerName
+                    $prof | Add-Member -Force -MemberType NoteProperty -Name InstanceName -Value $mailserver.InstanceName
+                    $prof | Add-Member -Force -MemberType NoteProperty -Name SqlInstance -Value $mailserver.SqlInstance
+                    $prof | Add-Member -Force -MemberType NoteProperty -Name MailAccount -Value $prof.EnumAccounts().AccountName
+                    $prof | Select-DefaultView -Property ComputerName, InstanceName, SqlInstance, ID, Name, Description, ForceDeleteForActiveProfiles, IsBusyProfile, MailAccount
+                }
             } catch {
                 Stop-Function -Message "Failure" -ErrorRecord $_ -Continue
             }


### PR DESCRIPTION
Add MailProfile property to Get-DbaDbMailAccount and MailAccount property to Get-DbaDbMailProfile, showing the association between accounts and profiles via SMO methods.

Fixes #7822

Generated with [Claude Code](https://claude.ai/code)