### PR TITLE
Update-DbaInstance - Add early validation for empty -Path parameter

### DIFF
--- a/public/Update-DbaInstance.ps1
+++ b/public/Update-DbaInstance.ps1
@@ -274,6 +274,10 @@ function Update-DbaInstance {
                 }
             }
         }
+        if (-not $Path) {
+            Stop-Function -Category InvalidArgument -Message "Path is required. Please provide a -Path to a folder containing (or to store) SQL Server updates, or configure a default with Set-DbatoolsConfig -Name Path.SQLServerUpdates -Value 'C:\patches'."
+            return
+        }
         $actions = @()
         $actionTemplate = @{ }
         if ($InstanceName) { $actionTemplate.InstanceName = $InstanceName }


### PR DESCRIPTION
Adds a check in the begin block to stop with a clear error message when -Path is not provided and no default is configured via Set-DbatoolsConfig. Previously this resulted in a confusing "Cannot index into a null array" runtime error deep in the download logic.

Fixes #10266

Generated with [Claude Code](https://claude.ai/code)