### PR TITLE
Fix test for Test-DbaSpn by suppressing the warning on AppVeyor

### DIFF
--- a/tests/Test-DbaSpn.Tests.ps1
+++ b/tests/Test-DbaSpn.Tests.ps1
@@ -23,7 +23,7 @@ Describe $CommandName -Tag UnitTests {
 Describe $CommandName -Tag IntegrationTests {
     Context "When getting SPN information" {
         BeforeAll {
-            $results = Test-DbaSpn -ComputerName $TestConfig.InstanceSingle
+            $results = Test-DbaSpn -ComputerName $TestConfig.InstanceSingle -WarningAction SilentlyContinue
         }
 
         It "Returns some results" {


### PR DESCRIPTION
Because AppVeyor is not domain-joined, we get this warning:
<img width="912" height="322" alt="image" src="https://github.com/user-attachments/assets/6c8f5c9e-fa32-4e55-a301-f105e757b1a7" />

To have a clean test output to be able to see real problem, we nw suppress this warning.