### PR TITLE
Copy-DbaLogin - Add -ExcludeDatabaseMapping to sync only server permissions

### DIFF
--- a/private/functions/Update-SqlPermission.ps1
+++ b/private/functions/Update-SqlPermission.ps1
@@ -32,6 +32,7 @@ function Update-SqlPermission {
         [ValidateNotNullOrEmpty()]
         [object]$DestLogin,
         [switch]$ObjectLevel,
+        [switch]$ExcludeDatabaseMapping,
         [switch]$EnableException
     )
 
@@ -192,6 +193,10 @@ function Update-SqlPermission {
                 }
             }
         }
+    }
+
+    if ($ExcludeDatabaseMapping) {
+        return
     }
 
     if ($DestServer.VersionMajor -lt 9) {

--- a/public/Copy-DbaLogin.ps1
+++ b/public/Copy-DbaLogin.ps1
@@ -46,6 +46,10 @@ function Copy-DbaLogin {
         Skips copying server roles, database permissions, and security mappings for the login accounts.
         Use this when you only need the login accounts created but plan to configure permissions separately, or when copying logins for testing purposes.
 
+    .PARAMETER ExcludeDatabaseMapping
+        Skips copying database-level permissions and role memberships, syncing only server-level roles and securables.
+        Use this when you want to sync server permissions (sysadmin membership, server securables, etc.) without iterating through all databases, which significantly improves performance on instances with many databases.
+
     .PARAMETER SyncSaName
         Renames the destination sa account to match the source sa account name if they differ.
         Use this during migrations when your organization has renamed the sa account for security purposes and you need consistent naming across instances.
@@ -215,6 +219,7 @@ function Copy-DbaLogin {
         [switch]$Force,
         [switch]$ObjectLevel,
         [switch]$ExcludePermissionSync,
+        [switch]$ExcludeDatabaseMapping,
         [switch]$EnableException
     )
 
@@ -508,7 +513,15 @@ function Copy-DbaLogin {
                         # In rare cases, when the instance has a case sensitive collation and there are two logins that differ only in case, New-DbaLogin will return them both into $destLogin
                         # So we loop, just in case...
                         foreach ($dl in $destLogin) {
-                            Update-SqlPermission -SourceServer $sourceServer -SourceLogin $Login -DestServer $destServer -DestLogin $dl -ObjectLevel:$ObjectLevel
+                            $splatPermission = @{
+                                SourceServer           = $sourceServer
+                                SourceLogin            = $Login
+                                DestServer             = $destServer
+                                DestLogin              = $dl
+                                ObjectLevel            = $ObjectLevel
+                                ExcludeDatabaseMapping = $ExcludeDatabaseMapping
+                            }
+                            Update-SqlPermission @splatPermission
                         }
                     }
                 }

--- a/tests/Copy-DbaLogin.Tests.ps1
+++ b/tests/Copy-DbaLogin.Tests.ps1
@@ -24,6 +24,7 @@ Describe $CommandName -Tag UnitTests {
                 "LoginRenameHashtable",
                 "KillActiveConnection",
                 "ExcludePermissionSync",
+                "ExcludeDatabaseMapping",
                 "NewSid",
                 "ObjectLevel",
                 "Force",


### PR DESCRIPTION
Adds a new `-ExcludeDatabaseMapping` switch to `Copy-DbaLogin` that syncs only server-level roles and securables, skipping the database mapping loop.

This addresses the performance concern for instances with many databases where full permission sync is slow but `-ExcludePermissionSync` discards desired server-level permissions.

Fixes #8312

Generated with [Claude Code](https://claude.ai/code)