### PR TITLE
Update-SqlPermission - Remove unnecessary SqlConnectionObject.Close() calls

### DIFF
--- a/private/functions/Update-SqlPermission.ps1
+++ b/private/functions/Update-SqlPermission.ps1
@@ -59,10 +59,6 @@ function Update-SqlPermission {
         }
     }
 
-    # gotta close because enum repeatedly causes problems with the datareader
-    $null = $SourceServer.ConnectionContext.SqlConnectionObject.Close()
-    $null = $DestServer.ConnectionContext.SqlConnectionObject.Close()
-
     # Server Roles: sysadmin, bulklogin, etc
     foreach ($role in $SourceServer.Roles) {
         $roleName = $role.Name
@@ -131,9 +127,6 @@ function Update-SqlPermission {
             These operations are only supported by SQL Server 2005 and above.
             Securables: Connect SQL, View any database, Administer Bulk Operations, etc.
         #>
-
-        $null = $sourceServer.ConnectionContext.SqlConnectionObject.Close()
-        $null = $destServer.ConnectionContext.SqlConnectionObject.Close()
 
         $perms = $SourceServer.EnumServerPermissions($loginName)
         foreach ($perm in $perms) {
@@ -259,8 +252,6 @@ function Update-SqlPermission {
                 }
             }
 
-            $null = $sourceDb.Parent.ConnectionContext.SqlConnectionObject.Close()
-            $null = $destDb.Parent.ConnectionContext.SqlConnectionObject.Close()
             # Remove Connect, Alter Any Assembly, etc
             $destPerms = $destDb.EnumDatabasePermissions($newLoginName)
             $perms = $sourceDb.EnumDatabasePermissions($loginName)
@@ -292,9 +283,6 @@ function Update-SqlPermission {
     }
 
     # Adding database mappings and securables
-    $null = $SourceLogin.Parent.ConnectionContext.SqlConnectionObject.Close()
-    $null = $DestServer.ConnectionContext.SqlConnectionObject.Close()
-
     foreach ($db in $SourceLogin.EnumDatabaseMappings()) {
         $dbName = $db.DbName
         $destDb = $DestServer.Databases[$dbName]
@@ -355,8 +343,6 @@ function Update-SqlPermission {
             } else {
                 # Database Roles: db_owner, db_datareader, etc
                 foreach ($role in $sourceDb.Roles) {
-                    $null = $sourceDb.Parent.ConnectionContext.SqlConnectionObject.Close()
-                    $null = $destDb.Parent.ConnectionContext.SqlConnectionObject.Close()
                     if ($role.EnumMembers() -contains $loginName) {
                         $roleName = $role.Name
                         $destDbRole = $destDb.Roles[$roleName]
@@ -375,7 +361,6 @@ function Update-SqlPermission {
                     }
                 }
                 # Connect, Alter Any Assembly, etc
-                $null = $sourceDb.Parent.ConnectionContext.SqlConnectionObject.Close()
                 $perms = $sourceDb.EnumDatabasePermissions($loginName)
                 foreach ($perm in $perms) {
                     $permState = $perm.PermissionState


### PR DESCRIPTION
Remove 11 `Close()` calls across 6 locations in `Update-SqlPermission` that caused 30-40 "max 1 DAC connections" errors in the SQL Error Log when `Sync-DbaAvailabilityGroup` runs.

The calls were added as a workaround for SMO DataReader conflicts, but modern SMO properly manages its own connection lifecycle - all Enum* methods open and close their DataReaders internally via SqlDataAdapter.Fill().

The calls were harmless with normal pooled connections but catastrophic with DAC connections: each Close() terminates the single DAC TCP slot, and the reconnect attempt to ADMIN:server fails when the slot hasn't been freed yet.

The worst offender was the Close() pair inside the `foreach ($role in $sourceDb.Roles)` loop - called once per role per database per login, producing 30-40 DAC errors in the scenario reported in #10284.

Fixes #10284

Generated with [Claude Code](https://claude.ai/code)