### PR TITLE
Test-DbaBuild: Fix bug introduced in last change

### DIFF
--- a/public/Test-DbaBuild.ps1
+++ b/public/Test-DbaBuild.ps1
@@ -286,11 +286,7 @@ function Test-DbaBuild {
             $compliant = $false
             $targetSPName = $null
             $targetCUName = $null
-            $releaseDate = $null
             $buildRefEntry = $IdxRef | Where-Object VersionObject -eq $inputbuild
-            if ($buildRefEntry -and $buildRefEntry.ReleaseDate) {
-                $releaseDate = [datetime]$buildRefEntry.ReleaseDate
-            }
             if ($BuildVersion.MatchType -eq 'Approximate') {
                 Write-Message -Level Warning -Message "$($BuildVersion.Build) is not recognized as a correct version"
             }
@@ -385,7 +381,6 @@ function Test-DbaBuild {
             Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name SPTarget -Value $targetSPName
             Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name CUTarget -Value $targetCUName
             Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name BuildTarget -Value $targetedBuild.VersionObject
-            Add-Member -InputObject $BuildVersion -MemberType NoteProperty -Name ReleaseDate -Value $releaseDate
             if ($Quiet) {
                 $BuildVersion.Compliant
             } else {

--- a/tests/Test-DbaBuild.Tests.ps1
+++ b/tests/Test-DbaBuild.Tests.ps1
@@ -30,8 +30,8 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag UnitTests {
     Context "MaxTimeBehind compliance" {
         It "Identifies a build as compliant with a wide time window" {
-            # SQL Server 2022 CU10 (16.0.4095) released 2023-11-16 - compliant within 36 months of today (2026-03-30)
-            $result = Test-DbaBuild -Build "16.0.4095" -MaxTimeBehind "36Mo"
+            # SQL Server 2022 CU10 (16.0.4095) released 2023-11-16 - compliant within 360 months of today (2026-03-30)
+            $result = Test-DbaBuild -Build "16.0.4095" -MaxTimeBehind "360Mo"
             $result.Compliant | Should -Be $true
         }
 
@@ -43,7 +43,9 @@ Describe $CommandName -Tag UnitTests {
 
         It "Returns non-compliant when no ReleaseDate is available" {
             # An unrecognized build version has no release date in the index
-            $result = Test-DbaBuild -Build "16.0.9999" -MaxTimeBehind "6Mo"
+            $result = Test-DbaBuild -Build "16.0.9999" -MaxTimeBehind "6Mo" -WarningAction SilentlyContinue
+            $WarnVar[0] | Should -BeLike "*16.0.9999 is not recognized as a correct version"
+            $WarnVar[1] | Should -BeLike "*No ReleaseDate found for build 16.0.9999 - cannot determine time-based compliance"
             $result.Compliant | Should -Be $false
         }
     }


### PR DESCRIPTION
As we moved the addition of ReleaseDateto Get-DbaBuild, we don't need that code here as the object always has this property already.

Before this fix:
<img width="1577" height="466" alt="image" src="https://github.com/user-attachments/assets/b52a40e1-b480-4b50-95cc-111d46ad4db2" />

After this fix:
<img width="742" height="342" alt="image" src="https://github.com/user-attachments/assets/eafe5038-3298-49d2-aa67-3d94a5eb0c63" />

