### PR TITLE
Test-DbaPath - Handle xp_fileexist execution failures gracefully

### DIFF
--- a/public/Test-DbaPath.ps1
+++ b/public/Test-DbaPath.ps1
@@ -95,7 +95,26 @@ function Test-DbaPath {
                     $query += "EXEC master.dbo.xp_fileexist '$p'"
                 }
                 $sql = $query -join ';'
-                $batchresult = $server.ConnectionContext.ExecuteWithResults($sql)
+                try {
+                    $batchresult = $server.ConnectionContext.ExecuteWithResults($sql)
+                } catch {
+                    Write-Message -Level Verbose -Message "xp_fileexist execution failed for path(s) on $instance. The SQL Server service account may not have access to the specified path(s). Error: $_"
+                    if ($Path.Count -eq 1 -and $SqlInstance.Count -eq 1 -and (-not($RawPath -is [array]))) {
+                        return $false
+                    } else {
+                        foreach ($p in $PathsBatch) {
+                            [PSCustomObject]@{
+                                SqlInstance  = $server.Name
+                                InstanceName = $server.ServiceName
+                                ComputerName = $server.ComputerName
+                                FilePath     = $p
+                                FileExists   = $false
+                                IsContainer  = $false
+                            }
+                        }
+                    }
+                    continue
+                }
                 if ($Path.Count -eq 1 -and $SqlInstance.Count -eq 1 -and (-not($RawPath -is [array]))) {
                     if ($batchresult.Tables.rows[0] -eq $true -or $batchresult.Tables.rows[1] -eq $true) {
                         return $true


### PR DESCRIPTION
When xp_fileexist raises a SQL exception (e.g. for UNC paths the SQL Server service account cannot resolve), wrap ExecuteWithResults in try/catch and return $false instead of crashing with "Cannot index into a null array".

Fixes #10286

Generated with [Claude Code](https://claude.ai/code)