### PR TITLE
Get-DbaNetworkEncryption - Add command to retrieve TLS certificate from SQL Server network

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -333,6 +333,7 @@
         'Get-DbaMsdtc',
         'Get-DbaNetworkActivity',
         'Get-DbaNetworkCertificate',
+        'Get-DbaNetworkEncryption',
         'Get-DbaNetworkConfiguration',
         'Get-DbaOpenTransaction',
         'Get-DbaOperatingSystem',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -1068,6 +1068,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Test-DbaComputerCertificateExpiration',
         'Test-DbaNetworkCertificate',
         'Get-DbaNetworkCertificate',
+        'Get-DbaNetworkEncryption',
         'Set-DbaNetworkCertificate',
         'Remove-DbaDbLogShipping',
         'Invoke-DbaDbLogShipping',

--- a/private/functions/Get-SqlServerTlsCertificate.ps1
+++ b/private/functions/Get-SqlServerTlsCertificate.ps1
@@ -370,7 +370,7 @@ public class TdsTlsStream : Stream {
                 "Client does not trust remote certificate: $($certState.SslPolicyErrors)"
                 $certState.ChainStatus | ForEach-Object { $_.Status; $_.StatusInformation }
             ) -join ([System.Environment]::NewLine)
-            Write-Warning -Message $msg.TrimEnd()
+            Write-Message -Level Warning -Message $msg.TrimEnd()
         }
 
         $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $sslStream.RemoteCertificate

--- a/private/functions/Get-SqlServerTlsCertificate.ps1
+++ b/private/functions/Get-SqlServerTlsCertificate.ps1
@@ -111,71 +111,80 @@ Function Get-SqlServerTlsCertificate {
         $StrictEncrypt
     )
 
