### PR TITLE
Test-DbaLinkedServerConnection - Fix test failure when Named Pipes is disabled

### DIFF
--- a/tests/Test-DbaLinkedServerConnection.Tests.ps1
+++ b/tests/Test-DbaLinkedServerConnection.Tests.ps1
@@ -30,9 +30,11 @@ Describe $CommandName -Tag IntegrationTests {
         $server = Connect-DbaInstance -SqlInstance $TestConfig.InstanceSingle
         if ($server.VersionMajor -ge 17) {
             # Starting with SQL Server 2025 (17.x), MSOLEDBSQL uses Microsoft OLE DB Driver version 19, which adds support for TDS 8.0. However, this driver introduces a breaking change. You must now specify the encrypt parameter.
-            $server.Query("EXEC master.dbo.sp_addlinkedserver @server=N'$target', @srvproduct=N'', @provider=N'MSOLEDBSQL', @provstr = N'encrypt=optional;TrustServerCertificate=yes'")
+            # Use @datasrc with tcp: prefix to force TCP/IP and avoid Named Pipes dependency.
+            $server.Query("EXEC master.dbo.sp_addlinkedserver @server=N'$target', @srvproduct=N'', @provider=N'MSOLEDBSQL', @datasrc=N'tcp:$target', @provstr = N'encrypt=optional;TrustServerCertificate=yes'")
         } elseif (-not $env:AppVeyor) {
-            $server.Query("EXEC master.dbo.sp_addlinkedserver @server=N'$target', @srvproduct=N'', @provider=N'MSOLEDBSQL'")
+            # Use @datasrc with tcp: prefix to force TCP/IP and avoid Named Pipes dependency.
+            $server.Query("EXEC master.dbo.sp_addlinkedserver @server=N'$target', @srvproduct=N'', @provider=N'MSOLEDBSQL', @datasrc=N'tcp:$target'")
         } else {
             # AppVeyor images do not have the MSOLEDBSQL provider installed, so we use SQLNCLI11 instead
             $server.Query("EXEC master.dbo.sp_addlinkedserver @server=N'$target', @srvproduct=N'SQL Server'")


### PR DESCRIPTION
Fix test failure when Named Pipes is not enabled.

Forces TCP/IP by specifying `@datasrc=N'tcp:$target'` when creating the linked server in test setup. Without this, MSOLEDBSQL defaults to Named Pipes which fails in environments where Named Pipes is not enabled.

Closes #10324

Generated with [Claude Code](https://claude.ai/code)