### PR TITLE
Add manual instance autocomplete list (Add/Get/Remove-DbaInstanceList)

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -759,7 +759,10 @@
         'New-DbaReplSubscription',
         'Remove-DbaReplSubscription',
         'New-DbaReplCreationScriptOptions',
-        'Get-DbaReplSubscription'
+        'Get-DbaReplSubscription',
+        'Add-DbaInstanceList',
+        'Get-DbaInstanceList',
+        'Remove-DbaInstanceList'
     )
 
     # Cmdlets to export from this module

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -939,7 +939,10 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Invoke-DbaDbAzSqlTip',
         'New-DbaAgentAlert',
         'Set-DbatoolsInsecureConnection',
-        'Test-DbaAgSpn'
+        'Test-DbaAgSpn',
+        'Add-DbaInstanceList',
+        'Get-DbaInstanceList',
+        'Remove-DbaInstanceList'
     )
     $script:noncoresmo = @(
         # SMO issues

--- a/private/dynamicparams/sqlinstance.ps1
+++ b/private/dynamicparams/sqlinstance.ps1
@@ -2,6 +2,23 @@
 if (-not [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"]) {
     [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] = @()
 }
+
+# Load user-defined instances from config (set via Add-DbaInstanceList)
+foreach ($instance in (Get-DbatoolsConfigValue -FullName "TabExpansion.KnownInstances" -Fallback @())) {
+    if ($instance -and [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $instance) {
+        [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $instance
+    }
+}
+
+# Load from environment variable (comma-separated list, e.g. set in PowerShell profile)
+if ($env:DBATOOLS_KNOWN_INSTANCES) {
+    foreach ($instance in ($env:DBATOOLS_KNOWN_INSTANCES -split ",")) {
+        $lower = $instance.Trim().ToLowerInvariant()
+        if ($lower -and [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $lower) {
+            [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $lower
+        }
+    }
+}
 #endregion Initialize Cache
 
 #region Tepp Data return

--- a/public/Add-DbaInstanceList.ps1
+++ b/public/Add-DbaInstanceList.ps1
@@ -1,0 +1,102 @@
+function Add-DbaInstanceList {
+    <#
+    .SYNOPSIS
+        Adds one or more SQL Server instances to the user-maintained autocomplete list.
+
+    .DESCRIPTION
+        Adds SQL Server instance names to a persistent list that pre-populates the tab completion
+        cache for the -SqlInstance parameter across all dbatools commands. This allows users to
+        have their frequently used instances available for autocomplete in their PowerShell
+        terminal without needing to connect to them first.
+
+        The instance list is stored using the dbatools configuration system. Use -Register to
+        persist the list across PowerShell sessions.
+
+        Instances can also be pre-loaded at module import time by setting the
+        $env:DBATOOLS_KNOWN_INSTANCES environment variable to a comma-separated list of instance
+        names in your PowerShell profile.
+
+    .PARAMETER SqlInstance
+        The SQL Server instance name or names to add to the autocomplete list.
+        Accepts pipeline input.
+
+    .PARAMETER Register
+        Persists the instance list to disk so it is available in future PowerShell sessions.
+        Without this switch, the list only exists for the current session.
+
+    .PARAMETER Scope
+        Determines where the persistent configuration is stored when using -Register.
+        UserDefault stores the setting for the current user only.
+
+    .OUTPUTS
+        None
+
+        This command updates the autocomplete cache but does not output any objects to the
+        pipeline. Use Get-DbaInstanceList to retrieve the configured instance names.
+
+    .NOTES
+        Tags: TabCompletion, Autocomplete
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Add-DbaInstanceList
+
+    .EXAMPLE
+        PS C:\> Add-DbaInstanceList -SqlInstance "sql01", "sql02\dev"
+
+        Adds sql01 and sql02\dev to the autocomplete instance list for the current session.
+
+    .EXAMPLE
+        PS C:\> Add-DbaInstanceList -SqlInstance "sql01" -Register
+
+        Adds sql01 to the autocomplete instance list and persists it across PowerShell sessions.
+
+    .EXAMPLE
+        PS C:\> "sql01", "sql02" | Add-DbaInstanceList -Register
+
+        Adds two instances to the list via pipeline and persists them across sessions.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$SqlInstance,
+        [switch]$Register,
+        [Dataplat.Dbatools.Configuration.ConfigScope]$Scope = [Dataplat.Dbatools.Configuration.ConfigScope]::UserDefault
+    )
+
+    begin {
+        $current = Get-DbatoolsConfigValue -FullName "TabExpansion.KnownInstances" -Fallback @()
+        $toAdd = @()
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            $lower = $instance.Trim().ToLowerInvariant()
+            if (-not $lower) { continue }
+
+            if ($current -notcontains $lower -and $toAdd -notcontains $lower) {
+                $toAdd += $lower
+            }
+
+            # Update the TEPP cache immediately for this session
+            if ([Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] -notcontains $lower) {
+                [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"] += $lower
+            }
+        }
+    }
+
+    end {
+        if ($toAdd.Count -gt 0) {
+            $combined = @($current) + @($toAdd)
+            Set-DbatoolsConfig -FullName "TabExpansion.KnownInstances" -Value $combined
+        }
+        if ($Register) {
+            Register-DbatoolsConfig -FullName "TabExpansion.KnownInstances" -Scope $Scope
+        }
+    }
+}

--- a/public/Get-DbaInstanceList.ps1
+++ b/public/Get-DbaInstanceList.ps1
@@ -1,0 +1,52 @@
+function Get-DbaInstanceList {
+    <#
+    .SYNOPSIS
+        Returns the user-maintained list of SQL Server instances used for tab completion.
+
+    .DESCRIPTION
+        Returns all SQL Server instance names from the user-maintained list that is pre-loaded
+        into the dbatools tab completion cache for the -SqlInstance parameter. This list allows
+        users to have their frequently used instances available for autocomplete in their
+        PowerShell terminal without needing to connect to them first.
+
+        Use Add-DbaInstanceList to add instances to the list and Remove-DbaInstanceList to
+        remove them.
+
+        Instances can also be pre-loaded at module import time by setting the
+        $env:DBATOOLS_KNOWN_INSTANCES environment variable to a comma-separated list of instance
+        names in your PowerShell profile.
+
+    .OUTPUTS
+        System.String
+
+        Returns instance names as strings. Each instance name in the user-maintained
+        autocomplete list is returned as a separate string object.
+
+    .NOTES
+        Tags: TabCompletion, Autocomplete
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Get-DbaInstanceList
+
+    .EXAMPLE
+        PS C:\> Get-DbaInstanceList
+
+        Returns all instance names from the user-maintained autocomplete list.
+
+    .EXAMPLE
+        PS C:\> Get-DbaInstanceList | Remove-DbaInstanceList
+
+        Removes all instances from the user-maintained autocomplete list.
+    #>
+    [CmdletBinding()]
+    param ()
+
+    process {
+        Get-DbatoolsConfigValue -FullName "TabExpansion.KnownInstances" -Fallback @()
+    }
+}

--- a/public/Remove-DbaInstanceList.ps1
+++ b/public/Remove-DbaInstanceList.ps1
@@ -1,0 +1,95 @@
+function Remove-DbaInstanceList {
+    <#
+    .SYNOPSIS
+        Removes one or more SQL Server instances from the user-maintained autocomplete list.
+
+    .DESCRIPTION
+        Removes SQL Server instance names from the user-maintained list that is pre-loaded into
+        the dbatools tab completion cache for the -SqlInstance parameter. The instances are
+        removed from the stored configuration but remain in the current session's TEPP cache
+        until the module is reloaded.
+
+        Use Add-DbaInstanceList to add instances to the list and Get-DbaInstanceList to view
+        the current list.
+
+    .PARAMETER SqlInstance
+        The SQL Server instance name or names to remove from the autocomplete list.
+        Accepts pipeline input.
+
+    .PARAMETER Register
+        Persists the updated instance list to disk after removal so the change is available in
+        future PowerShell sessions. Without this switch, the removal only affects the stored
+        configuration for the current session.
+
+    .PARAMETER Scope
+        Determines where the persistent configuration is stored when using -Register.
+        UserDefault stores the setting for the current user only.
+
+    .OUTPUTS
+        None
+
+        This command updates the stored configuration but does not output any objects to the
+        pipeline. Use Get-DbaInstanceList to retrieve the current configured instance names.
+
+    .NOTES
+        Tags: TabCompletion, Autocomplete
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Remove-DbaInstanceList
+
+    .EXAMPLE
+        PS C:\> Remove-DbaInstanceList -SqlInstance "sql01"
+
+        Removes sql01 from the autocomplete instance list.
+
+    .EXAMPLE
+        PS C:\> Remove-DbaInstanceList -SqlInstance "sql01", "sql02\dev" -Register
+
+        Removes two instances from the list and persists the change across PowerShell sessions.
+
+    .EXAMPLE
+        PS C:\> Get-DbaInstanceList | Remove-DbaInstanceList -Register
+
+        Removes all instances from the user-maintained autocomplete list and persists the change.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [string[]]$SqlInstance,
+        [switch]$Register,
+        [Dataplat.Dbatools.Configuration.ConfigScope]$Scope = [Dataplat.Dbatools.Configuration.ConfigScope]::UserDefault
+    )
+
+    begin {
+        $current = @(Get-DbatoolsConfigValue -FullName "TabExpansion.KnownInstances" -Fallback @())
+        $toRemove = @()
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            $lower = $instance.Trim().ToLowerInvariant()
+            if (-not $lower) { continue }
+            if ($toRemove -notcontains $lower) {
+                $toRemove += $lower
+            }
+        }
+    }
+
+    end {
+        if ($toRemove.Count -gt 0) {
+            if ($PSCmdlet.ShouldProcess("instance list", "Remove $($toRemove -join ', ')")) {
+                $updated = $current | Where-Object { $toRemove -notcontains $_ }
+                if ($null -eq $updated) { $updated = @() }
+                Set-DbatoolsConfig -FullName "TabExpansion.KnownInstances" -Value @($updated)
+                if ($Register) {
+                    Register-DbatoolsConfig -FullName "TabExpansion.KnownInstances" -Scope $Scope
+                }
+            }
+        }
+    }
+}

--- a/tests/Add-DbaInstanceList.Tests.ps1
+++ b/tests/Add-DbaInstanceList.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Add-DbaInstanceList",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "Register",
+                "Scope"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $instanceName = "dbatoolsci_testinstance_$(Get-Random)"
+    }
+
+    AfterAll {
+        $null = Remove-DbaInstanceList -SqlInstance $instanceName -Confirm:$false -ErrorAction SilentlyContinue
+    }
+
+    Context "adds instances to the list" {
+        It "adds an instance without error" {
+            { Add-DbaInstanceList -SqlInstance $instanceName } | Should -Not -Throw
+        }
+
+        It "instance appears in Get-DbaInstanceList after adding" {
+            $result = Get-DbaInstanceList
+            $result | Should -Contain $instanceName.ToLowerInvariant()
+        }
+
+        It "instance appears in the TEPP cache after adding" {
+            $cache = [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::Cache["sqlinstance"]
+            $cache | Should -Contain $instanceName.ToLowerInvariant()
+        }
+
+        It "does not add duplicates" {
+            Add-DbaInstanceList -SqlInstance $instanceName
+            $result = Get-DbaInstanceList
+            ($result | Where-Object { $PSItem -eq $instanceName.ToLowerInvariant() }).Count | Should -Be 1
+        }
+    }
+}

--- a/tests/Get-DbaInstanceList.Tests.ps1
+++ b/tests/Get-DbaInstanceList.Tests.ps1
@@ -9,7 +9,7 @@ Describe $CommandName -Tag UnitTests {
     Context "Parameter validation" {
         It "Should have the expected parameters" {
             $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
-            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters = @($TestConfig.CommonParameters)
             Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
         }
     }

--- a/tests/Get-DbaInstanceList.Tests.ps1
+++ b/tests/Get-DbaInstanceList.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Get-DbaInstanceList",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $instanceName = "dbatoolsci_testinstance_$(Get-Random)"
+        Add-DbaInstanceList -SqlInstance $instanceName
+    }
+
+    AfterAll {
+        $null = Remove-DbaInstanceList -SqlInstance $instanceName -Confirm:$false -ErrorAction SilentlyContinue
+    }
+
+    Context "returns the instance list" {
+        It "returns results without error" {
+            { Get-DbaInstanceList } | Should -Not -Throw
+        }
+
+        It "returns the added instance" {
+            $result = Get-DbaInstanceList
+            $result | Should -Contain $instanceName.ToLowerInvariant()
+        }
+    }
+}

--- a/tests/Remove-DbaInstanceList.Tests.ps1
+++ b/tests/Remove-DbaInstanceList.Tests.ps1
@@ -1,0 +1,39 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Remove-DbaInstanceList",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "Register",
+                "Scope"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $instanceName = "dbatoolsci_testinstance_$(Get-Random)"
+        Add-DbaInstanceList -SqlInstance $instanceName
+    }
+
+    Context "removes instances from the list" {
+        It "removes an instance without error" {
+            { Remove-DbaInstanceList -SqlInstance $instanceName -Confirm:$false } | Should -Not -Throw
+        }
+
+        It "instance no longer appears in Get-DbaInstanceList after removal" {
+            $result = Get-DbaInstanceList
+            $result | Should -Not -Contain $instanceName.ToLowerInvariant()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8918

Adds three new commands for managing a user-maintained list of SQL Server instance names pre-loaded into the TEPP cache for `-SqlInstance` autocomplete:

- `Add-DbaInstanceList` - add instances to the autocomplete list
- `Get-DbaInstanceList` - view the current list
- `Remove-DbaInstanceList` - remove instances from the list

Instances are stored via the dbatools config system and can be persisted with `-Register`. Also supports `$env:DBATOOLS_KNOWN_INSTANCES` (comma-separated) for profile-based setup.

Generated with [Claude Code](https://claude.ai/code)