### PR TITLE
Find-DbaInstance - Fix TcpConnected false for default instances

### DIFF
--- a/public/Find-DbaInstance.ps1
+++ b/public/Find-DbaInstance.ps1
@@ -355,6 +355,12 @@ function Find-DbaInstance {
                             # here to avoid an empty catch
                             $null = 1
                         }
+                        # Fall back to default port testing if Browser returned no port info
+                        # (e.g. SQL Server 2022+ where Browser is deprecated, or default instances
+                        # which don't report a TCP port via Browser UDP)
+                        if (-not $ports) {
+                            $ports = $TCPPort | Test-TcpPort -ComputerName $computer
+                        }
                     } else {
                         $ports = $TCPPort | Test-TcpPort -ComputerName $computer
                     }
@@ -452,6 +458,13 @@ function Find-DbaInstance {
 
                                 $object.PortsScanned | Where-Object Port -EQ $object.Port | ForEach-Object {
                                     $object.TcpConnected = $_.IsOpen
+                                }
+                            } else {
+                                # Default instance - Browser doesn't report a specific TCP port,
+                                # check if any of the fallback ports we tested is open
+                                $object.PortsScanned | Where-Object IsOpen | Select-Object -First 1 | ForEach-Object {
+                                    $object.Port = $_.Port
+                                    $object.TcpConnected = $true
                                 }
                             }
                         }

