### PR TITLE
Remove-DbaDbTableData - Normalize table name via Get-ObjectNameParts

### DIFF
--- a/public/Remove-DbaDbTableData.ps1
+++ b/public/Remove-DbaDbTableData.ps1
@@ -217,7 +217,15 @@ function Remove-DbaDbTableData {
             "
 
         if (Test-Bound Table) {
-            $sql += "    DELETE TOP ($BatchSize) FROM $Table;"
+            $nameParts = Get-ObjectNameParts -ObjectName $Table
+            if ($nameParts.Database) {
+                $bracketedTable = "[$($nameParts.Database)].[$($nameParts.Schema)].[$($nameParts.Name)]"
+            } elseif ($nameParts.Schema) {
+                $bracketedTable = "[$($nameParts.Schema)].[$($nameParts.Name)]"
+            } else {
+                $bracketedTable = "[$($nameParts.Name)]"
+            }
+            $sql += "    DELETE TOP ($BatchSize) FROM $bracketedTable;"
         } elseif (Test-Bound DeleteSql) {
             $sql += "    $DeleteSql;"
         }


### PR DESCRIPTION
Fixes Group 4 of issue #9010: bare dotted table names like Gross.Table.Name were interpreted by SQL Server as 3-part database.schema.table names in the DELETE statement.

Parse -Table via Get-ObjectNameParts and reconstruct a properly-bracketed T-SQL identifier before embedding in the DELETE statement.


Generated with [Claude Code](https://claude.ai/code)