### PR TITLE
Find-DbaObject - Add unified command to search database objects by name

### DIFF
--- a/dbatools.psd1
+++ b/dbatools.psd1
@@ -172,6 +172,7 @@
         'Find-DbaDbUnusedIndex',
         'Find-DbaInstance',
         'Find-DbaLoginInGroup',
+        'Find-DbaObject',
         'Find-DbaOrphanedFile',
         'Find-DbaSimilarTable',
         'Find-DbaStoredProcedure',

--- a/dbatools.psm1
+++ b/dbatools.psm1
@@ -500,6 +500,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
         'Export-DbaXESession',
         'Test-DbaOptimizeForAdHoc',
         'Find-DbaStoredProcedure',
+        'Find-DbaObject',
         'Measure-DbaBackupThroughput',
         'Get-DbaDatabase',
         'Find-DbaUserObject',

--- a/public/Find-DbaObject.ps1
+++ b/public/Find-DbaObject.ps1
@@ -1,0 +1,267 @@
+function Find-DbaObject {
+    <#
+    .SYNOPSIS
+        Searches database objects by name or column name across SQL Server databases using regex patterns.
+
+    .DESCRIPTION
+        Provides a unified search across all database object types (tables, views, stored procedures, functions,
+        synonyms, triggers) by matching their names against a regex pattern. Optionally extends the search to
+        column names within tables and views. This complements the existing Find-DbaStoredProcedure, Find-DbaView,
+        and Find-DbaTrigger commands which search object definition text rather than object or column names.
+
+        Uses T-SQL queries against sys.objects and sys.columns for optimal performance. Pattern matching is
+        performed in PowerShell using full regex syntax.
+
+    .PARAMETER SqlInstance
+        The target SQL Server instance or instances. This can be a collection and receive pipeline input.
+
+    .PARAMETER SqlCredential
+        Login to the target instance using alternative credentials. Accepts PowerShell credentials (Get-Credential).
+
+        Windows Authentication, SQL Server Authentication, Active Directory - Password, and Active Directory -
+        Integrated are all supported.
+
+        For MFA support, please use Connect-DbaInstance.
+
+    .PARAMETER Database
+        Specifies one or more databases to search. When omitted, searches all user databases on the instance.
+        Use this to focus searches on specific databases when you know where the objects are located.
+
+    .PARAMETER ExcludeDatabase
+        Specifies databases to skip during the search. Accepts multiple database names.
+        Use this to exclude large databases or test environments from the search.
+
+    .PARAMETER Pattern
+        The regular expression pattern to match against object names (and optionally column names).
+        Supports full regex syntax for complex pattern matching. For example, use "^Customer" to find objects
+        starting with "Customer", or "Service|Product" to find objects mentioning either term.
+
+    .PARAMETER ObjectType
+        Filters the search to specific object types. Accepts one or more of:
+        - Table: User tables (sys.objects type U)
+        - View: Views (sys.objects type V)
+        - StoredProcedure: Stored procedures (sys.objects type P)
+        - ScalarFunction: Scalar-valued functions (sys.objects type FN)
+        - TableValuedFunction: Inline and multi-statement table-valued functions (sys.objects type IF/TF)
+        - Synonym: Synonyms (sys.objects type SN)
+        - Trigger: SQL triggers (sys.objects type TR)
+        - All: All of the above (default)
+
+    .PARAMETER IncludeColumns
+        When specified, additionally searches column names within tables and views for the given pattern.
+        Results with column name matches include a MatchType of "ColumnName" and the matching column name.
+        This is useful for finding which tables or views contain a column related to a specific domain concept.
+
+    .PARAMETER IncludeSystemObjects
+        Includes system objects (those shipped with SQL Server) in the search results.
+        By default, only user-created objects are searched.
+
+    .PARAMETER IncludeSystemDatabases
+        Includes system databases (master, model, msdb, tempdb) in the search scope.
+        By default, only user databases are searched.
+
+    .PARAMETER EnableException
+        By default, when something goes wrong we try to catch it, interpret it and give you a friendly warning message.
+        This avoids overwhelming you with "sea of red" exceptions, but is inconvenient because it basically disables advanced scripting.
+        Using this switch turns this "nice by default" feature off and enables you to catch exceptions with your own try/catch.
+
+    .NOTES
+        Tags: Object, Lookup, Find
+        Author: the dbatools team + Claude
+
+        Website: https://dbatools.io
+        Copyright: (c) 2018 by dbatools, licensed under MIT
+        License: MIT https://opensource.org/licenses/MIT
+
+    .LINK
+        https://dbatools.io/Find-DbaObject
+
+    .OUTPUTS
+        PSCustomObject
+
+        Returns one object per match found. When -IncludeColumns is used, there may be multiple results
+        per database object (one for the object name match plus one per matching column name).
+
+        Properties:
+        - ComputerName: The computer name of the SQL Server instance
+        - SqlInstance: The SQL Server instance name
+        - Database: The database containing the matched object
+        - Schema: The schema of the matched object
+        - Name: The name of the matched object
+        - ObjectType: The SQL Server type description (e.g., USER_TABLE, VIEW, SQL_STORED_PROCEDURE)
+        - MatchType: "ObjectName" when the object name matched, "ColumnName" when a column name matched
+        - ColumnName: The matching column name when MatchType is "ColumnName", otherwise null
+        - CreateDate: DateTime when the object was created
+        - LastModified: DateTime when the object was last modified
+
+    .EXAMPLE
+        PS C:\> Find-DbaObject -SqlInstance DEV01 -Pattern Service
+
+        Searches all user databases on DEV01 for any object whose name contains "Service".
+
+    .EXAMPLE
+        PS C:\> Find-DbaObject -SqlInstance DEV01 -Pattern Service -IncludeColumns
+
+        Searches all user databases on DEV01 for objects named with "Service" and tables/views
+        that have columns whose names contain "Service".
+
+    .EXAMPLE
+        PS C:\> Find-DbaObject -SqlInstance DEV01 -Pattern "^Customer" -ObjectType Table
+
+        Finds all user tables on DEV01 whose names start with "Customer".
+
+    .EXAMPLE
+        PS C:\> Find-DbaObject -SqlInstance DEV01 -Pattern "Invoice" -Database Accounting -IncludeColumns
+
+        Searches the Accounting database for objects and columns related to "Invoice".
+
+    .EXAMPLE
+        PS C:\> Find-DbaObject -SqlInstance sql2019 -Pattern "Service|Product" -ObjectType Table, View
+
+        Finds all tables and views whose names contain either "Service" or "Product".
+
+    #>
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory, ValueFromPipeline)]
+        [DbaInstanceParameter[]]$SqlInstance,
+        [PSCredential]$SqlCredential,
+        [object[]]$Database,
+        [object[]]$ExcludeDatabase,
+        [parameter(Mandatory)]
+        [string]$Pattern,
+        [ValidateSet("Table", "View", "StoredProcedure", "ScalarFunction", "TableValuedFunction", "Synonym", "Trigger", "All")]
+        [string[]]$ObjectType = @("All"),
+        [switch]$IncludeColumns,
+        [switch]$IncludeSystemObjects,
+        [switch]$IncludeSystemDatabases,
+        [switch]$EnableException
+    )
+
+    begin {
+        $typeCodeMap = @{
+            "Table"               = @("'U'")
+            "View"                = @("'V'")
+            "StoredProcedure"     = @("'P'")
+            "ScalarFunction"      = @("'FN'")
+            "TableValuedFunction" = @("'IF'", "'TF'")
+            "Synonym"             = @("'SN'")
+            "Trigger"             = @("'TR'")
+        }
+
+        if ("All" -in $ObjectType) {
+            $typeFilter = "'U', 'V', 'P', 'FN', 'IF', 'TF', 'SN', 'TR'"
+        } else {
+            $typeCodes = @()
+            foreach ($type in $ObjectType) {
+                $typeCodes += $typeCodeMap[$type]
+            }
+            $typeFilter = ($typeCodes | Select-Object -Unique) -join ", "
+        }
+
+        $sysFilter = if ($IncludeSystemObjects) { "" } else { "AND o.is_ms_shipped = 0" }
+
+        $sqlObjects = "
+            SELECT
+                OBJECT_SCHEMA_NAME(o.object_id) AS SchemaName,
+                o.name                          AS ObjectName,
+                RTRIM(o.type)                   AS ObjectTypeCode,
+                o.type_desc                     AS ObjectType,
+                o.create_date                   AS CreateDate,
+                o.modify_date                   AS LastModified
+            FROM sys.objects o
+            WHERE o.type IN ($typeFilter)
+            $sysFilter"
+
+        $sqlColumns = "
+            SELECT
+                OBJECT_SCHEMA_NAME(c.object_id) AS SchemaName,
+                OBJECT_NAME(c.object_id)        AS ObjectName,
+                RTRIM(o.type)                   AS ObjectTypeCode,
+                o.type_desc                     AS ObjectType,
+                o.create_date                   AS CreateDate,
+                o.modify_date                   AS LastModified,
+                c.name                          AS ColumnName
+            FROM sys.columns c
+            INNER JOIN sys.objects o ON c.object_id = o.object_id
+            WHERE o.type IN ($typeFilter)
+            $sysFilter"
+    }
+
+    process {
+        foreach ($instance in $SqlInstance) {
+            try {
+                $server = Connect-DbaInstance -SqlInstance $instance -SqlCredential $SqlCredential
+            } catch {
+                Stop-Function -Message "Failure" -Category ConnectionError -ErrorRecord $_ -Target $instance -Continue
+            }
+
+            if ($server.versionMajor -lt 9) {
+                Write-Message -Level Warning -Message "This command only supports SQL Server 2005 and above."
+                Continue
+            }
+
+            if ($IncludeSystemDatabases) {
+                $dbs = $server.Databases | Where-Object { $_.Status -eq "normal" }
+            } else {
+                $dbs = $server.Databases | Where-Object { $_.Status -eq "normal" -and $_.IsSystemObject -eq $false }
+            }
+
+            if ($Database) {
+                $dbs = $dbs | Where-Object Name -In $Database
+            }
+
+            if ($ExcludeDatabase) {
+                $dbs = $dbs | Where-Object Name -NotIn $ExcludeDatabase
+            }
+
+            foreach ($db in $dbs) {
+                Write-Message -Level Verbose -Message "Searching object names in database $db on $instance"
+
+                Write-Message -Level Debug -Message $sqlObjects
+                $objectRows = $db.ExecuteWithResults($sqlObjects).Tables.Rows
+
+                foreach ($row in $objectRows) {
+                    if ($row.ObjectName -match $Pattern) {
+                        [PSCustomObject]@{
+                            ComputerName = $server.ComputerName
+                            SqlInstance  = $server.ServiceName
+                            Database     = $db.Name
+                            Schema       = $row.SchemaName
+                            Name         = $row.ObjectName
+                            ObjectType   = $row.ObjectType
+                            MatchType    = "ObjectName"
+                            ColumnName   = $null
+                            CreateDate   = $row.CreateDate
+                            LastModified = $row.LastModified
+                        }
+                    }
+                }
+
+                if ($IncludeColumns) {
+                    Write-Message -Level Verbose -Message "Searching column names in database $db on $instance"
+
+                    Write-Message -Level Debug -Message $sqlColumns
+                    $columnRows = $db.ExecuteWithResults($sqlColumns).Tables.Rows
+
+                    foreach ($row in $columnRows) {
+                        if ($row.ColumnName -match $Pattern) {
+                            [PSCustomObject]@{
+                                ComputerName = $server.ComputerName
+                                SqlInstance  = $server.ServiceName
+                                Database     = $db.Name
+                                Schema       = $row.SchemaName
+                                Name         = $row.ObjectName
+                                ObjectType   = $row.ObjectType
+                                MatchType    = "ColumnName"
+                                ColumnName   = $row.ColumnName
+                                CreateDate   = $row.CreateDate
+                                LastModified = $row.LastModified
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Find-DbaObject.Tests.ps1
+++ b/tests/Find-DbaObject.Tests.ps1
@@ -230,6 +230,7 @@ GO
                 Pattern                = "syslogins"
                 ObjectType             = "View"
                 IncludeSystemDatabases = $true
+                IncludeSystemObjects   = $true
             }
             $results = Find-DbaObject @splatFind
             $results | Should -Not -BeNullOrEmpty

--- a/tests/Find-DbaObject.Tests.ps1
+++ b/tests/Find-DbaObject.Tests.ps1
@@ -224,16 +224,43 @@ GO
     }
 
     Context "System databases" {
+        BeforeAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $systemDbTableName = "t_dbatoolsci_systemdb_$(Get-Random)"
+            $splatCreateTable = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = "master"
+                Query       = "CREATE TABLE dbo.$systemDbTableName (Id INT IDENTITY PRIMARY KEY)"
+            }
+            $null = Invoke-DbaQuery @splatCreateTable
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
+        AfterAll {
+            $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+            $splatDropTable = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = "master"
+                Query       = "DROP TABLE dbo.$systemDbTableName"
+            }
+            $null = Invoke-DbaQuery @splatDropTable
+
+            $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+        }
+
         It "Should include system databases when IncludeSystemDatabases is specified" {
             $splatFind = @{
                 SqlInstance            = $TestConfig.InstanceSingle
-                Pattern                = "syslogins"
-                ObjectType             = "View"
+                Pattern                = $systemDbTableName
+                ObjectType             = "Table"
                 IncludeSystemDatabases = $true
-                IncludeSystemObjects   = $true
             }
             $results = Find-DbaObject @splatFind
             $results | Should -Not -BeNullOrEmpty
+            $results.Database | Should -Contain "master"
         }
     }
 }

--- a/tests/Find-DbaObject.Tests.ps1
+++ b/tests/Find-DbaObject.Tests.ps1
@@ -1,0 +1,235 @@
+#Requires -Module @{ ModuleName="Pester"; ModuleVersion="5.0" }
+param(
+    $ModuleName  = "dbatools",
+    $CommandName = "Find-DbaObject",
+    $PSDefaultParameterValues = $TestConfig.Defaults
+)
+
+Describe $CommandName -Tag UnitTests {
+    Context "Parameter validation" {
+        It "Should have the expected parameters" {
+            $hasParameters = (Get-Command $CommandName).Parameters.Values.Name | Where-Object { $PSItem -notin ("WhatIf", "Confirm") }
+            $expectedParameters = $TestConfig.CommonParameters
+            $expectedParameters += @(
+                "SqlInstance",
+                "SqlCredential",
+                "Database",
+                "ExcludeDatabase",
+                "Pattern",
+                "ObjectType",
+                "IncludeColumns",
+                "IncludeSystemObjects",
+                "IncludeSystemDatabases",
+                "EnableException"
+            )
+            Compare-Object -ReferenceObject $expectedParameters -DifferenceObject $hasParameters | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe $CommandName -Tag IntegrationTests {
+    BeforeAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $testDbName = "dbatoolsci_findobject_$(Get-Random)"
+
+        $splatNewDb = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Name        = $testDbName
+        }
+        $null = New-DbaDatabase @splatNewDb
+
+        $createObjects = @"
+CREATE TABLE dbo.ServiceOrder (
+    ServiceOrderId INT IDENTITY PRIMARY KEY,
+    ServiceName    NVARCHAR(100),
+    CustomerCode   NVARCHAR(50)
+);
+
+CREATE TABLE dbo.CustomerAccount (
+    CustomerAccountId INT IDENTITY PRIMARY KEY,
+    AccountName       NVARCHAR(100),
+    ServiceCode       NVARCHAR(50)
+);
+
+CREATE VIEW dbo.v_ServiceSummary
+AS
+    SELECT ServiceOrderId, ServiceName
+    FROM dbo.ServiceOrder;
+
+CREATE PROCEDURE dbo.usp_GetServiceOrders
+AS
+    SELECT * FROM dbo.ServiceOrder;
+"@
+        $splatCreateObjects = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $testDbName
+            Query       = $createObjects
+        }
+        $null = Invoke-DbaQuery @splatCreateObjects
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues["*-Dba*:EnableException"] = $true
+
+        $splatRemoveDb = @{
+            SqlInstance = $TestConfig.InstanceSingle
+            Database    = $testDbName
+            Confirm     = $false
+        }
+        $null = Remove-DbaDatabase @splatRemoveDb
+
+        $PSDefaultParameterValues.Remove("*-Dba*:EnableException")
+    }
+
+    Context "Searching object names" {
+        It "Should find tables whose names match the pattern" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "Service"
+                ObjectType  = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Contain "ServiceOrder"
+        }
+
+        It "Should find views whose names match the pattern" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "Service"
+                ObjectType  = "View"
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Contain "v_ServiceSummary"
+        }
+
+        It "Should find stored procedures whose names match the pattern" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "ServiceOrders"
+                ObjectType  = "StoredProcedure"
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Should -Not -BeNullOrEmpty
+            $results.Name | Should -Contain "usp_GetServiceOrders"
+        }
+
+        It "Should return MatchType of ObjectName for object name matches" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "ServiceOrder"
+                ObjectType  = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $results.MatchType | Should -Be "ObjectName"
+        }
+
+        It "Should find objects across all types when ObjectType is All" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "Service"
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Should -Not -BeNullOrEmpty
+            ($results | Where-Object ObjectType -eq "USER_TABLE") | Should -Not -BeNullOrEmpty
+            ($results | Where-Object ObjectType -eq "VIEW") | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should return no results when ExcludeDatabase is specified" {
+            $splatFind = @{
+                SqlInstance     = $TestConfig.InstanceSingle
+                Pattern         = "Service"
+                ExcludeDatabase = $testDbName
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Where-Object Database -eq $testDbName | Should -BeNullOrEmpty
+        }
+
+        It "Should return results only for the specified database" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "Service"
+            }
+            $results = Find-DbaObject @splatFind
+            $results.Database | Select-Object -Unique | Should -Be $testDbName
+        }
+    }
+
+    Context "Searching column names" {
+        It "Should find tables with columns matching the pattern when IncludeColumns is used" {
+            $splatFind = @{
+                SqlInstance    = $TestConfig.InstanceSingle
+                Database       = $testDbName
+                Pattern        = "ServiceName"
+                IncludeColumns = $true
+                ObjectType     = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $columnMatches = $results | Where-Object MatchType -eq "ColumnName"
+            $columnMatches | Should -Not -BeNullOrEmpty
+            $columnMatches.ColumnName | Should -Contain "ServiceName"
+        }
+
+        It "Should find columns with ServiceCode in CustomerAccount table" {
+            $splatFind = @{
+                SqlInstance    = $TestConfig.InstanceSingle
+                Database       = $testDbName
+                Pattern        = "Service"
+                IncludeColumns = $true
+                ObjectType     = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $columnMatches = $results | Where-Object MatchType -eq "ColumnName"
+            $columnMatches | Should -Not -BeNullOrEmpty
+            $columnMatches.ColumnName | Should -Contain "ServiceCode"
+        }
+
+        It "Should return MatchType of ColumnName for column matches" {
+            $splatFind = @{
+                SqlInstance    = $TestConfig.InstanceSingle
+                Database       = $testDbName
+                Pattern        = "ServiceName"
+                IncludeColumns = $true
+                ObjectType     = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $columnMatches = $results | Where-Object MatchType -eq "ColumnName"
+            $columnMatches[0].MatchType | Should -Be "ColumnName"
+        }
+
+        It "Should not return column matches when IncludeColumns is not specified" {
+            $splatFind = @{
+                SqlInstance = $TestConfig.InstanceSingle
+                Database    = $testDbName
+                Pattern     = "ServiceName"
+                ObjectType  = "Table"
+            }
+            $results = Find-DbaObject @splatFind
+            $columnMatches = $results | Where-Object MatchType -eq "ColumnName"
+            $columnMatches | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "System databases" {
+        It "Should include system databases when IncludeSystemDatabases is specified" {
+            $splatFind = @{
+                SqlInstance            = $TestConfig.InstanceSingle
+                Pattern                = "syslogins"
+                ObjectType             = "View"
+                IncludeSystemDatabases = $true
+            }
+            $results = Find-DbaObject @splatFind
+            $results | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Find-DbaObject.Tests.ps1
+++ b/tests/Find-DbaObject.Tests.ps1
@@ -51,15 +51,18 @@ CREATE TABLE dbo.CustomerAccount (
     AccountName       NVARCHAR(100),
     ServiceCode       NVARCHAR(50)
 );
+GO
 
 CREATE VIEW dbo.v_ServiceSummary
 AS
     SELECT ServiceOrderId, ServiceName
     FROM dbo.ServiceOrder;
+GO
 
 CREATE PROCEDURE dbo.usp_GetServiceOrders
 AS
     SELECT * FROM dbo.ServiceOrder;
+GO
 "@
         $splatCreateObjects = @{
             SqlInstance = $TestConfig.InstanceSingle


### PR DESCRIPTION
Closes #9245

Adds `Find-DbaObject`, a unified command to search all database object types by name pattern, with optional column name searching.

## What does this PR do?

- Searches object names across tables, views, stored procedures, functions, synonyms, and triggers
- Optionally searches column names with `-IncludeColumns`
- Filter by object type with `-ObjectType`
- Uses T-SQL against sys.objects and sys.columns for performance
- Full regex support for pattern matching

Generated with [Claude Code](https://claude.ai/code)