### PR TITLE
Add Compare-DbaLogin command

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -84,6 +84,7 @@
         'Compare-DbaAgReplicaAgentJob',
         'Compare-DbaAgReplicaCredential',
         'Compare-DbaAgReplicaLogin',
+        'Compare-DbaLogin',
         'Compare-DbaAgReplicaOperator',
         'Compare-DbaAgReplicaSync',
         'Compare-DbaAvailabilityGroup',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -460,6 +460,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Compare-DbaAgReplicaAgentJob',
         'Compare-DbaAgReplicaCredential',
         'Compare-DbaAgReplicaLogin',
+        'Compare-DbaLogin',
         'Compare-DbaAgReplicaOperator',
         'Compare-DbaAgReplicaSync',
         'Compare-DbaAvailabilityGroup',

--- a/public/Compare-DbaLogin.ps1
+++ b/public/Compare-DbaLogin.ps1
@@ -1,0 +1,184 @@
+function Compare-DbaLogin {
+    <#
+    .SYNOPSIS
+        Compares SQL Server logins between a source and one or more destination instances.
+
+    .DESCRIPTION
+        Compares SQL Server logins between a source instance and one or more destination instances to identify which logins exist only on the source, only on the destination, or on both. This is useful for identifying logins that would be lost when using Copy-DbaLogin with -Force, or for auditing login consistency between environments.
+
+        Returns one object per login per destination instance, indicating whether the login exists on the source, destination, or both.
+
+    .PARAMETER Source
+        The source SQL Server instance.
+
+    .PARAMETER SourceSqlCredential
+        Login to the source instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Destination
+        The destination SQL Server instance or instances.
+
+    .PARAMETER DestinationSqlCredential
+        Login to the destination instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory - Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Login
+        Specifies one or more logins to include in the comparison. All other logins are excluded.
+
+    .PARAMETER ExcludeLogin
+        Specifies one or more logins to exclude from the comparison.
+
+    .PARAMETER ExcludeSystemLogin
+        Excludes built-in system logins from the comparison results.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Login, Security, Compare
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2026 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Compare-DbaLogin
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object for each login found on either the source or destination instance.
+
+        Properties:
+        - SourceServer: The name of the source SQL Server instance
+        - DestinationServer: The name of the destination SQL Server instance
+        - LoginName: The name of the login account
+        - LoginType: The login type (SqlLogin, WindowsUser, WindowsGroup, etc.)
+        - Status: Indicates where the login exists - "SourceOnly", "DestinationOnly", or "Both"
+
+    .EXAMPLE
+        PS C:\> Compare-DbaLogin -Source sql1 -Destination sql2
+
+        Compares all logins between sql1 and sql2, returning the status of each login.
+
+    .EXAMPLE
+        PS C:\> Compare-DbaLogin -Source sql1 -Destination sql2 | Where-Object Status -eq "DestinationOnly"
+
+        Returns logins that exist on sql2 but not on sql1. These logins would be lost if Copy-DbaLogin -Force were run from sql1 to sql2.
+
+    .EXAMPLE
+        PS C:\> Compare-DbaLogin -Source sql1 -Destination sql2 | Where-Object Status -eq "SourceOnly"
+
+        Returns logins that exist on sql1 but not on sql2. These are the logins that Copy-DbaLogin would create.
+
+    .EXAMPLE
+        PS C:\> Compare-DbaLogin -Source sql1 -Destination sql2 -ExcludeSystemLogin
+
+        Compares user-created logins between sql1 and sql2, excluding built-in system logins.
+
+    .EXAMPLE
+        PS C:\> Compare-DbaLogin -Source sql1 -Destination sql2, sql3 -Login 'appuser', 'reportuser'
+
+        Compares the specified logins between sql1 and both sql2 and sql3.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [DbaInstanceParameter]$Source,
+        [PSCredential]$SourceSqlCredential,
+        [Parameter(Mandatory)]
+        [DbaInstanceParameter[]]$Destination,
+        [PSCredential]$DestinationSqlCredential,
+        [string[]]$Login,
+        [string[]]$ExcludeLogin,
+        [switch]$ExcludeSystemLogin,
+        [switch]$EnableException
+    )
+
+    begin {
+        try {
+            $sourceServer = Connect-DbaInstance -SqlInstance $Source -SqlCredential $SourceSqlCredential
+        } catch {
+            Stop-Function -Message "Failure connecting to $Source" -Category ConnectionError -ErrorRecord $_ -Target $Source
+            return
+        }
+
+        $splatGetSource = @{
+            SqlInstance        = $sourceServer
+            ExcludeSystemLogin = $ExcludeSystemLogin
+        }
+        if ($Login) {
+            $splatGetSource["Login"] = $Login
+        }
+        if ($ExcludeLogin) {
+            $splatGetSource["ExcludeLogin"] = $ExcludeLogin
+        }
+        $sourceLogins = Get-DbaLogin @splatGetSource
+    }
+
+    process {
+        if (Test-FunctionInterrupt) { return }
+
+        foreach ($destInstance in $Destination) {
+            try {
+                $destServer = Connect-DbaInstance -SqlInstance $destInstance -SqlCredential $DestinationSqlCredential
+            } catch {
+                Stop-Function -Message "Failure connecting to $destInstance" -Category ConnectionError -ErrorRecord $_ -Target $destInstance -Continue
+            }
+
+            $splatGetDest = @{
+                SqlInstance        = $destServer
+                ExcludeSystemLogin = $ExcludeSystemLogin
+            }
+            if ($Login) {
+                $splatGetDest["Login"] = $Login
+            }
+            if ($ExcludeLogin) {
+                $splatGetDest["ExcludeLogin"] = $ExcludeLogin
+            }
+            $destLogins = Get-DbaLogin @splatGetDest
+
+            $allLoginNames = New-Object System.Collections.ArrayList
+            foreach ($srcLogin in $sourceLogins) {
+                if ($srcLogin.Name -notin $allLoginNames) {
+                    $null = $allLoginNames.Add($srcLogin.Name)
+                }
+            }
+            foreach ($dstLogin in $destLogins) {
+                if ($dstLogin.Name -notin $allLoginNames) {
+                    $null = $allLoginNames.Add($dstLogin.Name)
+                }
+            }
+
+            foreach ($loginName in $allLoginNames) {
+                $srcLogin = $sourceLogins | Where-Object Name -eq $loginName
+                $dstLogin = $destLogins | Where-Object Name -eq $loginName
+
+                if ($srcLogin -and $dstLogin) {
+                    $status = "Both"
+                } elseif ($srcLogin) {
+                    $status = "SourceOnly"
+                } else {
+                    $status = "DestinationOnly"
+                }
+
+                [PSCustomObject]@{
+                    SourceServer      = $sourceServer.Name
+                    DestinationServer = $destServer.Name
+                    LoginName         = $loginName
+                    LoginType         = if ($srcLogin) { $srcLogin.LoginType } else { $dstLogin.LoginType }
+                    Status            = $status
+                }
+            }
+        }
+    }
+}

