### PR TITLE
Get-DbaBackupInformation - Fix inconsistencies with Get-DbaDbBackupHistory

### DIFF
--- a/.github/scripts/gh-s3actions.ps1
+++ b/.github/scripts/gh-s3actions.ps1
@@ -215,7 +215,7 @@ Describe "S3 Backup Integration Tests" -Tag "IntegrationTests", "S3" {
 
             $result | Should -Not -BeNullOrEmpty
             $result.Database | Should -Be $script:TestDbName2
-            $result.Type | Should -Be "Database"
+            $result.Type | Should -Be "Full"
         }
     }
 
@@ -393,7 +393,7 @@ Describe "S3 Backup Integration Tests" -Tag "IntegrationTests", "S3" {
             # Should successfully read the specific file
             $result | Should -Not -BeNullOrEmpty
             $result.Database | Should -Be $script:TestDbName5
-            $result.Type | Should -Be "Database"
+            $result.Type | Should -Be "Full"
         }
 
         It "Should successfully enumerate local file system paths (contrast with S3)" {

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -419,7 +419,9 @@ function Get-DbaBackupInformation {
                 $historyObject.SoftwareVersionMajor = $group.Group[0].SoftwareVersionMajor
                 $historyObject.RecoveryModel = $group.Group.RecoveryModel
                 $historyObject.IsCopyOnly = $group.Group[0].IsCopyOnly
-                $historyObject.LastRecoveryForkGuid = $group.Group[0].LastRecoveryForkGUID
+                if ($null -ne $group.Group[0].LastRecoveryForkGUID) {
+                    $historyObject.LastRecoveryForkGuid = $group.Group[0].LastRecoveryForkGUID
+                }
                 $groupResults += $historyObject
             }
         }

