### PR TITLE
Test-DbaDbCompression, Get-DbaDbPageInfo - Normalize table names via Get-ObjectNameParts

### DIFF
--- a/public/Get-DbaDbPageInfo.ps1
+++ b/public/Get-DbaDbPageInfo.ps1
@@ -120,10 +120,11 @@ function Get-DbaDbPageInfo {
         }
 
         if ($Table) {
+            $tableNames = $Table | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
             if ($schema) {
-                $sql = "$sql AND st.name IN ('$($Table -join "','")')"
+                $sql = "$sql AND st.name IN ('$($tableNames -join "','")')"
             } else {
-                $sql = "$sql WHERE st.name IN ('$($Table -join "','")')"
+                $sql = "$sql WHERE st.name IN ('$($tableNames -join "','")')"
             }
         }
     }

--- a/public/Test-DbaDbCompression.ps1
+++ b/public/Test-DbaDbCompression.ps1
@@ -197,7 +197,8 @@ function Test-DbaDbCompression {
         }
 
         if ($Table) {
-            $sqlTableWhere = "AND t.name IN ('$($Table -join "','")')"
+            $tableNames = $Table | ForEach-Object { (Get-ObjectNameParts -ObjectName $_).Name }
+            $sqlTableWhere = "AND t.name IN ('$($tableNames -join "','")')"
         }
 
         if ($ResultSize) {


### PR DESCRIPTION
Fixes Group 2 of issue #9010: SQL IN clause comparisons failed when users passed bracketed table names like [Gross.Table.Name]. sys.tables.name stores bare names without brackets, so the filter silently returned nothing.

Normalize $Table values via Get-ObjectNameParts before embedding in SQL name IN (...) clauses in:
- Test-DbaDbCompression
- Get-DbaDbPageInfo


Generated with [Claude Code](https://claude.ai/code)