--- a/public/Find-DbaInstance.ps1
+++ b/public/Find-DbaInstance.ps1
@@ -350,8 +350,12 @@ function Find-DbaInstance {
                         try {
                             Write-ProgressHelper -Activity "Processing: $($computer)" -StepNumber ($stepCounter++) -Message "Probing Browser service"
                             $browseResult = Get-SQLInstanceBrowserUDP -ComputerName $computer -EnableException
-                            $ports = $browseResult.TCPPort | Test-TcpPort -ComputerName $computer
+                            Write-Message -Level Verbose -Message "Browser returned $($browseResult.Count) instance(s): $(($browseResult | ForEach-Object { "$($_.InstanceName):$($_.TCPPort)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                            # Filter port 0 - Browser returns 0 for instances that don't report a TCP port (default instances)
+                            $ports = $browseResult.TCPPort | Where-Object { $_ -gt 0 } | Test-TcpPort -ComputerName $computer
+                            Write-Message -Level Verbose -Message "Port test results from Browser: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
                         } catch {
+                            Write-Message -Level Verbose -Message "Browser scan failed: $_" -Target $computer -FunctionName Find-DbaInstance
                             # here to avoid an empty catch
                             $null = 1
                         }
@@ -359,7 +363,9 @@ function Find-DbaInstance {
                         # (e.g. SQL Server 2022+ where Browser is deprecated, or default instances
                         # which don't report a TCP port via Browser UDP)
                         if (-not $ports) {
+                            Write-Message -Level Verbose -Message "No port info from Browser, falling back to default ports: $($TCPPort -join ', ')" -Target $computer -FunctionName Find-DbaInstance
                             $ports = $TCPPort | Test-TcpPort -ComputerName $computer
+                            Write-Message -Level Verbose -Message "Fallback port test results: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
                         }
                     } else {
                         $ports = $TCPPort | Test-TcpPort -ComputerName $computer
@@ -455,16 +461,20 @@ function Find-DbaInstance {
                             $object.Confidence = 'Medium'
                             if ($object.BrowseReply.TCPPort) {
                                 $object.Port = $object.BrowseReply.TCPPort
+                                Write-Message -Level Verbose -Message "Instance $instance: Browser reported TCPPort $($object.Port), checking PortsScanned: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
 
                                 $object.PortsScanned | Where-Object Port -EQ $object.Port | ForEach-Object {
                                     $object.TcpConnected = $_.IsOpen
+                                    Write-Message -Level Verbose -Message "Instance $instance: Port $($_.Port) IsOpen=$($_.IsOpen), TcpConnected set to $($object.TcpConnected)" -Target $computer -FunctionName Find-DbaInstance
                                 }
                             } else {
                                 # Default instance - Browser doesn't report a specific TCP port,
                                 # check if any of the fallback ports we tested is open
+                                Write-Message -Level Verbose -Message "Instance $instance: Browser has no TCPPort (default instance), checking PortsScanned for any open port: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
                                 $object.PortsScanned | Where-Object IsOpen | Select-Object -First 1 | ForEach-Object {
                                     $object.Port = $_.Port
                                     $object.TcpConnected = $true
+                                    Write-Message -Level Verbose -Message "Instance $instance: Found open port $($_.Port), TcpConnected set to True" -Target $computer -FunctionName Find-DbaInstance
                                 }
                             }
                         }
@@ -814,21 +824,20 @@ function Find-DbaInstance {
                 [Parameter(ValueFromPipeline)][int[]]$Port
             )
 
-            begin {
-                $client = New-Object Net.Sockets.TcpClient
-            }
             process {
                 foreach ($item in $Port) {
+                    $client = New-Object Net.Sockets.TcpClient
                     try {
                         $client.Connect($ComputerName.ComputerName, $item)
                         if ($client.Connected) {
-                            $client.Close()
                             New-Object -TypeName Dataplat.Dbatools.Discovery.DbaPortReport -ArgumentList $ComputerName.ComputerName, $item, $true
                         } else {
                             New-Object -TypeName Dataplat.Dbatools.Discovery.DbaPortReport -ArgumentList $ComputerName.ComputerName, $item, $false
                         }
                     } catch {
                         New-Object -TypeName Dataplat.Dbatools.Discovery.DbaPortReport -ArgumentList $ComputerName.ComputerName, $item, $false
+                    } finally {
+                        $client.Dispose()
                     }
                 }
             }

--- a/public/Find-DbaInstance.ps1
+++ b/public/Find-DbaInstance.ps1
@@ -293,7 +293,7 @@ function Find-DbaInstance {
                         $null = $computersScanned.Add($computer.ComputerName)
                     }
                     Write-ProgressHelper -Activity "Processing: $($computer)" -StepNumber ($stepCounter++) -Message "Starting"
-                    Write-Message -Level Verbose -Message "Processing: $($computer)" -Target $computer -FunctionName Find-DbaInstance
+                    Write-Message -Level Verbose -Message "Processing: $($computer)"
 
                     #region Null variables to prevent scope lookup on conditional existence
                     $resolution = $null
@@ -350,12 +350,12 @@ function Find-DbaInstance {
                         try {
                             Write-ProgressHelper -Activity "Processing: $($computer)" -StepNumber ($stepCounter++) -Message "Probing Browser service"
                             $browseResult = Get-SQLInstanceBrowserUDP -ComputerName $computer -EnableException
-                            Write-Message -Level Verbose -Message "Browser returned $($browseResult.Count) instance(s): $(($browseResult | ForEach-Object { "$($_.InstanceName):$($_.TCPPort)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "Browser returned $($browseResult.Count) instance(s): $(($browseResult | ForEach-Object { "$($_.InstanceName):$($_.TCPPort)" }) -join ', ')"
                             # Filter port 0 - Browser returns 0 for instances that don't report a TCP port (default instances)
                             $ports = $browseResult.TCPPort | Where-Object { $_ -gt 0 } | Test-TcpPort -ComputerName $computer
-                            Write-Message -Level Verbose -Message "Port test results from Browser: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "Port test results from Browser: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')"
                         } catch {
-                            Write-Message -Level Verbose -Message "Browser scan failed: $_" -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "Browser scan failed: $_"
                             # here to avoid an empty catch
                             $null = 1
                         }
@@ -363,9 +363,9 @@ function Find-DbaInstance {
                         # (e.g. SQL Server 2022+ where Browser is deprecated, or default instances
                         # which don't report a TCP port via Browser UDP)
                         if (-not $ports) {
-                            Write-Message -Level Verbose -Message "No port info from Browser, falling back to default ports: $($TCPPort -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "No port info from Browser, falling back to default ports: $($TCPPort -join ', ')"
                             $ports = $TCPPort | Test-TcpPort -ComputerName $computer
-                            Write-Message -Level Verbose -Message "Fallback port test results: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "Fallback port test results: $(($ports | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')"
                         }
                     } else {
                         $ports = $TCPPort | Test-TcpPort -ComputerName $computer
@@ -425,10 +425,10 @@ function Find-DbaInstance {
                                     Ping         = $pingReply.Status -like 'Success'
                                 }
                             } else {
-                                Write-Message -Level Verbose -Message "Computer $computer could be contacted, but no trace of an SQL Instance was found. Skipping..." -Target $computer -FunctionName Find-DbaInstance
+                                Write-Message -Level Verbose -Message "Computer $computer could be contacted, but no trace of an SQL Instance was found. Skipping..."
                             }
                         } else {
-                            Write-Message -Level Verbose -Message "Computer $computer could not be contacted, skipping." -Target $computer -FunctionName Find-DbaInstance
+                            Write-Message -Level Verbose -Message "Computer $computer could not be contacted, skipping."
                         }
 
                         continue
@@ -439,6 +439,7 @@ function Find-DbaInstance {
 
                     #region Case: Named instance found
                     foreach ($instance in $instanceNames) {
+                        Write-Message -Level Verbose -Message "Processing named instance: $instance"
                         $object = New-Object Dataplat.Dbatools.Discovery.DbaInstanceReport
                         $object.MachineName = $computer.ComputerName
                         $object.ComputerName = $computer.ComputerName
@@ -461,20 +462,20 @@ function Find-DbaInstance {
                             $object.Confidence = 'Medium'
                             if ($object.BrowseReply.TCPPort) {
                                 $object.Port = $object.BrowseReply.TCPPort
-                                Write-Message -Level Verbose -Message "Instance $instance: Browser reported TCPPort $($object.Port), checking PortsScanned: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                                Write-Message -Level Verbose -Message "Browser reported TCPPort $($object.Port), checking PortsScanned: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')"
 
                                 $object.PortsScanned | Where-Object Port -EQ $object.Port | ForEach-Object {
                                     $object.TcpConnected = $_.IsOpen
-                                    Write-Message -Level Verbose -Message "Instance $instance: Port $($_.Port) IsOpen=$($_.IsOpen), TcpConnected set to $($object.TcpConnected)" -Target $computer -FunctionName Find-DbaInstance
+                                    Write-Message -Level Verbose -Message "Port $($_.Port) IsOpen=$($_.IsOpen), TcpConnected set to $($object.TcpConnected)"
                                 }
                             } else {
                                 # Default instance - Browser doesn't report a specific TCP port,
                                 # check if any of the fallback ports we tested is open
-                                Write-Message -Level Verbose -Message "Instance $instance: Browser has no TCPPort (default instance), checking PortsScanned for any open port: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')" -Target $computer -FunctionName Find-DbaInstance
+                                Write-Message -Level Verbose -Message "Browser has no TCPPort (default instance), checking PortsScanned for any open port: $(($object.PortsScanned | ForEach-Object { "Port $($_.Port)=$($_.IsOpen)" }) -join ', ')"
                                 $object.PortsScanned | Where-Object IsOpen | Select-Object -First 1 | ForEach-Object {
                                     $object.Port = $_.Port
                                     $object.TcpConnected = $true
-                                    Write-Message -Level Verbose -Message "Instance $instance: Found open port $($_.Port), TcpConnected set to True" -Target $computer -FunctionName Find-DbaInstance
+                                    Write-Message -Level Verbose -Message "Found open port $($_.Port), TcpConnected set to True"
                                 }
                             }
                         }


### PR DESCRIPTION
When Browser scan type is used, default SQL Server instances do not report a TCPPort via Browser UDP (clients are expected to use 1433). On SQL Server 2022+ where the Browser service is deprecated, no ports are returned at all.

Both cases caused TcpConnected to remain false even when the instance was reachable over TCP.

Fix:
1. After Browser scan, fall back to testing default TCP port(s) if Browser returned no port info.
2. When BrowseReply exists but has no TCPPort (default instance), set TcpConnected/Port from any open port found in PortsScanned.

Fixes #10322

Generated with [Claude Code](https://claude.ai/code)