### PR TITLE
Find-DbaInstance - Set TcpConnected=true when SqlConnect succeeds

### DIFF
--- a/public/Find-DbaInstance.ps1
+++ b/public/Find-DbaInstance.ps1
@@ -518,6 +518,7 @@ function Find-DbaInstance {
                             try {
                                 $server = Connect-DbaInstance -SqlInstance $dataSet.SqlInstance -SqlCredential $SqlCredential
                                 $dataSet.SqlConnected = $true
+                                $dataSet.TcpConnected = $true
                                 $dataSet.Confidence = 'High'
 
                                 # Remove duplicates
@@ -542,6 +543,7 @@ function Find-DbaInstance {
                                 if ($_.Exception.InnerException.Errors.Class -lt 25) {
                                     # There IS an SQL Instance and it listened to network traffic
                                     $dataSet.SqlConnected = $true
+                                    $dataSet.TcpConnected = $true
                                     $dataSet.Confidence = 'High'
                                 }
                                 #endregion Processing error (Access denied, server error, ...)


### PR DESCRIPTION
When a SQL connection is established (or reaches the instance with error class < 25), TCP connectivity is proven. Previously TcpConnected would remain false if the TCPPort scan type was not included in ScanType, even though SqlConnect requires TCP.

Fixes #10322

Generated with [Claude Code](https://claude.ai/code)