### PR TITLE
Fix AppVeyor dbatools.library cache miss by installing to AllUsers scope

### DIFF
--- a/tests/appveyor.prep.ps1
+++ b/tests/appveyor.prep.ps1
@@ -28,7 +28,9 @@ Install-Module -Name PSScriptAnalyzer -Force -SkipPublisherCheck -MaximumVersion
 #Get dbatools.library
 Write-Host -Object "appveyor.prep: Install dbatools.library" -ForegroundColor DarkGreen
 # Use centralized version management for dbatools.library installation
-& "$PSScriptRoot\..\.github\scripts\install-dbatools-library.ps1"
+# Use AllUsers scope so the module is installed to C:\Program Files\WindowsPowerShell\Modules
+# which matches the AppVeyor cache path configured in appveyor.yml
+& "$PSScriptRoot\..\.github\scripts\install-dbatools-library.ps1" -Scope AllUsers
 # Validate that the correct version was installed
 $expectedVersion = (Get-Content '.github/dbatools-library-version.json' | ConvertFrom-Json).version
 $installedModule = Get-Module dbatools.library -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1


### PR DESCRIPTION
Fixes #10333

The AppVeyor cache in `appveyor.yml` expects `dbatools.library` at `C:\Program Files\WindowsPowerShell\Modules\dbatools.library`, but the install script was called without a scope, defaulting to `CurrentUser` and installing to the user profile path instead.

Adding `-Scope AllUsers` to the install script call in `tests/appveyor.prep.ps1` ensures the module is installed to the path the cache is watching.

Generated with [Claude Code](https://claude.ai/code)