--- a/tests/Compare-DbaLogin.Tests.ps1
+++ b/tests/Compare-DbaLogin.Tests.ps1
@@ -31,7 +31,7 @@ Describe $CommandName -Tag IntegrationTests {
 
         $loginName = "dbatoolsci_comparelogin_$(Get-Random)"
 
-        $null = New-DbaLogin -SqlInstance $TestConfig.instance2 -Login $loginName -SecurePassword (ConvertTo-SecureString "Password1234!" -AsPlainText -Force)
+        $null = New-DbaLogin -SqlInstance $TestConfig.InstanceMulti2 -Login $loginName -SecurePassword (ConvertTo-SecureString "Password1234!" -AsPlainText -Force)
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
@@ -39,25 +39,17 @@ Describe $CommandName -Tag IntegrationTests {
     AfterAll {
         $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
 
-        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $loginName -Confirm:$false -ErrorAction SilentlyContinue
-        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login $loginName -Confirm:$false -ErrorAction SilentlyContinue
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.InstanceMulti2 -Login $loginName
 
         $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
     }
 
     Context "When comparing logins between instances" {
         It "Returns a result with a DestinationOnly login" {
-            $result = Compare-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login $loginName
+            $result = Compare-DbaLogin -Source $TestConfig.InstanceMulti1 -Destination $TestConfig.InstanceMulti2 -Login $loginName
             $result | Should -Not -BeNullOrEmpty
-            $result.Status | Should -Be "DestinationOnly"
-        }
-
-        It "Returns correct properties on the result object" {
-            $result = Compare-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login $loginName
             $result.LoginName | Should -Be $loginName
-            $result.SourceServer | Should -Not -BeNullOrEmpty
-            $result.DestinationServer | Should -Not -BeNullOrEmpty
-            $result.LoginType | Should -Not -BeNullOrEmpty
+            $result.Status | Should -Be "DestinationOnly"
         }
     }
 }

--- a/tests/Compare-DbaLogin.Tests.ps1
+++ b/tests/Compare-DbaLogin.Tests.ps1
@@ -1,0 +1,63 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Compare-DbaLogin",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "Source",
+                "SourceSqlCredential",
+                "Destination",
+                "DestinationSqlCredential",
+                "Login",
+                "ExcludeLogin",
+                "ExcludeSystemLogin",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $loginName = "dbatoolsci_comparelogin_$(Get-Random)"
+
+        $null = New-DbaLogin -SqlInstance $TestConfig.instance2 -Login $loginName -SecurePassword (ConvertTo-SecureString "Password1234!" -AsPlainText -Force)
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance2 -Login $loginName -Confirm:$false -ErrorAction SilentlyContinue
+        $null = Remove-DbaLogin -SqlInstance $TestConfig.instance1 -Login $loginName -Confirm:$false -ErrorAction SilentlyContinue
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "When comparing logins between instances" {
+        It "Returns a result with a DestinationOnly login" {
+            $result = Compare-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login $loginName
+            $result | Should -Not -BeNullOrEmpty
+            $result.Status | Should -Be "DestinationOnly"
+        }
+
+        It "Returns correct properties on the result object" {
+            $result = Compare-DbaLogin -Source $TestConfig.instance1 -Destination $TestConfig.instance2 -Login $loginName
+            $result.LoginName | Should -Be $loginName
+            $result.SourceServer | Should -Not -BeNullOrEmpty
+            $result.DestinationServer | Should -Not -BeNullOrEmpty
+            $result.LoginType | Should -Not -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
Implements a new `Compare-DbaLogin` command that compares SQL Server logins between a source and one or more destination instances. Returns each login's status as SourceOnly, DestinationOnly, or Both - enabling users to identify logins that would be lost when running Copy-DbaLogin -Force.

Closes #9179

Generated with [Claude Code](https://claude.ai/code)