### PR TITLE
Get-DbaDbIdentity, Set-DbaDbIdentity, Invoke-DbaDbDbccUpdateUsage - Normalize table names via Get-ObjectNameParts

### DIFF
--- a/public/Get-DbaDbIdentity.ps1
+++ b/public/Get-DbaDbIdentity.ps1
@@ -129,7 +129,13 @@ function Get-DbaDbIdentity {
                 foreach ($tbl in $Table) {
                     try {
                         $query = $StringBuilder.ToString()
-                        $query = $query.Replace('#options#', "'$($tbl)'")
+                        $nameParts = Get-ObjectNameParts -ObjectName $tbl
+                        if ($nameParts.Schema) {
+                            $tblIdentifier = "[$($nameParts.Schema)].[$($nameParts.Name)]"
+                        } else {
+                            $tblIdentifier = "[$($nameParts.Name)]"
+                        }
+                        $query = $query.Replace('#options#', "'$($tblIdentifier)'")
 
                         if ($Pscmdlet.ShouldProcess($server.Name, "Execute the command $query against $instance")) {
                             Write-Message -Message "Query to run: $query" -Level Verbose

--- a/public/Invoke-DbaDbDbccUpdateUsage.ps1
+++ b/public/Invoke-DbaDbDbccUpdateUsage.ps1
@@ -163,6 +163,14 @@ function Invoke-DbaDbDbccUpdateUsage {
                 try {
                     $query = $StringBuilder.ToString()
                     if (Test-Bound -ParameterName Table) {
+                        if ($Table -notmatch '^\d+$') {
+                            $tableNameParts = Get-ObjectNameParts -ObjectName $Table
+                            if ($tableNameParts.Schema) {
+                                $tableIdentifier = "[$($tableNameParts.Schema)].[$($tableNameParts.Name)]"
+                            } else {
+                                $tableIdentifier = "[$($tableNameParts.Name)]"
+                            }
+                        }
                         if (Test-Bound -ParameterName Index) {
                             if ($Table -match '^\d+$') {
                                 if ($Index -match '^\d+$') {
@@ -172,16 +180,16 @@ function Invoke-DbaDbDbccUpdateUsage {
                                 }
                             } else {
                                 if ($Index -match '^\d+$') {
-                                    $query = $query.Replace('#options#', "'$($db.name)', '$Table', $Index")
+                                    $query = $query.Replace('#options#', "'$($db.name)', '$tableIdentifier', $Index")
                                 } else {
-                                    $query = $query.Replace('#options#', "'$($db.name)', '$Table', '$Index'")
+                                    $query = $query.Replace('#options#', "'$($db.name)', '$tableIdentifier', '$Index'")
                                 }
                             }
                         } else {
                             if ($Table -match '^\d+$') {
                                 $query = $query.Replace('#options#', "'$($db.name)', $Table")
                             } else {
-                                $query = $query.Replace('#options#', "'$($db.name)', '$Table'")
+                                $query = $query.Replace('#options#', "'$($db.name)', '$tableIdentifier'")
                             }
                         }
                     } else {

--- a/public/Set-DbaDbIdentity.ps1
+++ b/public/Set-DbaDbIdentity.ps1
@@ -145,10 +145,16 @@ function Set-DbaDbIdentity {
                 foreach ($tbl in $Table) {
                     try {
                         $query = $StringBuilder.ToString()
-                        if (Test-Bound -Not -ParameterName ReSeedValue) {
-                            $query = $query.Replace('#options#', "'$($tbl)'")
+                        $nameParts = Get-ObjectNameParts -ObjectName $tbl
+                        if ($nameParts.Schema) {
+                            $tblIdentifier = "[$($nameParts.Schema)].[$($nameParts.Name)]"
                         } else {
-                            $query = $query.Replace('#options#', "'$($tbl)', RESEED, $($ReSeedValue)")
+                            $tblIdentifier = "[$($nameParts.Name)]"
+                        }
+                        if (Test-Bound -Not -ParameterName ReSeedValue) {
+                            $query = $query.Replace('#options#', "'$($tblIdentifier)'")
+                        } else {
+                            $query = $query.Replace('#options#', "'$($tblIdentifier)', RESEED, $($ReSeedValue)")
                         }
 
                         if ($Pscmdlet.ShouldProcess($server.Name, "Execute the command $query against $instance")) {

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -77,7 +77,7 @@ Describe $CommandName -Tag IntegrationTests {
     Context "Reseed option returns correct results" {
         It "Returns correct results" {
             $result = Set-DbaDbIdentity -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Table $tableName2 -ReSeedValue 400
-            $result.cmd | Should -Be "DBCC CHECKIDENT('$tableName2', RESEED, 400)"
+            $result.cmd | Should -Be "DBCC CHECKIDENT('[$tableName2]', RESEED, 400)"
             $result.IdentityValue | Should -Be "5."
         }
     }

--- a/tests/Set-DbaDbIdentity.Tests.ps1
+++ b/tests/Set-DbaDbIdentity.Tests.ps1
@@ -66,19 +66,19 @@ Describe $CommandName -Tag IntegrationTests {
         }
 
         It "Returns results for each table" {
-            $result.Count -eq 2 | Should -Be $true
+            $result.Count | Should -Be 2
         }
 
         It "Returns correct results" {
-            $result[1].IdentityValue -eq 5 | Should -Be $true
+            $result[1].IdentityValue | Should -Be 5
         }
     }
 
     Context "Reseed option returns correct results" {
         It "Returns correct results" {
             $result = Set-DbaDbIdentity -SqlInstance $TestConfig.InstanceSingle -Database $dbname -Table $tableName2 -ReSeedValue 400
-            $result.cmd -eq "DBCC CHECKIDENT('$tableName2', RESEED, 400)" | Should -Be $true
-            $result.IdentityValue -eq "5." | Should -Be $true
+            $result.cmd | Should -Be "DBCC CHECKIDENT('$tableName2', RESEED, 400)"
+            $result.IdentityValue | Should -Be "5."
         }
     }
 }


### PR DESCRIPTION
Fixes Group 5 of issue #9010: DBCC commands failed when bare dotted table names like Gross.Table.Name were passed - SQL Server interpreted them as 3-part database.schema.table names. Bracketed names like [Gross.Table.Name] already worked. Now both forms produce correct bracketed T-SQL identifiers.

Closes #9010

Generated with [Claude Code](https://claude.ai/code)