### PR TITLE
Set-DbaDbCompression, Invoke-DbaBalanceDataFiles, Invoke-DbaDbPiiScan - Normalize table names via Get-ObjectNameParts

### DIFF
--- a/public/Invoke-DbaBalanceDataFiles.ps1
+++ b/public/Invoke-DbaBalanceDataFiles.ps1
@@ -273,7 +273,8 @@ function Invoke-DbaBalanceDataFiles {
                             Stop-Function -Message "One or more tables cannot be found in database $db on instance $instance" -Target $instance -Continue
                         }
 
-                        $tableCollection = $db.Tables | Where-Object { $_.Name -in $Table }
+                        $tableNames = $Table | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
+                        $tableCollection = $db.Tables | Where-Object { $_.Name -in $tableNames }
                     } else {
                         $tableCollection = $db.Tables
                     }

--- a/public/Invoke-DbaDbPiiScan.ps1
+++ b/public/Invoke-DbaDbPiiScan.ps1
@@ -276,13 +276,15 @@ function Invoke-DbaDbPiiScan {
 
                 # Filter the tables if needed
                 if ($Table) {
-                    $tables = $db.Tables | Where-Object Name -In $Table
+                    $tableNames = $Table | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
+                    $tables = $db.Tables | Where-Object Name -In $tableNames
                 } else {
                     $tables = $db.Tables
                 }
 
                 if ($ExcludeTable) {
-                    $tables = $tables | Where-Object Name -NotIn $ExcludeTable
+                    $excludeTableNames = $ExcludeTable | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
+                    $tables = $tables | Where-Object Name -NotIn $excludeTableNames
                 }
 
                 # Filter the tables based on the column

--- a/public/Set-DbaDbCompression.ps1
+++ b/public/Set-DbaDbCompression.ps1
@@ -264,7 +264,8 @@ function Set-DbaDbCompression {
                     if ($Pscmdlet.ShouldProcess($db, "Applying $CompressionType compression")) {
                         $tables = $server.Databases[$($db.name)].Tables
                         if ($Table) {
-                            $tables = $tables | Where-Object Name -in $Table
+                            $tableNames = $Table | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
+                            $tables = $tables | Where-Object Name -in $tableNames
                         }
 
                         foreach ($obj in $tables | Where-Object { !$_.IsMemoryOptimized -and !$_.HasSparseColumn }) {


### PR DESCRIPTION
Fixes Group 1 of issue #9010: SMO name comparisons failed when users passed bracketed table names like [Gross.Table.Name]. SMO's .Name property never includes brackets, so the filter silently returned nothing.

Normalize $Table and $ExcludeTable values via Get-ObjectNameParts before SMO name comparisons in:
- Set-DbaDbCompression
- Invoke-DbaBalanceDataFiles
- Invoke-DbaDbPiiScan

Generated with [Claude Code](https://claude.ai/code)