### PR TITLE
Get-DbaPermission - Fix Azure SQL DB compatibility

### DIFF
--- a/public/Get-DbaPermission.ps1
+++ b/public/Get-DbaPermission.ps1
@@ -332,8 +332,18 @@ function Get-DbaPermission {
             }
 
             if ($IncludeServerLevel) {
-                Write-Message -Level Debug -Message "T-SQL: $ServPermsql"
-                $server.Query($ServPermsql)
+                if ($server.IsAzure) {
+                    Write-Message -Level Warning -Message "Server-level permissions are not supported on Azure SQL Database. Skipping -IncludeServerLevel."
+                } else {
+                    Write-Message -Level Debug -Message "T-SQL: $ServPermsql"
+                    $server.Query($ServPermsql)
+                }
+            }
+
+            $currentDBPermsql = if ($server.IsAzure) {
+                $DBPermsql.Replace("SUSER_SNAME(owner_sid)", "(SELECT TOP 1 name FROM sys.database_principals WHERE sid = owner_sid)")
+            } else {
+                $DBPermsql
             }
 
             $dbs = $server.Databases
@@ -354,9 +364,9 @@ function Get-DbaPermission {
                     Continue
                 }
 
-                Write-Message -Level Debug -Message "T-SQL: $DBPermsql"
+                Write-Message -Level Debug -Message "T-SQL: $currentDBPermsql"
                 try {
-                    $db.ExecuteWithResults($DBPermsql).Tables.Rows
+                    $db.ExecuteWithResults($currentDBPermsql).Tables.Rows
                 } catch {
                     Stop-Function -Message "Failure executing against $($db.Name) on $instance" -ErrorRecord $_ -Continue
                 }


### PR DESCRIPTION
Fix Get-DbaPermission for Azure SQL Database by skipping unsupported server-level permission queries and replacing SUSER_SNAME(owner_sid) with an Azure-compatible subquery.

Fixes #9612

Generated with [Claude Code](https://claude.ai/code)