### PR TITLE
Get-DbaHelpIndex - Fix SQL injection and remove SQL 2005 code path

### DIFF
--- a/public/Get-DbaHelpIndex.ps1
+++ b/public/Get-DbaHelpIndex.ps1
@@ -8,7 +8,7 @@ function Get-DbaHelpIndex {
 
         Essential for DBAs performing index tuning, this command helps identify unused indexes for removal, oversized indexes consuming storage, and indexes requiring maintenance based on fragmentation or usage statistics. The data combines structural information (key columns, include columns, filters) with runtime metrics (reads, updates, last used) to provide a complete index health picture.
 
-        Uses SQL Server DMVs and system tables, requiring SQL Server 2005 or later. For performance reasons, certain statistics details are limited in SQL Server 2005 unless you specify a specific table with the ObjectName parameter.
+        Uses SQL Server DMVs and system tables, requiring SQL Server 2008 or later.
 
         The data includes:
         - ObjectName: the table containing the index
@@ -23,10 +23,10 @@ function Get-DbaHelpIndex {
         - IndexRows: the number of the rows in the index (note filtered indexes will have fewer rows than exist in the table)
         - IndexLookups: the number of lookups that have been performed (only applicable for the heap or clustered index)
         - MostRecentlyUsed: when the index was most recently queried (default to 1900 for when never read)
-        - StatsSampleRows: the number of rows queried when the statistics were built/rebuilt (not included in SQL Server 2005 unless ObjectName is specified)
+        - StatsSampleRows: the number of rows queried when the statistics were built/rebuilt
         - StatsRowMods: the number of changes to the statistics since the last rebuild
-        - HistogramSteps: the number of steps in the statistics histogram (not included in SQL Server 2005 unless ObjectName is specified)
-        - StatsLastUpdated: when the statistics were last rebuilt (not included in SQL Server 2005 unless ObjectName is specified)
+        - HistogramSteps: the number of steps in the statistics histogram
+        - StatsLastUpdated: when the statistics were last rebuilt
 
     .PARAMETER SqlInstance
         The target SQL Server instance or instances.
@@ -108,10 +108,10 @@ function Get-DbaHelpIndex {
         - IndexRows: Numeric row count in the index or statistics; formatted with thousands separators unless -Raw
         - IndexLookups: Numeric count of lookup operations (only for heap or clustered index); empty string for statistics rows
         - MostRecentlyUsed: DateTime of most recent index usage; null if never used (1900 year) or no usage data
-        - StatsSampleRows: Number of rows sampled when statistics were built/updated; empty for index rows; null on SQL 2005 unless -ObjectName specified
-        - StatsRowMods: Number of modifications to underlying data since last statistics update; empty for index rows; null on SQL 2005 unless -ObjectName specified
-        - HistogramSteps: Number of steps in the statistics histogram; empty for index rows; null on SQL 2005 unless -ObjectName specified
-        - StatsLastUpdated: DateTime when statistics were last updated; empty for index rows; null on SQL 2005 unless -ObjectName specified
+        - StatsSampleRows: Number of rows sampled when statistics were built/updated; empty for index rows
+        - StatsRowMods: Number of modifications to underlying data since last statistics update; empty for index rows
+        - HistogramSteps: Number of steps in the statistics histogram; empty for index rows
+        - StatsLastUpdated: DateTime when statistics were last updated; empty for index rows
         - IndexFragInPercent: Fragmentation percentage (0-100 formatted as F2 decimal) of the index; only present when -IncludeFragmentation specified; empty string otherwise
 
         When -IncludeStats is specified, statistics-only objects are also returned with index-specific properties set to empty strings and statistics properties populated.
@@ -189,9 +189,9 @@ function Get-DbaHelpIndex {
 
         #Add the table predicate to the query
         if (!$ObjectName) {
-            $TablePredicate = "DECLARE @TableName NVARCHAR(256);";
+            $TablePredicate = "DECLARE @TableName NVARCHAR(256);"
         } else {
-            $TablePredicate = "DECLARE @TableName NVARCHAR(256); SET @TableName = '$ObjectName';";
+            $TablePredicate = "DECLARE @TableName NVARCHAR(256); SET @TableName = '$($ObjectName -replace "'", "''")';";
         }
 
         #Add Fragmentation info if requested
@@ -590,461 +590,9 @@ function Get-DbaHelpIndex {
         OPTION  ( RECOMPILE );
         "
         #endRegion SizesQuery
-
-
-        #region sizesQuery2005
-        $SizesQuery2005 = "
-        SET NOCOUNT ON;
-        SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-
-        $TablePredicate
-        $IncludeDataTypesPredicate
-        ;
-
-        DECLARE @AllResults TABLE
-            (
-                RowNum INT ,
-                FullObjectName    NVARCHAR(300) ,
-                IndexType    NVARCHAR(256) ,
-                IndexName    NVARCHAR(256) ,
-                KeyColumns    NVARCHAR(2000) ,
-                IncludeColumns    NVARCHAR(2000) ,
-                FilterDefinition    NVARCHAR(100) ,
-                [FillFactor]    TINYINT ,
-                DataCompression    CHAR(4) ,
-                IndexReads    BIGINT ,
-                IndexUpdates    BIGINT ,
-                SizeKB    BIGINT ,
-                IndexRows    BIGINT ,
-                IndexLookups    BIGINT ,
-                MostRecentlyUsed    DATETIME ,
-                StatsSampleRows    BIGINT ,
-                StatsRowMods    BIGINT ,
-                HistogramSteps    INT    ,
-                StatsLastUpdated    DATETIME ,
-                object_id BIGINT ,
-                index_id BIGINT
-            );
-
-        DECLARE @IndexUsageStats TABLE
-            (
-            object_id INT ,
-            index_id INT ,
-            user_scans BIGINT ,
-            user_seeks BIGINT ,
-            user_updates BIGINT ,
-            user_lookups BIGINT ,
-            last_user_lookup DATETIME ,
-            last_user_scan DATETIME ,
-            last_user_seek DATETIME ,
-            avg_fragmentation_in_percent FLOAT
-            );
-
-        DECLARE @StatsInfo TABLE
-            (
-            object_id INT ,
-            stats_id INT ,
-            stats_column_name NVARCHAR(128) ,
-            stats_column_id INT ,
-            stats_name NVARCHAR(128) ,
-            stats_last_updated DATETIME ,
-            stats_sampled_rows BIGINT ,
-            rowmods BIGINT ,
-            histogramsteps INT ,
-            StatsRows BIGINT ,
-            FullObjectName NVARCHAR(256)
-            );
-
-        INSERT  INTO @IndexUsageStats
-                ( object_id ,
-                index_id ,
-                user_scans ,
-                user_seeks ,
-                user_updates ,
-                user_lookups ,
-                last_user_lookup ,
-                last_user_scan ,
-                last_user_seek ,
-                avg_fragmentation_in_percent
-                )
-                SELECT  ustat.object_id ,
-                        ustat.index_id ,
-                        ustat.user_scans ,
-                        ustat.user_seeks ,
-                        ustat.user_updates ,
-                        ustat.user_lookups ,
-                        ustat.last_user_lookup ,
-                        ustat.last_user_scan ,
-                        ustat.last_user_seek
-                        $FragSelectColumn
-                FROM    sys.dm_db_index_usage_stats ustat
-                $FragJoin
-                WHERE   database_id = DB_ID();
-
-
-        INSERT  INTO @StatsInfo
-                ( object_id ,
-                stats_id ,
-                stats_column_name ,
-                stats_column_id ,
-                stats_name ,
-                stats_last_updated ,
-                stats_sampled_rows ,
-                rowmods ,
-                histogramsteps ,
-                StatsRows ,
-                FullObjectName
-                )
-                SELECT  s.object_id ,
-                        s.stats_id ,
-                        c.name ,
-                        sc.stats_column_id ,
-                        s.name ,
-                        NULL AS last_updated ,
-                        NULL AS rows_sampled ,
-                        NULL AS modification_counter ,
-                        NULL AS steps ,
-                        NULL AS rows ,
-                        QUOTENAME(sch.name) + '.' + QUOTENAME(t.name) AS FullObjectName
-                FROM    sys.stats AS s
-                        INNER JOIN sys.stats_columns sc ON s.stats_id = sc.stats_id
-                                                        AND s.object_id = sc.object_id
-                        INNER JOIN sys.columns c ON c.object_id = sc.object_id
-                                                    AND c.column_id = sc.column_id
-                        INNER JOIN sys.tables t ON c.object_id = t.object_id
-                        INNER JOIN sys.schemas sch ON sch.schema_id = t.schema_id
-                    --   OUTER APPLY sys.dm_db_stats_properties(s.object_id,
-                    --                                        s.stats_id) AS sp
-                WHERE   s.object_id = CASE WHEN @TableName IS NULL THEN s.object_id
-                                        ELSE OBJECT_ID(@TableName)
-                                    END;
-
-
-        ;
-        WITH    cteStatsInfo
-                AS ( SELECT   object_id ,
-                                si.stats_id ,
-                                si.stats_name ,
-                                STUFF((SELECT   N', ' + stats_column_name
-                                    FROM     @StatsInfo si2
-                                    WHERE    si2.object_id = si.object_id
-                                                AND si2.stats_id = si.stats_id
-                                    ORDER BY si2.stats_column_id
-                                FOR   XML PATH(N'') ,
-                                        TYPE).value(N'.[1]', N'nvarchar(1000)'), 1,
-                                    2, N'') AS StatsColumns ,
-                                MAX(si.stats_sampled_rows) AS SampleRows ,
-                                MAX(si.rowmods) AS RowMods ,
-                                MAX(si.histogramsteps) AS HistogramSteps ,
-                                MAX(si.stats_last_updated) AS StatsLastUpdated ,
-                                MAX(si.StatsRows) AS StatsRows,
-                                FullObjectName
-                    FROM     @StatsInfo si
-                    GROUP BY si.object_id ,
-                                si.stats_id ,
-                                si.stats_name ,
-                                si.FullObjectName
-                    ),
-                cteIndexSizes
-                AS ( SELECT   object_id ,
-                                index_id ,
-                                CASE WHEN index_id < 2
-                                    THEN ( ( SUM(in_row_data_page_count
-                                                + lob_used_page_count
-                                                + row_overflow_used_page_count)
-                                            * 8192 ) / 1024 )
-                                    else ( ( SUM(used_page_count) * 8192 ) / 1024 )
-                                END AS SizeKB
-                    FROM     sys.dm_db_partition_stats
-                    GROUP BY object_id ,
-                                index_id
-                    ),
-                cteRows
-                AS ( SELECT   object_id ,
-                                index_id ,
-                                SUM(rows) AS IndexRows
-                    FROM     sys.partitions
-                    GROUP BY object_id ,
-                                index_id
-                    ),
-                cteIndex
-                AS ( SELECT   OBJECT_NAME(c.object_id) AS ObjectName ,
-                                c.object_id ,
-                                c.index_id ,
-                                i.name COLLATE SQL_Latin1_General_CP1_CI_AS AS name ,
-                                c.index_column_id ,
-                                c.column_id ,
-                                c.is_included_column ,
-                                CASE WHEN @IncludeDataTypes = 0
-                                        AND c.is_descending_key = 1
-                                    THEN sc.name + ' DESC'
-                                    WHEN @IncludeDataTypes = 0
-                                        AND c.is_descending_key = 0 THEN sc.name
-                                    WHEN @IncludeDataTypes = 1
-                                        AND c.is_descending_key = 1
-                                        AND c.is_included_column = 0
-                                    THEN sc.name + ' DESC (' + t.name + ') '
-                                    WHEN @IncludeDataTypes = 1
-                                        AND c.is_descending_key = 0
-                                        AND c.is_included_column = 0
-                                    THEN sc.name + ' (' + t.name + ')'
-                                    ELSE sc.name
-                                END AS ColumnName ,
-                                '' AS filter_definition ,
-                                ISNULL(dd.user_scans, 0) AS user_scans ,
-                                ISNULL(dd.user_seeks, 0) AS user_seeks ,
-                                ISNULL(dd.user_updates, 0) AS user_updates ,
-                                ISNULL(dd.user_lookups, 0) AS user_lookups ,
-                                CONVERT(DATETIME, ISNULL(dd.last_user_lookup,
-                                                            '1901-01-01')) AS LastLookup ,
-                                CONVERT(DATETIME, ISNULL(dd.last_user_scan,
-                                                            '1901-01-01')) AS LastScan ,
-                                CONVERT(DATETIME, ISNULL(dd.last_user_seek,
-                                                            '1901-01-01')) AS LastSeek ,
-                                i.fill_factor ,
-                                c.is_descending_key ,
-                                'NONE' AS data_compression_desc ,
-                                i.type_desc ,
-                                i.is_unique ,
-                                i.is_unique_constraint ,
-                                i.is_primary_key ,
-                                ci.SizeKB ,
-                                cr.IndexRows ,
-                                QUOTENAME(sch.name) + '.' + QUOTENAME(tbl.name) AS FullObjectName ,
-                                ISNULL(dd.avg_fragmentation_in_percent, 0) AS avg_fragmentation_in_percent
-                    FROM     sys.indexes i
-                                JOIN sys.index_columns c ON i.object_id = c.object_id
-                                                            AND i.index_id = c.index_id
-                                JOIN sys.columns sc ON c.object_id = sc.object_id
-                                                    AND c.column_id = sc.column_id
-                                INNER JOIN sys.tables tbl ON c.object_id = tbl.object_id
-                                INNER JOIN sys.schemas sch ON sch.schema_id = tbl.schema_id
-                                LEFT JOIN sys.types t ON sc.user_type_id = t.user_type_id
-                                LEFT JOIN @IndexUsageStats dd ON i.object_id = dd.object_id
-                                                                AND i.index_id = dd.index_id --AND dd.database_id = DB_ID()
-                                JOIN sys.partitions p ON i.object_id = p.object_id
-                                                        AND i.index_id = p.index_id
-                                JOIN cteIndexSizes ci ON i.object_id = ci.object_id
-                                                        AND i.index_id = ci.index_id
-                                JOIN cteRows cr ON i.object_id = cr.object_id
-                                                AND i.index_id = cr.index_id
-                    WHERE    i.object_id = CASE WHEN @TableName IS NULL
-                                                THEN i.object_id
-                                                ELSE OBJECT_ID(@TableName)
-                                            END
-                    ),
-                cteResults
-                AS ( SELECT   ci.FullObjectName ,
-                                ci.object_id ,
-                                MAX(index_id) AS Index_Id ,
-                                ci.type_desc
-                                + CASE WHEN ci.is_primary_key = 1
-                                    THEN ' (PRIMARY KEY)'
-                                    WHEN ci.is_unique_constraint = 1
-                                    THEN ' (UNIQUE CONSTRAINT)'
-                                    WHEN ci.is_unique = 1 THEN ' (UNIQUE)'
-                                    ELSE ''
-                                END AS IndexType ,
-                                name AS IndexName ,
-                                STUFF((SELECT   N', ' + ColumnName
-                                    FROM     cteIndex ci2
-                                    WHERE    ci2.name = ci.name AND ci2.object_id=ci.object_id
-                                                AND ci2.is_included_column = 0
-                                    GROUP BY ci2.index_column_id ,
-                                                ci2.ColumnName
-                                    ORDER BY ci2.index_column_id
-                                FOR   XML PATH(N'') ,
-                                        TYPE).value(N'.[1]', N'nvarchar(1000)'), 1,
-                                    2, N'') AS KeyColumns ,
-                                ISNULL(STUFF((SELECT    N', ' + ColumnName
-                                            FROM      cteIndex ci3
-                                            WHERE     ci3.name = ci.name AND ci3.object_id=ci.object_id
-                                                        AND ci3.is_included_column = 1
-                                            GROUP BY  ci3.index_column_id ,
-                                                        ci3.ColumnName
-                                            ORDER BY  ci3.index_column_id
-                                    FOR   XML PATH(N'') ,
-                                                TYPE).value(N'.[1]',
-                                                            N'nvarchar(1000)'), 1, 2,
-                                            N''), '') AS IncludeColumns ,
-                                ISNULL(filter_definition, '') AS FilterDefinition ,
-                                ci.fill_factor ,
-                                CASE WHEN ci.data_compression_desc = 'NONE' THEN ''
-                                    ELSE ci.data_compression_desc
-                                END AS DataCompression ,
-                                MAX(ci.user_seeks) + MAX(ci.user_scans)
-                                + MAX(ci.user_lookups) AS IndexReads ,
-                                MAX(ci.user_lookups) AS IndexLookups ,
-                                ci.user_updates AS IndexUpdates ,
-                                ci.SizeKB AS SizeKB ,
-                                ci.IndexRows AS IndexRows ,
-                                CASE WHEN LastScan > LastSeek
-                                        AND LastScan > LastLookup THEN LastScan
-                                    WHEN LastSeek > LastScan
-                                        AND LastSeek > LastLookup THEN LastSeek
-                                    WHEN LastLookup > LastScan
-                                        AND LastLookup > LastSeek THEN LastLookup
-                                    ELSE ''
-                                END AS MostRecentlyUsed ,
-                                AVG(ci.avg_fragmentation_in_percent) AS avg_fragmentation_in_percent
-                    FROM     cteIndex ci
-                    GROUP BY ci.ObjectName ,
-                                ci.name ,
-                                ci.filter_definition ,
-                                ci.object_id ,
-                                ci.LastLookup ,
-                                ci.LastSeek ,
-                                ci.LastScan ,
-                                ci.user_updates ,
-                                ci.fill_factor ,
-                                ci.data_compression_desc ,
-                                ci.type_desc ,
-                                ci.is_primary_key ,
-                                ci.is_unique ,
-                                ci.is_unique_constraint ,
-                                ci.SizeKB ,
-                                ci.IndexRows ,
-                                ci.FullObjectName
-                    ), AllResults AS
-                        (         SELECT   c.FullObjectName ,
-                                ISNULL(IndexType, 'STATISTICS') AS IndexType ,
-                                ISNULL(IndexName, '') AS IndexName ,
-                                ISNULL(KeyColumns, '') AS KeyColumns ,
-                                ISNULL(IncludeColumns, '') AS IncludeColumns ,
-                                FilterDefinition ,
-                                fill_factor AS [FillFactor] ,
-                                DataCompression ,
-                                IndexReads ,
-                                IndexUpdates ,
-                                SizeKB ,
-                                IndexRows ,
-                                IndexLookups ,
-                                MostRecentlyUsed ,
-                                NULL AS StatsSampleRows ,
-                                NULL AS StatsRowMods ,
-                                NULL AS HistogramSteps ,
-                                NULL AS StatsLastUpdated ,
-                                avg_fragmentation_in_percent as IndexFragInPercent,
-                                1 AS Ordering ,
-                                c.object_id ,
-                                c.Index_Id
-                    FROM     cteResults c
-                                INNER JOIN cteStatsInfo si ON si.object_id = c.object_id
-                                                            AND si.stats_id = c.Index_Id
-                        UNION
-                    SELECT   QUOTENAME(sch.name) + '.' + QUOTENAME(tbl.name) AS FullObjectName ,
-                                'STATISTICS' ,
-                                stats_name ,
-                                StatsColumns ,
-                                '' ,
-                                '' AS FilterDefinition ,
-                                '' AS Fill_Factor ,
-                                '' AS DataCompression ,
-                                '' AS IndexReads ,
-                                '' AS IndexUpdates ,
-                                '' AS SizeKB ,
-                                StatsRows AS IndexRows ,
-                                '' AS IndexLookups ,
-                                '' AS MostRecentlyUsed ,
-                                SampleRows AS StatsSampleRows ,
-                                RowMods AS StatsRowMods ,
-                                csi.HistogramSteps ,
-                                csi.StatsLastUpdated ,
-                                '' AS IndexFragInPercent,
-                                2 ,
-                                csi.object_id ,
-                                csi.stats_id
-                    FROM     cteStatsInfo csi
-                    INNER JOIN sys.tables tbl ON csi.object_id = tbl.object_id
-                                INNER JOIN sys.schemas sch ON sch.schema_id = tbl.schema_id
-                                LEFT JOIN (SELECT si.object_id, si.stats_id
-                                            FROM    cteResults c
-                                            INNER JOIN cteStatsInfo si ON si.object_id = c.object_id
-                                                                    AND si.stats_id = c.Index_Id ) AS x ON csi.object_id = x.object_id AND csi.stats_id = x.stats_id
-                        WHERE x.object_id IS NULL
-                    )
-            INSERT INTO @AllResults
-            SELECT  row_number() OVER (ORDER BY FullObjectName) AS RowNum ,
-                    FullObjectName ,
-                    ISNULL(IndexType, 'STATISTICS') AS IndexType ,
-                    IndexName ,
-                    KeyColumns ,
-                    ISNULL(IncludeColumns, '') AS IncludeColumns ,
-                    FilterDefinition ,
-                    [FillFactor] AS [FillFactor] ,
-                    DataCompression ,
-                    IndexReads ,
-                    IndexUpdates ,
-                    SizeKB ,
-                    IndexRows ,
-                    IndexLookups ,
-                    MostRecentlyUsed ,
-                    StatsSampleRows ,
-                    StatsRowMods ,
-                    HistogramSteps ,
-                    StatsLastUpdated ,
-                    IndexFragInPercent ,
-                    object_id ,
-                    index_id
-            FROM    AllResults
-                    $IncludeStatsPredicate
-        OPTION  ( RECOMPILE );
-
-        /* Only update the stats data on 2005 for a single table, otherwise the run time for this is a potential problem for large table/index volumes */
-        IF @TableName IS NOT NULL
-        BEGIN
-
-            DECLARE @StatsInfo2005 TABLE (Name NVARCHAR(128), Updated DATETIME, Rows BIGINT, RowsSampled BIGINT, Steps INT, Density INT, AverageKeyLength INT, StringIndex NVARCHAR(20))
-
-            DECLARE @SqlCall NVARCHAR(2000), @RowNum INT;
-            SELECT @RowNum = MIN(RowNum) FROM @AllResults;
-            WHILE @RowNum IS NOT NULL
-            BEGIN
-                SELECT @SqlCall = 'DBCC SHOW_STATISTICS('+FullObjectName+', '+IndexName+') WITH STAT_HEADER' FROM @AllResults WHERE RowNum = @RowNum;
-                INSERT INTO @StatsInfo2005 EXEC (@SqlCall);
-                UPDATE @AllResults
-                    SET StatsSampleRows = RowsSampled,
-                    HistogramSteps = Steps,
-                    StatsLastUpdated = Updated
-                    FROM @StatsInfo2005
-                    WHERE RowNum = @RowNum;
-                DELETE FROM @StatsInfo2005
-                SELECT @RowNum = MIN(RowNum) FROM @AllResults WHERE RowNum > @RowNum;
-            END;
-
-        END;
-
-        UPDATE a
-        SET a.StatsRowMods = i.rowmodctr
-        FROM @AllResults a
-            JOIN sys.sysindexes i ON a.object_id = i.id AND a.index_id = i.indid;
-
-        SELECT    FullObjectName ,
-                IndexType ,
-                IndexName ,
-                KeyColumns ,
-                IncludeColumns ,
-                FilterDefinition ,
-                [FillFactor] ,
-                DataCompression ,
-                IndexReads ,
-                IndexUpdates ,
-                SizeKB ,
-                IndexRows ,
-                IndexLookups ,
-                MostRecentlyUsed ,
-                StatsSampleRows ,
-                StatsRowMods ,
-                HistogramSteps ,
-                StatsLastUpdated ,
-                IndexFragInPercent
-        FROM @AllResults;"
-
-        #endregion sizesQuery2005
     }
     process {
         Write-Message -Level Debug -Message $SizesQuery
-        Write-Message -Level Debug -Message $SizesQuery2005
 
         foreach ($instance in $SqlInstance) {
             try {
@@ -1059,20 +607,13 @@ function Get-DbaHelpIndex {
         foreach ($db in $InputObject) {
             $server = $db.Parent
 
-            #Need to check the version of SQL
-            if ($server.versionMajor -ge 10) {
-                $indexesQuery = $SizesQuery
-            } else {
-                $indexesQuery = $SizesQuery2005
-            }
-
             if (!$db.IsAccessible) {
                 Stop-Function -Message "$db is not accessible. Skipping." -Continue
             }
 
-            Write-Message -Level Debug -Message "$indexesQuery"
+            Write-Message -Level Debug -Message "$SizesQuery"
             try {
-                $IndexDetails = $db.Query($indexesQuery)
+                $IndexDetails = $db.Query($SizesQuery)
 
                 foreach ($detail in $IndexDetails) {
                     $recentlyused = [datetime]$detail.MostRecentlyUsed


### PR DESCRIPTION
Fixes #8716

- Escape single quotes in ObjectName to prevent SQL injection when building the @TableName DECLARE/SET statement
- Remove unused $SizesQuery2005 block and its conditional branching; Connect-DbaInstance -MinimumVersion 10 already enforces SQL 2008+
- Update docs to reflect SQL Server 2008+ minimum version requirement

Generated with [Claude Code](https://claude.ai/code)