### PR TITLE
Import-DbaCsv, Export-DbaCsv - Normalize table/schema names via Get-ObjectNameParts

### DIFF
--- a/public/Export-DbaCsv.ps1
+++ b/public/Export-DbaCsv.ps1
@@ -288,13 +288,19 @@ function Export-DbaCsv {
             if ($PSBoundParameters.Query) {
                 $sqlToExecute = $Query
             } elseif ($PSBoundParameters.Table) {
-                # Parse table name for schema
-                if ($Table -match "^(.+)\.(.+)$") {
-                    $schemaName = $Matches[1]
-                    $tableName = $Matches[2]
+                # Parse table name using Get-ObjectNameParts so that bracketed names
+                # (e.g. [My.Table]) and two-part names (e.g. schema.[My.Table]) are
+                # handled correctly instead of relying on a naive dot-split regex.
+                $parsedTable = Get-ObjectNameParts -ObjectName $Table
+                if ($parsedTable.Parsed -and $parsedTable.Schema) {
+                    $schemaName = $parsedTable.Schema
+                    $tableName  = $parsedTable.Name
+                } elseif ($parsedTable.Parsed) {
+                    $schemaName = "dbo"
+                    $tableName  = $parsedTable.Name
                 } else {
                     $schemaName = "dbo"
-                    $tableName = $Table
+                    $tableName  = $Table
                 }
                 $sqlToExecute = "SELECT * FROM [$schemaName].[$tableName]"
             }

--- a/public/Export-DbaCsv.ps1
+++ b/public/Export-DbaCsv.ps1
@@ -302,7 +302,6 @@ function Export-DbaCsv {
                     $schemaName = "dbo"
                     $tableName  = $Table
                 }
-                $tableName = $nameParts.Name
                 $sqlToExecute = "SELECT * FROM [$schemaName].[$tableName]"
             }
 

--- a/public/Import-DbaCsv.ps1
+++ b/public/Import-DbaCsv.ps1
@@ -1022,6 +1022,25 @@ WHERE c.object_id = OBJECT_ID(@tableName)
                 }
             }
 
+            # Normalize table and schema names using Get-ObjectNameParts.
+            # This handles bracketed names (e.g. [My.Table]) and two-part names (e.g. schema.[My.Table]).
+            # sys.tables/sys.schemas store bare names without brackets, so we must strip them
+            # before using the values in parameterized metadata queries.
+            $parsedTable = Get-ObjectNameParts -ObjectName $table
+            if ($parsedTable.Parsed) {
+                if ($parsedTable.Schema -and -not $PSBoundParameters.Schema) {
+                    $schema = $parsedTable.Schema
+                    Write-Message -Level Verbose -Message "Schema extracted from table name, using $schema"
+                }
+                if ($parsedTable.Name) {
+                    $table = $parsedTable.Name
+                }
+            }
+            # Strip surrounding brackets from schema in case the user passed -Schema "[dbo]"
+            if ($schema -like "[[]*[]]") {
+                $schema = $schema.Substring(1, $schema.Length - 2)
+            }
+
             foreach ($instance in $SqlInstance) {
                 $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
                 # Open Connection to SQL Server


### PR DESCRIPTION
Fixes inconsistency where commands with bracketed table names (e.g. [My.Table]) failed because sys.tables stores bare names without brackets.

- Import-DbaCsv: normalize $table/$schema with Get-ObjectNameParts before using them in parameterized metadata queries
- Export-DbaCsv: replace naive dot-split regex with Get-ObjectNameParts

Generated with [Claude Code](https://claude.ai/code)


Edit of andreasjordan:
Fixes part of #9010 - more PRs need to follow. So we keep the issue open but limit this PR to the DbaCsv commands. After this is merged we can find other commands that need the same fix.

IMPORTANT: This is a breaking change so maybe merge later together with other breaking changes and release a new version 2.8.0

