### PR TITLE
Invoke-TlsWebRequest - Auto-detect system proxy

### DIFF
--- a/private/configurations/settings/commands.ps1
+++ b/private/configurations/settings/commands.ps1
@@ -19,3 +19,6 @@ Set-DbatoolsConfig -FullName 'commands.test-elevationrequirement.disable' -Value
 
 # Get-DbaDbTable
 Set-DbatoolsConfig -FullName 'commands.get-dbadbtable.clearandinitialize' -Value $false -Initialize -Validation bool -Description "Controls whether Get-DbaDbTable uses ClearAndInitialize to load all table properties in one optimized query. Set to true to enable the optimization, which loads all properties in a single query but clears already loaded SMO properties. Keep at false when reusing SMO objects across multiple calls (e.g. in Copy-DbaDbTableData)."
+
+# Invoke-TlsWebRequest
+Set-DbatoolsConfig -FullName 'commands.invoke-tlswebrequest.disableautoproxy' -Value $false -Initialize -Validation bool -Description "Disable automatic system proxy detection in Invoke-TlsWebRequest. Set to true to skip auto-detection of the system proxy (useful if auto-detection causes issues in your environment)."

--- a/private/functions/Invoke-TlsWebRequest.ps1
+++ b/private/functions/Invoke-TlsWebRequest.ps1
@@ -14,9 +14,18 @@ function Invoke-TlsWebRequest {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_
     }
 
+    # Auto-detect system proxy if not already configured
+    if (-not [System.Net.WebRequest]::DefaultWebProxy.Address) {
+        $systemProxy = [System.Net.WebRequest]::GetSystemWebProxy()
+        if ($systemProxy) {
+            [System.Net.WebRequest]::DefaultWebProxy = $systemProxy
+            [System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+        }
+    }
+
     # IWR is crazy slow for large downloads
     $currentProgressPref = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue'
+    $ProgressPreference = "SilentlyContinue"
     Invoke-WebRequest @Args
     $ProgressPreference = $currentProgressPref
 

--- a/private/functions/Invoke-TlsWebRequest.ps1
+++ b/private/functions/Invoke-TlsWebRequest.ps1
@@ -14,8 +14,8 @@ function Invoke-TlsWebRequest {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $_
     }
 
-    # Auto-detect system proxy if not already configured
-    if (-not [System.Net.WebRequest]::DefaultWebProxy.Address) {
+    # Auto-detect system proxy if not already configured and not opted out
+    if (-not (Get-DbatoolsConfigValue -FullName "commands.invoke-tlswebrequest.disableautoproxy") -and -not [System.Net.WebRequest]::DefaultWebProxy.Address) {
         $systemProxy = [System.Net.WebRequest]::GetSystemWebProxy()
         if ($systemProxy) {
             [System.Net.WebRequest]::DefaultWebProxy = $systemProxy


### PR DESCRIPTION
Adds automatic proxy detection to `Invoke-TlsWebRequest` using `[System.Net.WebRequest]::GetSystemWebProxy()`. When no proxy is already configured, the system proxy is detected and set with default network credentials. Supports PAC files and is cross-platform. All callers benefit without individual changes.

Fixes #5884

Generated with [Claude Code](https://claude.ai/code)