### PR TITLE
Export-DbaCsv, Export-DbaDacPackage - Normalize table/schema names via Get-ObjectNameParts

### DIFF
--- a/public/Export-DbaCsv.ps1
+++ b/public/Export-DbaCsv.ps1
@@ -288,14 +288,14 @@ function Export-DbaCsv {
             if ($PSBoundParameters.Query) {
                 $sqlToExecute = $Query
             } elseif ($PSBoundParameters.Table) {
-                # Parse table name for schema
-                if ($Table -match "^(.+)\.(.+)$") {
-                    $schemaName = $Matches[1]
-                    $tableName = $Matches[2]
+                # Parse table name for schema using Get-ObjectNameParts to correctly handle bracketed names like [Gross.Table.Name]
+                $nameParts = Get-ObjectNameParts -ObjectName $Table
+                if ($nameParts.Schema) {
+                    $schemaName = $nameParts.Schema
                 } else {
                     $schemaName = "dbo"
-                    $tableName = $Table
                 }
+                $tableName = $nameParts.Name
                 $sqlToExecute = "SELECT * FROM [$schemaName].[$tableName]"
             }
 

--- a/public/Export-DbaDacPackage.ps1
+++ b/public/Export-DbaDacPackage.ps1
@@ -184,15 +184,14 @@ function Export-DbaDacPackage {
         if ($Table) {
             $tblList = New-Object 'System.Collections.Generic.List[Tuple[String, String]]'
             foreach ($tableItem in $Table) {
-                $tableSplit = $tableItem.Split('.')
-                if ($tableSplit.Count -gt 1) {
-                    $tblName = $tableSplit[-1]
-                    $schemaName = $tableSplit[-2]
+                # Use Get-ObjectNameParts to correctly handle bracketed names like [Gross.Table.Name]
+                $nameParts = Get-ObjectNameParts -ObjectName $tableItem
+                if ($nameParts.Schema) {
+                    $schemaName = $nameParts.Schema
                 } else {
-                    $tblName = [string]$tableSplit
-                    $schemaName = 'dbo'
+                    $schemaName = "dbo"
                 }
-                $tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName, $tblName))
+                $tblList.Add((New-Object "tuple[String, String]" -ArgumentList $schemaName, $nameParts.Name))
             }
         } else {
             $tblList = $null


### PR DESCRIPTION
Fixes Group 3 of issue #9010: naive dot-split parsing failed for bracketed dotted table names like [Gross.Table.Name].

- Export-DbaCsv: replace regex `^(.+)\.(.+)$` with Get-ObjectNameParts
- Export-DbaDacPackage: replace `tableItem.Split('.')` with Get-ObjectNameParts

Closes #9010

Generated with [Claude Code](https://claude.ai/code)