-    class TdsTlsStream : System.IO.Stream {
-        [System.IO.Stream]$InnerStream
-        [int]$PayloadLength = 0
+    if (-not ([System.Management.Automation.PSTypeName]"TdsTlsStream").Type) {
+        Add-Type -TypeDefinition @"
+using System;
+using System.IO;
 
-        TdsTlsStream([System.IO.Stream]$InnerStream) {
-            $this.InnerStream = $InnerStream
-        }
+public class TdsTlsStream : Stream {
+    private Stream _innerStream;
+    private int _payloadLength = 0;
 
-        [bool] get_CanRead() { return $this.InnerStream.CanRead }
-        [bool] get_CanWrite() { return $this.InnerStream.CanWrite }
-        [bool] get_CanSeek() { return $this.InnerStream.CanSeek }
-        [Int64] get_Length() { return $this.InnerStream.Length }
-        [Int64] get_Position() { return $this.InnerStream.Position }
-        [void] set_Position([Int64]$Value) { $this.InnerStream.Position = $Value }
-        [int] get_ReadTimeout() { return $this.InnerStream.ReadTimeout }
-        [int] get_WriteTimeout() { return $this.InnerStream.WriteTimeout }
+    public TdsTlsStream(Stream innerStream) {
+        _innerStream = innerStream;
+    }
 
-        [void] Flush() { $this.InnerStream.Flush() }
-        [Int64] Seek([Int64]$Offset, [System.IO.SeekOrigin]$Origin) { return $this.InnerStream.Seek($Offset, $Origin) }
-        [void] SetLength([Int64]$Value) { $this.InnerStream.SetLength($Value) }
+    public override bool CanRead { get { return _innerStream.CanRead; } }
+    public override bool CanWrite { get { return _innerStream.CanWrite; } }
+    public override bool CanSeek { get { return _innerStream.CanSeek; } }
+    public override long Length { get { return _innerStream.Length; } }
+    public override long Position {
+        get { return _innerStream.Position; }
+        set { _innerStream.Position = value; }
+    }
+    public override int ReadTimeout { get { return _innerStream.ReadTimeout; } }
+    public override int WriteTimeout { get { return _innerStream.WriteTimeout; } }
 
-        [int] Read([byte[]]$Buffer, [int]$Offset, [int]$Count) {
-            # We need to strip off the TDS header before setting the Buffer
-            if ($this.PayloadLength -eq 0) {
-                $header = [byte[]]::new(8)
-                $read = 0
-                while ($read -lt 8) {
-                    $read += $this.InnerStream.Read($header, 0, 8)
-                }
+    public override void Flush() { _innerStream.Flush(); }
+    public override long Seek(long offset, SeekOrigin origin) { return _innerStream.Seek(offset, origin); }
+    public override void SetLength(long value) { _innerStream.SetLength(value); }
 
-                $lengthBeforeHeader = [System.BitConverter]::ToUInt16([byte[]]@($header[3], $header[2]), 0)
-                $lengthBeforeHeader -= 8
-                $this.PayloadLength = $lengthBeforeHeader
+    public override int Read(byte[] buffer, int offset, int count) {
+        // We need to strip off the TDS header before setting the Buffer
+        if (_payloadLength == 0) {
+            byte[] header = new byte[8];
+            int read = 0;
+            while (read < 8) {
+                read += _innerStream.Read(header, 0, 8);
             }
 
-            if ($Count -gt $this.PayloadLength) {
-                $Count = $this.PayloadLength
-            }
-            $read = $this.InnerStream.Read($Buffer, $Offset, $Count)
-            $this.PayloadLength -= $read
-            return $read
+            int lengthBeforeHeader = (int)BitConverter.ToUInt16(new byte[] { header[3], header[2] }, 0);
+            lengthBeforeHeader -= 8;
+            _payloadLength = lengthBeforeHeader;
         }
 
-        [void] Write([byte[]]$Buffer, [int]$Offset, [int]$Count) {
-            $newPayload = $this.GenerateTdsHeader($Buffer, $Offset, $Count)
-            $this.InnerStream.Write($newPayload, 0, $newPayload.Length)
+        if (count > _payloadLength) {
+            count = _payloadLength;
         }
+        int bytesRead = _innerStream.Read(buffer, offset, count);
+        _payloadLength -= bytesRead;
+        return bytesRead;
+    }
 
-        [byte[]] GenerateTdsHeader([byte[]]$Payload, [int]$Offset, [int]$Count) {
-            # The length is big endian encoded so it is inserted in reverse order
-            $lengthBytes = [System.BitConverter]::GetBytes([uint16]($Count + 8))
+    public override void Write(byte[] buffer, int offset, int count) {
+        byte[] newPayload = GenerateTdsHeader(buffer, offset, count);
+        _innerStream.Write(newPayload, 0, newPayload.Length);
+    }
 
-            $newPayload = [byte[]]::new(8 + $Count)
-            $newPayload[0] = 0x12  # Type - Pre-Login
-            $newPayload[1] = 0x01  # Status - End of message (EOM)
-            $newPayload[2] = $lengthBytes[1]
-            $newPayload[3] = $lengthBytes[0]
-            $newPayload[4] = 0  # SPID
-            $newPayload[5] = 0  # SPID
-            $newPayload[6] = 0  # PacketID
-            $newPayload[7] = 0  # Window
-            [System.Array]::Copy($Payload, $Offset, $newPayload, 8, $Count)
+    private byte[] GenerateTdsHeader(byte[] payload, int offset, int count) {
+        // The length is big endian encoded so it is inserted in reverse order
+        byte[] lengthBytes = BitConverter.GetBytes((ushort)(count + 8));
 
-            return $newPayload
-        }
+        byte[] newPayload = new byte[8 + count];
+        newPayload[0] = 0x12;  // Type - Pre-Login
+        newPayload[1] = 0x01;  // Status - End of message (EOM)
+        newPayload[2] = lengthBytes[1];
+        newPayload[3] = lengthBytes[0];
+        newPayload[4] = 0;  // SPID
+        newPayload[5] = 0;  // SPID
+        newPayload[6] = 0;  // PacketID
+        newPayload[7] = 0;  // Window
+        Array.Copy(payload, offset, newPayload, 8, count);
+
+        return newPayload;
+    }
+}
+"@
     }
 
     $udpClient = $socket = $targetStream = $sslStream = $null
@@ -190,7 +199,7 @@ Function Get-SqlServerTlsCertificate {
         if ($ConnectionType -eq "SQLBrowser") {
             # Use the SQLBrowser
             # https://learn.microsoft.com/en-us/openspecs/windows_protocols/mc-sqlr/2e1560c9-5097-4023-9f5e-72b9ff1ec3b1
-            $udpClient = [System.Net.Sockets.UdpClient]::new($ComputerName, 1434)
+            $udpClient = New-Object -TypeName System.Net.Sockets.UdpClient -ArgumentList @($ComputerName, 1434)
             $udpClient.Client.SendTimeout = $ConnectTimeout
             $udpClient.Client.ReceiveTimeout = $ConnectTimeout
             $null = $udpClient.Send([byte[]]@(0x03), 1)  # CLNT_UCAST_EX
@@ -239,18 +248,17 @@ Function Get-SqlServerTlsCertificate {
         if ($ConnectionType -eq "TCP") {
             Write-Verbose -Message "Connecting to TCP/IP endpoint $($ComputerName):$Port"
 
-            $socket = [System.Net.Sockets.TcpClient]::new()
+            $socket = New-Object -TypeName System.Net.Sockets.TcpClient
             $connectTask = $socket.ConnectAsync($ComputerName, $Port)
             if (-not $connectTask.Wait($ConnectTimeout)) {
                 throw "Timed out connecting to TCP/IP endpoint $($ComputerName):$Port"
             }
 
-            $null = $connectTask.GetAwaiter().GetResult()
             $targetStream = $socket.GetStream()
         }
         else {
             Write-Verbose -Message "Connecting to Named Pipe endpoint \\$($ComputerName)\pipe\$pipeName"
-            $targetStream = [System.IO.Pipes.NamedPipeClientStream]::new(
+            $targetStream = New-Object -TypeName System.IO.Pipes.NamedPipeClientStream -ArgumentList @(
                 $ComputerName,
                 $pipeName,
                 [System.IO.Pipes.PipeDirection]::InOut)
@@ -281,7 +289,7 @@ Function Get-SqlServerTlsCertificate {
             )
             $targetStream.Write($tdsPreLogin, 0, $tdsPreLogin.Count)
 
-            $headerBytes = [byte[]]::new(8)
+            $headerBytes = New-Object byte[] 8
             $read = 0
             while ($read -ne $headerBytes.Length) {
                 $read += $targetStream.Read($headerBytes, $read, $headerBytes.Length - $read)
@@ -292,7 +300,7 @@ Function Get-SqlServerTlsCertificate {
             $payloadLength = [System.BitConverter]::ToUInt16([byte[]]@($headerBytes[3], $headerBytes[2]), 0)
             $payloadLength -= 8
 
-            $tdsPreLoginResp = [byte[]]::new($payloadLength)
+            $tdsPreLoginResp = New-Object byte[] $payloadLength
             $read = 0
             while ($read -ne $tdsPreLoginResp.Length) {
                 $read += $targetStream.Read($tdsPreLoginResp, $read, $tdsPreLoginResp.Length - $read)
@@ -337,7 +345,7 @@ Function Get-SqlServerTlsCertificate {
             # there is a note that TDS 7.1 or earlier (SQL Server 2000 or earlier)
             # should use the table response type (0x04) instead. As this is so old
             # I'm not going to implement that.
-            $streamToWrap = [TdsTlsStream]::new($targetStream)
+            $streamToWrap = New-Object -TypeName TdsTlsStream -ArgumentList $targetStream
         }
 
         # Create the SslStream with a disable certificate verification callback.
@@ -345,13 +353,14 @@ Function Get-SqlServerTlsCertificate {
         # hostname. The callback will also capture more information about the peer
         # Allows us to emit warnings if it was going to fail.
         $certState = @{}
-        $sslStream = [System.Net.Security.SslStream]::new($streamToWrap, $false, {
-                param($Sender, $Certificate, $Chain, $SslPolicyErrors)
+        $sslValidationCallback = [System.Net.Security.RemoteCertificateValidationCallback] {
+            param($Sender, $Certificate, $Chain, $SslPolicyErrors)
 
-                $certState.Chain = $chain
-                $certState.SslPolicyErrors = $SslPolicyErrors
-                $true
-            })
+            $certState.Chain = $Chain
+            $certState.SslPolicyErrors = $SslPolicyErrors
+            $true
+        }
+        $sslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($streamToWrap, $false, $sslValidationCallback)
         Write-Verbose -Message "Starting TLS Handshake"
         $sslStream.AuthenticateAsClient($ComputerName)
         Write-Verbose -Message "TLS result: $($certState.SslPolicyErrors)"
@@ -364,7 +373,7 @@ Function Get-SqlServerTlsCertificate {
             Write-Warning -Message $msg.TrimEnd()
         }
 
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($sslStream.RemoteCertificate)
+        $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $sslStream.RemoteCertificate
         Write-Verbose -Message "Found cert for $($cert.Subject), Expires: $($cert.NotAfter), SANs: $($cert.DnsNameList -join ", ")"
 
         $cert

--- a/private/functions/Get-SqlServerTlsCertificate.ps1
+++ b/private/functions/Get-SqlServerTlsCertificate.ps1
@@ -207,7 +207,7 @@ public class TdsTlsStream : Stream {
 
             $respSize = [System.BitConverter]::ToUInt16($resp, 1)
             $rawResponse = [System.Text.Encoding]::UTF8.GetString($resp, 3, $respSize)
-            Write-Verbose -Message "Recieved SQL Browser response: '$rawResponse'"
+            Write-Message -Level Verbose -Message "Recieved SQL Browser response: '$rawResponse'"
             $response = $rawResponse -split ';'
 
             $instanceInfo = [Ordered]@{}
@@ -221,7 +221,7 @@ public class TdsTlsStream : Stream {
                     }
                     else {
                         $info = [PSCustomObject]$instanceInfo
-                        Write-Verbose -Message "Processed SQL Browser Response:`n$($info | Out-String)"
+                        Write-Message -Level Verbose -Message "Processed SQL Browser Response:`n$($info | Out-String)"
 
                         $info
                         $instanceInfo = [Ordered]@{}
@@ -246,7 +246,7 @@ public class TdsTlsStream : Stream {
         }
 
         if ($ConnectionType -eq "TCP") {
-            Write-Verbose -Message "Connecting to TCP/IP endpoint $($ComputerName):$Port"
+            Write-Message -Level Verbose -Message "Connecting to TCP/IP endpoint $($ComputerName):$Port"
 
             $socket = New-Object -TypeName System.Net.Sockets.TcpClient
             $connectTask = $socket.ConnectAsync($ComputerName, $Port)
@@ -257,7 +257,7 @@ public class TdsTlsStream : Stream {
             $targetStream = $socket.GetStream()
         }
         else {
-            Write-Verbose -Message "Connecting to Named Pipe endpoint \\$($ComputerName)\pipe\$pipeName"
+            Write-Message -Level Verbose -Message "Connecting to Named Pipe endpoint \\$($ComputerName)\pipe\$pipeName"
             $targetStream = New-Object -TypeName System.IO.Pipes.NamedPipeClientStream -ArgumentList @(
                 $ComputerName,
                 $pipeName,
@@ -270,11 +270,11 @@ public class TdsTlsStream : Stream {
         # payload making it more difficult. TDS 8.0 (Encrypt=strict) is a lot
         # simpler as the TLS handshake is done before anything.
         if ($StrictEncrypt) {
-            Write-Verbose -Message "Using TDS 8 TLS Handshake"
+            Write-Message -Level Verbose -Message "Using TDS 8 TLS Handshake"
             $streamToWrap = $targetStream
         }
         else {
-            Write-Verbose -Message "Using TDS 7.x Pre-Login method for the TLS handshake"
+            Write-Message -Level Verbose -Message "Using TDS 7.x Pre-Login method for the TLS handshake"
 
             # This is a pre-calculated TDS Pre-Login payload with the ENCRYPTION
             # value of ENCRYPT_REQ (0x03).
@@ -361,9 +361,9 @@ public class TdsTlsStream : Stream {
             $true
         }
         $sslStream = New-Object -TypeName System.Net.Security.SslStream -ArgumentList @($streamToWrap, $false, $sslValidationCallback)
-        Write-Verbose -Message "Starting TLS Handshake"
+        Write-Message -Level Verbose -Message "Starting TLS Handshake"
         $sslStream.AuthenticateAsClient($ComputerName)
-        Write-Verbose -Message "TLS result: $($certState.SslPolicyErrors)"
+        Write-Message -Level Verbose -Message "TLS result: $($certState.SslPolicyErrors)"
 
         if ($certState.SslPolicyErrors -ne 'None') {
             $msg = @(
@@ -374,7 +374,7 @@ public class TdsTlsStream : Stream {
         }
 
         $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $sslStream.RemoteCertificate
-        Write-Verbose -Message "Found cert for $($cert.Subject), Expires: $($cert.NotAfter), SANs: $($cert.DnsNameList -join ", ")"
+        Write-Message -Level Verbose -Message "Found cert for $($cert.Subject), Expires: $($cert.NotAfter), SANs: $($cert.DnsNameList -join ", ")"
 
         $cert
     }

--- a/private/functions/Get-SqlServerTlsCertificate.ps1
+++ b/private/functions/Get-SqlServerTlsCertificate.ps1
@@ -1,0 +1,381 @@
+# Source: https://gist.github.com/jborean93/44f92e4dfa613c5a1e7889fa7a7c2563
+
+# Copyright: (c) 2023, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+Function Get-SqlServerTlsCertificate {
+    <#
+    .SYNOPSIS
+    Gets the MS SQL X509 Certificate.
+
+    .DESCRIPTION
+    Gets the X509 Certificate that is being used by a remote MS SQL Server.
+    This certificate contains information like the Subject, SAN entries, expiry and other useful information for debugging purposes.
+
+    .PARAMETER ComputerName
+    The remote MS SQL Server to extract the certificate from.
+
+    .PARAMETER ConnectTimeout
+    The timeout, in milliseconds, to wait until the connection was successful, defaults to 5000 (5 seconds).
+    If the timeout is reached, the cmdlet will write an error.
+
+    .PARAMETER ConnectionType
+    The connection type to use for retrieving the certificate, defaults to SQLBrowser.
+    This can be set to SQLBrowser, NamedPipe, or TCP.
+    The SQLBrowser option will use the SQL Browser service to find the named pipe or TCP port for the instance requested.
+    The SQLBrowser needs access to the UDP port 1434 as well as the NamedPipe or TCP Port that is selected to work.
+    The NamedPipe option will connect to the named pipe for the instance requested.
+    The NamedPipe will need access to the TCP port 445 to work.
+    The TCP option will connect to the TCP port requested.
+
+    .PARAMETER InstanceName
+    The MS SQL instance to connect to.
+    When used with '-ConnectionType SQLBrowser', it will only connect to the instance that matches this name.
+    When used with '-ConnectionType NamedPipe', it will use this instance name to build the named pipe name.
+    Set to an empty string to use the first instance found by the SQLBrowser.
+
+    .PARAMETER Port
+    The TCP port to use for the connection, defaults to 1433.
+    This is only used if '-ConnectionType TCP' is requested.
+
+    .PARAMETER StrictEncrypt
+    Perform strict encryption that was introduced with TDS 8.0 (SQL Server 2022 and newer).
+    Strict encryption simplifies the connection process but will only work if the server is new enough to support it.
+
+    .EXAMPLE
+    PS> Get-SqlServerTlsCertificate -ComputerName sql01
+    Gets the certificate of the first instance found on sql01 using the SQL Browser service to find the TCP port or Named Pipe.
+
+    .EXAMPLE
+    PS> Get-SqlServerTlsCertificate -ComputerName sql01 -Instance MySQLInstance
+    Gets the certificate for the instance 'sql01\MySQLInstance' using the SQL Browser service to find the TCP port or Named Pipe.
+
+    .EXAMPLE
+    PS> Get-SqlServerTlSCertificate -ComputerName sql01 -Port 65334 -ConnectionType TCP
+    Gets the certificate for server sql01 using the TCP port 65334
+
+    .EXAMPLE
+    PS> Get-SqlServerTlsCertificate -ComputerName sql01 -ConnectionType NamedPipe
+    Gets the certificate for the default instance on sql01 using the Named Pipe connection.
+
+    .EXAMPLE
+    PS> Get-SqlServerTlsCertificate -ComputerName sql01 -InstanceName MySQLInstance -ConnectionType NamedPipe
+    Gets the certificate for the instance 'sql01\MySQLInstance' using the Named Pipe connection.
+
+    .EXAMPLE
+    PS> $cert = Get-SqlServerTlsCertificate -ComputerName sql01
+    PS> $certBytes = $cert.Export("Cert")
+    PS> $setParams = @{}
+    PS> if ($PSVersionTable.PSVersion -lt [Version]'6.0') {
+    ...     $setParams.Raw = $true
+    ... } else {
+    ...     $setParams.AsByteStream = $true
+    ... }
+    PS> Set-Content -Path sql01.crt -Value $certBytes @setParams
+    Gets the certificate for the SQL server sql01 and exports it to a .crt file for use in Windows.
+
+    .OUTPUTS
+    System.Security.Cryptography.X509Certificates.X509Certificate2
+    This cmdlet will output the X509Certificate2 object retrieved from the server.
+
+    .NOTES
+    Run with -Verbose to get a better understanding of how this cmdlet connects to the MS SQL server.
+    A warning will be emitted if the remote certificate is not trusted and it will try to include the reasons why.
+    #>
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $ComputerName,
+
+        [Parameter()]
+        [int]
+        $ConnectTimeout = 5000,
+
+        [Parameter()]
+        [ValidateSet("SQLBrowser", "TCP", "NamedPipe")]
+        [string]
+        $ConnectionType = "SQLBrowser",
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string]
+        $InstanceName = "",
+
+        [Parameter()]
+        [int]
+        $Port = 1433,
+
+        [Parameter()]
+        [switch]
+        $StrictEncrypt
+    )
+
+    class TdsTlsStream : System.IO.Stream {
+        [System.IO.Stream]$InnerStream
+        [int]$PayloadLength = 0
+
+        TdsTlsStream([System.IO.Stream]$InnerStream) {
+            $this.InnerStream = $InnerStream
+        }
+
+        [bool] get_CanRead() { return $this.InnerStream.CanRead }
+        [bool] get_CanWrite() { return $this.InnerStream.CanWrite }
+        [bool] get_CanSeek() { return $this.InnerStream.CanSeek }
+        [Int64] get_Length() { return $this.InnerStream.Length }
+        [Int64] get_Position() { return $this.InnerStream.Position }
+        [void] set_Position([Int64]$Value) { $this.InnerStream.Position = $Value }
+        [int] get_ReadTimeout() { return $this.InnerStream.ReadTimeout }
+        [int] get_WriteTimeout() { return $this.InnerStream.WriteTimeout }
+
+        [void] Flush() { $this.InnerStream.Flush() }
+        [Int64] Seek([Int64]$Offset, [System.IO.SeekOrigin]$Origin) { return $this.InnerStream.Seek($Offset, $Origin) }
+        [void] SetLength([Int64]$Value) { $this.InnerStream.SetLength($Value) }
+
+        [int] Read([byte[]]$Buffer, [int]$Offset, [int]$Count) {
+            # We need to strip off the TDS header before setting the Buffer
+            if ($this.PayloadLength -eq 0) {
+                $header = [byte[]]::new(8)
+                $read = 0
+                while ($read -lt 8) {
+                    $read += $this.InnerStream.Read($header, 0, 8)
+                }
+
+                $lengthBeforeHeader = [System.BitConverter]::ToUInt16([byte[]]@($header[3], $header[2]), 0)
+                $lengthBeforeHeader -= 8
+                $this.PayloadLength = $lengthBeforeHeader
+            }
+
+            if ($Count -gt $this.PayloadLength) {
+                $Count = $this.PayloadLength
+            }
+            $read = $this.InnerStream.Read($Buffer, $Offset, $Count)
+            $this.PayloadLength -= $read
+            return $read
+        }
+
+        [void] Write([byte[]]$Buffer, [int]$Offset, [int]$Count) {
+            $newPayload = $this.GenerateTdsHeader($Buffer, $Offset, $Count)
+            $this.InnerStream.Write($newPayload, 0, $newPayload.Length)
+        }
+
+        [byte[]] GenerateTdsHeader([byte[]]$Payload, [int]$Offset, [int]$Count) {
+            # The length is big endian encoded so it is inserted in reverse order
+            $lengthBytes = [System.BitConverter]::GetBytes([uint16]($Count + 8))
+
+            $newPayload = [byte[]]::new(8 + $Count)
+            $newPayload[0] = 0x12  # Type - Pre-Login
+            $newPayload[1] = 0x01  # Status - End of message (EOM)
+            $newPayload[2] = $lengthBytes[1]
+            $newPayload[3] = $lengthBytes[0]
+            $newPayload[4] = 0  # SPID
+            $newPayload[5] = 0  # SPID
+            $newPayload[6] = 0  # PacketID
+            $newPayload[7] = 0  # Window
+            [System.Array]::Copy($Payload, $Offset, $newPayload, 8, $Count)
+
+            return $newPayload
+        }
+    }
+
+    $udpClient = $socket = $targetStream = $sslStream = $null
+    try {
+        $pipeName = if ($InstanceName -and $InstanceName -ne 'MSSQLSERVER') {
+            'MSSQL${0}\sql\query' -f $InstanceName
+        }
+        else {
+            'sql\query'
+        }
+
+        if ($ConnectionType -eq "SQLBrowser") {
+            # Use the SQLBrowser
+            # https://learn.microsoft.com/en-us/openspecs/windows_protocols/mc-sqlr/2e1560c9-5097-4023-9f5e-72b9ff1ec3b1
+            $udpClient = [System.Net.Sockets.UdpClient]::new($ComputerName, 1434)
+            $udpClient.Client.SendTimeout = $ConnectTimeout
+            $udpClient.Client.ReceiveTimeout = $ConnectTimeout
+            $null = $udpClient.Send([byte[]]@(0x03), 1)  # CLNT_UCAST_EX
+            $resp = $udpClient.Receive([ref]$null)
+
+            $respSize = [System.BitConverter]::ToUInt16($resp, 1)
+            $rawResponse = [System.Text.Encoding]::UTF8.GetString($resp, 3, $respSize)
+            Write-Verbose -Message "Recieved SQL Browser response: '$rawResponse'"
+            $response = $rawResponse -split ';'
+
+            $instanceInfo = [Ordered]@{}
+            $remoteInstance = @(
+                for ($i = 0; $i -lt $response.Length; $i += 2) {
+                    if ($response[$i]) {
+                        $instanceInfo[$response[$i]] = $response[$i + 1]
+                    }
+                    elseif ($i -eq $response.Length - 1) {
+                        break
+                    }
+                    else {
+                        $info = [PSCustomObject]$instanceInfo
+                        Write-Verbose -Message "Processed SQL Browser Response:`n$($info | Out-String)"
+
+                        $info
+                        $instanceInfo = [Ordered]@{}
+                        $i -= 1
+                    }
+                }
+            ) | Where-Object { -not $InstanceName -or $_.InstanceName -eq $InstanceName } | Select-Object -First 1
+
+            if ($remoteInstance.np) {
+                $ConnectionType = 'NamedPipe'
+                $ComputerName = $remoteInstance.ServerName
+                $pipeName = $remoteInstance.np -replace "\\\\.*?\\pipe\\(.*)", '$1'
+            }
+            elseif ($remoteInstance.tcp) {
+                $ConnectionType = 'TCP'
+                $ComputerName = $remoteInstance.ServerName
+                $Port = $remoteInstance.tcp
+            }
+            else {
+                throw "Failed to receive any SQL Browser responses from $($ComputerName):1434, cannot continue"
+            }
+        }
+
+        if ($ConnectionType -eq "TCP") {
+            Write-Verbose -Message "Connecting to TCP/IP endpoint $($ComputerName):$Port"
+
+            $socket = [System.Net.Sockets.TcpClient]::new()
+            $connectTask = $socket.ConnectAsync($ComputerName, $Port)
+            if (-not $connectTask.Wait($ConnectTimeout)) {
+                throw "Timed out connecting to TCP/IP endpoint $($ComputerName):$Port"
+            }
+
+            $null = $connectTask.GetAwaiter().GetResult()
+            $targetStream = $socket.GetStream()
+        }
+        else {
+            Write-Verbose -Message "Connecting to Named Pipe endpoint \\$($ComputerName)\pipe\$pipeName"
+            $targetStream = [System.IO.Pipes.NamedPipeClientStream]::new(
+                $ComputerName,
+                $pipeName,
+                [System.IO.Pipes.PipeDirection]::InOut)
+            $targetStream.Connect($ConnectTimeout)
+        }
+
+        # Before TDS 8.0, TLS was done after the Pre-Login message after it was
+        # negotiated with the server. It also needs to prepend a header to each TLS
+        # payload making it more difficult. TDS 8.0 (Encrypt=strict) is a lot
+        # simpler as the TLS handshake is done before anything.
+        if ($StrictEncrypt) {
+            Write-Verbose -Message "Using TDS 8 TLS Handshake"
+            $streamToWrap = $targetStream
+        }
+        else {
+            Write-Verbose -Message "Using TDS 7.x Pre-Login method for the TLS handshake"
+
+            # This is a pre-calculated TDS Pre-Login payload with the ENCRYPTION
+            # value of ENCRYPT_REQ (0x03).
+            # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/60f56408-0188-4cd5-8b90-25c6f2423868
+            $tdsPreLogin = [byte[]]@(
+                0x12, 0x01, 0x00, 0x2f, 0x00, 0x00, 0x01, 0x00,
+                0x00, 0x00, 0x1a, 0x00, 0x06, 0x01, 0x00, 0x20,
+                0x00, 0x01, 0x02, 0x00, 0x21, 0x00, 0x01, 0x03,
+                0x00, 0x22, 0x00, 0x04, 0x04, 0x00, 0x26, 0x00,
+                0x01, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            )
+            $targetStream.Write($tdsPreLogin, 0, $tdsPreLogin.Count)
+
+            $headerBytes = [byte[]]::new(8)
+            $read = 0
+            while ($read -ne $headerBytes.Length) {
+                $read += $targetStream.Read($headerBytes, $read, $headerBytes.Length - $read)
+            }
+
+            # Integer values are big endian encoded so swap them around. It also
+            # includes the header length which we've already gotten
+            $payloadLength = [System.BitConverter]::ToUInt16([byte[]]@($headerBytes[3], $headerBytes[2]), 0)
+            $payloadLength -= 8
+
+            $tdsPreLoginResp = [byte[]]::new($payloadLength)
+            $read = 0
+            while ($read -ne $tdsPreLoginResp.Length) {
+                $read += $targetStream.Read($tdsPreLoginResp, $read, $tdsPreLoginResp.Length - $read)
+            }
+
+            # The TDS Pre-Login payload starts with a variable amount of headers
+            #	TYPE - BYTE
+            #	OFFSET - USHORT (offset in the payload of the value)
+            #	LENGTH - USHORT
+            # The headers are terminated with the type 0xFF. We want to extract the
+            # value for the ENCRYPT type (1) from the payload to see if the server
+            # supported encryption.
+            $serverEncrypt = 0
+            $offset = 0
+            while ($true) {
+                $plOptionType = $tdsPreLoginResp[$offset]
+                if ($plOptionType -eq 0xFF) {
+                    break
+                }
+                elseif ($plOptionType -ne 1) {
+                    $offset += 5
+                    continue
+                }
+
+                $valueOffset = [System.BitConverter]::ToUInt16([byte[]]@($tdsPreLoginResp[$offset + 2], $tdsPreLoginResp[$offset + 1]), 0)
+                $serverEncrypt = $tdsPreLoginResp[$valueOffset]
+                break
+            }
+
+            # Strip off the extra flags, we only care about these specific bits
+            $serverEncrypt = $serverEncrypt -band 0x0F
+
+            # ENCRYPT_OFF, ENCRYPT_NOT_SUP
+            if ($serverEncrypt -in @(0, 2)) {
+                $msg = 'Server reported an encryption level of 0x{0:X2} which indicates it does not support TDS encryption.' -f $serverEncrypt
+                throw $msg
+            }
+
+            # Now we know the server supports TLS we need to wrap the raw stream
+            # with a custom wrapper to ensure each TLS payload sent below is
+            # preceeded with the TDS header as required. While not implemented
+            # there is a note that TDS 7.1 or earlier (SQL Server 2000 or earlier)
+            # should use the table response type (0x04) instead. As this is so old
+            # I'm not going to implement that.
+            $streamToWrap = [TdsTlsStream]::new($targetStream)
+        }
+
+        # Create the SslStream with a disable certificate verification callback.
+        # This allows it to connect to a self signed or cert with different
+        # hostname. The callback will also capture more information about the peer
+        # Allows us to emit warnings if it was going to fail.
+        $certState = @{}
+        $sslStream = [System.Net.Security.SslStream]::new($streamToWrap, $false, {
+                param($Sender, $Certificate, $Chain, $SslPolicyErrors)
+
+                $certState.Chain = $chain
+                $certState.SslPolicyErrors = $SslPolicyErrors
+                $true
+            })
+        Write-Verbose -Message "Starting TLS Handshake"
+        $sslStream.AuthenticateAsClient($ComputerName)
+        Write-Verbose -Message "TLS result: $($certState.SslPolicyErrors)"
+
+        if ($certState.SslPolicyErrors -ne 'None') {
+            $msg = @(
+                "Client does not trust remote certificate: $($certState.SslPolicyErrors)"
+                $certState.ChainStatus | ForEach-Object { $_.Status; $_.StatusInformation }
+            ) -join ([System.Environment]::NewLine)
+            Write-Warning -Message $msg.TrimEnd()
+        }
+
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($sslStream.RemoteCertificate)
+        Write-Verbose -Message "Found cert for $($cert.Subject), Expires: $($cert.NotAfter), SANs: $($cert.DnsNameList -join ", ")"
+
+        $cert
+    }
+    catch {
+        $PSCmdlet.WriteError($_)
+    }
+    finally {
+        if ($udpClient) { $udpClient.Dispose() }
+        if ($sslStream) { $sslStream.Dispose() }
+        if ($targetStream) { $targetStream.Dispose() }
+        if ($socket) { $socket.Dispose() }
+    }
+}

--- a/public/Get-DbaNetworkEncryption.ps1
+++ b/public/Get-DbaNetworkEncryption.ps1
@@ -84,21 +84,31 @@ function Get-DbaNetworkEncryption {
         foreach ($instance in $SqlInstance) {
             try {
                 $computerName = $instance.ComputerName
+                Write-Message -Level Verbose -Message "Using computerName '$computerName'"
                 $instanceName = $instance.InstanceName
+                Write-Message -Level Verbose -Message "Using instanceName '$instanceName'"
                 $tlsInstanceName = if ($instanceName -eq "MSSQLSERVER") { "" } else { $instanceName }
+                Write-Message -Level Verbose -Message "Using tlsInstanceName '$tlsInstanceName'"
                 $sqlInstanceName = if ($instanceName -eq "MSSQLSERVER") { $computerName } else { "$computerName\$instanceName" }
+                Write-Message -Level Verbose -Message "Using sqlInstanceName '$sqlInstanceName'"
 
                 $splatTls = @{
                     ComputerName = $computerName
                     InstanceName = $tlsInstanceName
+                    ErrorAction  = "Stop"
                 }
 
                 if ($instance.Port -gt 0) {
                     $splatTls.ConnectionType = "TCP"
                     $splatTls.Port           = $instance.Port
+                    Write-Message -Level Verbose -Message "Using explicit port $($instance.Port) for TLS connection"
                 }
 
-                $cert = Get-SqlServerTlsCertificate @splatTls
+                try {
+                    $cert = Get-SqlServerTlsCertificate @splatTls
+                } catch {
+                    Stop-Function -Message "Failed to retrieve TLS certificate from $instance" -Target $instance -ErrorRecord $_ -Continue
+                }
 
                 if (-not $cert) {
                     continue

--- a/public/Get-DbaNetworkEncryption.ps1
+++ b/public/Get-DbaNetworkEncryption.ps1
@@ -18,10 +18,6 @@ function Get-DbaNetworkEncryption {
     .PARAMETER SqlInstance
         The target SQL Server instance or instances. Accepts pipeline input.
 
-    .PARAMETER SqlCredential
-        Not used by this command - included for pipeline compatibility. Authentication is not
-        required since this command connects at the TLS layer before SQL Server authentication.
-
     .PARAMETER EnableException
         By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
         This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
@@ -47,7 +43,6 @@ function Get-DbaNetworkEncryption {
         - ComputerName: The hostname of the SQL Server
         - InstanceName: The SQL Server instance name (MSSQLSERVER for default)
         - SqlInstance: The full SQL Server instance identifier
-        - Port: The TCP port used to connect
         - Subject: The certificate subject (Common Name)
         - Issuer: The certificate issuer
         - Thumbprint: SHA-1 hash thumbprint of the certificate
@@ -82,13 +77,8 @@ function Get-DbaNetworkEncryption {
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [DbaInstanceParameter[]]$SqlInstance,
-        [PSCredential]$SqlCredential,
         [switch]$EnableException
     )
-
-    begin {
-
-    }
 
     process {
         foreach ($instance in $SqlInstance) {
@@ -96,20 +86,7 @@ function Get-DbaNetworkEncryption {
                 $computerName = $instance.ComputerName
                 $instanceName = $instance.InstanceName
                 $tlsInstanceName = if ($instanceName -eq "MSSQLSERVER") { "" } else { $instanceName }
-
-                $resolvedPort = if ($instance.Port -gt 0) {
-                    $instance.Port
-                } elseif ($instanceName -eq "MSSQLSERVER") {
-                    1433
-                } else {
-                    $null
-                }
-
-                $sqlInstanceName = if ($instanceName -ne "MSSQLSERVER") {
-                    "$computerName\$instanceName"
-                } else {
-                    $computerName
-                }
+                $sqlInstanceName = if ($instanceName -eq "MSSQLSERVER") { $computerName } else { "$computerName\$instanceName" }
 
                 $splatTls = @{
                     ComputerName = $computerName
@@ -131,7 +108,6 @@ function Get-DbaNetworkEncryption {
                     ComputerName = $computerName
                     InstanceName = $instanceName
                     SqlInstance  = $sqlInstanceName
-                    Port         = $resolvedPort
                     Subject      = $cert.Subject
                     Issuer       = $cert.Issuer
                     Thumbprint   = $cert.Thumbprint

--- a/public/Get-DbaNetworkEncryption.ps1
+++ b/public/Get-DbaNetworkEncryption.ps1
@@ -1,0 +1,118 @@
+function Get-DbaNetworkEncryption {
+    <#
+    .SYNOPSIS
+        Retrieves the TLS/SSL certificate presented by a SQL Server instance over the network.
+
+    .DESCRIPTION
+        Connects directly to a SQL Server instance's TCP port and retrieves the TLS/SSL certificate
+        that the server presents during the TLS handshake. This does not require Windows host access
+        or WinRM - it works purely over the network like a client connecting to SQL Server.
+
+        This complements Get-DbaNetworkCertificate, which reads the configured certificate from the
+        Windows registry (requires WinRM). This command instead shows what certificate is actually
+        being presented to clients over the network, without requiring any host-level access.
+
+        For named instances, the SQL Browser service is queried on UDP port 1434 to determine the
+        TCP port number. For default instances, port 1433 is used unless overridden.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. Accepts pipeline input.
+
+    .PARAMETER SqlCredential
+        Not used by this command - included for pipeline compatibility. Authentication is not
+        required since this command connects at the TLS layer before SQL Server authentication.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Certificate, Encryption, Security, Network
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2024 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaNetworkEncryption
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object per SQL Server instance that successfully presents a TLS certificate.
+
+        Properties:
+        - ComputerName: The hostname of the SQL Server
+        - InstanceName: The SQL Server instance name (MSSQLSERVER for default)
+        - SqlInstance: The full SQL Server instance identifier
+        - Port: The TCP port used to connect
+        - Subject: The certificate subject (Common Name)
+        - Issuer: The certificate issuer
+        - Thumbprint: SHA-1 hash thumbprint of the certificate
+        - NotBefore: DateTime when the certificate becomes valid
+        - Expires: DateTime when the certificate expires
+        - DnsNameList: Array of DNS names from the Subject Alternative Names extension
+        - SerialNumber: Certificate serial number
+        - Certificate: The full X509Certificate2 object
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkEncryption -SqlInstance sql2016
+
+        Retrieves the TLS certificate presented by the default SQL Server instance on sql2016.
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkEncryption -SqlInstance sql2016\sqlexpress
+
+        Retrieves the TLS certificate presented by the named instance sqlexpress on sql2016.
+        Queries the SQL Browser service to determine the port.
+
+    .EXAMPLE
+        PS C:\> Get-DbaNetworkEncryption -SqlInstance sql2016, sql2017, sql2019 | Select-Object SqlInstance, Subject, Expires, Thumbprint
+
+        Retrieves certificates from multiple SQL Server instances and shows key certificate details.
+
+    .EXAMPLE
+        PS C:\> $servers | Get-DbaNetworkEncryption | Where-Object { $_.Expires -lt (Get-Date).AddDays(30) }
+
+        Finds SQL Server instances whose TLS certificates expire within the next 30 days.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [switch]$EnableException
+    )
+
+    begin {
+
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+
+            try {
+
+
+                [PSCustomObject]@{
+                    ComputerName = $computerName
+                    InstanceName = $instanceName
+                    SqlInstance  = $sqlInstanceName
+                    Port         = $port
+                    Subject      = $cert.Subject
+                    Issuer       = $cert.Issuer
+                    Thumbprint   = $cert.Thumbprint
+                    NotBefore    = $cert.NotBefore
+                    Expires      = $cert.NotAfter
+                    DnsNameList  = $dnsNames
+                    SerialNumber = $cert.SerialNumber
+                    Certificate  = $cert
+                }
+            } catch {
+                Stop-Function -Message "Failed to retrieve certificate from $instance" -Target $instance -ErrorRecord $_ -Continue
+            }
+        }
+    }
+}

--- a/public/Get-DbaNetworkEncryption.ps1
+++ b/public/Get-DbaNetworkEncryption.ps1
@@ -105,7 +105,7 @@ function Get-DbaNetworkEncryption {
                     $null
                 }
 
-                $sqlInstanceName = if ($instanceName -and $instanceName -ne "MSSQLSERVER") {
+                $sqlInstanceName = if ($instanceName -ne "MSSQLSERVER") {
                     "$computerName\$instanceName"
                 } else {
                     $computerName
@@ -127,8 +127,6 @@ function Get-DbaNetworkEncryption {
                     continue
                 }
 
-                $dnsNames = $cert.DnsNameList
-
                 [PSCustomObject]@{
                     ComputerName = $computerName
                     InstanceName = $instanceName
@@ -139,7 +137,7 @@ function Get-DbaNetworkEncryption {
                     Thumbprint   = $cert.Thumbprint
                     NotBefore    = $cert.NotBefore
                     Expires      = $cert.NotAfter
-                    DnsNameList  = $dnsNames
+                    DnsNameList  = $cert.DnsNameList
                     SerialNumber = $cert.SerialNumber
                     Certificate  = $cert
                 }

--- a/public/Get-DbaNetworkEncryption.ps1
+++ b/public/Get-DbaNetworkEncryption.ps1
@@ -92,15 +92,48 @@ function Get-DbaNetworkEncryption {
 
     process {
         foreach ($instance in $SqlInstance) {
-
             try {
+                $computerName = $instance.ComputerName
+                $instanceName = $instance.InstanceName
+                $tlsInstanceName = if ($instanceName -eq "MSSQLSERVER") { "" } else { $instanceName }
 
+                $resolvedPort = if ($instance.Port -gt 0) {
+                    $instance.Port
+                } elseif ($instanceName -eq "MSSQLSERVER") {
+                    1433
+                } else {
+                    $null
+                }
+
+                $sqlInstanceName = if ($instanceName -and $instanceName -ne "MSSQLSERVER") {
+                    "$computerName\$instanceName"
+                } else {
+                    $computerName
+                }
+
+                $splatTls = @{
+                    ComputerName = $computerName
+                    InstanceName = $tlsInstanceName
+                }
+
+                if ($instance.Port -gt 0) {
+                    $splatTls.ConnectionType = "TCP"
+                    $splatTls.Port           = $instance.Port
+                }
+
+                $cert = Get-SqlServerTlsCertificate @splatTls
+
+                if (-not $cert) {
+                    continue
+                }
+
+                $dnsNames = $cert.DnsNameList
 
                 [PSCustomObject]@{
                     ComputerName = $computerName
                     InstanceName = $instanceName
                     SqlInstance  = $sqlInstanceName
-                    Port         = $port
+                    Port         = $resolvedPort
                     Subject      = $cert.Subject
                     Issuer       = $cert.Issuer
                     Thumbprint   = $cert.Thumbprint

--- a/tests/Get-DbaNetworkEncryption.Tests.ps1
+++ b/tests/Get-DbaNetworkEncryption.Tests.ps1
@@ -21,11 +21,6 @@ Describe $CommandName -Tag UnitTests {
 }
 
 Describe $CommandName -Tag IntegrationTests {
-    BeforeAll {
-        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
-        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
-    }
-
     Context "Certificate retrieval" {
         BeforeAll {
             # Attempt to retrieve the certificate - not all environments have TLS configured

--- a/tests/Get-DbaNetworkEncryption.Tests.ps1
+++ b/tests/Get-DbaNetworkEncryption.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Get-DbaNetworkEncryption",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Certificate retrieval" {
+        BeforeAll {
+            # Attempt to retrieve the certificate - not all environments have TLS configured
+            $result = Get-DbaNetworkEncryption -SqlInstance $TestConfig.InstanceSingle -WarningAction SilentlyContinue
+        }
+
+        It "Should return certificate with expected properties when TLS is configured" {
+            if ($null -eq $result) {
+                Set-ItResult -Skipped -Because "No TLS certificate is configured on this SQL Server instance"
+            }
+            $result.SqlInstance | Should -Not -BeNullOrEmpty
+            $result.Subject | Should -Not -BeNullOrEmpty
+            $result.Thumbprint | Should -Not -BeNullOrEmpty
+            $result.Expires | Should -BeOfType [datetime]
+            $result.NotBefore | Should -BeOfType [datetime]
+        }
+    }
+}

--- a/tests/Get-DbaNetworkEncryption.Tests.ps1
+++ b/tests/Get-DbaNetworkEncryption.Tests.ps1
@@ -12,7 +12,6 @@ Describe $CommandName -Tag UnitTests {
             $expectedParameters = $TestConfig.CommonParameters
             $expectedParameters += @(
                 "SqlInstance",
-                "SqlCredential",
                 "EnableException"
             )
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty


### PR DESCRIPTION
Adds `Get-DbaNetworkEncryption` which retrieves the TLS/SSL certificate presented by a SQL Server instance during the TLS handshake, without requiring Windows host access or WinRM.

**Key features:**
- Connects directly to SQL Server's TCP port via TLS/SSL
- No Windows host access required (no WinRM)
- Handles named instances via SQL Browser (UDP 1434) with proper DNS resolution
- Returns Subject, Issuer, Thumbprint, Expiration, DNS SANs, and more
- Graceful error handling for instances without TLS configured

This complements `Get-DbaNetworkCertificate` (which reads from the Windows registry, requires WinRM) by instead showing what certificate is actually being presented to clients.