### PR TITLE
Export-DbaCredential - Add IF NOT EXISTS guard to exported SQL scripts

### DIFF
--- a/public/Export-DbaCredential.ps1
+++ b/public/Export-DbaCredential.ps1
@@ -165,6 +165,7 @@ function Export-DbaCredential {
 
             foreach ($cred in $credentials) {
                 $quotename = $cred.Quotename
+                $credName = $cred.Name.Replace("'", "''")
                 $identity = $cred.Identity.Replace("'", "''")
                 $password = $cred.Password.Replace("'", "''")
                 $cryptoSql = ""
@@ -172,7 +173,7 @@ function Export-DbaCredential {
                     $providerName = $cred.ProviderName
                     $cryptoSql = " FOR CRYPTOGRAPHIC PROVIDER $providerName"
                 }
-                $sql += "CREATE CREDENTIAL $quotename WITH IDENTITY = N'$identity', SECRET = N'$password'" + $cryptoSql
+                $sql += "IF NOT EXISTS (SELECT 1 FROM sys.credentials WHERE name = N'$credName') CREATE CREDENTIAL $quotename WITH IDENTITY = N'$identity', SECRET = N'$password'" + $cryptoSql
             }
 
             if ($Passthru) {

--- a/tests/Export-DbaCredential.Tests.ps1
+++ b/tests/Export-DbaCredential.Tests.ps1
@@ -108,6 +108,10 @@ Describe $CommandName -Tag IntegrationTests {
         It "Should have the password" {
             $exportResults | Should -Match "ReallyT3rrible!"
         }
+
+        It "Should include IF NOT EXISTS guard" {
+            $exportResults | Should -Match "IF NOT EXISTS"
+        }
     }
 
     Context "Should export a specific credential" {


### PR DESCRIPTION
Wraps each CREATE CREDENTIAL statement with an IF NOT EXISTS check against sys.credentials so that exported scripts are idempotent and only create missing credentials during migrations or DR script replays.

Closes #8618

Generated with [Claude Code](https://claude.ai/code)