--- a/public/Get-DbaBackupInformation.ps1
+++ b/public/Get-DbaBackupInformation.ps1
@@ -360,7 +360,16 @@ function Get-DbaBackupInformation {
                 if (-not $dbLsn) {
                     $dbLsn = 0
                 }
-                $description = $group.Group[0].BackupTypeDescription
+                $description = switch ($group.Group[0].BackupTypeDescription) {
+                    "Database"              { "Full" }
+                    "Database Differential" { "Differential" }
+                    "Transaction Log"       { "Log" }
+                    "File or Filegroup"     { "File" }
+                    "File Differential"     { "Differential File" }
+                    "Partial Database"      { "Partial Full" }
+                    "Partial Differential"  { "Partial Differential" }
+                    default                 { $group.Group[0].BackupTypeDescription }
+                }
                 if (-not $description) {
                     try {
                         $header = Read-DbaBackupHeader -SqlInstance $server -Path $Path -EnableException | Select-Object -First 1
@@ -375,7 +384,13 @@ function Get-DbaBackupInformation {
                 }
                 $historyObject = New-Object Dataplat.Dbatools.Database.BackupHistory
                 $historyObject.ComputerName = $group.Group[0].MachineName
-                $historyObject.InstanceName = $group.Group[0].ServiceName
+                $instanceName = $group.Group[0].ServiceName
+                if (-not $instanceName -and $group.Group[0].ServerName -like "*\*") {
+                    $instanceName = $group.Group[0].ServerName.Split("\")[1]
+                } elseif (-not $instanceName) {
+                    $instanceName = "MSSQLSERVER"
+                }
+                $historyObject.InstanceName = $instanceName
                 $historyObject.SqlInstance = $group.Group[0].ServerName
                 $historyObject.Database = $group.Group[0].DatabaseName
                 $historyObject.UserName = $group.Group[0].UserName
@@ -383,7 +398,10 @@ function Get-DbaBackupInformation {
                 $historyObject.End = [DateTime]$group.Group[0].BackupFinishDate
                 $historyObject.Duration = ([DateTime]$group.Group[0].BackupFinishDate - [DateTime]$group.Group[0].BackupStartDate)
                 $historyObject.Path = [string[]]$group.Group.BackupPath
-                $historyObject.FileList = ($group.Group.FileList | Select-Object Type, LogicalName, PhysicalName, @{
+                $historyObject.FileList = ($group.Group.FileList | Select-Object @{
+                        Name       = "FileType"
+                        Expression = { $PSItem.Type }
+                    }, LogicalName, PhysicalName, @{
                         Name       = "Size"
                         Expression = { [dbasize]$PSItem.Size }
                     } -Unique)
@@ -401,6 +419,7 @@ function Get-DbaBackupInformation {
                 $historyObject.SoftwareVersionMajor = $group.Group[0].SoftwareVersionMajor
                 $historyObject.RecoveryModel = $group.Group.RecoveryModel
                 $historyObject.IsCopyOnly = $group.Group[0].IsCopyOnly
+                $historyObject.LastRecoveryForkGuid = $group.Group[0].LastRecoveryForkGUID
                 $groupResults += $historyObject
             }
         }
@@ -420,7 +439,7 @@ function Get-DbaBackupInformation {
                 $group.UserName = Get-HashString -InString $group.UserName
                 $group.Path = Get-HashString -InString  $group.Path
                 $group.FullName = Get-HashString -InString $group.FullName
-                $group.FileList = ($group.FileList | Select-Object Type,
+                $group.FileList = ($group.FileList | Select-Object FileType,
                     @{Name = "LogicalName"; Expression = { Get-HashString -InString $_."LogicalName" } },
                     @{Name = "PhysicalName"; Expression = { Get-HashString -InString $_."PhysicalName" } })
             }

--- a/tests/Get-DbaBackupInformation.Tests.ps1
+++ b/tests/Get-DbaBackupInformation.Tests.ps1
@@ -129,11 +129,11 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should return 2 full backups" {
-            ($results | Where-Object Type -eq "Database").Count | Should -BeExactly 2
+            ($results | Where-Object Type -eq "Full").Count | Should -BeExactly 2
         }
 
         It "Should return 2 log backups" {
-            ($results | Where-Object Type -eq "Transaction Log").Count | Should -BeExactly 2
+            ($results | Where-Object Type -eq "Log").Count | Should -BeExactly 2
         }
     }
 
@@ -152,11 +152,11 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should Be 1 full backup" {
-            ($results | Where-Object Type -eq "Database").Count | Should -BeExactly 1
+            ($results | Where-Object Type -eq "Full").Count | Should -BeExactly 1
         }
 
         It "Should be 1 log backups" {
-            ($results | Where-Object Type -eq "Transaction Log").Count | Should -BeExactly 1
+            ($results | Where-Object Type -eq "Log").Count | Should -BeExactly 1
         }
 
         It "Should only be backups of $dbname2" {
@@ -199,11 +199,11 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Should Be 1 full backup" {
-            ($results | Where-Object Type -eq "Database").Count | Should -BeExactly 1
+            ($results | Where-Object Type -eq "Full").Count | Should -BeExactly 1
         }
 
         It "Should be 1 log backups" {
-            ($results | Where-Object Type -eq "Transaction Log").Count | Should -BeExactly 1
+            ($results | Where-Object Type -eq "Log").Count | Should -BeExactly 1
         }
 
         It "Should only be backups of $dbname3" {
@@ -229,7 +229,7 @@ Describe $CommandName -Tag IntegrationTests {
                 IgnoreLogBackup     = $true
             }
             $ResultsSanLog = Get-DbaBackupInformation @splatMaintenanceNoLog
-            ($ResultsSanLog | Where-Object Type -eq "Database").Count | Should -BeExactly 1
+            ($ResultsSanLog | Where-Object Type -eq "Full").Count | Should -BeExactly 1
         }
 
         It "Should be 0 log backups when ignoring log backups" {
@@ -240,7 +240,7 @@ Describe $CommandName -Tag IntegrationTests {
                 IgnoreLogBackup     = $true
             }
             $resultsSanLog = Get-DbaBackupInformation @splatMaintenanceNoLog
-            ($resultsSanLog | Where-Object Type -eq "Transaction Log").Count | Should -BeExactly 0
+            ($resultsSanLog | Where-Object Type -eq "Log").Count | Should -BeExactly 0
         }
 
         It "Should Warn if IgnoreLogBackup without MaintenanceSolution" {


### PR DESCRIPTION
Fixes inconsistencies between `Get-DbaBackupInformation` and `Get-DbaDbBackupHistory` as reported in #8205.

**Changes:**
- Normalize `Type` values to match Get-DbaDbBackupHistory ("Database" → "Full", etc.)
- Rename `FileList` property `Type` to `FileType`
- Fix `LastRecoveryForkGuid` (was always "00000000-0000-...")
- Fix `InstanceName` (extract from ServerName when ServiceName is empty)

Closes #8205

Generated with [Claude Code](https://claude.ai/code)


IMPORTANT: This is a breaking change so maybe merge later together with other breaking changes and release a new version 2.8.0