### PR TITLE
Fix DAC connection reuse detection causing excessive DAC errors in Sync-DbaAvailabilityGroup

### DIFF
--- a/public/Copy-DbaCredential.ps1
+++ b/public/Copy-DbaCredential.ps1
@@ -156,7 +156,7 @@ function Copy-DbaCredential {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Copy-DbaDbMail.ps1
+++ b/public/Copy-DbaDbMail.ps1
@@ -390,7 +390,7 @@ function Copy-DbaDbMail {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Copy-DbaLinkedServer.ps1
+++ b/public/Copy-DbaLinkedServer.ps1
@@ -307,7 +307,7 @@ function Copy-DbaLinkedServer {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Export-DbaCredential.ps1
+++ b/public/Export-DbaCredential.ps1
@@ -115,7 +115,7 @@ function Export-DbaCredential {
                 if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
                 $dacOpened = $false
                 if ($dacNeeded) {

--- a/public/Export-DbaInstance.ps1
+++ b/public/Export-DbaInstance.ps1
@@ -240,7 +240,7 @@ function Export-DbaInstance {
                 if ($ExcludePassword) { $dacNeeded = $false }
 
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
                 $dacOpened = $false
                 if ($dacNeeded) {

--- a/public/Export-DbaLinkedServer.ps1
+++ b/public/Export-DbaLinkedServer.ps1
@@ -129,7 +129,7 @@ function Export-DbaLinkedServer {
                 if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
                 $dacOpened = $false
                 if ($dacNeeded) {

--- a/public/Invoke-DbaDbDecryptObject.ps1
+++ b/public/Invoke-DbaDbDecryptObject.ps1
@@ -198,7 +198,7 @@ function Invoke-DbaDbDecryptObject {
             # Try to connect to instance
             try {
                 # Do we have a dedicated admin connection already?
-                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.Name -match '^ADMIN:'
+                $dacConnected = $instance.Type -eq 'Server' -and $instance.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
                 $dacOpened = $false
                 if ($dacConnected) {
                     Write-Message -Level Verbose -Message "Reusing dedicated admin connection."

--- a/public/Start-DbaMigration.ps1
+++ b/public/Start-DbaMigration.ps1
@@ -366,7 +366,7 @@ function Start-DbaMigration {
             if ($ExcludePassword) { $dacNeeded = $false }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.Name -match '^ADMIN:'
+            $dacConnected = $Source.Type -eq 'Server' -and $Source.InputObject.ConnectionContext.ServerInstance -match '^ADMIN:'
 
             $dacOpened = $false
             if ($dacNeeded) {

--- a/public/Sync-DbaAvailabilityGroup.ps1
+++ b/public/Sync-DbaAvailabilityGroup.ps1
@@ -194,7 +194,7 @@ function Sync-DbaAvailabilityGroup {
             if ($ExcludePassword) { $dacNeeded = $false } else { $dacNeeded = $true }
 
             # Do we have a dedicated admin connection already?
-            $dacConnected = $InputObject.Parent.Name -match '^ADMIN:'
+            $dacConnected = $InputObject.Parent.ConnectionContext.ServerInstance -match '^ADMIN:'
 
             if ($dacNeeded -and -not $dacConnected) {
                 Stop-Function -Message "Pipeline source must use a dedicated admin connection to retrieve passwords. Use -ExcludePassword to bypass this requirement if you don't need passwords."
@@ -399,7 +399,18 @@ function Sync-DbaAvailabilityGroup {
 
             if ($Exclude -notcontains "LoginPermissions") {
                 Write-ProgressHelper -Activity $activity -StepNumber ($stepCounter++) -Message "Syncing login permissions"
-                Sync-DbaLoginPermission -Source $server -Destination $secondaries -Login $Login -ExcludeLogin $ExcludeLogin
+                # Use DomainInstanceName (string) instead of the server object to ensure Sync-DbaLoginPermission
+                # opens a normal (non-DAC) connection. Update-SqlPermission calls SqlConnectionObject.Close()
+                # in loops, which on a DAC connection causes repeated DAC slot acquire/release cycles
+                # that generate "max 1 DAC connections" errors in the SQL Error Log.
+                $splatLoginPermission = @{
+                    Source              = $server.DomainInstanceName
+                    SourceSqlCredential = $PrimarySqlCredential
+                    Destination         = $secondaries
+                    Login               = $Login
+                    ExcludeLogin        = $ExcludeLogin
+                }
+                Sync-DbaLoginPermission @splatLoginPermission
             }
         }
 


### PR DESCRIPTION
Fix two bugs introduced in v2.7.25 that cause 30-40 "max 1 DAC connections" errors in the SQL Error Log when Sync-DbaAvailabilityGroup runs.

**Bug 1: dacConnected check used Server.Name instead of ConnectionContext.ServerInstance**

Server.Name never has the ADMIN: prefix for DAC connections — that lives in ConnectionContext.ServerInstance. The broken check caused Copy-DbaCredential, Copy-DbaDbMail, and Copy-DbaLinkedServer to always think no DAC was open, set $dacOpened = $true, and disconnect the shared DAC in their end blocks.

**Bug 2: Sync-DbaLoginPermission received the DAC server object**

Update-SqlPermission calls SqlConnectionObject.Close() in tight loops (per role per database per login). With a DAC connection, each Close() physically terminates the TCP connection and the next SMO operation immediately tries to reconnect to ADMIN:server. TCP close propagation timing causes SQL Server to see the old connection as still active, generating the errors.

Fixes #10284

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/dataplat/dbatools/tree/claude/issue-10284-20260327-2247